### PR TITLE
Properly work around Mac GCM issues when the system Java is 8 (or below)

### DIFF
--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -33,14 +33,12 @@ fi
 
 git-credential-manager install
 
-# Determine what Java version we have so we can construct a valid path to java
+# If our Java version is 9+ (the formatting of 'java -version' changed in Java 9), work around
+# https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/issues/71
 JAVAVERSION="$(java -version 2>&1 | egrep -o '"[[:digit:]]+.[[:digit:]]+.[[:digit:]]+"' | xargs)"
-if [[ -z $JAVAVERSION ]]; then
-    JAVAVERSION="10.0.2"
+if [[ ! -z $JAVAVERSION ]]; then
+    git config --global credential.helper "!/usr/bin/java -Ddebug=false --add-modules java.xml.bind -Djava.net.useSystemProxies=true -jar /usr/local/Cellar/git-credential-manager/2.0.3/libexec/git-credential-manager-2.0.3.jar" || exit 1
 fi
-
-# Work around https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/issues/71
-git config --global credential.helper "!/Library/Java/JavaVirtualMachines/jdk-$JAVAVERSION.jdk/Contents/Home/bin/java -Ddebug=false --add-modules java.xml.bind -Djava.net.useSystemProxies=true -jar /usr/local/Cellar/git-credential-manager/2.0.3/libexec/git-credential-manager-2.0.3.jar" || exit 1
 
 # If we're running on an agent where the PAT environment variable is set and a URL is passed into the script, add it to the keychain.
 PAT=$SYSTEM_ACCESSTOKEN

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -7,6 +7,10 @@ GVFSPROPS=$SCRIPTDIR/../../GVFS/GVFS.Build/GVFS.props
 GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]{1,}')"
 ROOTDIR=$SCRIPTDIR/../../..
 GITDIR=$ROOTDIR/packages/gitformac.gvfs.installer/$GITVERSION/tools
+if [[ ! -d $GITDIR ]]; then
+    echo "GVFS-aware Git package not found. Run BuildGVFSForMac.sh and try again"
+    exit 1
+fi
 hdiutil attach $GITDIR/*.dmg || exit 1
 GITPKG="$(find /Volumes/Git* -type f -name *.pkg)" || exit 1
 sudo installer -pkg "$GITPKG" -target / || exit 1


### PR DESCRIPTION
Our prep script that configures machines (dev machines and build agents) to run functional tests has a workaround for an issue with the Git Credential Manager (https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/issues/71). 

This workaround only needs to be applied on machines who's default Java is 9 or 10 (which changed the format of 'java -version'). Applying the workaround to Java 8 installations will instead break the GCM on those machines.

See #155 