### PR TITLE
Mac: prjfs-log improvements

### DIFF
--- a/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/xcschemes/PrjFS.xcscheme
+++ b/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/xcschemes/PrjFS.xcscheme
@@ -34,6 +34,20 @@
                ReferencedContainer = "container:PrjFSLib/PrjFSLib.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D308477D20B4431200F69E92"
+               BuildableName = "prjfs-log"
+               BlueprintName = "prjfs-log"
+               ReferencedContainer = "container:PrjFSLib/PrjFSLib.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KextLog.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KextLog.cpp
@@ -81,6 +81,11 @@ void KextLog_DeregisterUserClient(PrjFSLogUserClient* userClient)
 
 void KextLog_Printf(KextLog_Level loglevel, const char* fmt, ...)
 {
+    if (nullptr == s_currentUserClient)
+    {
+        return;
+    }
+    
     // Stack-allocated message with 128-character string buffer for fast path
     struct KextLog_StackMessageBuffer message = {};
     KextLog_MessageHeader* messagePtr = &message.header;
@@ -121,10 +126,6 @@ void KextLog_Printf(KextLog_Level loglevel, const char* fmt, ...)
             uint64_t time = mach_absolute_time();
             messagePtr->machAbsoluteTimestamp = time;
             s_currentUserClient->sendLogMessage(messagePtr, messageSize);
-        }
-        else
-        {
-            kprintf("%s\n", messagePtr->logString);
         }
     }
     RWLock_ReleaseShared(s_kextLogRWLock);

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KextLog.hpp
@@ -42,5 +42,47 @@ template <typename... args>
 #define KextLog_FileInfo(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_INFO, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
 #define KextLog_FileNote(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_NOTE, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
 
+#define KextLog_VnodeOp(vnode, vnodeType, procname, action, message) \
+    do { \
+        if (VDIR == vnodeType) \
+        { \
+            KextLog_FileNote( \
+                vnode, \
+                message ". Proc name: %s. Directory vnode action: %s%s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
+                procname, \
+                (action & KAUTH_VNODE_LIST_DIRECTORY)       ? " \n    KAUTH_VNODE_LIST_DIRECTORY" : "", \
+                (action & KAUTH_VNODE_ADD_FILE)             ? " \n    KAUTH_VNODE_ADD_FILE" : "", \
+                (action & KAUTH_VNODE_SEARCH)               ? " \n    KAUTH_VNODE_SEARCH" : "", \
+                (action & KAUTH_VNODE_DELETE)               ? " \n    KAUTH_VNODE_DELETE" : "", \
+                (action & KAUTH_VNODE_ADD_SUBDIRECTORY)     ? " \n    KAUTH_VNODE_ADD_SUBDIRECTORY" : "", \
+                (action & KAUTH_VNODE_DELETE_CHILD)         ? " \n    KAUTH_VNODE_DELETE_CHILD" : "", \
+                (action & KAUTH_VNODE_READ_ATTRIBUTES)      ? " \n    KAUTH_VNODE_READ_ATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? " \n    KAUTH_VNODE_WRITE_ATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? " \n    KAUTH_VNODE_READ_EXTATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? " \n    KAUTH_VNODE_WRITE_EXTATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_READ_SECURITY)        ? " \n    KAUTH_VNODE_READ_SECURITY" : "", \
+                (action & KAUTH_VNODE_WRITE_SECURITY)       ? " \n    KAUTH_VNODE_WRITE_SECURITY" : "", \
+                (action & KAUTH_VNODE_TAKE_OWNERSHIP)       ? " \n    KAUTH_VNODE_TAKE_OWNERSHIP" : ""); \
+        } \
+        else \
+        { \
+            KextLog_FileNote( \
+                vnode, \
+                message ". Proc name: %s. File vnode action: %s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
+                procname, \
+                (action & KAUTH_VNODE_READ_DATA)            ? " \n    KAUTH_VNODE_READ_DATA" : "", \
+                (action & KAUTH_VNODE_WRITE_DATA)           ? " \n    KAUTH_VNODE_WRITE_DATA" : "", \
+                (action & KAUTH_VNODE_EXECUTE)              ? " \n    KAUTH_VNODE_EXECUTE" : "", \
+                (action & KAUTH_VNODE_DELETE)               ? " \n    KAUTH_VNODE_DELETE" : "", \
+                (action & KAUTH_VNODE_APPEND_DATA)          ? " \n    KAUTH_VNODE_APPEND_DATA" : "", \
+                (action & KAUTH_VNODE_READ_ATTRIBUTES)      ? " \n    KAUTH_VNODE_READ_ATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? " \n    KAUTH_VNODE_WRITE_ATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? " \n    KAUTH_VNODE_READ_EXTATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? " \n    KAUTH_VNODE_WRITE_EXTATTRIBUTES" : "", \
+                (action & KAUTH_VNODE_READ_SECURITY)        ? " \n    KAUTH_VNODE_READ_SECURITY" : "", \
+                (action & KAUTH_VNODE_WRITE_SECURITY)       ? " \n    KAUTH_VNODE_WRITE_SECURITY" : "", \
+                (action & KAUTH_VNODE_TAKE_OWNERSHIP)       ? " \n    KAUTH_VNODE_TAKE_OWNERSHIP" : ""); \
+        } \
+    } while (0)
 
 #endif /* KextLog_h */

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -5,7 +5,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <mach/mach_time.h>
-#include <sys/time.h>
 
 static const char* KextLogLevelAsString(KextLog_Level level);
 
@@ -49,12 +48,8 @@ int main(int argc, const char * argv[])
                 memcpy(&message, entry->data, sizeof(KextLog_MessageHeader));
                 const char* messageType = KextLogLevelAsString(message.level);
                 int logStringLength = messageSize - sizeof(KextLog_MessageHeader) - 1;
-
-                struct timeval tp;
-                gettimeofday(&tp, NULL);
-                long int timestamp = tp.tv_sec * 1000 + tp.tv_usec / 1000;
                 
-                printf("(%d: %ld) %s: %.*s\n", lineCount, timestamp, messageType, logStringLength, entry->data + sizeof(KextLog_MessageHeader));
+                printf("(%d: %llu) %s: %.*s\n", lineCount, message.machAbsoluteTimestamp, messageType, logStringLength, entry->data + sizeof(KextLog_MessageHeader));
                 lineCount++;
             }
             


### PR DESCRIPTION
* Build prjfs-log under the same scheme as everything else
* Added a utility function for logging vnode actions
* Removed a call to kprintf as it seems to be quite slow
* Added line numbers and timestamps to the output of prjfs-log