### PR TITLE
Add --force flag to fast fetch

### DIFF
--- a/GVFS/FastFetch/CheckoutJob.cs
+++ b/GVFS/FastFetch/CheckoutJob.cs
@@ -1,6 +1,8 @@
-﻿using GVFS.Common.FileSystem;
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Prefetch.Git;
+using GVFS.Common.Prefetch.Jobs;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Concurrent;
@@ -9,7 +11,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GVFS.Common.Prefetch.Jobs
+namespace FastFetch
 {
     public class CheckoutJob : Job
     {
@@ -19,7 +21,7 @@ namespace GVFS.Common.Prefetch.Jobs
         private ITracer tracer;
         private Enlistment enlistment;
         private string targetCommitSha;
-        private bool force;
+        private bool forceCheckout;
 
         private DiffHelper diff;
 
@@ -32,14 +34,14 @@ namespace GVFS.Common.Prefetch.Jobs
         // Checkout requires synchronization between the delete/directory/add stages, so control the parallelization
         private int maxParallel;
 
-        public CheckoutJob(int maxParallel, IEnumerable<string> folderList, string targetCommitSha, ITracer tracer, Enlistment enlistment, bool force = false)
+        public CheckoutJob(int maxParallel, IEnumerable<string> folderList, string targetCommitSha, ITracer tracer, Enlistment enlistment, bool forceCheckout)
             : base(1)
         {
             this.tracer = tracer.StartActivity(AreaPath, EventLevel.Informational, Keywords.Telemetry, metadata: null);
             this.enlistment = enlistment;
             this.diff = new DiffHelper(tracer, enlistment, new string[0], folderList);
             this.targetCommitSha = targetCommitSha;
-            this.force = force;
+            this.forceCheckout = forceCheckout;
             this.AvailableBlobShas = new BlockingCollection<string>();
 
             // Keep track of how parallel we're expected to be later during DoWork
@@ -64,14 +66,14 @@ namespace GVFS.Common.Prefetch.Jobs
 
         protected override void DoBeforeWork()
         {
-            if (this.force)
+            if (this.forceCheckout)
             {
-                // When using force set the sourceCommitSha to null to act like an uninitialized repo
-                this.diff.PerformDiff(null, this.targetCommitSha);
+                // Force search the entire tree by treating the repo as if it were brand new.
+                this.diff.PerformDiff(sourceTreeSha: null, targetTreeSha: this.targetCommitSha);
             }
             else
             {
-                // This variant of diff uses the HEAD as the SourceCommitSha.
+                // Let the diff find the sourceTreeSha on its own.
                 this.diff.PerformDiff(this.targetCommitSha);
             }
 

--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -33,7 +33,7 @@ namespace FastFetch
         }
 
         /// <param name="branchOrCommit">A specific branch to filter for, or null for all branches returned from info/refs</param>
-        public override void Prefetch(string branchOrCommit, bool isBranch)
+        public override void Prefetch(string branchOrCommit, bool isBranch, bool force = false)
         {
             if (string.IsNullOrWhiteSpace(branchOrCommit))
             {
@@ -66,7 +66,7 @@ namespace FastFetch
             // Configure pipeline
             // Checkout uses DiffHelper when running checkout.Start(), which we use instead of LsTreeHelper
             // Checkout diff output => FindMissingBlobs => BatchDownload => IndexPack => Checkout available blobs
-            CheckoutJob checkout = new CheckoutJob(this.checkoutThreadCount, this.FolderList, commitToFetch, this.Tracer, this.Enlistment);
+            CheckoutJob checkout = new CheckoutJob(this.checkoutThreadCount, this.FolderList, commitToFetch, this.Tracer, this.Enlistment, force: force);
             FindMissingBlobsJob blobFinder = new FindMissingBlobsJob(this.SearchThreadCount, checkout.RequiredBlobs, checkout.AvailableBlobShas, this.Tracer, this.Enlistment);
             BatchObjectDownloadJob downloader = new BatchObjectDownloadJob(this.DownloadThreadCount, this.ChunkSize, blobFinder.MissingBlobs, checkout.AvailableBlobShas, this.Tracer, this.Enlistment, this.ObjectRequestor, this.GitObjects);
             IndexPackJob packIndexer = new IndexPackJob(this.IndexThreadCount, downloader.AvailablePacks, checkout.AvailableBlobShas, this.Tracer, this.GitObjects);

--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -56,6 +56,7 @@
     <Compile Include="$(BuildOutputDir)\CommonAssemblyVersion.cs">
       <Link>CommonAssemblyVersion.cs</Link>
     </Compile>
+    <Compile Include="CheckoutJob.cs" />
     <Compile Include="CheckoutPrefetcher.cs" />
     <Compile Include="FastFetchVerb.cs" />
     <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Windows.cs" />

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -139,7 +139,7 @@ namespace FastFetch
             "force",
             Required = false,
             Default = false,
-            HelpText = "Force FastFetch to download content as if the current repo was at commit id 0 (Had just been initialized).")]
+            HelpText = "Force FastFetch to download content as if the current repository was just initialized.")]
         public bool Force { get; set; }
 
         public void Execute()

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -58,9 +58,9 @@ namespace FastFetch
             "force-checkout",
             Required = false,
             Default = false,
-            HelpText = "Force FastFetch to fetch and checkout content as if the current repo had just been initialized." +
+            HelpText = "Force FastFetch to checkout content as if the current repo had just been initialized." +
                        "This allows you to include more folders from the repo that were not originally checked out." +
-                       "Can only be used with --checkout")]
+                       "Can only be used with the --checkout option.")]
         public bool ForceCheckout { get; set; }
 
         [Option(

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -135,6 +135,13 @@ namespace FastFetch
             HelpText = "The GUID of the caller - used for telemetry purposes.")]
         public string ParentActivityId { get; set; }
 
+        [Option(
+            "force",
+            Required = false,
+            Default = false,
+            HelpText = "Force FastFetch to download content as if the current repo was at commit id 0 (Had just been initialized).")]
+        public bool Force { get; set; }
+
         public void Execute()
         {
             Environment.ExitCode = this.ExecuteWithExitCode();
@@ -237,7 +244,7 @@ namespace FastFetch
                             try
                             {
                                 bool isBranch = this.Commit == null;
-                                prefetcher.Prefetch(commitish, isBranch);
+                                prefetcher.Prefetch(commitish, isBranch, force: this.Force);
                                 return !prefetcher.HasFailures;
                             }
                             catch (BlobPrefetcher.FetchException e)

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -162,13 +162,13 @@ namespace GVFS.Common.Prefetch
         }
 
         /// <param name="branchOrCommit">A specific branch to filter for, or null for all branches returned from info/refs</param>
-        public virtual void Prefetch(string branchOrCommit, bool isBranch, bool force = false)
+        public virtual void Prefetch(string branchOrCommit, bool isBranch)
         {
             int matchedBlobCount;
             int downloadedBlobCount;
             int readFileCount;
             
-            this.PrefetchWithStats(branchOrCommit, isBranch, false, out matchedBlobCount, out downloadedBlobCount, out readFileCount, force: force);
+            this.PrefetchWithStats(branchOrCommit, isBranch, false, out matchedBlobCount, out downloadedBlobCount, out readFileCount);
         }
 
         public void PrefetchWithStats(
@@ -177,8 +177,7 @@ namespace GVFS.Common.Prefetch
             bool readFilesAfterDownload,
             out int matchedBlobCount,
             out int downloadedBlobCount,
-            out int readFileCount,
-            bool force = false)
+            out int readFileCount)
         {
             matchedBlobCount = 0;
             downloadedBlobCount = 0;
@@ -220,7 +219,7 @@ namespace GVFS.Common.Prefetch
 
             // Use the shallow file to find a recent commit to diff against to try and reduce the number of SHAs to check.
             // Unless force flag has been given, in which case treat as if it's a fresh repo.
-            if (!force && File.Exists(shallowFile))
+            if (File.Exists(shallowFile))
             {
                 previousCommit = File.ReadAllLines(shallowFile).Where(line => !string.IsNullOrWhiteSpace(line)).LastOrDefault();
                 if (string.IsNullOrWhiteSpace(previousCommit))

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -218,7 +218,6 @@ namespace GVFS.Common.Prefetch
             string previousCommit = null;
 
             // Use the shallow file to find a recent commit to diff against to try and reduce the number of SHAs to check.
-            // Unless force flag has been given, in which case treat as if it's a fresh repo.
             if (File.Exists(shallowFile))
             {
                 previousCommit = File.ReadAllLines(shallowFile).Where(line => !string.IsNullOrWhiteSpace(line)).LastOrDefault();

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -101,7 +101,7 @@ namespace GVFS.FunctionalTests.Tests
         }
 
         [TestCase]
-        public void CanFetchAndCheckoutMultipleTimesUsingForceFlag()
+        public void CanFetchAndCheckoutMultipleTimesUsingForceCheckoutFlag()
         {
             this.RunFastFetch($"--checkout --folders \"/GVFS\" -b {Settings.Default.Commitish}");
 
@@ -122,7 +122,7 @@ namespace GVFS.FunctionalTests.Tests
             this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
 
             // Run a second time in the same repo on the same branch with more folders. 
-            this.RunFastFetch($"--checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force");
+            this.RunFastFetch($"--checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force-checkout");
             dirs = Directory.EnumerateFileSystemEntries(this.fastFetchRepoRoot).ToList();
             dirs.SequenceEqual(new[]
             {
@@ -137,23 +137,15 @@ namespace GVFS.FunctionalTests.Tests
         }
 
         [TestCase]
-        public void CanFetchWithoutCheckoutMultipleTimesUsingForceFlagAndThenCheckout()
+        public void ForceCheckoutRequiresCheckout()
         {
-            this.RunFastFetch($"--folders \"/GVFS\" -b {Settings.Default.Commitish}");
-
-            this.GetRefTreeSha("remotes/origin/" + Settings.Default.Commitish).ShouldNotBeNull();
+            this.RunFastFetch($"--checkout --folders \"/Scripts\" -b {Settings.Default.Commitish}");
 
             // Run a second time in the same repo on the same branch with more folders. 
-            this.RunFastFetch($"--folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force");
-            
-            this.RunFastFetch($"--checkout -b {Settings.Default.Commitish}");
-            Directory.EnumerateFileSystemEntries(Path.Combine(this.fastFetchRepoRoot, "GVFS"), "*", SearchOption.AllDirectories)
-                .Count()
-                .ShouldEqual(345);
+            string result = this.RunFastFetch($"--force-checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish}");
 
-            Directory.EnumerateFileSystemEntries(Path.Combine(this.fastFetchRepoRoot, "Scripts"), "*", SearchOption.AllDirectories)
-                .Count()
-                .ShouldEqual(5);
+            string[] expectedResults = new string[] { "Cannot use --force-checkout option without --checkout option." };
+            result.ShouldContain(expectedResults);
         }
 
         [TestCase]


### PR DESCRIPTION
# Adding `--force` to FastFetch

This adds a `--force` option when using FastFetch. This will cause FastFetch to treat the repo as if it had just been initialized meaning new folders can be fetched after the initial FastFetch is run. You can effectively grow the number of folders a FastFetched repo has.

This is required for boot-strapping scenarios where the set of desired folders to fetch must be dynamically computed after an initial fast fetch.