### PR TITLE
Remove incorrect file header

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Info.plist
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2018 Microsoft. All rights reserved.</string>
+	<string>Copyright © Microsoft</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>PrjFS</key>

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.cpp
@@ -1,11 +1,3 @@
-//
-//  VnodeUtilities.cpp
-//  PrjFSKext
-//
-//  Created by Phil Dennis-Jordan on 15/05/18.
-//  Copyright © 2018 GVFS. All rights reserved.
-//
-
 #include "VnodeUtilities.hpp"
 #include "kernel-header-wrappers/vnode.h"
 #include "kernel-header-wrappers/mount.h"


### PR DESCRIPTION
See #149 

Removed the incorrect file header from `VnodeUtilities.cpp`. Also removed the phrase "All rights reserved" from `Info.plist`