### PR TITLE
ObjectPool: Create Pool Size of 100 instead of throwing on 0

### DIFF
--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
@@ -303,8 +303,12 @@ namespace GVFS.UnitTests.Virtualization.Git
         public void MinimumPoolSize()
         {
             LazyUTF8String.ResetPool(new MockTracer(), 0);
+
             LazyUTF8String.FreePool();
+            LazyUTF8String.BytePoolSize().ShouldBeAtLeast(1);
+
             LazyUTF8String.InitializePools(new MockTracer(), 0);
+            LazyUTF8String.BytePoolSize().ShouldBeAtLeast(1);
         }
 
         private static void CheckPoolSizes(int expectedBytePoolSize, int expectedStringPoolSize)

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
@@ -299,6 +299,14 @@ namespace GVFS.UnitTests.Virtualization.Git
                 });
         }
 
+        [TestCase]
+        public void MinimumPoolSize()
+        {
+            LazyUTF8String.ResetPool(new MockTracer(), 0);
+            LazyUTF8String.FreePool();
+            LazyUTF8String.InitializePools(new MockTracer(), 0);
+        }
+
         private static void CheckPoolSizes(int expectedBytePoolSize, int expectedStringPoolSize)
         {
             LazyUTF8String.BytePoolSize().ShouldEqual(expectedBytePoolSize, $"{nameof(LazyUTF8String.BytePoolSize)} should be {expectedBytePoolSize}");

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
@@ -128,8 +128,14 @@ namespace GVFS.UnitTests.Virtualization.Git
         public void SmallEntries()
         {
             SortedFolderEntries.FreePool();
+
             SortedFolderEntries.InitializePools(new MockTracer(), indexEntryCount: 0);
+            SortedFolderEntries.FilePoolSize().ShouldBeAtLeast(1);
+            SortedFolderEntries.FolderPoolSize().ShouldBeAtLeast(1);
+
             SortedFolderEntries.ResetPool(new MockTracer(), indexEntryCount: 0);
+            SortedFolderEntries.FilePoolSize().ShouldBeAtLeast(1);
+            SortedFolderEntries.FolderPoolSize().ShouldBeAtLeast(1);
         }
 
         private static int CaseInsensitiveStringCompare(string x, string y)

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
@@ -124,6 +124,14 @@ namespace GVFS.UnitTests.Virtualization.Git
             sfe.Count.ShouldEqual(0);
         }
 
+        [TestCase]
+        public void SmallEntries()
+        {
+            SortedFolderEntries.FreePool();
+            SortedFolderEntries.InitializePools(new MockTracer(), indexEntryCount: 0);
+            SortedFolderEntries.ResetPool(new MockTracer(), indexEntryCount: 0);
+        }
+
         private static int CaseInsensitiveStringCompare(string x, string y)
         {
             return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.ObjectPool.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.ObjectPool.cs
@@ -15,6 +15,7 @@ namespace GVFS.Virtualization.Projection
         /// <typeparam name="T">The type of object to be stored in the array pool</typeparam>
         internal class ObjectPool<T>
         {
+            private const int MinPoolSize = 100;
             private int allocationSize;
             private T[] pool;
             private int freeIndex;
@@ -23,9 +24,9 @@ namespace GVFS.Virtualization.Projection
 
             public ObjectPool(ITracer tracer, int allocationSize, Func<T> objectCreator)
             {
-                if (allocationSize <= 0)
+                if (allocationSize < MinPoolSize)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(allocationSize), "Must be greater than zero");
+                    allocationSize = MinPoolSize;
                 }
 
                 this.tracer = tracer;


### PR DESCRIPTION
A user reported an issue when cloning a repo with no files (other than `.gitignore` and `.gitattributes`). This is recorded by #162.

The issue is that the `ObjectPool` throws an exception when given a pool size of 0, and we multiply the number of index entries by a double less than 1.0 and cast down to an `int`. This is easily fixed by adding a minimum pool size. This is verified with a simple unit test.