### PR TITLE
Fix parsing of GVFS-aware Git version numbers that contain - (for PR validation builds)

### DIFF
--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -34,7 +34,7 @@ fi
 
 $SCRIPTDIR/DownloadGVFSGit.sh || exit 1
 GVFSPROPS=$SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]{1,}')"
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
 GITPATH="$(find $PACKAGES/gitformac.gvfs.installer/$GITVERSION -type f -name *.dmg)" || exit 1
 # Now that we have a path containing the version number, generate GVFSConstants.GitVersion.cs
 $SCRIPTDIR/GenerateGitVersionConstants.sh "$GITPATH" $BUILDDIR || exit 1

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -33,8 +33,7 @@ if [ ! -d $BUILDDIR ]; then
 fi
 
 $SCRIPTDIR/DownloadGVFSGit.sh || exit 1
-GVFSPROPS=$SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
+GITVERSION="$($SCRIPTDIR/GetGitVersionNumber.sh)"
 GITPATH="$(find $PACKAGES/gitformac.gvfs.installer/$GITVERSION -type f -name *.dmg)" || exit 1
 # Now that we have a path containing the version number, generate GVFSConstants.GitVersion.cs
 $SCRIPTDIR/GenerateGitVersionConstants.sh "$GITPATH" $BUILDDIR || exit 1

--- a/Scripts/Mac/DownloadGVFSGit.sh
+++ b/Scripts/Mac/DownloadGVFSGit.sh
@@ -3,7 +3,7 @@ SRCDIR=$SCRIPTDIR/../..
 BUILDDIR=$SRCDIR/../BuildOutput/GVFS.Build
 PACKAGESDIR=$SRCDIR/../packages
 GVFSPROPS=$SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]{1,}')"
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
 cp $SRCDIR/nuget.config $BUILDDIR
 dotnet new classlib -n GVFS.Restore -o $BUILDDIR --force
 dotnet add $BUILDDIR/GVFS.Restore.csproj package --package-directory $PACKAGESDIR GitForMac.GVFS.Installer --version $GITVERSION

--- a/Scripts/Mac/DownloadGVFSGit.sh
+++ b/Scripts/Mac/DownloadGVFSGit.sh
@@ -2,8 +2,7 @@ SCRIPTDIR="$(dirname ${BASH_SOURCE[0]})"
 SRCDIR=$SCRIPTDIR/../..
 BUILDDIR=$SRCDIR/../BuildOutput/GVFS.Build
 PACKAGESDIR=$SRCDIR/../packages
-GVFSPROPS=$SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
+GITVERSION="$($SCRIPTDIR/GetGitVersionNumber.sh)"
 cp $SRCDIR/nuget.config $BUILDDIR
 dotnet new classlib -n GVFS.Restore -o $BUILDDIR --force
 dotnet add $BUILDDIR/GVFS.Restore.csproj package --package-directory $PACKAGESDIR GitForMac.GVFS.Installer --version $GITVERSION

--- a/Scripts/Mac/GetGitVersionNumber.sh
+++ b/Scripts/Mac/GetGitVersionNumber.sh
@@ -1,0 +1,4 @@
+SCRIPTDIR="$(dirname ${BASH_SOURCE[0]})"
+GVFSPROPS=$SCRIPTDIR/../../GVFS/GVFS.Build/GVFS.props
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
+echo $GITVERSION

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -4,7 +4,7 @@ SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 
 # Install GVFS-aware Git (that was downloaded by the build script)
 GVFSPROPS=$SCRIPTDIR/../../GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]{1,}')"
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
 ROOTDIR=$SCRIPTDIR/../../..
 GITDIR=$ROOTDIR/packages/gitformac.gvfs.installer/$GITVERSION/tools
 if [[ ! -d $GITDIR ]]; then

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -3,8 +3,7 @@
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 
 # Install GVFS-aware Git (that was downloaded by the build script)
-GVFSPROPS=$SCRIPTDIR/../../GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
+GITVERSION="$($SCRIPTDIR/GetGitVersionNumber.sh)"
 ROOTDIR=$SCRIPTDIR/../../..
 GITDIR=$ROOTDIR/packages/gitformac.gvfs.installer/$GITVERSION/tools
 if [[ ! -d $GITDIR ]]; then


### PR DESCRIPTION
Correct regex used to match GVFS-aware Git package to actually match the NuGet spec for what defines a package. See https://docs.microsoft.com/en-us/nuget/reference/package-versioning

This fixes #175