### PR TITLE
GitStatusCache: fix race condition in test setup

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -98,6 +98,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         private void RepositoryIgnoreTestSetup()
         {
+            this.WaitForUpToDateStatusCache();
+
             string statusCachePath = Path.Combine(this.Enlistment.DotGVFSRoot, "GitStatusCache", "GitStatusCache.dat");
             File.Delete(statusCachePath);
 
@@ -108,6 +110,18 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             // Verify that status from the status cache includes the "test.ign" entry
             this.ValidateGitCommand("status");
+        }
+
+        /// <summary>
+        /// Wait for an up-to-date status cache file to exist on disk.
+        /// </summary>
+        private void WaitForUpToDateStatusCache()
+        {
+            // Run "git status" for the side effect that it will delete any stale status cache file.
+            this.ValidateGitCommand("status");
+
+            // Wait for a new status cache to be generated.
+            this.WaitForStatusCacheToBeGenerated(waitForNewFile: false);
         }
 
         private void WaitForStatusCacheToBeGenerated(bool waitForNewFile = true)


### PR DESCRIPTION
**Issue**
The following functional test run failed with the following logs from [build 18226.25](https://gvfs.visualstudio.com/ci/_build/results?buildId=397&_a=summary):

```
System.IO.DirectoryNotFoundException : Could not find a part of the path 'C:\Repos\GVFSFunctionalTests\enlistment\287fdef1a84b4204977e\.gvfs\GitStatusCache\GitStatusCache.dat'.
    at System.IO.FileSystem.DeleteFile(String fullPath)
    at System.IO.File.Delete(String path)
    at GVFS.FunctionalTests.Tests.GitCommands.StatusTests.RepositoryIgnoreTestSetup() in C:\agent\_work\3\s\GVFS\GVFS.FunctionalTests\Tests\GitCommands\StatusTests.cs:line 102
    at GVFS.FunctionalTests.Tests.GitCommands.StatusTests.NewRepositoryExcludeFileInvalidatesCache() in C:\agent\_work\3\s\GVFS\GVFS.FunctionalTests\Tests\GitCommands\StatusTests.cs:line 59
```
Looking at the logs, this test attempted to delete the on disk status cache file before the status cache generation was run. The test assumed that at least the directory containing the status cache file existed before this point. Usually this is the case, but if this logic loses the race with the background status (the status cache directory is usually created just before running the actual git command to generate the status cache), then it will fail.

**Fix**
The test setup waits for the initial status cache to be generated, so it can proceed from a known state. Waiting for the system to settle down and start from a known state ensures it can handle cases where the status cache is in the middle of being generated, and not cause intermittent test issues later on.

Related issue: #170 