### PR TITLE
Add FileOp specific ShouldHandleFileOpEvent helper to kext

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -569,8 +569,6 @@ static bool ShouldHandleFileOpEvent(
     }
     
     *root = VirtualizationRoots_FindForVnode(vnode);
-    int16_t rootIndex = nullptr == *root ? -1 : (*root)->index;
-    
     if (nullptr == *root)
     {
         KextLog_FileNote(vnode, "ShouldHandleFileOpEvent(%d): No virtualization root found for file with set flag.", action);


### PR DESCRIPTION
Cleanup work for #152 (related to change in #156).

We should have separate logic for deciding if FileOp and VnodeOp events should be handled.  In #156 we incorrectly used the same helper function for both.