### PR TITLE
Fix test reliability issues with checks in GetObjectRoot

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
+++ b/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
@@ -173,6 +173,22 @@ namespace GVFS.FunctionalTests.Should
                 return this.WithItems("*");
             }
 
+            public IEnumerable<FileInfo> WithFiles()
+            {
+                IEnumerable<FileSystemInfo> items = this.WithItems();
+                IEnumerable<FileInfo> files = items.Where(info => info is FileInfo).Cast<FileInfo>();
+                files.Any().ShouldEqual(true, this.Path + " does not have any files. Contents: " + string.Join(",", items));
+                return files;
+            }
+
+            public IEnumerable<DirectoryInfo> WithDirectories()
+            {
+                IEnumerable<FileSystemInfo> items = this.WithItems();
+                IEnumerable<DirectoryInfo> directories = items.Where(info => info is DirectoryInfo).Cast<DirectoryInfo>();
+                directories.Any().ShouldEqual(true, this.Path + " does not have any directories. Contents: " + string.Join(",", items));
+                return directories;
+            }
+
             public IEnumerable<FileSystemInfo> WithItems(string searchPattern)
             {
                 DirectoryInfo directory = new DirectoryInfo(this.Path);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -124,7 +124,6 @@ namespace GVFS.FunctionalTests.Tools
 
             this.LocalCacheRoot.ShouldBeADirectory(fileSystem).WithFiles().ShouldNotContain(f => !allowedFileNames.Contains(f.Name)); 
                                                                                             
-
             DirectoryInfo[] directories = this.LocalCacheRoot.ShouldBeADirectory(fileSystem).WithDirectories().ToArray();
             directories.Length.ShouldEqual(
                 1, 

--- a/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
+++ b/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
@@ -48,7 +48,7 @@ namespace GVFS.Tests.Should
         public static void ShouldNotContain<T>(this IEnumerable<T> group, Func<T, bool> predicate)
         {
             T item = group.SingleOrDefault(predicate);
-            item.ShouldEqual(default(T));
+            item.ShouldEqual(default(T), "Unexpected matching entry found in {" + string.Join(",", group) + "}");
         }
 
         public static IEnumerable<T> ShouldNotContain<T>(this IEnumerable<T> group, IEnumerable<T> unexpectedValues, Func<T, T, bool> predicate)


### PR DESCRIPTION
Fix for issue #178 

The problem with the current `GetObjectRoot` is the check there are only two items in the local cache root folder.

This was a valid check when the functional tests were not run in parallel, but now that they are run in parallel it's possible that in one test GVFS is reading `mapping.dat` (which requires creating\holding `mapping.dat.lock`) while another test is calling `GetObjectRoot` (which doesn't need to read `mapping.dat` but still wants to validate the integrity of the local cache root folder).

To make these checks more robust `GetObjectRoot` will now check for the specific files it expects (and does not expect) to be present.

Example of a test failing due to this issue:
[18227.3](https://gvfs.visualstudio.com/ci/_build/results?buildId=492)