### PR TITLE
Mac: Add PreDelete Notification

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -12,6 +12,7 @@
         {
             public const string M1 = "M1_CloneAndMount";
             public const string M2 = "M2_StaticViewGitCommands";
+            public const string M2TODO = "M2_StaticViewGitCommandsStillTODO";
             public const string M3 = "M3_AllGitCommands";
             public const string M4 = "M4_All";
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -31,6 +32,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         private static string[] permissionDeniedMessage = new string[]
         {
             "Permission denied"
+        };
+
+        private static string[] resourceUnavailableMessage = new string[]
+        {
+            "Resource temporarily unavailable",
         };
 
         private readonly string pathToBash;
@@ -233,7 +239,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
-            this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
+            }
+            else
+            {
+                this.DeleteFile(path).ShouldContain(resourceUnavailableMessage);
+            }
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -32,11 +31,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         private static string[] permissionDeniedMessage = new string[]
         {
             "Permission denied"
-        };
-
-        private static string[] resourceUnavailableMessage = new string[]
-        {
-            "Resource temporarily unavailable",
         };
 
         private readonly string pathToBash;
@@ -239,14 +233,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
-            }
-            else
-            {
-                this.DeleteFile(path).ShouldContain(resourceUnavailableMessage);
-            }
+            this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -67,6 +67,7 @@ namespace GVFS.FunctionalTests
             {
                 includeCategories.Add(Categories.Mac.M1);
                 includeCategories.Add(Categories.Mac.M2);
+                excludeCategories.Add(Categories.Mac.M2TODO);
                 excludeCategories.Add(Categories.Mac.M3);
                 excludeCategories.Add(Categories.Mac.M4);
                 excludeCategories.Add(Categories.Windows);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -784,7 +784,6 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-        [Category(Categories.Mac.M4)]
         public void DeleteIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -784,6 +784,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [Category(Categories.Mac.M4)]
         public void DeleteIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(GitFilesTestsRunners), GitFilesTestsRunners.TestRunners)]
+    [Category(Categories.Mac.M2)]
     public class GitFilesTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;
@@ -23,6 +24,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(1)]
+        [Category(Categories.Mac.M2TODO)]
         public void CreateFileTest()
         {
             string fileName = "file1.txt";
@@ -36,6 +38,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(2)]
+        [Category(Categories.Mac.M2TODO)]
         public void CreateFileInFolderTest()
         {
             string folderName = "folder2";
@@ -51,11 +54,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + Environment.NewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + fileName + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + fileName + GVFSHelpers.ModifiedPathsNewLine);
         }
 
         [TestCase, Order(3)]
+        [Category(Categories.Mac.M2TODO)]
         public void RenameEmptyFolderTest()
         {
             string folderName = "folder3a";
@@ -76,6 +80,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
+        [Category(Categories.Mac.M2TODO)]
         public void RenameFolderTest()
         {
             string folderName = "folder4a";
@@ -108,6 +113,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
+        [Category(Categories.Mac.M2TODO)]
         public void CaseOnlyRenameOfNewFolderKeepsExcludeEntries()
         {
             string[] expectedModifiedPathsEntries =
@@ -129,7 +135,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
-        [Category(Categories.Mac.M2)]
         public void ReadingFileDoesNotUpdateIndexOrSparseCheckout()
         {
             string gitFileToCheck = "GVFS/GVFS.FunctionalTests/Category/CategoryConstants.cs";
@@ -153,11 +158,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             afterUpdateResult.Output.StartsWith("S ").ShouldEqual(true);
             afterUpdateResult.Output.ShouldContain("ctime: 0:0", "mtime: 0:0", "size: 0\t");
 
-            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToCheck + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToCheck + GVFSHelpers.ModifiedPathsNewLine);
         }
 
+        // TODO(Mac): Enable this test once the LockHolder is converted to .NET Core
         [TestCase, Order(7)]
-        public void ModifiedFileWillGetSkipworktreeBitCleared()
+        [Category(Categories.Mac.M2TODO)]
+        public void ModifiedFileWillGetAddedToModifiedPathsFile()
         {
             string gitFileToTest = "GVFS/GVFS.Common/RetryWrapper.cs";
             string fileToCreate = this.Enlistment.GetVirtualPathTo(gitFileToTest);
@@ -171,11 +178,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations did not complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToTest + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToTest + GVFSHelpers.ModifiedPathsNewLine);
             this.VerifyWorktreeBit(gitFileToTest, LsFilesStatus.Cached);
         }
 
         [TestCase, Order(8)]
+        [Category(Categories.Mac.M2TODO)]
         public void RenamedFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs";
@@ -189,14 +197,15 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + Environment.NewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
         }
 
         [TestCase, Order(9)]
+        [Category(Categories.Mac.M2TODO)]
         public void RenamedFileAndOverwrittenTargetAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests_2/MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite/RunUnitTests.bat";
@@ -211,8 +220,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + Environment.NewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
@@ -220,23 +229,22 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(10)]
-        public void DeletedFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
+        public void DeletedFileAddedToModifiedPathsFile()
         {
             string fileToDeleteEntry = "GVFlt_DeleteFileTest/GVFlt_DeleteFullFileWithoutFileContext_DeleteOnClose/a.txt";
-            string fileToDeleteRelativePath = "GVFlt_DeleteFileTest\\GVFlt_DeleteFullFileWithoutFileContext_DeleteOnClose\\a.txt";
             this.VerifyWorktreeBit(fileToDeleteEntry, LsFilesStatus.SkipWorktree);
 
-            this.fileSystem.DeleteFile(this.Enlistment.GetVirtualPathTo(fileToDeleteRelativePath));
+            this.fileSystem.DeleteFile(this.Enlistment.GetVirtualPathTo(fileToDeleteEntry));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToDeleteEntry + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToDeleteEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToDeleteEntry, LsFilesStatus.Cached);
         }
 
         [TestCase, Order(11)]
-        public void DeletedFolderAndChildrenAddedToSparseCheckoutAndSkipWorktreeBitCleared()
+        public void DeletedFolderAndChildrenAddedToToModifiedPathsFile()
         {
             string folderToDelete = "Scripts";
             string[] filesToDelete = new string[]
@@ -268,25 +276,25 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(12)]
-        public void FileRenamedOutOfRepoAddedToSparseCheckoutAndSkipWorktreeBitCleared()
+        public void FileRenamedOutOfRepoAddedToModifiedPathsFile()
         {
             string fileToRenameEntry = "GVFlt_MoveFileTest/PartialToOutside/from/lessInFrom.txt";
-            string fileToRenameVirtualPath = this.Enlistment.GetVirtualPathTo("GVFlt_MoveFileTest\\PartialToOutside\\from\\lessInFrom.txt");
+            string fileToRenameVirtualPath = this.Enlistment.GetVirtualPathTo(fileToRenameEntry);
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.SkipWorktree);
 
             string fileOutsideRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, "FileRenamedOutOfRepoAddedToSparseCheckoutAndSkipWorktreeBitCleared.txt");
             this.fileSystem.MoveFile(fileToRenameVirtualPath, fileOutsideRepoPath);
+            fileOutsideRepoPath.ShouldBeAFile(this.fileSystem).WithContents("lessData");
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
         }
 
         [TestCase, Order(13)]
-        [Category(Categories.Mac.M2)]
         public void OverwrittenFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToOverwriteEntry = "Test_EPF_WorkingDirectoryTests/1/2/3/4/ReadDeepProjectedFile.cpp";
@@ -300,13 +308,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             fileToOverwriteVirtualPath.ShouldBeAFile(this.fileSystem).WithContents(testContents);
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToOverwriteEntry + "\r\n");
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToOverwriteEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToOverwriteEntry, LsFilesStatus.Cached);
         }
 
         [TestCase, Order(14)]
+        [Category(Categories.Mac.M2TODO)]
         public void SupersededFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToSupersedeEntry = "GVFlt_FileOperationTest/WriteAndVerify.txt";
@@ -318,7 +327,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             SupersedeFile(fileToSupersedePath, newContent).ShouldEqual(true);
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToSupersedeEntry + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToSupersedeEntry + GVFSHelpers.ModifiedPathsNewLine);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToSupersedeEntry, LsFilesStatus.Cached);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -34,7 +34,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
             this.Enlistment.GetVirtualPathTo(fileName).ShouldBeAFile(this.fileSystem).WithContents("Some content here");
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileName + Environment.NewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileName);
         }
 
         [TestCase, Order(2)]
@@ -54,8 +54,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + GVFSHelpers.ModifiedPathsNewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + fileName + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/");
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + fileName);
         }
 
         [TestCase, Order(3)]
@@ -88,12 +88,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string[] fileNames = { "a", "b", "c" };
             string[] expectedModifiedEntries =
             {
-                renamedFolderName + "/" + fileNames[0] + Environment.NewLine,
-                renamedFolderName + "/" + fileNames[1] + Environment.NewLine,
-                renamedFolderName + "/" + fileNames[2] + Environment.NewLine,
-                folderName + "/" + fileNames[0] + Environment.NewLine,
-                folderName + "/" + fileNames[1] + Environment.NewLine,
-                folderName + "/" + fileNames[2] + Environment.NewLine,
+                renamedFolderName + "/" + fileNames[0],
+                renamedFolderName + "/" + fileNames[1],
+                renamedFolderName + "/" + fileNames[2],
+                folderName + "/" + fileNames[0],
+                folderName + "/" + fileNames[1],
+                folderName + "/" + fileNames[2],
             };
 
             this.Enlistment.GetVirtualPathTo(folderName).ShouldNotExistOnDisk(this.fileSystem);
@@ -158,7 +158,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             afterUpdateResult.Output.StartsWith("S ").ShouldEqual(true);
             afterUpdateResult.Output.ShouldContain("ctime: 0:0", "mtime: 0:0", "size: 0\t");
 
-            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToCheck + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToCheck);
         }
 
         // TODO(Mac): Enable this test once the LockHolder is converted to .NET Core
@@ -178,7 +178,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations did not complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToTest + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToTest);
             this.VerifyWorktreeBit(gitFileToTest, LsFilesStatus.Cached);
         }
 
@@ -197,8 +197,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
@@ -220,8 +220,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameTargetEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
@@ -237,7 +237,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteFile(this.Enlistment.GetVirtualPathTo(fileToDeleteEntry));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToDeleteEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToDeleteEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToDeleteEntry, LsFilesStatus.Cached);
@@ -288,7 +288,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
@@ -308,7 +308,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             fileToOverwriteVirtualPath.ShouldBeAFile(this.fileSystem).WithContents(testContents);
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToOverwriteEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToOverwriteEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToOverwriteEntry, LsFilesStatus.Cached);
@@ -327,7 +327,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             SupersedeFile(fileToSupersedePath, newContent).ShouldEqual(true);
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToSupersedeEntry + GVFSHelpers.ModifiedPathsNewLine);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToSupersedeEntry);
 
             // Verify skip-worktree cleared
             this.VerifyWorktreeBit(fileToSupersedeEntry, LsFilesStatus.Cached);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -66,8 +66,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string renamedFolderName = "folder3b";
             string[] expectedModifiedEntries =
             {
-                folderName + "/" + Environment.NewLine,
-                renamedFolderName + "/" + Environment.NewLine,
+                folderName + "/",
+                renamedFolderName + "/",
             };
 
             this.Enlistment.GetVirtualPathTo(folderName).ShouldNotExistOnDisk(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -11,6 +11,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
     [Category(Categories.GitCommands)]
+    [Category(Categories.Mac.M2)]
     public class GitMoveRenameTests : TestsWithEnlistmentPerFixture
     {
         private string testFileContents = "0123456789";
@@ -31,6 +32,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(2)]
+        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterNewFile()
         {
             string filename = "new.cs";
@@ -48,6 +50,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(3)]
+        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterFileNameCaseChange()
         {
             string oldFilename = "new.cs";
@@ -65,6 +68,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
+        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterFileRename()
         {
             string oldFilename = "New.cs";
@@ -82,6 +86,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
+        [Category(Categories.Mac.M3)]
         public void GitStatusAndObjectAfterGitAdd()
         {
             string existingFilename = "test.cs";
@@ -117,6 +122,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
+        [Category(Categories.Mac.M3)]
         public void GitStatusAfterUnstage()
         {
             string existingFilename = "test.cs";
@@ -139,7 +145,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         public void GitStatusAfterFileDelete()
         {
             string existingFilename = "test.cs";
-            this.Enlistment.GetVirtualPathTo(existingFilename).ShouldBeAFile(this.fileSystem);
+            this.EnsureTestFileExists(existingFilename);
             this.fileSystem.DeleteFile(this.Enlistment.GetVirtualPathTo(existingFilename));
             this.Enlistment.GetVirtualPathTo(existingFilename).ShouldNotExistOnDisk(this.fileSystem);
 
@@ -170,6 +176,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(9)]
+        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterRenameFileIntoRepo()
         {
             string filename = "GitStatusAfterRenameFileIntoRepo.cs";
@@ -196,7 +203,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(10)]
         public void GitStatusAfterRenameFileOutOfRepo()
         {
-            string existingFilename = "Test_EPF_MoveRenameFileTests\\ChangeUnhydratedFileName\\Program.cs";
+            string existingFilename = Path.Combine("Test_EPF_MoveRenameFileTests", "ChangeUnhydratedFileName", "Program.cs");
 
             // Move the test file to this.Enlistment.EnlistmentRoot as it's outside of src 
             // and is cleaned up when the functional tests run
@@ -210,6 +217,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(11)]
+        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterRenameFolderIntoRepo()
         {
             string folderName = "GitStatusAfterRenameFolderIntoRepo";
@@ -234,6 +242,17 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 "Untracked files:",
                 folderName + "/",
                 folderName + "/" + fileName);
+        }
+
+        private void EnsureTestFileExists(string relativePath)
+        {
+            string filePath = this.Enlistment.GetVirtualPathTo(relativePath);
+            if (!this.fileSystem.FileExists(filePath))
+            {
+                this.fileSystem.WriteAllText(filePath, this.testFileContents);
+            }
+
+            this.Enlistment.GetVirtualPathTo(relativePath).ShouldBeAFile(this.fileSystem);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
@@ -10,6 +10,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [Category(Categories.Mac.M2TODO)]
     public class MoveRenameFileTests : TestsWithEnlistmentPerFixture
     {
         public const string TestFileContents =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
@@ -8,6 +8,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [Category(Categories.Mac.M2TODO)]
     public class MoveRenameFileTests_2 : TestsWithEnlistmentPerFixture
     {
         private const string TestFileFolder = "Test_EPF_MoveRenameFileTests_2";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [Category(Categories.Mac.M2TODO)]
     public class MoveRenameFolderTests : TestsWithEnlistmentPerFixture
     {       
         private const string TestFileContents =
@@ -118,6 +119,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void MoveFullFolderToFullFolderInDotGitFolder()
         {
             string fileContents = "Test contents for MoveFullFolderToFullFolderInDotGitFolder";
@@ -132,7 +134,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             oldFilePath.ShouldBeAFile(this.fileSystem).WithContents(fileContents);
 
             string newFolderName = "NewMoveFullFolderToFullFolderInDotGitFolder";
-            string newFolderPath = this.Enlistment.GetVirtualPathTo(".git\\" + newFolderName);
+            string newFolderPath = this.Enlistment.GetVirtualPathTo(".git", newFolderName);
             newFolderPath.ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.CreateDirectory(newFolderPath);
             newFolderPath.ShouldBeADirectory(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -274,7 +274,6 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.Mac.M3)]
         public void MoveProjectedFileToInvalidFolder()
         {
             string targetFolderName = "test_folder";
@@ -449,9 +448,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             (folder + @"\MoveUnhydratedFileToDotGitFolder\Program.cs").ShouldBeAFile(this.fileSystem).WithContents(MoveRenameFileTests.TestFileContents);
         }
 
-        // TODO(Mac) This test is technically part of M2, but we need further investigation of why this test fails on build agents, but not on dev machines.
+        // TODO(Mac) This *should* be working already, we need further investigation of why this test fails on build agents, but not on dev machines.
         [TestCase, Order(15)]
-        [Category(Categories.Mac.M3)]
+        [Category(Categories.Mac.M2TODO)]
         public void FilterNonUTF8FileName()
         {
             string encodingFilename = "ريلٌأكتوبرûمارسأغسطسºٰٰۂْٗ۵ريلٌأك.txt";
@@ -498,8 +497,8 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             (badObject as FileInfo).ShouldNotBeNull().Length.ShouldEqual(objectFileInfo.Length);
         }
 
+        // TODO(Mac): Figure out why git for Mac is not requesting a redownload of the truncated object
         [TestCase, Order(17)]
-        //// TODO(Mac): Figure out why git for Mac is not requesting a redownload of the truncated object
         [Category(Categories.Mac.M3)]
         public void TruncatedObjectRedownloaded()
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -437,7 +437,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.fileSystem.MoveDirectory(newFolder, folder);
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/");
 
             // Switch back to this.ControlGitRepo.Commitish and confirm that folder contents are correct
             GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "checkout " + Properties.Settings.Default.Commitish);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -12,6 +12,8 @@ namespace GVFS.FunctionalTests.Tools
 {
     public static class GVFSHelpers
     {
+        public const string ModifiedPathsNewLine = "\r\n";
+
         public static readonly string BackgroundOpsFile = Path.Combine("databases", "BackgroundGitOperations.dat");
         public static readonly string PlaceholderListFile = Path.Combine("databases", "PlaceholderList.dat");
         public static readonly string RepoMetadataName = Path.Combine("databases", "RepoMetadata.dat");

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -6,14 +6,13 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace GVFS.FunctionalTests.Tools
 {
     public static class GVFSHelpers
     {
-        public const string ModifiedPathsNewLine = "\r\n";
-
         public static readonly string BackgroundOpsFile = Path.Combine("databases", "BackgroundGitOperations.dat");
         public static readonly string PlaceholderListFile = Path.Combine("databases", "PlaceholderList.dat");
         public static readonly string RepoMetadataName = Path.Combine("databases", "RepoMetadata.dat");
@@ -23,6 +22,8 @@ namespace GVFS.FunctionalTests.Tools
         private const string LocalCacheRootKey = "LocalCacheRoot";
         private const string GitObjectsRootKey = "GitObjectsRoot";
         private const string BlobSizesRootKey = "BlobSizesRoot";
+
+        private const string ModifiedPathsNewLine = "\r\n";
 
         public static void SaveDiskLayoutVersion(string dotGVFSRoot, string majorVersion, string minorVersion)
         {
@@ -105,7 +106,8 @@ namespace GVFS.FunctionalTests.Tools
         {
             string modifiedPathsDatabase = Path.Combine(dotGVFSRoot, TestConstants.Databases.ModifiedPaths);
             modifiedPathsDatabase.ShouldBeAFile(fileSystem);
-            GVFSHelpers.ReadAllTextFromWriteLockedFile(modifiedPathsDatabase).ShouldContain(gitPaths);
+            GVFSHelpers.ReadAllTextFromWriteLockedFile(modifiedPathsDatabase).ShouldContain(
+                gitPaths.Select(path => path + ModifiedPathsNewLine).ToArray());
         }
 
         public static void ModifiedPathsShouldNotContain(FileSystemRunner fileSystem, string dotGVFSRoot, params string[] gitPaths)

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -292,19 +292,6 @@ namespace GVFS.Platform.Mac
                     return Result.EIOError;
                 }
 
-                if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
-                {
-                    string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
-                    if (string.IsNullOrEmpty(lockedGitCommand))
-                    {
-                        EventMetadata metadata = this.CreateEventMetadata(relativePath);
-                        metadata.Add(TracingConstants.MessageKey.WarningMessage, "Blocked index delete outside the lock");
-                        this.Context.Tracer.RelatedEvent(EventLevel.Warning, $"{nameof(this.OnPreDelete)}_BlockedIndexDelete", metadata);
-
-                        return Result.EAccessDenied;
-                    }
-                }
-
                 bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
                 if (pathInsideDotGit)
                 {

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -100,6 +100,7 @@ namespace GVFS.Platform.Mac
             this.virtualizationInstance.OnEnumerateDirectory = this.OnEnumerateDirectory;
             this.virtualizationInstance.OnGetFileStream = this.OnGetFileStream;
             this.virtualizationInstance.OnFileModified = this.OnFileModified;
+            this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -165,7 +166,7 @@ namespace GVFS.Platform.Mac
                     activity.RelatedEvent(EventLevel.Informational, $"{nameof(this.OnGetFileStream)}_MountNotComplete", metadata);
                     activity.Dispose();
 
-                    // TODO: Is this the correct Result to return?
+                    // TODO(Mac): Is this the correct Result to return?
                     return Result.EIOError;
                 }
 
@@ -174,7 +175,7 @@ namespace GVFS.Platform.Mac
                     activity.RelatedError(metadata, nameof(this.OnGetFileStream) + ": Unexpected placeholder version");
                     activity.Dispose();
 
-                    // TODO: Is this the correct Result to return?
+                    // TODO(Mac): Is this the correct Result to return?
                     return Result.EIOError;
                 }
 
@@ -274,6 +275,54 @@ namespace GVFS.Platform.Mac
             {
                 this.LogUnhandledExceptionAndExit(nameof(this.OnFileModified), this.CreateEventMetadata(relativePath, e));
             }
+        }
+
+        private Result OnPreDelete(string relativePath, bool isDirectory)
+        {
+            try
+            {
+                if (!this.FileSystemCallbacks.IsMounted)
+                {
+                    EventMetadata metadata = this.CreateEventMetadata(relativePath);
+                    metadata.Add(nameof(isDirectory), isDirectory);
+                    metadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.OnPreDelete)} failed, mount has not yet completed");
+                    this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.OnPreDelete)}_MountNotComplete", metadata);
+
+                    // TODO(Mac): Is this the correct Result to return?
+                    return Result.EIOError;
+                }
+
+                if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+                {
+                    string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
+                    if (string.IsNullOrEmpty(lockedGitCommand))
+                    {
+                        EventMetadata metadata = this.CreateEventMetadata(relativePath);
+                        metadata.Add(TracingConstants.MessageKey.WarningMessage, "Blocked index delete outside the lock");
+                        this.Context.Tracer.RelatedEvent(EventLevel.Warning, $"{nameof(this.OnPreDelete)}_BlockedIndexDelete", metadata);
+
+                        return Result.EAccessDenied;
+                    }
+                }
+
+                bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
+                if (pathInsideDotGit)
+                {
+                    this.OnDotGitFileOrFolderDeleted(relativePath);
+                }
+                else
+                {
+                    this.OnWorkingDirectoryFileOrFolderDeleted(relativePath, isDirectory);
+                }
+            }
+            catch (Exception e)
+            {
+                EventMetadata metadata = this.CreateEventMetadata(relativePath, e);
+                metadata.Add("isDirectory", isDirectory);
+                this.LogUnhandledExceptionAndExit(nameof(this.OnPreDelete), metadata);
+            }
+
+            return Result.Success;
         }
 
         private Result OnEnumerateDirectory(

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1284,21 +1284,7 @@ namespace GVFS.Platform.Windows
                     }
                     else
                     {
-                        if (isDirectory)
-                        {
-                            // Don't want to add folders to the modified list if git is the one deleting the directory
-                            GitCommandLineParser gitCommand = new GitCommandLineParser(this.Context.Repository.GVFSLock.GetLockedGitCommand());
-                            if (!gitCommand.IsValidGitCommand)
-                            {
-                                this.FileSystemCallbacks.OnFolderDeleted(virtualPath);
-                            }
-                        }
-                        else
-                        {
-                            this.FileSystemCallbacks.OnFileDeleted(virtualPath);
-                        }
-
-                        this.FileSystemCallbacks.InvalidateGitStatusCache();
+                        this.OnWorkingDirectoryFileOrFolderDeleted(virtualPath, isDirectory);
                     }
                 }
             }

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -190,6 +190,25 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
+        protected void OnWorkingDirectoryFileOrFolderDeleted(string relativePath, bool isDirectory)
+        {
+            if (isDirectory)
+            {
+                // Don't want to add folders to the modified list if git is the one deleting the directory
+                GitCommandLineParser gitCommand = new GitCommandLineParser(this.Context.Repository.GVFSLock.GetLockedGitCommand());
+                if (!gitCommand.IsValidGitCommand)
+                {
+                    this.FileSystemCallbacks.OnFolderDeleted(relativePath);
+                }
+            }
+            else
+            {
+                this.FileSystemCallbacks.OnFileDeleted(relativePath);
+            }
+
+            this.FileSystemCallbacks.InvalidateGitStatusCache();
+        }
+
         protected EventMetadata CreateEventMetadata(
             Guid enumerationId,
             string relativePath = null,

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -21,6 +21,7 @@ namespace MirrorProvider.Mac
             this.virtualizationInstance.OnEnumerateDirectory = this.OnEnumerateDirectory;
             this.virtualizationInstance.OnGetFileStream = this.OnGetFileStream;
             this.virtualizationInstance.OnFileModified = this.OnFileModified;
+            this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
@@ -61,7 +62,7 @@ namespace MirrorProvider.Mac
 
                         if (result != Result.Success)
                         {
-                            Console.WriteLine("WritePlaceholderDirectory failed: " + result);
+                            Console.WriteLine($"WritePlaceholderDirectory failed: {result}");
                             return result;
                         }
                     }
@@ -81,7 +82,7 @@ namespace MirrorProvider.Mac
                             fileMode: fileMode);
                         if (result != Result.Success)
                         {
-                            Console.WriteLine("WritePlaceholderFile failed: " + result);
+                            Console.WriteLine($"WritePlaceholderFile failed: {result}");
                             return result;
                         }
                     }
@@ -89,7 +90,7 @@ namespace MirrorProvider.Mac
             }
             catch (IOException e)
             {
-                Console.WriteLine("IOException in OnEnumerateDirectory: " + e.Message);
+                Console.WriteLine($"IOException in OnEnumerateDirectory: {e.Message}");
                 return Result.EIOError;
             }
 
@@ -126,7 +127,7 @@ namespace MirrorProvider.Mac
                             (uint)bytesToCopy);
                         if (result != Result.Success)
                         {
-                            Console.WriteLine("WriteFileContents failed: " + result);
+                        Console.WriteLine($"WriteFileContents failed: {result}");
                             return false;
                         }
 
@@ -140,7 +141,7 @@ namespace MirrorProvider.Mac
             }
             catch (IOException e)
             {
-                Console.WriteLine("IOException in OnGetFileStream: " + e.Message);
+                Console.WriteLine($"IOException in OnGetFileStream: {e.Message}");
                 return Result.EIOError;
             }
 
@@ -149,7 +150,13 @@ namespace MirrorProvider.Mac
 
         private void OnFileModified(string relativePath)
         {
-            Console.WriteLine("OnFileModified: " + relativePath);
+            Console.WriteLine($"OnFileModified: {relativePath}");
+        }
+
+        private Result OnPreDelete(string relativePath, bool isDirectory)
+        {
+            Console.WriteLine($"OnPreDelete (isDirectory: {isDirectory}): {relativePath}");
+            return Result.Success;
         }
 
         private static byte[] ToVersionIdByteArray(byte version)

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -41,8 +41,7 @@ namespace MirrorProvider.Windows
 
             NotificationMapping[] notificationMappings = new NotificationMapping[]
             {
-                new NotificationMapping(NotificationType.PreDelete, string.Empty),
-                new NotificationMapping(NotificationType.FileHandleClosedFileModified, string.Empty),
+                new NotificationMapping(NotificationType.PreDelete | NotificationType.FileHandleClosedFileModified, string.Empty),
             };
 
             HResult result = this.virtualizationInstance.StartVirtualizationInstance(

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -34,12 +34,14 @@ namespace MirrorProvider.Windows
 
             this.virtualizationInstance.OnGetPlaceholderInformation = this.GetPlaceholderInformation;
             this.virtualizationInstance.OnGetFileStream = this.GetFileStream;
+            this.virtualizationInstance.OnNotifyPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.OnFileModifiedOrDeleted;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
             NotificationMapping[] notificationMappings = new NotificationMapping[]
             {
+                new NotificationMapping(NotificationType.PreDelete, string.Empty),
                 new NotificationMapping(NotificationType.FileHandleClosedFileModified, string.Empty),
             };
 
@@ -280,6 +282,12 @@ namespace MirrorProvider.Windows
                 return HResult.InternalError;
             }
 
+            return HResult.Ok;
+        }
+
+        private HResult OnPreDelete(string relativePath, bool isDirectory)
+        {
+            Console.WriteLine($"OnPreDelete (isDirectory: {isDirectory}): {relativePath}");
             return HResult.Ok;
         }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 				TargetAttributes = {
 					C6C780AF207FC67200E7E054 = {
 						CreatedOnToolsVersion = 9.3;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -413,6 +414,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.gvfs.PrjFSKext;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WARNING_CFLAGS = (
+					"-Werror",
 					"-Werror=undefined-internal",
 					"-Werror=missing-prototypes",
 					"-Werror=format",
@@ -435,6 +437,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.gvfs.PrjFSKext;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WARNING_CFLAGS = (
+					"-Werror",
 					"-Werror=undefined-internal",
 					"-Werror=missing-prototypes",
 					"-Werror=format",

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -296,7 +296,8 @@ static int HandleVnodeOperation(
                 }
             }
         }
-        else if (ActionBitIsSet(action, KAUTH_VNODE_DELETE))
+        
+        if (ActionBitIsSet(action, KAUTH_VNODE_DELETE))
         {
             if (!TrySendRequestAndWaitForResponse(
                     root,
@@ -327,7 +328,8 @@ static int HandleVnodeOperation(
                 goto CleanupAndReturn;
             }
         }
-        else if (ActionBitIsSet(
+        
+        if (ActionBitIsSet(
                 action,
                 KAUTH_VNODE_READ_ATTRIBUTES |
                 KAUTH_VNODE_WRITE_ATTRIBUTES |

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -35,6 +35,7 @@ static int HandleFileOpOperation(
 static int GetPid(vfs_context_t context);
 
 static uint32_t ReadVNodeFileFlags(vnode_t vn, vfs_context_t context);
+static bool HasParentInVirtualizationRoot(vnode_t vnode,  vfs_context_t context);
 static bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 static bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 static bool ActionBitsNotSet(kauth_action_t action, kauth_action_t mask);
@@ -215,6 +216,17 @@ void KauthHandler_HandleKernelMessageResponse(uint64_t messageId, MessageType re
             }
             Mutex_Release(s_outstandingMessagesMutex);
         }
+        
+        // The follow are not valid responses to kernel messages
+        case MessageType_Invalid:
+        case MessageType_UtoK_StartVirtualizationInstance:
+        case MessageType_UtoK_StopVirtualizationInstance:
+        case MessageType_KtoU_EnumerateDirectory:
+        case MessageType_KtoU_HydrateFile:
+        case MessageType_KtoU_NotifyFileModified:
+        case MessageType_KtoU_NotifyFilePreDelete:
+        case MessageType_KtoU_NotifyDirectoryPreDelete:
+            break;
     }
     
     return;
@@ -284,10 +296,56 @@ static int HandleVnodeOperation(
                 }
             }
         }
+        else if (ActionBitIsSet(action, KAUTH_VNODE_DELETE))
+        {
+            if (!TrySendRequestAndWaitForResponse(
+                    root,
+                    MessageType_KtoU_NotifyDirectoryPreDelete,
+                    currentVnode,
+                    pid,
+                    procname,
+                    &kauthResult,
+                    kauthError))
+            {
+                goto CleanupAndReturn;
+            }
+        }
     }
     else
     {
-        if (ActionBitIsSet(
+        if (ActionBitIsSet(action, KAUTH_VNODE_DELETE))
+        {
+            if (!TrySendRequestAndWaitForResponse(
+                    root,
+                    MessageType_KtoU_NotifyFilePreDelete,
+                    currentVnode,
+                    pid,
+                    procname,
+                    &kauthResult,
+                    kauthError))
+            {
+                goto CleanupAndReturn;
+            }
+            
+            // This delete could be part of a rename, and so we must hydrate the file now to
+            // ensure it's hydrated post-rename
+            if (kauthResult == KAUTH_RESULT_DEFER &&
+                FileFlagsBitIsSet(currentVnodeFileFlags, FileFlags_IsEmpty))
+            {
+                if (!TrySendRequestAndWaitForResponse(
+                        root,
+                        MessageType_KtoU_HydrateFile,
+                        currentVnode,
+                        pid,
+                        procname,
+                        &kauthResult,
+                        kauthError))
+                {
+                    goto CleanupAndReturn;
+                }
+            }
+        }
+        else if (ActionBitIsSet(
                 action,
                 KAUTH_VNODE_READ_ATTRIBUTES |
                 KAUTH_VNODE_WRITE_ATTRIBUTES |
@@ -412,13 +470,21 @@ static bool ShouldHandleVnodeOpEvent(
     }
     
     *vnodeFileFlags = ReadVNodeFileFlags(vnode, context);
-    if (!FileFlagsBitIsSet(*vnodeFileFlags, FileFlags_IsInVirtualizationRoot))
+    bool filedFlaggedAsInVirtualizationRoot = FileFlagsBitIsSet(*vnodeFileFlags, FileFlags_IsInVirtualizationRoot);
+    if (!filedFlaggedAsInVirtualizationRoot)
     {
-        // This vnode is not part of ANY virtualization root, so exit now before doing any more work.
-        // This gives us a cheap way to avoid adding overhead to IO outside of a virtualization root.
-        
-        *kauthResult = KAUTH_RESULT_DEFER;
-        return false;
+        // TODO(Mac): Determine the overhead of making this check for all actions and
+        // vnodes.  If it's too high, this check can be further reduced to the scenarios
+        // that VFSForGit care about.
+        if (!HasParentInVirtualizationRoot(vnode, context))
+        {
+            // This vnode is not part of ANY virtualization root (and none of its ancestors
+            // are either), so exit now before doing any more work.  This gives us a cheap
+            // way to avoid adding overhead to IO outside of a virtualization root.
+            
+            *kauthResult = KAUTH_RESULT_DEFER;
+            return false;
+        }
     }
     
     *pid = GetPid(context);
@@ -457,7 +523,12 @@ static bool ShouldHandleVnodeOpEvent(
         
         // TODO(Mac): why do we need to check rootIndex > 0 here?
         // If root was null, we would have already exited. And if not null, it can't be < 0.
-        if (rootIndex >= 0)
+        //
+        // TODO(Mac): Double check that rules are properly enforced when filedFlaggedAsInVirtualizationRoot
+        // is false.  These checks are currently skipped when filedFlaggedAsInVirtualizationRoot is false to
+        // allow providers to create new files inside of their root before starting the virtualization
+        // instance
+        if (filedFlaggedAsInVirtualizationRoot && rootIndex >= 0)
         {
             bool vnodeIsDir = (*vnodeType == VDIR);
             
@@ -738,6 +809,34 @@ static uint32_t ReadVNodeFileFlags(vnode_t vn, vfs_context_t context)
     assert(0 == err);
     assert(VATTR_IS_SUPPORTED(&attributes, va_flags));
     return attributes.va_flags;
+}
+
+static bool HasParentInVirtualizationRoot(vnode_t vnode, vfs_context_t context)
+{
+    vnode_get(vnode);
+    
+    bool inRoot = false;
+    // Search up the tree until we hit a folder know to be inside a virtualization root
+    // or THE root of the file system
+    while (NULLVP != vnode && !vnode_isvroot(vnode))
+    {
+        uint32_t vnodeFileFlags = ReadVNodeFileFlags(vnode, context);
+        if (FileFlagsBitIsSet(vnodeFileFlags, FileFlags_IsInVirtualizationRoot))
+        {
+            inRoot = true;
+            break;
+        }
+        vnode_t parent = vnode_getparent(vnode);
+        vnode_put(vnode);
+        vnode = parent;
+    }
+    
+    if (NULLVP != vnode)
+    {
+        vnode_put(vnode);
+    }
+    
+    return inRoot;
 }
 
 static bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -225,6 +225,7 @@ void KauthHandler_HandleKernelMessageResponse(uint64_t messageId, MessageType re
         case MessageType_KtoU_NotifyFileModified:
         case MessageType_KtoU_NotifyFilePreDelete:
         case MessageType_KtoU_NotifyDirectoryPreDelete:
+            KextLog_Error("KauthHandler_HandleKernelMessageResponse: Unexpected responseType: %d", responseType);
             break;
     }
     

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -35,7 +35,6 @@ static int HandleFileOpOperation(
 static int GetPid(vfs_context_t context);
 
 static uint32_t ReadVNodeFileFlags(vnode_t vn, vfs_context_t context);
-static bool HasParentInVirtualizationRoot(vnode_t vnode,  vfs_context_t context);
 static bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 static bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 static bool ActionBitsNotSet(kauth_action_t action, kauth_action_t mask);
@@ -326,24 +325,6 @@ static int HandleVnodeOperation(
             {
                 goto CleanupAndReturn;
             }
-            
-            // This delete could be part of a rename, and so we must hydrate the file now to
-            // ensure it's hydrated post-rename
-            if (kauthResult == KAUTH_RESULT_DEFER &&
-                FileFlagsBitIsSet(currentVnodeFileFlags, FileFlags_IsEmpty))
-            {
-                if (!TrySendRequestAndWaitForResponse(
-                        root,
-                        MessageType_KtoU_HydrateFile,
-                        currentVnode,
-                        pid,
-                        procname,
-                        &kauthResult,
-                        kauthError))
-                {
-                    goto CleanupAndReturn;
-                }
-            }
         }
         else if (ActionBitIsSet(
                 action,
@@ -470,21 +451,13 @@ static bool ShouldHandleVnodeOpEvent(
     }
     
     *vnodeFileFlags = ReadVNodeFileFlags(vnode, context);
-    bool filedFlaggedAsInVirtualizationRoot = FileFlagsBitIsSet(*vnodeFileFlags, FileFlags_IsInVirtualizationRoot);
-    if (!filedFlaggedAsInVirtualizationRoot)
+    if (!FileFlagsBitIsSet(*vnodeFileFlags, FileFlags_IsInVirtualizationRoot))
     {
-        // TODO(Mac): Determine the overhead of making this check for all actions and
-        // vnodes.  If it's too high, this check can be further reduced to the scenarios
-        // that VFSForGit care about.
-        if (!HasParentInVirtualizationRoot(vnode, context))
-        {
-            // This vnode is not part of ANY virtualization root (and none of its ancestors
-            // are either), so exit now before doing any more work.  This gives us a cheap
-            // way to avoid adding overhead to IO outside of a virtualization root.
-            
-            *kauthResult = KAUTH_RESULT_DEFER;
-            return false;
-        }
+        // This vnode is not part of ANY virtualization root, so exit now before doing any more work.
+        // This gives us a cheap way to avoid adding overhead to IO outside of a virtualization root.
+        
+        *kauthResult = KAUTH_RESULT_DEFER;
+        return false;
     }
     
     *pid = GetPid(context);
@@ -523,12 +496,7 @@ static bool ShouldHandleVnodeOpEvent(
         
         // TODO(Mac): why do we need to check rootIndex > 0 here?
         // If root was null, we would have already exited. And if not null, it can't be < 0.
-        //
-        // TODO(Mac): Double check that rules are properly enforced when filedFlaggedAsInVirtualizationRoot
-        // is false.  These checks are currently skipped when filedFlaggedAsInVirtualizationRoot is false to
-        // allow providers to create new files inside of their root before starting the virtualization
-        // instance
-        if (filedFlaggedAsInVirtualizationRoot && rootIndex >= 0)
+        if (rootIndex >= 0)
         {
             bool vnodeIsDir = (*vnodeType == VDIR);
             
@@ -809,34 +777,6 @@ static uint32_t ReadVNodeFileFlags(vnode_t vn, vfs_context_t context)
     assert(0 == err);
     assert(VATTR_IS_SUPPORTED(&attributes, va_flags));
     return attributes.va_flags;
-}
-
-static bool HasParentInVirtualizationRoot(vnode_t vnode, vfs_context_t context)
-{
-    vnode_get(vnode);
-    
-    bool inRoot = false;
-    // Search up the tree until we hit a folder know to be inside a virtualization root
-    // or THE root of the file system
-    while (NULLVP != vnode && !vnode_isvroot(vnode))
-    {
-        uint32_t vnodeFileFlags = ReadVNodeFileFlags(vnode, context);
-        if (FileFlagsBitIsSet(vnodeFileFlags, FileFlags_IsInVirtualizationRoot))
-        {
-            inRoot = true;
-            break;
-        }
-        vnode_t parent = vnode_getparent(vnode);
-        vnode_put(vnode);
-        vnode = parent;
-    }
-    
-    if (NULLVP != vnode)
-    {
-        vnode_put(vnode);
-    }
-    
-    return inRoot;
 }
 
 static bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Message_Kernel.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Message_Kernel.cpp
@@ -12,6 +12,16 @@ void Message_Init(
 {
     header->messageId = messageId;
     header->messageType = messageType;
+    header->pid = pid;
+    
+    if (nullptr != procname)
+    {
+        strlcpy(header->procname, procname, sizeof(header->procname));
+    }
+    else
+    {
+        header->procname[0] = '\0';
+    }
     
     if (nullptr != path)
     {

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -17,6 +17,8 @@ typedef enum
     MessageType_KtoU_HydrateFile,
     
     MessageType_KtoU_NotifyFileModified,
+    MessageType_KtoU_NotifyFilePreDelete,
+    MessageType_KtoU_NotifyDirectoryPreDelete,
     
     // Responses
     MessageType_Response_Success,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -15,6 +15,7 @@ namespace PrjFSLib.Mac
         public virtual GetFileStreamCallback OnGetFileStream { get; set; }
 
         public virtual NotifyFileModified OnFileModified { get; set; }
+        public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
 
         public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
         {
@@ -134,6 +135,9 @@ namespace PrjFSLib.Mac
         {
             switch (notificationType)
             {
+                case NotificationType.PreDelete:
+                    return this.OnPreDelete(relativePath, isDirectory);
+
                 case NotificationType.FileModified:
                     this.OnFileModified(relativePath);
                     return Result.Success;

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -391,7 +391,7 @@ static Message ParseMessageMemory(const void* messageMemory, uint32_t size)
         abort();
     }
             
-    const char* path = nullptr;
+    const char* path = "";
     if (header->pathSizeBytes > 0)
     {
         path = static_cast<const char*>(messageMemory) + sizeof(*header);
@@ -587,7 +587,8 @@ static PrjFS_Result HandleFileNotification(
 {
 #ifdef DEBUG
     std::cout << "PrjFSLib.HandleFileNotification: " << path
-              << " notificationType: " << NotificationTypeToString(notificationType) << std::endl;
+              << " notificationType: " << NotificationTypeToString(notificationType)
+              << " isDirectory: " << isDirectory << std::endl;
 #endif
     
     char fullPath[PrjFSMaxPath];

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -22,6 +22,8 @@
 #include "PrjFSKext/public/Message.h"
 #include "PrjFSUser.hpp"
 
+#define STRINGIFY(s) #s
+
 using std::endl; using std::cerr;
 using std::unordered_map; using std::set; using std::string;
 using std::mutex;
@@ -51,11 +53,17 @@ static errno_t RegisterVirtualizationRootPath(const char* path);
 static void HandleKernelRequest(Message requestSpec, void* messageMemory);
 static PrjFS_Result HandleEnumerateDirectoryRequest(const MessageHeader* request, const char* path);
 static PrjFS_Result HandleHydrateFileRequest(const MessageHeader* request, const char* path);
-static PrjFS_Result HandleFileModifiedNotification(const MessageHeader* request, const char* path);
+static PrjFS_Result HandleFileNotification(
+    const MessageHeader* request,
+    const char* path,
+    bool isDirectory,
+    PrjFS_NotificationType notificationType);
 
 static Message ParseMessageMemory(const void* messageMemory, uint32_t size);
 
 static void ClearMachNotification(mach_port_t port);
+
+static const char* NotificationTypeToString(PrjFS_NotificationType notificationType);
 
 // State
 static io_connect_t s_kernelServiceConnection = IO_OBJECT_NULL;
@@ -415,7 +423,31 @@ static void HandleKernelRequest(Message request, void* messageMemory)
             
         case MessageType_KtoU_NotifyFileModified:
         {
-            result = HandleFileModifiedNotification(requestHeader, request.path);
+            result = HandleFileNotification(
+                requestHeader,
+                request.path,
+                false,  // isDirectory
+                PrjFS_NotificationType_FileModified);
+            break;
+        }
+        
+        case MessageType_KtoU_NotifyFilePreDelete:
+        {
+            result = HandleFileNotification(
+                requestHeader,
+                request.path,
+                false,  // isDirectory
+                PrjFS_NotificationType_PreDelete);
+            break;
+        }
+        
+        case MessageType_KtoU_NotifyDirectoryPreDelete:
+        {
+            result = HandleFileNotification(
+                requestHeader,
+                request.path,
+                true,  // isDirectory
+                PrjFS_NotificationType_PreDelete);
             break;
         }
     }
@@ -547,33 +579,33 @@ static PrjFS_Result HandleHydrateFileRequest(const MessageHeader* request, const
     return callbackResult;
 }
 
-static PrjFS_Result HandleFileModifiedNotification(const MessageHeader* request, const char* path)
+static PrjFS_Result HandleFileNotification(
+    const MessageHeader* request,
+    const char* path,
+    bool isDirectory,
+    PrjFS_NotificationType notificationType)
 {
 #ifdef DEBUG
-    std::cout << "PrjFSLib.HandleFileModifiedNotification: " << path << std::endl;
+    std::cout << "PrjFSLib.HandleFileNotification: " << path
+              << " notificationType: " << NotificationTypeToString(notificationType) << std::endl;
 #endif
     
     char fullPath[PrjFSMaxPath];
     CombinePaths(s_virtualizationRootFullPath.c_str(), path, fullPath);
     
     PrjFSFileXAttrData xattrData = {};
-    if (!GetXAttr(fullPath, PrjFSFileXAttrName, sizeof(PrjFSFileXAttrData), &xattrData))
-    {
-        return PrjFS_Result_EIOError;
-    }
-    
-    s_callbacks.NotifyOperation(
+    GetXAttr(fullPath, PrjFSFileXAttrName, sizeof(PrjFSFileXAttrData), &xattrData);
+
+    return s_callbacks.NotifyOperation(
         0 /* commandId */,
         path,
         xattrData.providerId,
         xattrData.contentId,
         request->pid,
         request->procname,
-        false /* isDirectory */,
-        PrjFS_NotificationType_FileModified,
+        isDirectory,
+        notificationType,
         nullptr /* destinationRelativePath */);
-    
-    return PrjFS_Result_Success;
 }
 
 static bool InitializeEmptyPlaceholder(const char* fullPath)
@@ -711,4 +743,31 @@ static void ClearMachNotification(mach_port_t port)
         mach_msg_trailer_t	trailer;
     } msg;
     mach_msg(&msg.msgHdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(msg), port, 0, MACH_PORT_NULL);
+}
+
+static const char* NotificationTypeToString(PrjFS_NotificationType notificationType)
+{
+    switch(notificationType)
+    {
+        case PrjFS_NotificationType_Invalid:
+            return STRINGIFY(PrjFS_NotificationType_Invalid);
+
+        case PrjFS_NotificationType_None:
+            return STRINGIFY(PrjFS_NotificationType_None);
+        case PrjFS_NotificationType_NewFileCreated:
+            return STRINGIFY(PrjFS_NotificationType_NewFileCreated);
+        case PrjFS_NotificationType_PreDelete:
+            return STRINGIFY(PrjFS_NotificationType_PreDelete);
+        case PrjFS_NotificationType_FileRenamed:
+            return STRINGIFY(PrjFS_NotificationType_FileRenamed);
+        case PrjFS_NotificationType_PreConvertToFull:
+            return STRINGIFY(PrjFS_NotificationType_PreConvertToFull);
+            
+        case PrjFS_NotificationType_PreModify:
+            return STRINGIFY(PrjFS_NotificationType_PreModify);
+        case PrjFS_NotificationType_FileModified:
+            return STRINGIFY(PrjFS_NotificationType_FileModified);
+        case PrjFS_NotificationType_FileDeleted:
+            return STRINGIFY(PrjFS_NotificationType_FileDeleted);
+    }
 }


### PR DESCRIPTION
Part of the work required for #152.

**Changes for PreDelete**

- Added `MessageType_KtoU_NotifyFilePreDelete` and `MessageType_KtoU_NotifyDirectoryPreDelete` (kernel->user) notifications
- Updated VFSForGit's user mode code to handle the PreDelete notification
- Added new `Categories.Mac.M2TODO` functional test categories for tests that are required for M2 but not yet passing
- Enabled additional functional tests for file\folder deletes
- Added PreDelete handling to `MirrorProvider`

**Unrelated Fixes\Changes**
- Updated `Message_Init` to properly set the pid and procname in the `MessageHeader`
- Updated `ParseMessageMemory` to set the path to empty string rather than null (when the message from the kernel has a null path)
- Made log formatting more consistent in `MirrorProvider`
- Updated Kext project to treat warnings as errors

**Mac functional test run with these changes**

```
Test Run Summary
  Overall result: Warning
  Test Count: 156, Passed: 154, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 2
    Skipped Tests - Ignored: 2, Explicit: 0, Other: 0
  Start time: 2018-08-17 15:55:50Z
    End time: 2018-08-17 15:59:53Z
    Duration: 242.238 seconds
```
