### PR TITLE
Centralize business logic for starting background prefetch.

### DIFF
--- a/GVFS/GVFS.Common/Prefetch/BackgroundPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BackgroundPrefetcher.cs
@@ -29,14 +29,14 @@ namespace GVFS.Common.Prefetch
 
             this.prefetchJobThread = null;
 
-            if (gitObjects.IsUsingCacheServer())
+            if (gitObjects.IsUsingCacheServer() && !GVFSEnlistment.IsUnattended(tracer))
             {
                 this.prefetchJobTimer = new Timer((state) => this.LaunchPrefetchJobIfIdle(), null, this.timerPeriod, this.timerPeriod);
                 this.tracer.RelatedInfo(nameof(BackgroundPrefetcher) + ": starting background prefetch timer");
             }
             else
             {
-                this.tracer.RelatedInfo(nameof(BackgroundPrefetcher) + ": no configured cache server, not starting background prefetch timer");
+                this.tracer.RelatedInfo(nameof(BackgroundPrefetcher) + ": no configured cache server or enlistment is unattended, not starting background prefetch timer");
             }
         }
 

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -515,11 +515,7 @@ namespace GVFS.Mount
             }
 
             this.fileSystemCallbacks = this.CreateOrReportAndExit(() => new FileSystemCallbacks(this.context, this.gitObjects, RepoMetadata.Instance, virtualizer, gitStatusCache), "Failed to create src folder callback listener");
-
-            if (!this.context.Unattended)
-            {
-                this.prefetcher = this.CreateOrReportAndExit(() => new BackgroundPrefetcher(this.tracer, this.enlistment, this.context.FileSystem, this.gitObjects), "Failed to start background prefetcher");
-            }
+            this.prefetcher = this.CreateOrReportAndExit(() => new BackgroundPrefetcher(this.tracer, this.enlistment, this.context.FileSystem, this.gitObjects), "Failed to start background prefetcher");
 
             int majorVersion;
             int minorVersion;


### PR DESCRIPTION
Move the check for unattended enlistment from `InProcessMount` to `BackgroundPrefetcher`.