### PR TITLE
Enable runFastFetch to expect an error

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -141,11 +141,8 @@ namespace GVFS.FunctionalTests.Tests
         {
             this.RunFastFetch($"--checkout --folders \"/Scripts\" -b {Settings.Default.Commitish}");
 
-            // Run a second time in the same repo on the same branch with more folders. 
+            // Run a second time in the same repo on the same branch with more folders but expect an error.
             string result = this.RunFastFetch($"--force-checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish}", expectError: true);
-
-            string[] expectedResults = new string[] { "Cannot use --force-checkout option without --checkout option." };
-            result.ShouldContain(expectedResults);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -497,6 +497,7 @@ namespace GVFS.FunctionalTests.Tests
                 result.Errors.ShouldBeEmpty(result.Errors);
                 result.ExitCode.ShouldEqual(0);
             }
+
             return result.Output;
         }
         

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -142,7 +142,7 @@ namespace GVFS.FunctionalTests.Tests
             this.RunFastFetch($"--checkout --folders \"/Scripts\" -b {Settings.Default.Commitish}");
 
             // Run a second time in the same repo on the same branch with more folders. 
-            string result = this.RunFastFetch($"--force-checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish}");
+            string result = this.RunFastFetch($"--force-checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish}", expectError: true);
 
             string[] expectedResults = new string[] { "Cannot use --force-checkout option without --checkout option." };
             result.ShouldContain(expectedResults);
@@ -471,7 +471,7 @@ namespace GVFS.FunctionalTests.Tests
             return headTreeSha;
         }
 
-        private string RunFastFetch(string args)
+        private string RunFastFetch(string args, bool expectError = false)
         {
             args = args + " --verbose";
 
@@ -491,9 +491,12 @@ namespace GVFS.FunctionalTests.Tests
             processInfo.RedirectStandardError = true;
             
             ProcessResult result = ProcessHelper.Run(processInfo);
-            result.Output.Contains("Error").ShouldEqual(false, result.Output);
-            result.Errors.ShouldBeEmpty(result.Errors);
-            result.ExitCode.ShouldEqual(0);
+            result.Output.Contains("Error").ShouldEqual(expectError, result.Output);
+            if (!expectError)
+            {
+                result.Errors.ShouldBeEmpty(result.Errors);
+                result.ExitCode.ShouldEqual(0);
+            }
             return result.Output;
         }
         

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -494,7 +494,7 @@ namespace GVFS.FunctionalTests.Tests
             result.Output.Contains("Error").ShouldEqual(expectError, result.Output);
             if (expectError)
             {
-                Assert.IsTrue(result.Errors.Length > 0);
+                result.Errors.Length.ShouldBeAtLeast(1, "Expected at lest 1 error");
                 result.ExitCode.ShouldBeAtLeast(1, $"Exit code should be a failure (> 0) but was {result.ExitCode}");
             }
             else

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -492,7 +492,12 @@ namespace GVFS.FunctionalTests.Tests
             
             ProcessResult result = ProcessHelper.Run(processInfo);
             result.Output.Contains("Error").ShouldEqual(expectError, result.Output);
-            if (!expectError)
+            if (expectError)
+            {
+                Assert.IsTrue(result.Errors.Length > 0);
+                result.ExitCode.ShouldBeAtLeast(1, $"Exit code should be a failure (> 0) but was {result.ExitCode}");
+            }
+            else
             {
                 result.Errors.ShouldBeEmpty(result.Errors);
                 result.ExitCode.ShouldEqual(0);


### PR DESCRIPTION
This should fix the somehow missed test failure for FastFetch addressing #185 