### PR TITLE
Spike: capture git_trace during test runs

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20180730.3</GitPackageVersion>
+    <GitPackageVersion>2.20180817.1-pr</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20180820.1-pr</GitPackageVersion>
+    <GitPackageVersion>2.20180820.2-pr</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20180817.1-pr</GitPackageVersion>
+    <GitPackageVersion>2.20180820.1-pr</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -354,6 +354,7 @@ namespace GVFS.Common
                 this.cacheState = CacheState.Rebuilding;
 
                 GitProcess git = this.context.Enlistment.CreateGitProcess();
+                git.TraceOutputPath = this.context.Enlistment.GVFSLogsRoot;
                 statusResult = git.SerializeStatus(
                     allowObjectDownloads: true,
                     serializePath: tmpStatusFilePath);


### PR DESCRIPTION
NOT FOR MERGING

This is a test PR to run functional tests against and get more detailed logging on failed background git status commands.