### PR TITLE
Mac: New file created notification

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -24,17 +24,21 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(1)]
-        [Category(Categories.Mac.M2TODO)]
         public void CreateFileTest()
         {
             string fileName = "file1.txt";
             GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileName);
             this.fileSystem.WriteAllText(this.Enlistment.GetVirtualPathTo(fileName), "Some content here");
-
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
-
-            this.Enlistment.GetVirtualPathTo(fileName).ShouldBeAFile(this.fileSystem).WithContents("Some content here");
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileName);
+            this.Enlistment.GetVirtualPathTo(fileName).ShouldBeAFile(this.fileSystem).WithContents("Some content here");
+
+            string emptyFileName = "file1empty.txt";
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, emptyFileName);
+            this.fileSystem.CreateEmptyFile(this.Enlistment.GetVirtualPathTo(emptyFileName));
+            this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, emptyFileName);
+            this.Enlistment.GetVirtualPathTo(fileName).ShouldBeAFile(this.fileSystem);
         }
 
         [TestCase, Order(2)]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -32,14 +32,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(2)]
-        [Category(Categories.Mac.M2TODO)]
         public void GitStatusAfterNewFile()
         {
             string filename = "new.cs";
+            string filePath = this.Enlistment.GetVirtualPathTo(filename);
 
-            this.fileSystem.WriteAllText(this.Enlistment.GetVirtualPathTo(filename), this.testFileContents);
+            this.fileSystem.WriteAllText(filePath, this.testFileContents);
 
-            this.Enlistment.GetVirtualPathTo(filename).ShouldBeAFile(this.fileSystem).WithContents(this.testFileContents);
+            filePath.ShouldBeAFile(this.fileSystem).WithContents(this.testFileContents);
 
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
                 this.Enlistment.RepoRoot,
@@ -47,6 +47,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 "On branch " + Properties.Settings.Default.Commitish,
                 "Untracked files:",
                 filename);
+
+            this.fileSystem.DeleteFile(filePath);
         }
 
         [TestCase, Order(3)]
@@ -54,7 +56,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         public void GitStatusAfterFileNameCaseChange()
         {
             string oldFilename = "new.cs";
-            this.Enlistment.GetVirtualPathTo(oldFilename).ShouldBeAFile(this.fileSystem);
+            this.EnsureTestFileExists(oldFilename);
 
             string newFilename = "New.cs";
             this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(oldFilename), this.Enlistment.GetVirtualPathTo(newFilename));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedModifiedPathsTests.cs
@@ -10,8 +10,7 @@ using System.Linq;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
     [TestFixture]
-    //// TODO(Mac): Enable for M2 once notifications are working
-    //// [Category(Categories.Mac.M2)]
+    [Category(Categories.Mac.M2TODO)]
     public class PersistedModifiedPathsTests : TestsWithEnlistmentPerTestCase
     {
         private static readonly string FileToAdd = Path.Combine("GVFS", "TestAddFile.txt");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -6,6 +6,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.Mac.M3)]
     public class AddStageTests : GitRepoTests
     {
         public AddStageTests() : base(enlistmentPerTest: false)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -88,48 +88,56 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void UntrackedFileTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "add .");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void UntrackedEmptyFileTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "add .");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void UntrackedFileAddAllTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "add --all");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void UntrackedEmptyFileAddAllTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "add --all");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void StageUntrackedFileTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "stage .");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void StageUntrackedEmptyFileTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "stage .");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void StageUntrackedFileAddAllTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "stage --all");
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void StageUntrackedEmptyFileAddAllTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "stage --all");
@@ -234,27 +242,33 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.Mac.M2)]
         public void DeleteFilesWithNameAheadOfDot()
         {
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\1", "#test");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\1\\#test");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\1");
+            string folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "1");
+            this.FolderShouldExistAndHaveFile(folder, "#test");
+            this.DeleteFile(Path.Combine(folder, "#test"));
+            this.FolderShouldExistAndBeEmpty(folder);
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\2", "$test");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\2\\$test");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\2");
+            folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "2");
+            this.FolderShouldExistAndHaveFile(folder, "$test");
+            this.DeleteFile(Path.Combine(folder, "$test"));
+            this.FolderShouldExistAndBeEmpty(folder);
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\3", ")");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\3\\)");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\3");
+            folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "3");
+            this.FolderShouldExistAndHaveFile(folder, ")");
+            this.DeleteFile(Path.Combine(folder, ")"));
+            this.FolderShouldExistAndBeEmpty(folder);
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\4", "+.test");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\4\\+.test");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\4");
+            folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "4");
+            this.FolderShouldExistAndHaveFile(folder, "+.test");
+            this.DeleteFile(Path.Combine(folder, "+.test"));
+            this.FolderShouldExistAndBeEmpty(folder);
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\5", "-.test");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\5\\-.test");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\5");
+            folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "5");
+            this.FolderShouldExistAndHaveFile(folder, "-.test");
+            this.DeleteFile(Path.Combine(folder, "-.test"));
+            this.FolderShouldExistAndBeEmpty(folder);
 
             this.ValidateGitCommand("status");
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
+    [Category(Categories.Mac.M3)]
     public class HashObjectTests : GitRepoTests
     {
         public HashObjectTests() : base(enlistmentPerTest: false)

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -22,6 +22,7 @@ namespace MirrorProvider.Mac
             this.virtualizationInstance.OnGetFileStream = this.OnGetFileStream;
             this.virtualizationInstance.OnFileModified = this.OnFileModified;
             this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
+            this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
@@ -157,6 +158,11 @@ namespace MirrorProvider.Mac
         {
             Console.WriteLine($"OnPreDelete (isDirectory: {isDirectory}): {relativePath}");
             return Result.Success;
+        }
+
+        private void OnNewFileCreated(string relativePath, bool isDirectory)
+        {
+            Console.WriteLine($"OnNewFileCreated (isDirectory: {isDirectory}): {relativePath}");
         }
 
         private static byte[] ToVersionIdByteArray(byte version)

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -35,13 +35,18 @@ namespace MirrorProvider.Windows
             this.virtualizationInstance.OnGetPlaceholderInformation = this.GetPlaceholderInformation;
             this.virtualizationInstance.OnGetFileStream = this.GetFileStream;
             this.virtualizationInstance.OnNotifyPreDelete = this.OnPreDelete;
+            this.virtualizationInstance.OnNotifyNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.OnFileModifiedOrDeleted;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
             NotificationMapping[] notificationMappings = new NotificationMapping[]
             {
-                new NotificationMapping(NotificationType.PreDelete | NotificationType.FileHandleClosedFileModified, string.Empty),
+                new NotificationMapping(
+                    NotificationType.NewFileCreated |
+                    NotificationType.PreDelete | 
+                    NotificationType.FileHandleClosedFileModified, 
+                    string.Empty),
             };
 
             HResult result = this.virtualizationInstance.StartVirtualizationInstance(
@@ -288,6 +293,18 @@ namespace MirrorProvider.Windows
         {
             Console.WriteLine($"OnPreDelete (isDirectory: {isDirectory}): {relativePath}");
             return HResult.Ok;
+        }
+
+        private void OnNewFileCreated(
+            string relativePath,
+            bool isDirectory,
+            uint desiredAccess,
+            uint shareMode,
+            uint createDisposition,
+            uint createOptions,
+            ref NotificationType notificationMask)
+        {
+            Console.WriteLine($"OnNewFileCreated (isDirectory: {isDirectory}): {relativePath}");
         }
 
         private void OnFileModifiedOrDeleted(string relativePath, bool isDirectory, bool isFileModified, bool isFileDeleted)

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -19,6 +19,7 @@ typedef enum
     MessageType_KtoU_NotifyFileModified,
     MessageType_KtoU_NotifyFilePreDelete,
     MessageType_KtoU_NotifyDirectoryPreDelete,
+    MessageType_KtoU_NotifyFileCreated,
     
     // Responses
     MessageType_Response_Success,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -16,6 +16,7 @@ namespace PrjFSLib.Mac
 
         public virtual NotifyFileModified OnFileModified { get; set; }
         public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
+        public virtual NotifyNewFileCreatedEvent OnNewFileCreated { get; set; }
 
         public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
         {
@@ -140,6 +141,10 @@ namespace PrjFSLib.Mac
 
                 case NotificationType.FileModified:
                     this.OnFileModified(relativePath);
+                    return Result.Success;
+
+                case NotificationType.NewFileCreated:
+                    this.OnNewFileCreated(relativePath, isDirectory);
                     return Result.Success;
             }
 

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -455,6 +455,8 @@ static void HandleKernelRequest(Message request, void* messageMemory)
         {
             char fullPath[PrjFSMaxPath];
             CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
+			
+			// TODO(Mac): Handle SetBitInFileFlags failures
             SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
         
             result = HandleFileNotification(

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -456,7 +456,7 @@ static void HandleKernelRequest(Message request, void* messageMemory)
             char fullPath[PrjFSMaxPath];
             CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
 			
-			// TODO(Mac): Handle SetBitInFileFlags failures
+            // TODO(Mac): Handle SetBitInFileFlags failures
             SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
         
             result = HandleFileNotification(

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -450,6 +450,20 @@ static void HandleKernelRequest(Message request, void* messageMemory)
                 PrjFS_NotificationType_PreDelete);
             break;
         }
+        
+        case MessageType_KtoU_NotifyFileCreated:
+        {
+            char fullPath[PrjFSMaxPath];
+            CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
+            SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
+        
+            result = HandleFileNotification(
+                requestHeader,
+                request.path,
+                false,  // isDirectory
+                PrjFS_NotificationType_NewFileCreated);
+            break;
+        }
     }
     
     // async callbacks are not yet implemented


### PR DESCRIPTION
Part of the work required for #152.

Changes include:

- Adding "new file created" notification to kext and user-mode
- Adding new file notification handling to `MirrorProvider`
- Enabling additional functional tests
- Categorizing more functional tests (that were previously uncategorized)
- Removing the code that blocks modifications to the repo when GVFS is offline

Regarding the last point above, the code for blocking notifications was also preventing copying in new hooks and repairing broken repos (now that newly created files are flagged as being in the root).  The code for supporting this feature can be revisited once we have the rest of notifications and projection changes working on Mac.

It should also be noted that the "new file" notification will be raised for both newly created files, and any files that were created as part of `gvfs clone` (prior to the root of the repo getting marked as such).  This doesn't cause a problem for VFSForGit because it ignores new files created in the .git folder.

Functional test run with these changes:

```
Test Run Summary
  Overall result: Warning
  Test Count: 166, Passed: 164, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 2
    Skipped Tests - Ignored: 2, Explicit: 0, Other: 0
  Start time: 2018-08-20 16:50:23Z
    End time: 2018-08-20 16:54:19Z
    Duration: 236.021 seconds
```

