### PR TITLE
GitStatusCache: fix race condition in test setup

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -98,6 +98,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         private void RepositoryIgnoreTestSetup()
         {
+            this.WaitForUpToDateStatusCache();
+
             string statusCachePath = Path.Combine(this.Enlistment.DotGVFSRoot, "GitStatusCache", "GitStatusCache.dat");
             File.Delete(statusCachePath);
 
@@ -108,6 +110,18 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             // Verify that status from the status cache includes the "test.ign" entry
             this.ValidateGitCommand("status");
+        }
+
+        /// <summary>
+        /// Wait for an up-to-date status cache file to exist on disk.
+        /// </summary>
+        private void WaitForUpToDateStatusCache()
+        {
+            // Run "git status" for the side effect that it will delete any stale status cache file.
+            this.ValidateGitCommand("status");
+
+            // Wait for a new status cache to be generated.
+            this.WaitForStatusCacheToBeGenerated(waitForNewFile: false);
         }
 
         private void WaitForStatusCacheToBeGenerated(bool waitForNewFile = true)


### PR DESCRIPTION
This is to fix an issue that happened (intermittently) in the functional
tests. There is a race condition where the test is attempting to delete
the status cache file, but the status cache might not have been
generated for the test repository.

To fix this, the test setup will wait for the initial status cache to be
generated, so it can proceed from a known state.

(cherry picked from commit 97975e4)
(port pull request #172)
