### PR TITLE
Fix lock issue causing problems in unmounting repository

### DIFF
--- a/GVFS/GVFS.Common/GVFSLock.Shared.cs
+++ b/GVFS/GVFS.Common/GVFSLock.Shared.cs
@@ -81,13 +81,14 @@ namespace GVFS.Common
                     }
                 };
 
+            bool isSuccessfulLockResult;
             if (unattended)
             {
-                waitForLock();
+                isSuccessfulLockResult = waitForLock();
             }
             else
             {
-                ConsoleHelper.ShowStatusWhileRunning(
+                isSuccessfulLockResult = ConsoleHelper.ShowStatusWhileRunning(
                     waitForLock,
                     message,
                     output: Console.Out,
@@ -96,7 +97,7 @@ namespace GVFS.Common
             }
 
             result = null;
-            return true;
+            return isSuccessfulLockResult;
         }
 
         public static void ReleaseGVFSLock(

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -195,8 +195,11 @@ namespace GVFS.Virtualization
                 this.postFetchJobThread?.Abort();
             }
 
-            this.fileSystemVirtualizer.PrepareToStop();
+            // Shutdown the GitStatusCache before other
+            // components that it depends on.
             this.gitStatusCache.Shutdown();
+
+            this.fileSystemVirtualizer.PrepareToStop();
             this.backgroundFileSystemTaskRunner.Shutdown();
             this.GitIndexProjection.Shutdown();
             this.BlobSizes.Shutdown();


### PR DESCRIPTION
This fixes the main issue that was leading to functional test failures when unmounting repositories.

Due to an bug in the locking logic, the background git status scan (run to rebuild the GitStatusCache), could be denied the GVFS lock, but the command would still be run. This hit other problems later in the command, eventually crashing the GVFS Mount process.

(port pull request #157)
