### PR TITLE
Update name of file that indicates installation version

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -192,6 +192,11 @@ namespace GVFS.Common
             }
         }
 
+        public static class InstallationCapabilityFiles
+        {
+            public const string OnDiskVersion16CapableInstallation = "OnDiskVersion16CapableInstallation.dat";
+        }
+
         public static class VerbParameters
         {
             public static class Mount

--- a/GVFS/GVFS.Installer/Setup.iss
+++ b/GVFS/GVFS.Installer/Setup.iss
@@ -283,15 +283,15 @@ begin
     end;
 end;
 
-procedure WriteGitStatusCacheAvailableFile();
+procedure WriteOnDiskVersion16CapableFile();
 var
-  TokenFilePath: string;
+  FilePath: string;
 begin
-  TokenFilePath := ExpandConstant('{app}\GitStatusCacheAvailable');
-  if not FileExists(TokenFilePath) then
+  FilePath := ExpandConstant('{app}\OnDiskVersion16CapableInstallation.dat');
+  if not FileExists(FilePath) then
     begin
-      Log('WritingGitStatusCacheAvailableFile: Writing file ' + TokenFilePath);
-      SaveStringToFile(TokenFilePath, '', False);
+      Log('WriteOnDiskVersion16CapableFile: Writing file ' + FilePath);
+      SaveStringToFile(FilePath, '', False);
     end
 end;
 
@@ -319,7 +319,7 @@ begin
           end;
       end;
 
-    WriteGitStatusCacheAvailableFile();
+    WriteOnDiskVersion16CapableFile();
   finally
     WizardForm.StatusLabel.Caption := StatusText;
     WizardForm.ProgressGauge.Style := npbstNormal;


### PR DESCRIPTION
Update name of file that the GVFS installer creates when an on disk version 16 capable GVFS is first installed.

After discussions on how GVFS determines whether the GitStatusCache should be enabled to ensure that the machine has been rebooted since a GitStatusCache aware GVFS was installed, we decided on two changes:

1) The name of the file created by the GVFS installer should be changed to `OnDiskVersion16CapableInstallation.dat`

2) Move the logic for determining whether the GitStatusCache should enabled for a GVFS installation from the GVFS.Service to individual mount processes. This means we could get rid of the `EnableGitStatusCacheToken.dat` file that exists in the `GVFS.Service` common application directory.

This PR addresses issue 1.

I want to get agreement on the changes for the file written out by the installer. I can follow up with the changes for the second issue, either for the M139 release, or as a future change.

I am doing another round of testing on these changes, and can do a final verification after we agree on the name.
