### PR TITLE
Hardlink notifications on Mac & Windows and rename notifications on Mac

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -5,7 +5,7 @@
         bool SupportsFileMode { get; }
         void FlushFileBuffers(string path);
         void MoveAndOverwriteFile(string sourceFileName, string destinationFilename);
-        void CreateHardLink(string newFileName, string existingFileName);
+        void CreateHardLink(string newLinkFileName, string existingFileName);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);
         void ChangeMode(string path, int mode);
     }

--- a/GVFS/GVFS.Common/NativeMethods.cs
+++ b/GVFS/GVFS.Common/NativeMethods.cs
@@ -98,11 +98,11 @@ namespace GVFS.Common
             }
         }
 
-        public static void CreateHardLink(string newFileName, string existingFileName)
+        public static void CreateHardLink(string newLinkFileName, string existingFileName)
         {
-            if (!CreateHardLink(newFileName, existingFileName, IntPtr.Zero))
+            if (!CreateHardLink(newLinkFileName, existingFileName, IntPtr.Zero))
             {
-                ThrowLastWin32Exception($"Failed to create hard link from '{newFileName}' to '{existingFileName}'");
+                ThrowLastWin32Exception($"Failed to create hard link from '{newLinkFileName}' to '{existingFileName}'");
             }
         }
 
@@ -172,7 +172,7 @@ namespace GVFS.Common
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern bool CreateHardLink(
-            string newFileName,
+            string newLinkFileName,
             string existingFileName,
             IntPtr securityAttributes);
 

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -47,6 +47,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             }
         }
 
+        public override bool SupportsHardlinkCreation
+        {
+            get { return true; }
+        }
+
         protected override string FileName
         {
             get
@@ -156,6 +161,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             string bashPath = this.ConvertWinPathToBashPath(path);
 
             this.RunProcess(string.Format("-c \"touch {0}\"", bashPath));
+        }
+
+        public override void CreateHardLink(string existingPath, string newLinkPath)
+        {
+            string existingFileBashPath = this.ConvertWinPathToBashPath(existingPath);
+            string newLinkBashPath = this.ConvertWinPathToBashPath(existingPath);
+
+            this.RunProcess(string.Format("-c \"ln {0} {1}\"", existingFileBashPath, newLinkBashPath));
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -166,7 +166,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void CreateHardLink(string existingPath, string newLinkPath)
         {
             string existingFileBashPath = this.ConvertWinPathToBashPath(existingPath);
-            string newLinkBashPath = this.ConvertWinPathToBashPath(existingPath);
+            string newLinkBashPath = this.ConvertWinPathToBashPath(newLinkPath);
 
             this.RunProcess(string.Format("-c \"ln {0} {1}\"", existingFileBashPath, newLinkBashPath));
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -163,10 +163,10 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("-c \"touch {0}\"", bashPath));
         }
 
-        public override void CreateHardLink(string existingPath, string newLinkPath)
+        public override void CreateHardLink(string newLinkFilePath, string existingFilePath)
         {
-            string existingFileBashPath = this.ConvertWinPathToBashPath(existingPath);
-            string newLinkBashPath = this.ConvertWinPathToBashPath(newLinkPath);
+            string existingFileBashPath = this.ConvertWinPathToBashPath(existingFilePath);
+            string newLinkBashPath = this.ConvertWinPathToBashPath(newLinkFilePath);
 
             this.RunProcess(string.Format("-c \"ln {0} {1}\"", existingFileBashPath, newLinkBashPath));
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -27,6 +27,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "The process cannot access the file because it is being used by another process"
         };
 
+        public override bool SupportsHardlinkCreation
+        {
+            get { return true; }
+        }
+
         protected override string FileName
         {
             get
@@ -106,6 +111,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void CreateEmptyFile(string path)
         {
             this.RunProcess(string.Format("/C type NUL > \"{0}\"", path));
+        }
+
+        public override void CreateHardLink(string targetPath, string newLinkPath)
+        {
+            this.RunProcess(string.Format("/C mklink /H \"{0}\" \"{1}\"", newLinkPath, targetPath));
         }
 
         public override void AppendAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -113,9 +113,9 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("/C type NUL > \"{0}\"", path));
         }
 
-        public override void CreateHardLink(string targetPath, string newLinkPath)
+        public override void CreateHardLink(string newLinkFilePath, string existingFilePath)
         {
-            this.RunProcess(string.Format("/C mklink /H \"{0}\" \"{1}\"", newLinkPath, targetPath));
+            this.RunProcess(string.Format("/C mklink /H \"{0}\" \"{1}\"", newLinkFilePath, existingFilePath));
         }
 
         public override void AppendAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -46,6 +46,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             get { return defaultRunner; }
         }
 
+        public abstract bool SupportsHardlinkCreation { get; }
+
         // File methods
         public abstract bool FileExists(string path);       
         public abstract string MoveFile(string sourcePath, string targetPath);
@@ -68,6 +70,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public abstract void ReadAllText_FileShouldNotBeFound(string path);
 
         public abstract void CreateEmptyFile(string path);
+
+        public abstract void CreateHardLink(string targetPath, string newLinkPath);
 
         /// <summary>
         /// Write the specified contents to the specified file.  By calling this method the caller is

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
 {
@@ -46,7 +47,10 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             get { return defaultRunner; }
         }
 
-        public abstract bool SupportsHardlinkCreation { get; }
+        public virtual bool SupportsHardlinkCreation 
+        { 
+            get { return false; } 
+        }
 
         // File methods
         public abstract bool FileExists(string path);       
@@ -71,7 +75,10 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public abstract void CreateEmptyFile(string path);
 
-        public abstract void CreateHardLink(string targetPath, string newLinkPath);
+        public virtual void CreateHardLink(string targetPath, string newLinkPath)
+        {
+            Assert.Fail($"This runner does not support {nameof(this.CreateHardLink)}");
+        }
 
         /// <summary>
         /// Write the specified contents to the specified file.  By calling this method the caller is

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -75,7 +75,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public abstract void CreateEmptyFile(string path);
 
-        public virtual void CreateHardLink(string targetPath, string newLinkPath)
+        public virtual void CreateHardLink(string newLinkFilePath, string existingFilePath)
         {
             Assert.Fail($"This runner does not support {nameof(this.CreateHardLink)}");
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Tests.Should;
+using NUnit.Framework;
 using System.IO;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -31,6 +32,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             "PermissionDenied"
         };
+
+        public override bool SupportsHardlinkCreation
+        {
+            get { return false; }
+        }
 
         protected override string FileName
         {
@@ -103,6 +109,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void CreateEmptyFile(string path)
         {
             this.RunProcess(string.Format("-Command \"&{{ New-Item -ItemType file {0}}}\"", path));
+        }
+
+        public override void CreateHardLink(string targetPath, string newLinkPath)
+        {
+            Assert.Fail($"{nameof(PowerShellRunner)} does not support {nameof(this.CreateHardLink)}");
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -1,5 +1,4 @@
 ﻿using GVFS.Tests.Should;
-using NUnit.Framework;
 using System.IO;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -32,11 +31,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             "PermissionDenied"
         };
-
-        public override bool SupportsHardlinkCreation
-        {
-            get { return false; }
-        }
 
         protected override string FileName
         {
@@ -109,11 +103,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void CreateEmptyFile(string path)
         {
             this.RunProcess(string.Format("-Command \"&{{ New-Item -ItemType file {0}}}\"", path));
-        }
-
-        public override void CreateHardLink(string targetPath, string newLinkPath)
-        {
-            Assert.Fail($"{nameof(PowerShellRunner)} does not support {nameof(this.CreateHardLink)}");
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -9,11 +9,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 {
     public class SystemIORunner : FileSystemRunner
     {
-        public override bool SupportsHardlinkCreation
-        {
-            get { return false; }
-        }
-
         public override bool FileExists(string path)
         {
             return File.Exists(path);
@@ -78,11 +73,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             using (FileStream fs = File.Create(path))
             {
             }
-        }
-
-        public override void CreateHardLink(string targetPath, string newLinkPath)
-        {
-            Assert.Fail($"{nameof(SystemIORunner)} does not support {nameof(this.CreateHardLink)}");
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -9,6 +9,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 {
     public class SystemIORunner : FileSystemRunner
     {
+        public override bool SupportsHardlinkCreation
+        {
+            get { return false; }
+        }
+
         public override bool FileExists(string path)
         {
             return File.Exists(path);
@@ -73,6 +78,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             using (FileStream fs = File.Create(path))
             {
             }
+        }
+
+        public override void CreateHardLink(string targetPath, string newLinkPath)
+        {
+            Assert.Fail($"{nameof(SystemIORunner)} does not support {nameof(this.CreateHardLink)}");
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -189,8 +189,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(8)]
         public void RenamedFileAddedToModifiedPathsFile()
         {
-            GitMoveRenameTests.IgnoreSystemIOMoveOnMac(this.fileSystem);
-
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs";
             string fileToRenameTargetEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program2.cs";
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.SkipWorktree);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -187,18 +187,17 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(8)]
-        [Category(Categories.Mac.M2TODO)]
-        public void RenamedFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
+        public void RenamedFileAddedToModifiedPathsFile()
         {
+            GitMoveRenameTests.IgnoreSystemIOMoveOnMac(this.fileSystem);
+
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs";
             string fileToRenameTargetEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program2.cs";
-            string fileToRenameRelativePath = "Test_EPF_MoveRenameFileTests\\ChangeUnhydratedFileName\\Program.cs";
-            string fileToRenameTargetRelativePath = "Test_EPF_MoveRenameFileTests\\ChangeUnhydratedFileName\\Program2.cs";
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.SkipWorktree);
 
             this.fileSystem.MoveFile(
-                this.Enlistment.GetVirtualPathTo(fileToRenameRelativePath), 
-                this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
+                this.Enlistment.GetVirtualPathTo(fileToRenameEntry), 
+                this.Enlistment.GetVirtualPathTo(fileToRenameTargetEntry));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry);
@@ -209,19 +208,16 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(9)]
-        [Category(Categories.Mac.M2TODO)]
-        public void RenamedFileAndOverwrittenTargetAddedToSparseCheckoutAndSkipWorktreeBitCleared()
+        public void RenamedFileAndOverwrittenTargetAddedToModifiedPathsFile()
         {
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests_2/MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite/RunUnitTests.bat";
             string fileToRenameTargetEntry = "Test_EPF_MoveRenameFileTests_2/MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite/RunFunctionalTests.bat";
-            string fileToRenameRelativePath = "Test_EPF_MoveRenameFileTests_2\\MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite\\RunUnitTests.bat";
-            string fileToRenameTargetRelativePath = "Test_EPF_MoveRenameFileTests_2\\MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite\\RunFunctionalTests.bat";
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.SkipWorktree);
             this.VerifyWorktreeBit(fileToRenameTargetEntry, LsFilesStatus.SkipWorktree);
 
             this.fileSystem.ReplaceFile(
-                this.Enlistment.GetVirtualPathTo(fileToRenameRelativePath),
-                this.Enlistment.GetVirtualPathTo(fileToRenameTargetRelativePath));
+                this.Enlistment.GetVirtualPathTo(fileToRenameEntry),
+                this.Enlistment.GetVirtualPathTo(fileToRenameTargetEntry));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, fileToRenameEntry);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -38,10 +38,35 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.CreateEmptyFile(this.Enlistment.GetVirtualPathTo(emptyFileName));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, emptyFileName);
-            this.Enlistment.GetVirtualPathTo(fileName).ShouldBeAFile(this.fileSystem);
+            this.Enlistment.GetVirtualPathTo(emptyFileName).ShouldBeAFile(this.fileSystem);
         }
 
         [TestCase, Order(2)]
+        public void CreateHardLinkTest()
+        {
+            if (!this.fileSystem.SupportsHardlinkCreation)
+            {
+                return;
+            }
+
+            string targetFileName = "hardLinkTarget.txt";
+            string targetFilePath = this.Enlistment.GetVirtualPathTo(targetFileName);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, targetFileName);
+            this.fileSystem.WriteAllText(targetFilePath, "Some content here");
+            this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, targetFileName);
+            targetFilePath.ShouldBeAFile(this.fileSystem).WithContents("Some content here");
+
+            string linkFileName = "hardLink.txt";
+            string linkFilePath = this.Enlistment.GetVirtualPathTo(linkFileName);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, linkFileName);
+            this.fileSystem.CreateHardLink(targetFilePath, linkFilePath);
+            this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, linkFileName);
+            linkFilePath.ShouldBeAFile(this.fileSystem).WithContents("Some content here");
+        }
+
+        [TestCase, Order(3)]
         [Category(Categories.Mac.M2TODO)]
         public void CreateFileInFolderTest()
         {
@@ -62,7 +87,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, folderName + "/" + fileName);
         }
 
-        [TestCase, Order(3)]
+        [TestCase, Order(4)]
         [Category(Categories.Mac.M2TODO)]
         public void RenameEmptyFolderTest()
         {
@@ -83,7 +108,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedEntries);
         }
 
-        [TestCase, Order(4)]
+        [TestCase, Order(5)]
         [Category(Categories.Mac.M2TODO)]
         public void RenameFolderTest()
         {
@@ -116,7 +141,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedEntries);
         }
 
-        [TestCase, Order(5)]
+        [TestCase, Order(6)]
         [Category(Categories.Mac.M2TODO)]
         public void CaseOnlyRenameOfNewFolderKeepsExcludeEntries()
         {
@@ -138,7 +163,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedPathsEntries);
         }
 
-        [TestCase, Order(6)]
+        [TestCase, Order(7)]
         public void ReadingFileDoesNotUpdateIndexOrSparseCheckout()
         {
             string gitFileToCheck = "GVFS/GVFS.FunctionalTests/Category/CategoryConstants.cs";
@@ -166,7 +191,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         // TODO(Mac): Enable this test once the LockHolder is converted to .NET Core
-        [TestCase, Order(7)]
+        [TestCase, Order(8)]
         [Category(Categories.Mac.M2TODO)]
         public void ModifiedFileWillGetAddedToModifiedPathsFile()
         {
@@ -186,7 +211,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(gitFileToTest, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(8)]
+        [TestCase, Order(9)]
         public void RenamedFileAddedToModifiedPathsFile()
         {
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs";
@@ -205,7 +230,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(9)]
+        [TestCase, Order(10)]
         public void RenamedFileAndOverwrittenTargetAddedToModifiedPathsFile()
         {
             string fileToRenameEntry = "Test_EPF_MoveRenameFileTests_2/MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite/RunUnitTests.bat";
@@ -226,7 +251,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToRenameTargetEntry, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(10)]
+        [TestCase, Order(11)]
         public void DeletedFileAddedToModifiedPathsFile()
         {
             string fileToDeleteEntry = "GVFlt_DeleteFileTest/GVFlt_DeleteFullFileWithoutFileContext_DeleteOnClose/a.txt";
@@ -241,7 +266,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToDeleteEntry, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(11)]
+        [TestCase, Order(12)]
         public void DeletedFolderAndChildrenAddedToToModifiedPathsFile()
         {
             string folderToDelete = "Scripts";
@@ -273,7 +298,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
-        [TestCase, Order(12)]
+        [TestCase, Order(13)]
         public void FileRenamedOutOfRepoAddedToModifiedPathsFile()
         {
             string fileToRenameEntry = "GVFlt_MoveFileTest/PartialToOutside/from/lessInFrom.txt";
@@ -292,7 +317,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(13)]
+        [TestCase, Order(14)]
         public void OverwrittenFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToOverwriteEntry = "Test_EPF_WorkingDirectoryTests/1/2/3/4/ReadDeepProjectedFile.cpp";
@@ -312,7 +337,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToOverwriteEntry, LsFilesStatus.Cached);
         }
 
-        [TestCase, Order(14)]
+        [TestCase, Order(15)]
         [Category(Categories.Mac.M2TODO)]
         public void SupersededFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string newLinkFileName = "newHardLink.txt";
             string newLinkFilePath = this.Enlistment.GetVirtualPathTo(newLinkFileName);
             GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, newLinkFileName);
-            this.fileSystem.CreateHardLink(existingFilePath, newLinkFilePath);
+            this.fileSystem.CreateHardLink(newLinkFilePath, existingFilePath);
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, newLinkFileName);
             newLinkFilePath.ShouldBeAFile(this.fileSystem).WithContents("Some content here");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -22,15 +22,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem = fileSystem;
         }
 
-        public static void IgnoreSystemIOMoveOnMac(FileSystemRunner runner)
-        {
-            if (runner is SystemIORunner &&
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Assert.Ignore("TODO(Mac): SystemIORunner rename tests require hardlink notifications");
-            }
-        }
-
         [TestCase, Order(1)]
         public void GitStatus()
         {
@@ -85,8 +76,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(4)]
         public void GitStatusAfterFileRename()
         {
-            IgnoreSystemIOMoveOnMac(this.fileSystem);
-
             string oldFilename = "New.cs";
             this.EnsureTestFileExists(oldFilename);
 
@@ -195,8 +184,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(9)]
         public void GitStatusAfterRenameFileIntoRepo()
         {
-            IgnoreSystemIOMoveOnMac(this.fileSystem);
-
             string filename = "GitStatusAfterRenameFileIntoRepo.cs";
 
             // Create the test file in this.Enlistment.EnlistmentRoot as it's outside of src 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
@@ -10,7 +10,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2TODO)]
+    [Category(Categories.Mac.M2)]
     public class MoveRenameFileTests : TestsWithEnlistmentPerFixture
     {
         public const string TestFileContents =
@@ -53,8 +53,8 @@ namespace GVFS.StressTests
         [TestCase]
         public void ChangeUnhydratedFileName()
         {
-            string oldFilename = "Test_EPF_MoveRenameFileTests\\ChangeUnhydratedFileName\\Program.cs";
-            string newFilename = "Test_EPF_MoveRenameFileTests\\ChangeUnhydratedFileName\\renamed_Program.cs";
+            string oldFilename = Path.Combine("Test_EPF_MoveRenameFileTests", "ChangeUnhydratedFileName", "Program.cs");
+            string newFilename = Path.Combine("Test_EPF_MoveRenameFileTests", "ChangeUnhydratedFileName", "renamed_Program.cs");
 
             // Don't read oldFilename or check for its existence before calling MoveFile, because doing so
             // can cause the file to hydrate
@@ -86,7 +86,7 @@ namespace GVFS.StressTests
         {
             string oldName = "Program.cs";
             string newName = "program.cs";
-            string folderName = "Test_EPF_MoveRenameFileTests\\ChangeNestedUnhydratedFileNameCase\\";
+            string folderName = Path.Combine("Test_EPF_MoveRenameFileTests", "ChangeNestedUnhydratedFileNameCase");
 
             string oldVirtualPath = this.Enlistment.GetVirtualPathTo(Path.Combine(folderName, oldName));
             string newVirtualPath = this.Enlistment.GetVirtualPathTo(Path.Combine(folderName, newName));
@@ -101,8 +101,8 @@ namespace GVFS.StressTests
             this.Enlistment.GetVirtualPathTo(targetFolderName).ShouldBeADirectory(this.fileSystem);
 
             string testFileName = "Program.cs";
-            string testFileFolder = "Test_EPF_MoveRenameFileTests\\MoveUnhydratedFileToDotGitFolder";
-            string testFilePathSubPath = testFileFolder + "\\" + testFileName;
+            string testFileFolder = Path.Combine("Test_EPF_MoveRenameFileTests", "MoveUnhydratedFileToDotGitFolder");
+            string testFilePathSubPath = Path.Combine(testFileFolder, testFileName);
 
             string newTestFileVirtualPath = Path.Combine(this.Enlistment.GetVirtualPathTo(targetFolderName), testFileName);
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
@@ -8,7 +8,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2TODO)]
+    [Category(Categories.Mac.M2)]
     public class MoveRenameFileTests_2 : TestsWithEnlistmentPerFixture
     {
         private const string TestFileFolder = "Test_EPF_MoveRenameFileTests_2";
@@ -44,8 +44,8 @@ IF ""%1""=="""" (SET ""Configuration=Debug"") ELSE (SET ""Configuration=%1"")
             // Assume there will always be a GVFS folder when running tests
             string testFolderName = "GVFS";
 
-            string oldTestFileVirtualPath = this.Enlistment.GetVirtualPathTo(TestFileFolder + "\\" + testFileName);
-            string newTestFileVirtualPath = this.Enlistment.GetVirtualPathTo(testFolderName + "\\" + testFileName);
+            string oldTestFileVirtualPath = this.Enlistment.GetVirtualPathTo(TestFileFolder, testFileName);
+            string newTestFileVirtualPath = this.Enlistment.GetVirtualPathTo(testFolderName, testFileName);
 
             this.fileSystem.MoveFile(oldTestFileVirtualPath, newTestFileVirtualPath);
             oldTestFileVirtualPath.ShouldNotExistOnDisk(this.fileSystem);
@@ -72,8 +72,8 @@ IF ""%1""=="""" (SET ""Configuration=Debug"") ELSE (SET ""Configuration=%1"")
 
             string newTestFileVirtualPath = Path.Combine(this.Enlistment.GetVirtualPathTo(testFolderName), testFolderName);
 
-            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(TestFileFolder + "\\" + testFileName), newTestFileVirtualPath);
-            this.Enlistment.GetVirtualPathTo(TestFileFolder + "\\" + testFileName).ShouldNotExistOnDisk(this.fileSystem);
+            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(TestFileFolder, testFileName), newTestFileVirtualPath);
+            this.Enlistment.GetVirtualPathTo(TestFileFolder, testFileName).ShouldNotExistOnDisk(this.fileSystem);
             newTestFileVirtualPath.ShouldBeAFile(this.fileSystem).WithContents(testFileContents);
 
             // Writing after the move should succeed
@@ -92,8 +92,8 @@ IF ""%1""=="""" (SET ""Configuration=Debug"") ELSE (SET ""Configuration=%1"")
         [TestCase, Order(3)]
         public void MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite()
         {
-            string targetFilename = TestFileFolder + "\\MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite\\RunFunctionalTests.bat";
-            string sourceFilename = TestFileFolder + "\\MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite\\RunUnitTests.bat";
+            string targetFilename = Path.Combine(TestFileFolder, "MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite", "RunFunctionalTests.bat");
+            string sourceFilename = Path.Combine(TestFileFolder, "MoveUnhydratedFileToOverwriteUnhydratedFileAndWrite", "RunUnitTests.bat");
             string sourceFileContents = RunUnitTestsContents;
 
             // Overwriting one unhydrated file with another should create a file at the target
@@ -130,7 +130,11 @@ IF ""%1""=="""" (SET ""Configuration=Debug"") ELSE (SET ""Configuration=%1"")
             string targetFilename = "TargetFile.txt";
             string targetFileContents = "The Target";
 
-            string sourceFilename = TestFileFolder + "\\MoveUnhydratedFileToOverwriteFullFileAndWrite\\MoveUnhydratedFileToOverwriteFullFileAndWrite.txt";
+            string sourceFilename = Path.Combine(
+                TestFileFolder, 
+                "MoveUnhydratedFileToOverwriteFullFileAndWrite", 
+                "MoveUnhydratedFileToOverwriteFullFileAndWrite.txt");
+            
             string sourceFileContents =
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <packages>

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -32,12 +32,30 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase, Order(3)]
+        [Category(Categories.Mac.M2)]
+        public void AddAndStageHardLinksTest()
+        {
+            if (!this.FileSystem.SupportsHardlinkCreation)
+            {
+                return;
+            }
+
+            this.CreateHardLink("Readme.md", "ReadmeLink.md");
+            this.ValidateGitCommand("add ReadmeLink.md");
+            this.RunGitCommand("commit -m \"Created ReadmeLink.md\"");
+
+            this.CreateHardLink("AuthoringTests.md", "AuthoringTestsLink.md");
+            this.ValidateGitCommand("stage AuthoringTestsLink.md");
+            this.RunGitCommand("commit -m \"Created AuthoringTestsLink.md\"");
+        }
+
+        [TestCase, Order(4)]
         public void AddAllowsPlaceholderCreation()
         {
             this.CommandAllowsPlaceholderCreation("add", @"GVFS\GVFS\Program.cs");
         }
 
-        [TestCase, Order(4)]
+        [TestCase, Order(5)]
         public void StageAllowsPlaceholderCreation()
         {
             this.CommandAllowsPlaceholderCreation("stage", @"GVFS\GVFS\App.config");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -40,11 +40,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
                 return;
             }
 
-            this.CreateHardLink("Readme.md", "ReadmeLink.md");
+            this.CreateHardLink("ReadmeLink.md", "Readme.md");
             this.ValidateGitCommand("add ReadmeLink.md");
             this.RunGitCommand("commit -m \"Created ReadmeLink.md\"");
 
-            this.CreateHardLink("AuthoringTests.md", "AuthoringTestsLink.md");
+            this.CreateHardLink("AuthoringTestsLink.md", "AuthoringTests.md");
             this.ValidateGitCommand("stage AuthoringTestsLink.md");
             this.RunGitCommand("commit -m \"Created AuthoringTestsLink.md\"");
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -215,6 +215,16 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.AppendAllText(controlFile, content);
         }
 
+        protected void CreateHardLink(string targetPath, string newLinkPath)
+        {
+            string virtualTargetFile = Path.Combine(this.Enlistment.RepoRoot, targetPath);
+            string controlTargetFile = Path.Combine(this.ControlGitRepo.RootPath, targetPath);
+            string virtualNewLinkFile = Path.Combine(this.Enlistment.RepoRoot, newLinkPath);
+            string controlNewLinkFile = Path.Combine(this.ControlGitRepo.RootPath, newLinkPath);
+            this.FileSystem.CreateHardLink(virtualTargetFile, virtualNewLinkFile);
+            this.FileSystem.CreateHardLink(controlTargetFile, controlNewLinkFile);
+        }
+
         protected void SetFileAsReadOnly(string filePath)
         {
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -221,8 +221,16 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string controlTargetFile = Path.Combine(this.ControlGitRepo.RootPath, targetPath);
             string virtualNewLinkFile = Path.Combine(this.Enlistment.RepoRoot, newLinkPath);
             string controlNewLinkFile = Path.Combine(this.ControlGitRepo.RootPath, newLinkPath);
-            this.FileSystem.CreateHardLink(virtualTargetFile, virtualNewLinkFile);
-            this.FileSystem.CreateHardLink(controlTargetFile, controlNewLinkFile);
+
+            // GitRepoTests are only run with SystemIORunner (which does not support hardlink
+            // creation) so use a BashRunner instead.
+            this.FileSystem.ShouldBeOfType<SystemIORunner>();
+            this.FileSystem.SupportsHardlinkCreation.ShouldBeFalse(
+                "FileSystem *does* support hard link creation, CreateHardLink no longer needs to create a BashRunner");
+            FileSystemRunner runner = new BashRunner();
+
+            runner.CreateHardLink(virtualTargetFile, virtualNewLinkFile);
+            runner.CreateHardLink(controlTargetFile, controlNewLinkFile);
         }
 
         protected void SetFileAsReadOnly(string filePath)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -215,22 +215,21 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.AppendAllText(controlFile, content);
         }
 
-        protected void CreateHardLink(string targetPath, string newLinkPath)
+        protected void CreateHardLink(string newLinkFileName, string existingFileName)
         {
-            string virtualTargetFile = Path.Combine(this.Enlistment.RepoRoot, targetPath);
-            string controlTargetFile = Path.Combine(this.ControlGitRepo.RootPath, targetPath);
-            string virtualNewLinkFile = Path.Combine(this.Enlistment.RepoRoot, newLinkPath);
-            string controlNewLinkFile = Path.Combine(this.ControlGitRepo.RootPath, newLinkPath);
+            string virtualExistingFile = Path.Combine(this.Enlistment.RepoRoot, existingFileName);
+            string controlExistingFile = Path.Combine(this.ControlGitRepo.RootPath, existingFileName);
+            string virtualNewLinkFile = Path.Combine(this.Enlistment.RepoRoot, newLinkFileName);
+            string controlNewLinkFile = Path.Combine(this.ControlGitRepo.RootPath, newLinkFileName);
 
             // GitRepoTests are only run with SystemIORunner (which does not support hardlink
             // creation) so use a BashRunner instead.
-            this.FileSystem.ShouldBeOfType<SystemIORunner>();
             this.FileSystem.SupportsHardlinkCreation.ShouldBeFalse(
-                "FileSystem *does* support hard link creation, CreateHardLink no longer needs to create a BashRunner");
+                "If this.FileSystem.SupportsHardlinkCreation is true, CreateHardLink no longer needs to create a BashRunner");
             FileSystemRunner runner = new BashRunner();
 
-            runner.CreateHardLink(virtualTargetFile, virtualNewLinkFile);
-            runner.CreateHardLink(controlTargetFile, controlNewLinkFile);
+            runner.CreateHardLink(virtualNewLinkFile, virtualExistingFile);
+            runner.CreateHardLink(controlNewLinkFile, controlExistingFile);
         }
 
         protected void SetFileAsReadOnly(string filePath)

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -362,24 +362,9 @@ namespace GVFS.Platform.Mac
 
         private void OnHardLinkCreated(string relativeNewLinkPath)
         {
-            try
-            {
-                bool pathInDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativeNewLinkPath);
-
-                if (pathInDotGit)
-                {
-                    this.OnDotGitFileOrFolderChanged(relativeNewLinkPath);
-                }
-                else
-                {
-                    this.FileSystemCallbacks.OnFileHardLinkCreated(relativeNewLinkPath);
-                }
-            }
-            catch (Exception e)
-            {
-                EventMetadata metadata = this.CreateEventMetadata(relativeNewLinkPath, e);
-                this.LogUnhandledExceptionAndExit(nameof(this.OnHardLinkCreated), metadata);
-            }
+            this.OnHardLinkCreated(
+                relativeTargetPath: string.Empty, 
+                relativeNewLinkPath: relativeNewLinkPath);
         }
 
         private Result OnEnumerateDirectory(

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -102,6 +102,7 @@ namespace GVFS.Platform.Mac
             this.virtualizationInstance.OnFileModified = this.OnFileModified;
             this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
+            this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -346,6 +347,16 @@ namespace GVFS.Platform.Mac
                 metadata.Add("isDirectory", isDirectory);
                 this.LogUnhandledExceptionAndExit(nameof(this.OnNewFileCreated), metadata);
             }
+        }
+        
+        private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
+        {
+            // relativeSourcePath is handled in the OnPreDelete callback that's triggered
+            // prior to OnFileRenamed
+            this.OnFileRenamed(
+                relativeSourcePath: string.Empty, 
+                relativeDestinationPath: relativeDestinationPath, 
+                isDirectory: isDirectory);
         }
 
         private Result OnEnumerateDirectory(

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -103,6 +103,7 @@ namespace GVFS.Platform.Mac
             this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
+            this.virtualizationInstance.OnHardLinkCreated = this.OnHardLinkCreated;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -357,6 +358,28 @@ namespace GVFS.Platform.Mac
                 relativeSourcePath: string.Empty, 
                 relativeDestinationPath: relativeDestinationPath, 
                 isDirectory: isDirectory);
+        }
+
+        private void OnHardLinkCreated(string relativeNewLinkPath)
+        {
+            try
+            {
+                bool pathInDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativeNewLinkPath);
+
+                if (pathInDotGit)
+                {
+                    this.OnDotGitFileOrFolderChanged(relativeNewLinkPath);
+                }
+                else
+                {
+                    this.FileSystemCallbacks.OnFileHardLinkCreated(relativeNewLinkPath);
+                }
+            }
+            catch (Exception e)
+            {
+                EventMetadata metadata = this.CreateEventMetadata(relativeNewLinkPath, e);
+                this.LogUnhandledExceptionAndExit(nameof(this.OnHardLinkCreated), metadata);
+            }
         }
 
         private Result OnEnumerateDirectory(

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -352,8 +352,9 @@ namespace GVFS.Platform.Mac
         
         private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
         {
-            // relativeSourcePath is handled in the OnPreDelete callback that's triggered
-            // prior to OnFileRenamed
+            // ProjFS for Mac *could* be updated to provide us with relativeSourcePath as well,
+            // but because VFSForGit doesn't need the source path on Mac for correct behavior
+            // the relativeSourcePath is left out of the notification to keep the kext simple
             this.OnFileRenamed(
                 relativeSourcePath: string.Empty, 
                 relativeDestinationPath: relativeDestinationPath, 
@@ -363,7 +364,7 @@ namespace GVFS.Platform.Mac
         private void OnHardLinkCreated(string relativeNewLinkPath)
         {
             this.OnHardLinkCreated(
-                relativeTargetPath: string.Empty, 
+                relativeExistingFilePath: string.Empty, 
                 relativeNewLinkPath: relativeNewLinkPath);
         }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -159,7 +159,7 @@ namespace GVFS.Platform.Windows
             this.virtualizationInstance.OnNotifyPreRename = this.NotifyPreRenameHandler;
             this.virtualizationInstance.OnNotifyPreSetHardlink = null;
             this.virtualizationInstance.OnNotifyFileRenamed = this.NotifyFileRenamedHandler;
-            this.virtualizationInstance.OnNotifyHardlinkCreated = null;
+            this.virtualizationInstance.OnNotifyHardlinkCreated = this.NotifyHardlinkCreated;
             this.virtualizationInstance.OnNotifyFileHandleClosedNoModification = null;
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.NotifyFileHandleClosedFileModifiedOrDeletedHandler;
             this.virtualizationInstance.OnNotifyFilePreConvertToFull = this.NotifyFilePreConvertToFullHandler;
@@ -1224,6 +1224,13 @@ namespace GVFS.Platform.Windows
             ref NotificationType notificationMask)
         {
             this.OnFileRenamed(virtualPath, destinationPath, isDirectory);
+        }
+
+        private void NotifyHardlinkCreated(
+            string relativePath,
+            string destinationPath)
+        {
+            this.OnHardLinkCreated(relativePath, destinationPath);
         }
 
         private void NotifyFileHandleClosedFileModifiedOrDeletedHandler(

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1223,35 +1223,7 @@ namespace GVFS.Platform.Windows
             bool isDirectory,
             ref NotificationType notificationMask)
         {
-            try
-            {
-                bool srcPathInDotGit = FileSystemCallbacks.IsPathInsideDotGit(virtualPath);
-                bool dstPathInDotGit = FileSystemCallbacks.IsPathInsideDotGit(destinationPath);
-
-                if (dstPathInDotGit)
-                {
-                    this.OnDotGitFileOrFolderChanged(destinationPath);
-                }
-
-                if (!(srcPathInDotGit && dstPathInDotGit))
-                {
-                    if (isDirectory)
-                    {
-                        this.FileSystemCallbacks.OnFolderRenamed(virtualPath, destinationPath);
-                    }
-                    else
-                    {
-                        this.FileSystemCallbacks.OnFileRenamed(virtualPath, destinationPath);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                EventMetadata metadata = this.CreateEventMetadata(virtualPath, e);
-                metadata.Add("destinationPath", destinationPath);
-                metadata.Add("isDirectory", isDirectory);
-                this.LogUnhandledExceptionAndExit(nameof(this.NotifyFileRenamedHandler), metadata);
-            }
+            this.OnFileRenamed(virtualPath, destinationPath, isDirectory);
         }
 
         private void NotifyFileHandleClosedFileModifiedOrDeletedHandler(

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1227,10 +1227,10 @@ namespace GVFS.Platform.Windows
         }
 
         private void NotifyHardlinkCreated(
-            string relativePath,
-            string destinationPath)
+            string relativeExistingFilePath,
+            string relativeNewLinkPath)
         {
-            this.OnHardLinkCreated(relativePath, destinationPath);
+            this.OnHardLinkCreated(relativeExistingFilePath, relativeNewLinkPath);
         }
 
         private void NotifyFileHandleClosedFileModifiedOrDeletedHandler(

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1365,19 +1365,23 @@ namespace GVFS.Platform.Windows
                 NotificationType.PreRename |
                 NotificationType.PreDelete |
                 NotificationType.FileRenamed |
+                NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileModified;
 
             public const NotificationType LogsHeadFile = 
-                NotificationType.FileRenamed | 
+                NotificationType.FileRenamed |
+                NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileModified;
 
             public const NotificationType ExcludeAndHeadFile =
                 NotificationType.FileRenamed |
+                NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileDeleted |
                 NotificationType.FileHandleClosedFileModified;
 
             public const NotificationType FilesAndFoldersInRefsHeads =
                 NotificationType.FileRenamed |
+                NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileDeleted |
                 NotificationType.FileHandleClosedFileModified;
 
@@ -1385,6 +1389,7 @@ namespace GVFS.Platform.Windows
                 NotificationType.NewFileCreated |
                 NotificationType.FileSupersededOrOverwritten |
                 NotificationType.FileRenamed |
+                NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileDeleted |
                 NotificationType.FilePreConvertToFull |
                 NotificationType.FileHandleClosedFileModified;

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -277,6 +277,12 @@ namespace GVFS.UnitTests.Virtualization
 
                 this.CallbackSchedulesBackgroundTask(
                     backgroundTaskRunner,
+                    (path) => fileSystemCallbacks.OnFileHardLinkCreated(path),
+                    "OnFileHardLinkCreated.txt",
+                    FileSystemTask.OperationType.OnFileHardLinkCreated);
+
+                this.CallbackSchedulesBackgroundTask(
+                    backgroundTaskRunner,
                     (path) => fileSystemCallbacks.OnFileSuperseded(path),
                     "OnFileSuperseded.txt",
                     FileSystemTask.OperationType.OnFileSuperseded);

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
@@ -28,7 +28,8 @@ namespace GVFS.Virtualization.Background
             OnFolderDeleted,
             OnFolderFirstWrite,
             OnIndexWriteWithoutProjectionChange,
-            OnPlaceholderCreationsBlockedForGit
+            OnPlaceholderCreationsBlockedForGit,
+            OnFileHardLinkCreated
         }
 
         public OperationType Operation { get; }
@@ -44,6 +45,11 @@ namespace GVFS.Virtualization.Background
         public static FileSystemTask OnFileRenamed(string oldVirtualPath, string newVirtualPath)
         {
             return new FileSystemTask(OperationType.OnFileRenamed, newVirtualPath, oldVirtualPath);
+        }
+
+        public static FileSystemTask OnFileHardLinkCreated(string newLinkRelativePath)
+        {
+            return new FileSystemTask(OperationType.OnFileHardLinkCreated, newLinkRelativePath, oldVirtualPath: null);
         }
 
         public static FileSystemTask OnFileDeleted(string virtualPath)

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -242,6 +242,29 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
+        protected void OnHardLinkCreated(string relativeTargetPath, string relativeNewLinkPath)
+        {
+            try
+            {
+                bool pathInDotGit = FileSystemCallbacks.IsPathInsideDotGit(relativeNewLinkPath);
+
+                if (pathInDotGit)
+                {
+                    this.OnDotGitFileOrFolderChanged(relativeNewLinkPath);
+                }
+                else
+                {
+                    this.FileSystemCallbacks.OnFileHardLinkCreated(relativeNewLinkPath);
+                }
+            }
+            catch (Exception e)
+            {
+                EventMetadata metadata = this.CreateEventMetadata(relativeNewLinkPath, e);
+                metadata.Add(nameof(relativeTargetPath), relativeTargetPath);
+                this.LogUnhandledExceptionAndExit(nameof(this.OnHardLinkCreated), metadata);
+            }
+        }
+
         protected EventMetadata CreateEventMetadata(
             Guid enumerationId,
             string relativePath = null,

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -242,7 +242,7 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
-        protected void OnHardLinkCreated(string relativeTargetPath, string relativeNewLinkPath)
+        protected void OnHardLinkCreated(string relativeExistingFilePath, string relativeNewLinkPath)
         {
             try
             {
@@ -260,7 +260,7 @@ namespace GVFS.Virtualization.FileSystem
             catch (Exception e)
             {
                 EventMetadata metadata = this.CreateEventMetadata(relativeNewLinkPath, e);
-                metadata.Add(nameof(relativeTargetPath), relativeTargetPath);
+                metadata.Add(nameof(relativeExistingFilePath), relativeExistingFilePath);
                 this.LogUnhandledExceptionAndExit(nameof(this.OnHardLinkCreated), metadata);
             }
         }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -423,6 +423,11 @@ namespace GVFS.Virtualization
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileRenamed(oldRelativePath, newRelativePath));
         }
 
+        public virtual void OnFileHardLinkCreated(string newLinkRelativePath)
+        {
+            this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileHardLinkCreated(newLinkRelativePath));
+        }
+
         public void OnFileDeleted(string relativePath)
         {
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileDeleted(relativePath));
@@ -606,6 +611,7 @@ namespace GVFS.Virtualization
             {
                 case FileSystemTask.OperationType.OnFileCreated:
                 case FileSystemTask.OperationType.OnFailedPlaceholderDelete:
+                case FileSystemTask.OperationType.OnFileHardLinkCreated:
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     result = this.AddModifiedPathAndRemoveFromPlaceholderList(gitUpdate.VirtualPath);
                     break;

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -24,6 +24,7 @@ namespace MirrorProvider.Mac
             this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
+            this.virtualizationInstance.OnHardLinkCreated = this.OnHardLinkCreated;
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
@@ -169,6 +170,11 @@ namespace MirrorProvider.Mac
         private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
         {
             Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}) destination: {relativeDestinationPath}");
+        }
+
+        private void OnHardLinkCreated(string relativeNewLinkPath)
+        {
+            Console.WriteLine($"OnHardLinkCreated: {relativeNewLinkPath}");
         }
 
         private static byte[] ToVersionIdByteArray(byte version)

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -23,6 +23,7 @@ namespace MirrorProvider.Mac
             this.virtualizationInstance.OnFileModified = this.OnFileModified;
             this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
+            this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
@@ -163,6 +164,11 @@ namespace MirrorProvider.Mac
         private void OnNewFileCreated(string relativePath, bool isDirectory)
         {
             Console.WriteLine($"OnNewFileCreated (isDirectory: {isDirectory}): {relativePath}");
+        }
+
+        private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
+        {
+            Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}) destination: {relativeDestinationPath}");
         }
 
         private static byte[] ToVersionIdByteArray(byte version)

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -37,6 +37,7 @@ namespace MirrorProvider.Windows
             this.virtualizationInstance.OnNotifyPreDelete = this.OnPreDelete;
             this.virtualizationInstance.OnNotifyNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.OnFileModifiedOrDeleted;
+            this.virtualizationInstance.OnNotifyFileRenamed = this.OnFileRenamed;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -44,7 +45,8 @@ namespace MirrorProvider.Windows
             {
                 new NotificationMapping(
                     NotificationType.NewFileCreated |
-                    NotificationType.PreDelete | 
+                    NotificationType.PreDelete |
+                    NotificationType.FileRenamed |
                     NotificationType.FileHandleClosedFileModified, 
                     string.Empty),
             };
@@ -314,6 +316,15 @@ namespace MirrorProvider.Windows
             // Once MacFileSystemVirtualizer supports delete notifications we'll register for
             // NotificationType.FileHandleClosedFileDeleted and this method will be called for both modifications and deletions.
             Console.WriteLine($"OnFileModifiedOrDeleted: `{relativePath}`, isDirectory: {isDirectory}, isModfied: {isFileDeleted}, isDeleted: {isFileDeleted}");
+        }
+
+        private void OnFileRenamed(
+            string relativePath,
+            string relativeDestinationPath,
+            bool isDirectory,
+            ref NotificationType notificationMask)
+        {
+            Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}), relativePath: {relativePath}, relativeDestinationPath: {relativeDestinationPath}");
         }
 
         // TODO: Add this to the ProjFS API

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -38,6 +38,7 @@ namespace MirrorProvider.Windows
             this.virtualizationInstance.OnNotifyNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.OnFileModifiedOrDeleted;
             this.virtualizationInstance.OnNotifyFileRenamed = this.OnFileRenamed;
+            this.virtualizationInstance.OnNotifyHardlinkCreated = this.OnHardlinkCreated;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -47,6 +48,7 @@ namespace MirrorProvider.Windows
                     NotificationType.NewFileCreated |
                     NotificationType.PreDelete |
                     NotificationType.FileRenamed |
+                    NotificationType.HardlinkCreated |
                     NotificationType.FileHandleClosedFileModified, 
                     string.Empty),
             };
@@ -325,6 +327,13 @@ namespace MirrorProvider.Windows
             ref NotificationType notificationMask)
         {
             Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}), relativePath: {relativePath}, relativeDestinationPath: {relativeDestinationPath}");
+        }
+
+        private void OnHardlinkCreated(
+            string relativePath,
+            string relativeDestinationPath)
+        {
+            Console.WriteLine($"OnHardlinkCreated, relativePath: {relativePath}, relativeDestinationPath: {relativeDestinationPath}");
         }
 
         // TODO: Add this to the ProjFS API

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -321,19 +321,19 @@ namespace MirrorProvider.Windows
         }
 
         private void OnFileRenamed(
-            string relativePath,
+            string relativeSourcePath,
             string relativeDestinationPath,
             bool isDirectory,
             ref NotificationType notificationMask)
         {
-            Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}), relativePath: {relativePath}, relativeDestinationPath: {relativeDestinationPath}");
+            Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}), relativeSourcePath: {relativeSourcePath}, relativeDestinationPath: {relativeDestinationPath}");
         }
 
         private void OnHardlinkCreated(
-            string relativePath,
-            string relativeDestinationPath)
+            string relativeExistingFilePath,
+            string relativeNewLinkFilePath)
         {
-            Console.WriteLine($"OnHardlinkCreated, relativePath: {relativePath}, relativeDestinationPath: {relativeDestinationPath}");
+            Console.WriteLine($"OnHardlinkCreated, relativeExistingFilePath: {relativeExistingFilePath}, relativeNewLinkFilePath: {relativeNewLinkFilePath}");
         }
 
         // TODO: Add this to the ProjFS API

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
@@ -18,7 +18,7 @@ struct VirtualizationRoot
     fsid_t                      rootFsid;
     uint64_t                    rootInode;
     
-    // TODO: this should eventually be entirely diagnostic and not used for decisions
+    // TODO(Mac): this should eventually be entirely diagnostic and not used for decisions
     char                        path[PrjFSMaxPath];
 
     int32_t                     index;

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -22,6 +22,7 @@ typedef enum
     MessageType_KtoU_NotifyFileCreated,
     MessageType_KtoU_NotifyFileRenamed,
     MessageType_KtoU_NotifyDirectoryRenamed,
+    MessageType_KtoU_NotifyFileHardLinkCreated,
     
     // Responses
     MessageType_Response_Success,

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -20,6 +20,8 @@ typedef enum
     MessageType_KtoU_NotifyFilePreDelete,
     MessageType_KtoU_NotifyDirectoryPreDelete,
     MessageType_KtoU_NotifyFileCreated,
+    MessageType_KtoU_NotifyFileRenamed,
+    MessageType_KtoU_NotifyDirectoryRenamed,
     
     // Responses
     MessageType_Response_Success,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
@@ -31,8 +31,7 @@ namespace PrjFSLib.Mac
         int triggeringProcessId,
         string triggeringProcessName,
         bool isDirectory,
-        NotificationType notificationType,
-        string destinationRelativePath);
+        NotificationType notificationType);
 
     // Pre-event notifications
     public delegate Result NotifyPreDeleteEvent(
@@ -51,7 +50,6 @@ namespace PrjFSLib.Mac
         bool isDirectory);
 
     public delegate void NotifyFileRenamedEvent(
-        string relativeSourcePath,
         string relativeDestinationPath,
         bool isDirectory);
 

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
@@ -53,6 +53,9 @@ namespace PrjFSLib.Mac
         string relativeDestinationPath,
         bool isDirectory);
 
+    public delegate void NotifyHardLinkCreatedEvent(
+        string relativeNewLinkPath);
+
     public delegate void NotifyFileModified(
         string relativePath);
 

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationType.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationType.cs
@@ -11,6 +11,7 @@ namespace PrjFSLib.Mac
         NewFileCreated      = 0x00000004,
         PreDelete           = 0x00000010,
         FileRenamed         = 0x00000080,
+        HardLinkCreated     = 0x00000100,
         PreConvertToFull    = 0x00001000,
 
         PreModify           = 0x10000001,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -17,6 +17,7 @@ namespace PrjFSLib.Mac
         public virtual NotifyFileModified OnFileModified { get; set; }
         public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
         public virtual NotifyNewFileCreatedEvent OnNewFileCreated { get; set; }
+        public virtual NotifyFileRenamedEvent OnFileRenamed { get; set; }
 
         public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
         {
@@ -131,8 +132,7 @@ namespace PrjFSLib.Mac
             int triggeringProcessId,
             string triggeringProcessName,
             bool isDirectory,
-            NotificationType notificationType,
-            string destinationRelativePath)
+            NotificationType notificationType)
         {
             switch (notificationType)
             {
@@ -145,6 +145,10 @@ namespace PrjFSLib.Mac
 
                 case NotificationType.NewFileCreated:
                     this.OnNewFileCreated(relativePath, isDirectory);
+                    return Result.Success;
+
+                case NotificationType.FileRenamed:
+                    this.OnFileRenamed(relativePath, isDirectory);
                     return Result.Success;
             }
 

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -18,6 +18,7 @@ namespace PrjFSLib.Mac
         public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
         public virtual NotifyNewFileCreatedEvent OnNewFileCreated { get; set; }
         public virtual NotifyFileRenamedEvent OnFileRenamed { get; set; }
+        public virtual NotifyHardLinkCreatedEvent OnHardLinkCreated { get; set; }
 
         public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
         {
@@ -149,6 +150,10 @@ namespace PrjFSLib.Mac
 
                 case NotificationType.FileRenamed:
                     this.OnFileRenamed(relativePath, isDirectory);
+                    return Result.Success;
+
+                case NotificationType.HardLinkCreated:
+                    this.OnHardLinkCreated(relativePath);
                     return Result.Success;
             }
 

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -44,7 +44,7 @@ template<typename TPlaceholder> static bool InitializeEmptyPlaceholder(const cha
 static bool AddXAttr(const char* path, const char* name, const void* value, size_t size);
 static bool GetXAttr(const char* path, const char* name, size_t size, _Out_ void* value);
 
-static PrjFS_NotificationType KUMessageTypeToNotificationType(MessageType kuNotificationType);
+static inline PrjFS_NotificationType KUMessageTypeToNotificationType(MessageType kuNotificationType);
 
 static bool IsVirtualizationRoot(const char* path);
 static void CombinePaths(const char* root, const char* relative, char (&combined)[PrjFSMaxPath]);

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -458,6 +458,7 @@ static void HandleKernelRequest(Message request, void* messageMemory)
         
         case MessageType_KtoU_NotifyFileRenamed:
         case MessageType_KtoU_NotifyDirectoryRenamed:
+        case MessageType_KtoU_NotifyFileHardLinkCreated:
         {
             char fullPath[PrjFSMaxPath];
             CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
@@ -465,11 +466,22 @@ static void HandleKernelRequest(Message request, void* messageMemory)
             // TODO(Mac): Handle SetBitInFileFlags failures
             SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
 
+            bool isDirectory = requestHeader->messageType == MessageType_KtoU_NotifyDirectoryRenamed;
+            PrjFS_NotificationType notificationType;
+            if (requestHeader->messageType == MessageType_KtoU_NotifyFileHardLinkCreated)
+            {
+                notificationType = PrjFS_NotificationType_HardLinkCreated;
+            }
+            else
+            {
+                notificationType = PrjFS_NotificationType_FileRenamed;
+            }
+            
             result = HandleFileNotification(
                 requestHeader,
                 request.path,
-                requestHeader->messageType == MessageType_KtoU_NotifyDirectoryRenamed,  // isDirectory
-                PrjFS_NotificationType_FileRenamed);
+                isDirectory,
+                notificationType);
             break;
         }
     }
@@ -783,6 +795,8 @@ static const char* NotificationTypeToString(PrjFS_NotificationType notificationT
             return STRINGIFY(PrjFS_NotificationType_PreDelete);
         case PrjFS_NotificationType_FileRenamed:
             return STRINGIFY(PrjFS_NotificationType_FileRenamed);
+        case PrjFS_NotificationType_HardLinkCreated:
+            return STRINGIFY(PrjFS_NotificationType_HardLinkCreated);
         case PrjFS_NotificationType_PreConvertToFull:
             return STRINGIFY(PrjFS_NotificationType_PreConvertToFull);
             

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -432,21 +432,12 @@ static void HandleKernelRequest(Message request, void* messageMemory)
         }
         
         case MessageType_KtoU_NotifyFilePreDelete:
-        {
-            result = HandleFileNotification(
-                requestHeader,
-                request.path,
-                false,  // isDirectory
-                PrjFS_NotificationType_PreDelete);
-            break;
-        }
-        
         case MessageType_KtoU_NotifyDirectoryPreDelete:
         {
             result = HandleFileNotification(
                 requestHeader,
                 request.path,
-                true,  // isDirectory
+                requestHeader->messageType == MessageType_KtoU_NotifyDirectoryPreDelete,  // isDirectory
                 PrjFS_NotificationType_PreDelete);
             break;
         }
@@ -455,8 +446,6 @@ static void HandleKernelRequest(Message request, void* messageMemory)
         {
             char fullPath[PrjFSMaxPath];
             CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
-			
-            // TODO(Mac): Handle SetBitInFileFlags failures
             SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
         
             result = HandleFileNotification(
@@ -464,6 +453,23 @@ static void HandleKernelRequest(Message request, void* messageMemory)
                 request.path,
                 false,  // isDirectory
                 PrjFS_NotificationType_NewFileCreated);
+            break;
+        }
+        
+        case MessageType_KtoU_NotifyFileRenamed:
+        case MessageType_KtoU_NotifyDirectoryRenamed:
+        {
+            char fullPath[PrjFSMaxPath];
+            CombinePaths(s_virtualizationRootFullPath.c_str(), request.path, fullPath);
+			
+            // TODO(Mac): Handle SetBitInFileFlags failures
+            SetBitInFileFlags(fullPath, FileFlags_IsInVirtualizationRoot, true);
+
+            result = HandleFileNotification(
+                requestHeader,
+                request.path,
+                requestHeader->messageType == MessageType_KtoU_NotifyDirectoryRenamed,  // isDirectory
+                PrjFS_NotificationType_FileRenamed);
             break;
         }
     }

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -46,6 +46,7 @@ typedef enum
     PrjFS_NotificationType_NewFileCreated           = 0x00000004,
     PrjFS_NotificationType_PreDelete                = 0x00000010,
     PrjFS_NotificationType_FileRenamed              = 0x00000080,
+    PrjFS_NotificationType_HardLinkCreated          = 0x00000100,
     PrjFS_NotificationType_PreConvertToFull         = 0x00001000,
     
     PrjFS_NotificationType_PreModify                = 0x10000001,


### PR DESCRIPTION
Part of the work for #152 and fixes #200.

*Summary of changes*

- Added hardlink notifications to VFSForGit for Mac and Windows
- Added new hardlink functional tests
- Added rename notifications on Mac
- Enabled additional functional tests on Mac

*Future work*

Unlike VFSForGit on Windows, on Mac users can rename\move folders have not been expanded.  To ensure that all placeholders are on disk prior to the rename the folder must be expanded in the PreDelete notification (#202)

Functional test run (on Mac) with these changes:

```
Test Run Summary
  Overall result: Warning
  Test Count: 206, Passed: 204, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 2
    Skipped Tests - Ignored: 2, Explicit: 0, Other: 0
  Start time: 2018-08-22 22:09:59Z
    End time: 2018-08-22 22:14:22Z
    Duration: 263.482 seconds
``` 