### PR TITLE
Remove temp paths from ModifiedPathsDatabase

### DIFF
--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -138,7 +138,11 @@ namespace GVFS.Common
             metadata.Add("Area", "ModifiedPathsDatabase");
             metadata.Add(nameof(entry), entry);
             metadata.Add(nameof(isFolder), isFolder);
-            metadata.Add("Exception", e.ToString());
+            if (e != null)
+            {
+                metadata.Add("Exception", e.ToString());
+            }
+
             return metadata;
         }
 

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -84,8 +84,6 @@ namespace GVFS.Common
                     isRetryable = false;
                     return false;
                 }
-
-                return true;
             }
 
             return true;
@@ -113,8 +111,6 @@ namespace GVFS.Common
                     isRetryable = false;
                     return false;
                 }
-
-                return true;
             }
 
             return true;

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
@@ -324,24 +324,30 @@ namespace GVFS.FunctionalTests.Windows.Tests
             this.Enlistment.MountGVFS();
             this.Enlistment.UnmountGVFS();
 
-            string expectedModifiedPaths = @"A .gitattributes
-A developer/me/
-A developer/me/JLANGE9._prerazzle
-A developer/me/StateSwitch.Save
-A tools/x86/remote.exe
-A tools/x86/runelevated.exe
-A tools/amd64/remote.exe
-A tools/amd64/runelevated.exe
-A tools/perllib/MS/TraceLogging.dll
-A tools/managed/v2.0/midldd.CheckedInExe
-A tools/managed/v4.0/sdapi.dll
-A tools/managed/v2.0/midlpars.dll
-A tools/managed/v2.0/RPCDataSupport.dll
-A tools/managed/v2.0/MidlStaticAnalysis.dll
-A tools/perllib/MS/Somefile.txt
-";
+            string[] expectedModifiedPaths =
+                {
+                    "A .gitattributes",
+                    "A developer/me/",
+                    "A developer/me/JLANGE9._prerazzle",
+                    "A developer/me/StateSwitch.Save",
+                    "A tools/x86/remote.exe",
+                    "A tools/x86/runelevated.exe",
+                    "A tools/amd64/remote.exe",
+                    "A tools/amd64/runelevated.exe",
+                    "A tools/perllib/MS/TraceLogging.dll",
+                    "A tools/managed/v2.0/midldd.CheckedInExe",
+                    "A tools/managed/v4.0/sdapi.dll",
+                    "A tools/managed/v2.0/midlpars.dll",
+                    "A tools/managed/v2.0/RPCDataSupport.dll",
+                    "A tools/managed/v2.0/MidlStaticAnalysis.dll",
+                    "A tools/perllib/MS/Somefile.txt",
+                };
 
-            modifiedPathsDatabasePath.ShouldBeAFile(this.fileSystem).WithContents(expectedModifiedPaths);
+            modifiedPathsDatabasePath.ShouldBeAFile(this.fileSystem);
+            this.fileSystem.ReadAllText(modifiedPathsDatabasePath)
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .OrderBy(x => x)
+                .ShouldMatchInOrder(expectedModifiedPaths.OrderBy(x => x));
 
             this.ValidatePersistedVersionMatchesCurrentVersion();
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -88,7 +88,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string renamedFolderName = "folder3b";
             string[] expectedModifiedEntries =
             {
-                folderName + "/",
                 renamedFolderName + "/",
             };
 
@@ -110,19 +109,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string[] fileNames = { "a", "b", "c" };
             string[] expectedModifiedEntries =
             {
-                renamedFolderName + "/" + fileNames[0],
-                renamedFolderName + "/" + fileNames[1],
-                renamedFolderName + "/" + fileNames[2],
-                folderName + "/" + fileNames[0],
-                folderName + "/" + fileNames[1],
-                folderName + "/" + fileNames[2],
+                renamedFolderName + "/",
             };
 
             this.Enlistment.GetVirtualPathTo(folderName).ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.CreateDirectory(this.Enlistment.GetVirtualPathTo(folderName));
             foreach (string fileName in fileNames)
             {
-                string filePath = folderName + "\\" + fileName;
+                string filePath = Path.Combine(folderName, fileName);
                 this.fileSystem.CreateEmptyFile(this.Enlistment.GetVirtualPathTo(filePath));
                 this.Enlistment.GetVirtualPathTo(filePath).ShouldBeAFile(this.fileSystem);
             }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -132,22 +132,32 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [Category(Categories.MacTODO.M2)]
         public void CaseOnlyRenameOfNewFolderKeepsModifiedPathsEntries()
         {
-            string[] expectedModifiedPathsEntries =
+            if (this.fileSystem is PowerShellRunner)
             {
-                "Folder/",
-                "Folder/testfile",
+                Assert.Ignore("Powershell does not support case only renames.");
+            }
+
+            string[] expectedModifiedPathsEntriesAfterCreate =
+            {
+                "A Folder/",
+                "A Folder/testfile",
+            };
+
+            string[] expectedModifiedPathsEntriesAfterRename =
+            {
+                "A folder/",
             };
 
             this.fileSystem.CreateDirectory(Path.Combine(this.Enlistment.RepoRoot, "Folder"));
             this.fileSystem.CreateEmptyFile(Path.Combine(this.Enlistment.RepoRoot, "Folder", "testfile"));
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedPathsEntries);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedPathsEntriesAfterCreate);
 
             this.fileSystem.RenameDirectory(this.Enlistment.RepoRoot, "Folder", "folder");
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
-            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedPathsEntries);
+            GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, expectedModifiedPathsEntriesAfterRename);
         }
 
         [TestCase, Order(7)]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -34,7 +34,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
                 $"A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}",
                 $"A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}",
                 $"A {FolderToCreate}/",
-                $"A {FolderToRename}/",
                 $"A {RenameFolderTarget}/",
                 $"A {RenameNewDotGitFileTarget}",
                 $"A {FileToCreateOutsideRepo}",
@@ -162,11 +161,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
         public void ModifiedPathsCorrectAfterHardLinking(FileSystemRunner fileSystem)
         {
-            const string ExpectedModifiedFilesContentsAfterHardlinks =
-@"A .gitattributes
-A LinkToReadme.md
-A LinkToFileOutsideSrc.txt
-";
+            string[] expectedModifiedFilesContentsAfterHardlinks =
+                {
+                    "A .gitattributes",
+                    "A LinkToReadme.md",
+                    "A LinkToFileOutsideSrc.txt",
+                };
 
             // Create a link from src\LinkToReadme.md to src\Readme.md
             string existingFileInRepoPath = this.Enlistment.GetVirtualPathTo("Readme.md");
@@ -198,7 +198,8 @@ A LinkToFileOutsideSrc.txt
             modifiedPathsDatabase.ShouldBeAFile(fileSystem);
             using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {
-                reader.ReadToEnd().ShouldEqual(ExpectedModifiedFilesContentsAfterHardlinks);
+                reader.ReadToEnd().Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x)
+                    .ShouldMatchInOrder(expectedModifiedFilesContentsAfterHardlinks.OrderBy(x => x));
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -109,7 +109,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string folderToRenameTarget = this.Enlistment.GetVirtualPathTo(RenameFolderTarget);
             fileSystem.MoveDirectory(folderToRename, folderToRenameTarget);
 
-            // Moving the new folder out of the repo should not change the modified paths
+            // Moving the new folder out of the repo should not change the modified paths file
             string folderTargetOutsideSrc = Path.Combine(this.Enlistment.EnlistmentRoot, RenameFolderTarget);
             folderTargetOutsideSrc.ShouldNotExistOnDisk(fileSystem);
             fileSystem.MoveDirectory(folderToRenameTarget, folderTargetOutsideSrc);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -34,7 +34,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
                 $"A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}",
                 $"A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}",
                 $"A {FolderToCreate}/",
-                $"A {RenameFolderTarget}/",
                 $"A {RenameNewDotGitFileTarget}",
                 $"A {FileToCreateOutsideRepo}",
                 $"A {FolderToCreateOutsideRepo}/",
@@ -108,7 +107,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string folderToRenameTarget = this.Enlistment.GetVirtualPathTo(RenameFolderTarget);
             fileSystem.MoveDirectory(folderToRename, folderToRenameTarget);
 
-            // Moving the new folder out of the repo should not change the modified paths file
+            // Moving the new folder out of the repo will remove it from the modified paths file
             string folderTargetOutsideSrc = Path.Combine(this.Enlistment.EnlistmentRoot, RenameFolderTarget);
             folderTargetOutsideSrc.ShouldNotExistOnDisk(fileSystem);
             fileSystem.MoveDirectory(folderToRenameTarget, folderTargetOutsideSrc);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -3,7 +3,9 @@ using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
+using System;
 using System.IO;
+using System.Linq;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
@@ -23,26 +25,64 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         private static readonly string FileToCreateOutsideRepo = $"{nameof(ModifiedPathsTests)}_outsideRepo.txt";
         private static readonly string FolderToCreateOutsideRepo = $"{nameof(ModifiedPathsTests)}_outsideFolder";
         private static readonly string FolderToDelete = "Scripts";
-        private static readonly string ExpectedModifiedFilesContentsAfterRemount = 
-$@"A .gitattributes
-A {GVFSHelpers.ConvertPathToGitFormat(FileToAdd)}
-A {GVFSHelpers.ConvertPathToGitFormat(FileToUpdate)}
-A {FileToDelete}
-A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}
-A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}
-A {FolderToCreate}/
-A {FolderToRename}/
-A {RenameFolderTarget}/
-A {RenameNewDotGitFileTarget}
-A {FileToCreateOutsideRepo}
-A {FolderToCreateOutsideRepo}/
-A {FolderToDelete}/CreateCommonAssemblyVersion.bat
-A {FolderToDelete}/CreateCommonCliAssemblyVersion.bat
-A {FolderToDelete}/CreateCommonVersionHeader.bat
-A {FolderToDelete}/RunFunctionalTests.bat
-A {FolderToDelete}/RunUnitTests.bat
-A {FolderToDelete}/
-";
+        private static readonly string[] ExpectedModifiedFilesContentsAfterRemount =
+            {
+                $"A .gitattributes",
+                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToAdd)}",
+                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToUpdate)}",
+                $"A {FileToDelete}",
+                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}",
+                $"A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}",
+                $"A {FolderToCreate}/",
+                $"A {FolderToRename}/",
+                $"A {RenameFolderTarget}/",
+                $"A {RenameNewDotGitFileTarget}",
+                $"A {FileToCreateOutsideRepo}",
+                $"A {FolderToCreateOutsideRepo}/",
+                $"A {FolderToDelete}/CreateCommonAssemblyVersion.bat",
+                $"A {FolderToDelete}/CreateCommonCliAssemblyVersion.bat",
+                $"A {FolderToDelete}/CreateCommonVersionHeader.bat",
+                $"A {FolderToDelete}/RunFunctionalTests.bat",
+                $"A {FolderToDelete}/RunUnitTests.bat",
+                $"A {FolderToDelete}/",
+            };
+
+        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        public void DeletedTempFileIsRemovedFromModifiedFiles(FileSystemRunner fileSystem)
+        {
+            string tempFile = this.CreateFile(fileSystem, "temp.txt");
+            fileSystem.DeleteFile(tempFile);
+            tempFile.ShouldNotExistOnDisk(fileSystem);
+
+            this.Enlistment.UnmountGVFS();
+            this.ValidateModifiedPathsDoNotContain(fileSystem, "temp.txt");
+        }
+
+        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        public void DeletedTempFolderIsRemovedFromModifiedFiles(FileSystemRunner fileSystem)
+        {
+            string tempFolder = this.CreateDirectory(fileSystem, "Temp");
+            fileSystem.DeleteDirectory(tempFolder);
+            tempFolder.ShouldNotExistOnDisk(fileSystem);
+
+            this.Enlistment.UnmountGVFS();
+            this.ValidateModifiedPathsDoNotContain(fileSystem, "Temp/");
+        }
+
+        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        public void DeletedTempFolderDeletesFilesFromModifiedFiles(FileSystemRunner fileSystem)
+        {
+            string tempFolder = this.CreateDirectory(fileSystem, "Temp");
+            string tempFile1 = this.CreateFile(fileSystem, Path.Combine("Temp", "temp1.txt"));
+            string tempFile2 = this.CreateFile(fileSystem, Path.Combine("Temp", "temp2.txt"));
+            fileSystem.DeleteDirectory(tempFolder);
+            tempFolder.ShouldNotExistOnDisk(fileSystem);
+            tempFile1.ShouldNotExistOnDisk(fileSystem);
+            tempFile2.ShouldNotExistOnDisk(fileSystem);
+
+            this.Enlistment.UnmountGVFS();
+            this.ValidateModifiedPathsDoNotContain(fileSystem, "Temp/", "Temp/temp1.txt", "Temp/temp2.txt");
+        }
 
         [Category(Categories.MacTODO.M2)]
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
@@ -114,7 +154,8 @@ A {FolderToDelete}/
             modifiedPathsDatabase.ShouldBeAFile(fileSystem);
             using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {
-                reader.ReadToEnd().ShouldEqual(ExpectedModifiedFilesContentsAfterRemount);
+                reader.ReadToEnd().Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x)
+                    .ShouldMatchInOrder(ExpectedModifiedFilesContentsAfterRemount.OrderBy(x => x));
             }
         }
 
@@ -159,6 +200,28 @@ A LinkToFileOutsideSrc.txt
             {
                 reader.ReadToEnd().ShouldEqual(ExpectedModifiedFilesContentsAfterHardlinks);
             }
+        }
+
+        private string CreateDirectory(FileSystemRunner fileSystem, string relativePath)
+        {
+            string tempFolder = this.Enlistment.GetVirtualPathTo(relativePath);
+            fileSystem.CreateDirectory(tempFolder);
+            tempFolder.ShouldBeADirectory(fileSystem);
+            return tempFolder;
+        }
+
+        private string CreateFile(FileSystemRunner fileSystem, string relativePath)
+        {
+            string tempFile = this.Enlistment.GetVirtualPathTo(relativePath);
+            fileSystem.WriteAllText(tempFile, $"Contents for the {relativePath} file");
+            tempFile.ShouldBeAFile(fileSystem);
+            return tempFile;
+        }
+
+        private void ValidateModifiedPathsDoNotContain(FileSystemRunner fileSystem, params string[] paths)
+        {
+            GVFSHelpers.ModifiedPathsShouldNotContain(fileSystem, this.Enlistment.DotGVFSRoot, paths.Select(x => $"A {x}" + Environment.NewLine).ToArray());
+            GVFSHelpers.ModifiedPathsShouldNotContain(fileSystem, this.Enlistment.DotGVFSRoot, paths.Select(x => $"D {x}" + Environment.NewLine).ToArray());
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1041,7 +1041,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             fileSystemAction();
             this.ValidateGitCommand("status");
             this.ValidateGitCommand(addCommand);
-            this.RunGitCommand("commit -m \"BasicCommit for {test}\"");
+            this.RunGitCommand($"commit -m \"BasicCommit for {test}\"");
         }
 
         private void SwitchBranch(Action fileSystemAction, [CallerMemberName]string test = GitCommandsTests.UnknownTestName)

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -352,7 +352,7 @@ namespace GVFS.Platform.Mac
                 }
                 else
                 {
-                    this.OnWorkingDirectoryFileOrFolderDeleted(relativePath, isDirectory);
+                    this.OnWorkingDirectoryFileOrFolderDeleteNotification(relativePath, isDirectory, isPreDelete: true);
                 }
             }
             catch (Exception e)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1296,7 +1296,7 @@ namespace GVFS.Platform.Windows
                     }
                     else
                     {
-                        this.OnWorkingDirectoryFileOrFolderDeleted(virtualPath, isDirectory);
+                        this.OnWorkingDirectoryFileOrFolderDeleteNotification(virtualPath, isDirectory, isPreDelete: false);
                     }
                 }
             }

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
@@ -29,7 +29,9 @@ namespace GVFS.Virtualization.Background
             OnFolderFirstWrite,
             OnIndexWriteWithoutProjectionChange,
             OnPlaceholderCreationsBlockedForGit,
-            OnFileHardLinkCreated
+            OnFileHardLinkCreated,
+            OnFilePreDelete,
+            OnFolderPreDelete,
         }
 
         public OperationType Operation { get; }
@@ -55,6 +57,11 @@ namespace GVFS.Virtualization.Background
         public static FileSystemTask OnFileDeleted(string virtualPath)
         {
             return new FileSystemTask(OperationType.OnFileDeleted, virtualPath, oldVirtualPath: null);
+        }
+
+        public static FileSystemTask OnFilePreDelete(string virtualPath)
+        {
+            return new FileSystemTask(OperationType.OnFilePreDelete, virtualPath, oldVirtualPath: null);
         }
 
         public static FileSystemTask OnFileOverwritten(string virtualPath)
@@ -95,6 +102,11 @@ namespace GVFS.Virtualization.Background
         public static FileSystemTask OnFolderDeleted(string virtualPath)
         {
             return new FileSystemTask(OperationType.OnFolderDeleted, virtualPath, oldVirtualPath: null);
+        }
+
+        public static FileSystemTask OnFolderPreDelete(string virtualPath)
+        {
+            return new FileSystemTask(OperationType.OnFolderPreDelete, virtualPath, oldVirtualPath: null);
         }
 
         public static FileSystemTask OnIndexWriteWithoutProjectionChange()

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -185,7 +185,7 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
-        protected void OnWorkingDirectoryFileOrFolderDeleted(string relativePath, bool isDirectory)
+        protected void OnWorkingDirectoryFileOrFolderDeleteNotification(string relativePath, bool isDirectory, bool isPreDelete)
         {
             if (isDirectory)
             {
@@ -193,12 +193,26 @@ namespace GVFS.Virtualization.FileSystem
                 GitCommandLineParser gitCommand = new GitCommandLineParser(this.Context.Repository.GVFSLock.GetLockedGitCommand());
                 if (!gitCommand.IsValidGitCommand)
                 {
-                    this.FileSystemCallbacks.OnFolderDeleted(relativePath);
+                    if (isPreDelete)
+                    {
+                        this.FileSystemCallbacks.OnFolderPreDelete(relativePath);
+                    }
+                    else
+                    {
+                        this.FileSystemCallbacks.OnFolderDeleted(relativePath);
+                    }
                 }
             }
             else
             {
-                this.FileSystemCallbacks.OnFileDeleted(relativePath);
+                if (isPreDelete)
+                {
+                    this.FileSystemCallbacks.OnFilePreDelete(relativePath);
+                }
+                else
+                {
+                    this.FileSystemCallbacks.OnFileDeleted(relativePath);
+                }
             }
 
             this.FileSystemCallbacks.InvalidateGitStatusCache();

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -661,6 +661,9 @@ namespace GVFS.Virtualization
                     break;
 
                 case FileSystemTask.OperationType.OnFilePreDelete:
+                    // This code assumes that the current implementations of FileSystemVirtualizer will call either
+                    // the PreDelete or the Delete not both so if a new implementation starts calling both
+                    // this will need to be cleaned up to not duplicate the work that is being done.
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.VirtualPath))
                     {
@@ -682,6 +685,9 @@ namespace GVFS.Virtualization
                     break;
 
                 case FileSystemTask.OperationType.OnFileDeleted:
+                    // This code assumes that the current implementations of FileSystemVirtualizer will call either
+                    // the PreDelete or the Delete not both so if a new implementation starts calling both
+                    // this will need to be cleaned up to not duplicate the work that is being done.
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.VirtualPath))
                     {
@@ -796,6 +802,9 @@ namespace GVFS.Virtualization
                     break;
 
                 case FileSystemTask.OperationType.OnFolderPreDelete:
+                    // This code assumes that the current implementations of FileSystemVirtualizer will call either
+                    // the PreDelete or the Delete not both so if a new implementation starts calling both
+                    // this will need to be cleaned up to not duplicate the work that is being done.
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.VirtualPath))
                     {
@@ -817,6 +826,9 @@ namespace GVFS.Virtualization
                     break;
 
                 case FileSystemTask.OperationType.OnFolderDeleted:
+                    // This code assumes that the current implementations of FileSystemVirtualizer will call either
+                    // the PreDelete or the Delete not both so if a new implementation starts calling both
+                    // this will need to be cleaned up to not duplicate the work that is being done.
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.VirtualPath))
                     {

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -425,7 +425,6 @@ namespace GVFS.Virtualization
 
         public virtual void OnFileRenamed(string oldRelativePath, string newRelativePath)
         {
-            this.newlyCreatedFileAndFolderPaths.Add(newRelativePath);
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileRenamed(oldRelativePath, newRelativePath));
         }
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -718,20 +718,22 @@ namespace GVFS.Virtualization
                     metadata.Add("oldVirtualPath", gitUpdate.OldVirtualPath);
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
 
+                    if (!string.IsNullOrEmpty(gitUpdate.OldVirtualPath) &&
+                        this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.OldVirtualPath))
+                    {
+                        result = this.TryRemoveModifiedPath(gitUpdate.OldVirtualPath, isFolder: true);
+                    }
+
                     // An empty destination path means the folder was renamed to somewhere outside of the repo
                     // Note that only full folders can be moved\renamed, and so there will already be a recursive
                     // sparse-checkout entry for the virtualPath of the folder being moved (meaning that no 
                     // additional work is needed for any files\folders inside the folder being moved)
-                    if (!string.IsNullOrEmpty(gitUpdate.VirtualPath))
+                    if (result == FileSystemTaskResult.Success && !string.IsNullOrEmpty(gitUpdate.VirtualPath))
                     {
                         result = this.TryAddModifiedPath(gitUpdate.VirtualPath, isFolder: true);
                         if (result == FileSystemTaskResult.Success)
                         {
                             this.newlyCreatedFileAndFolderPaths.Add(gitUpdate.VirtualPath);
-                            if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.OldVirtualPath))
-                            {
-                                result = this.TryRemoveModifiedPath(gitUpdate.OldVirtualPath, isFolder: true);
-                            }
 
                             Queue<string> relativeFolderPaths = new Queue<string>();
                             relativeFolderPaths.Enqueue(gitUpdate.VirtualPath);

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -691,14 +691,10 @@ namespace GVFS.Virtualization
                         result = this.TryAddModifiedPath(gitUpdate.VirtualPath, isFolder: true);
                         if (result == FileSystemTaskResult.Success)
                         {
-                            if (!this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.VirtualPath))
-                            {
-                                this.newlyCreatedFileAndFolderPaths.Add(gitUpdate.VirtualPath);
-                            }
-
+                            this.newlyCreatedFileAndFolderPaths.Add(gitUpdate.VirtualPath);
                             if (this.newlyCreatedFileAndFolderPaths.Contains(gitUpdate.OldVirtualPath))
                             {
-                                this.TryRemoveModifiedPath(gitUpdate.OldVirtualPath, isFolder: true);
+                                result = this.TryRemoveModifiedPath(gitUpdate.OldVirtualPath, isFolder: true);
                             }
 
                             Queue<string> relativeFolderPaths = new Queue<string>();
@@ -716,14 +712,11 @@ namespace GVFS.Virtualization
                                         {
                                             string itemVirtualPath = Path.Combine(folderPath, itemInfo.Name);
                                             string oldItemVirtualPath = gitUpdate.OldVirtualPath + itemVirtualPath.Substring(gitUpdate.VirtualPath.Length);
-                                            if (!this.newlyCreatedFileAndFolderPaths.Contains(itemVirtualPath))
-                                            {
-                                                this.newlyCreatedFileAndFolderPaths.Add(itemVirtualPath);
-                                            }
 
+                                            this.newlyCreatedFileAndFolderPaths.Add(itemVirtualPath);
                                             if (this.newlyCreatedFileAndFolderPaths.Contains(oldItemVirtualPath))
                                             {
-                                                this.TryRemoveModifiedPath(oldItemVirtualPath, isFolder: itemInfo.IsDirectory);
+                                                result = this.TryRemoveModifiedPath(oldItemVirtualPath, isFolder: itemInfo.IsDirectory);
                                             }
 
                                             if (itemInfo.IsDirectory)


### PR DESCRIPTION
Builds and other processes will write temp files or create temp directories in the source directory which then adds the file or folder path to the ModifiedPathsDatabase.  This causes performance issues because the ModifiedPathsDatabase is currently append only.

This PR is an initial change to address the issue of files or folder being created and deleted.  This change only removes from the ModifiedPathsDatabase when the file or folder was created and then delete and the index has not changed in between to solve the issue with builds and other processes creating and deleting a bunch of files and folders.

See #117 