### PR TITLE
Don't perform upgrade when local ring is set to None

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -84,10 +84,20 @@ namespace GVFS.Common
         {
             List<Release> releases;
 
-            if (this.TryLoadRingConfig(out errorMessage) && 
-                this.TryFetchReleases(out releases, out errorMessage))
+            newVersion = null;
+            if (!this.TryLoadRingConfig(out errorMessage))
             {
-                newVersion = null;
+                return false;
+            }
+
+            if (this.Ring == RingType.None)
+            {
+                errorMessage = "Upgrade ring set to None. No upgrade check was performed.";
+                return false;
+            }
+
+            if (this.TryFetchReleases(out releases, out errorMessage))
+            {
                 foreach (Release nextRelease in releases)
                 {
                     Version releaseVersion;
@@ -105,7 +115,6 @@ namespace GVFS.Common
                 return true;
             }
 
-            newVersion = null;
             return false;
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
@@ -21,7 +21,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.None,
-                expectedReturn: false,
+                expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
 
@@ -32,7 +32,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.None,
-                expectedReturn: false,
+                expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
@@ -21,6 +21,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.None,
+                expectedReturn: false,
                 expectedUpgradeVersion: null);
         }
 
@@ -31,6 +32,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.None,
+                expectedReturn: false,
                 expectedUpgradeVersion: null);
         }
 
@@ -41,6 +43,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.Slow,
+                expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
 
@@ -51,6 +54,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.Slow,
+                expectedReturn: true,
                 expectedUpgradeVersion: UpgradeTests.NewerThanLocalVersion);
         }
 
@@ -61,6 +65,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing: ProductUpgrader.RingType.Fast,
+                expectedReturn: true,
                 expectedUpgradeVersion: UpgradeTests.NewerThanLocalVersion);
         }
 
@@ -71,6 +76,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 remoteRing: ProductUpgrader.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
                 localRing:ProductUpgrader.RingType.Fast,
+                expectedReturn: true,
                 expectedUpgradeVersion:UpgradeTests.NewerThanLocalVersion);
         }
 
@@ -87,6 +93,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             ProductUpgrader.RingType remoteRing,
             string remoteVersion,
             ProductUpgrader.RingType localRing,
+            bool expectedReturn,
             string expectedUpgradeVersion)
         {
             this.Upgrader.LocalRingConfig = localRing;
@@ -96,7 +103,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
             Version newVersion;
             string errorMessage;
-            this.Upgrader.TryGetNewerVersion(out newVersion, out errorMessage).ShouldEqual(true);
+            this.Upgrader.TryGetNewerVersion(out newVersion, out errorMessage).ShouldEqual(expectedReturn);
 
             if (string.IsNullOrEmpty(expectedUpgradeVersion))
             {

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
@@ -62,41 +62,21 @@ namespace GVFS.UnitTests.Windows.Upgrader
         }
 
         [TestCase]
-        public void InvalidUpgradeRing()
+        public override void NoneLocalRing()
         {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.Upgrader.LocalRingConfig = GVFS.Common.ProductUpgrader.RingType.Invalid;
-                },
-                expectedReturn: ReturnCode.GenericError,
-                expectedOutput: new List<string>
-                {
-                    "Invalid upgrade ring type(Invalid) specified in Git config."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Invalid upgrade ring type(Invalid) specified in Git config."
-                });
+            base.NoneLocalRing();
         }
 
         [TestCase]
-        public void FetchReleaseInfoError()
+        public override void InvalidUpgradeRing()
         {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.Upgrader.SetFailOnAction(MockProductUpgrader.ActionType.FetchReleaseInfo);
-                },
-                expectedReturn: ReturnCode.GenericError,
-                expectedOutput: new List<string>
-                {
-                    "Error fetching upgrade release info."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Error fetching upgrade release info."
-                });
+            base.InvalidUpgradeRing();
+        }
+
+        [TestCase]
+        public override void FetchReleaseInfo()
+        {
+            base.FetchReleaseInfo();
 
             this.CallSequenceTracker.VerifyMethodsNotCalled(
                 new List<string>()

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -37,20 +37,19 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
         public virtual void NoneLocalRing()
         {
-            string errorString = "Upgrade ring set to None. No upgrade check was performed.";
+            string message = "Upgrade ring set to None. No upgrade check was performed.";
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
                     this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.None;
                 },
-                expectedReturn: ReturnCode.GenericError,
+                expectedReturn: ReturnCode.Success,
                 expectedOutput: new List<string>
                 {
-                    errorString
+                    message
                 },
                 expectedErrors: new List<string>
                 {
-                    errorString
                 });
         }
 
@@ -112,7 +111,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             {
                 this.Output.AllLines.ShouldContain(
                 expectedOutput,
-                (line, expectedLine) => { return line.Equals(expectedLine, StringComparison.Ordinal); });
+                (line, expectedLine) => { return line.Contains(expectedLine); });
             }
 
             if (expectedErrors != null)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -35,6 +35,63 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.Slow;
         }
 
+        public virtual void NoneLocalRing()
+        {
+            string errorString = "Upgrade ring set to None. No upgrade check was performed.";
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.None;
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    errorString
+                },
+                expectedErrors: new List<string>
+                {
+                    errorString
+                });
+        }
+
+        public virtual void InvalidUpgradeRing()
+        {
+            string errorString = "Invalid upgrade ring type(Invalid) specified in Git config.";
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.LocalRingConfig = GVFS.Common.ProductUpgrader.RingType.Invalid;
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    errorString
+                },
+                expectedErrors: new List<string>
+                {
+                    errorString
+                });
+        }
+
+        public virtual void FetchReleaseInfo()
+        {
+            string errorString = "Error fetching upgrade release info.";
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.SetFailOnAction(MockProductUpgrader.ActionType.FetchReleaseInfo);
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    errorString
+                },
+                expectedErrors: new List<string>
+                {
+                    errorString
+                });
+        }
+
         protected abstract void RunUpgrade();
 
         protected abstract ReturnCode ExitCode();

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -88,43 +88,23 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
-        public void InvalidLocalRing()
+        public override void NoneLocalRing()
         {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.Invalid;
-                },
-                expectedReturn: ReturnCode.GenericError,
-                expectedOutput: new List<string>
-                {
-                    "Checking for GVFS upgrades...Failed",
-                    "Invalid upgrade ring type(Invalid) specified in Git config."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Invalid upgrade ring type(Invalid) specified in Git config."
-                });
+            base.NoneLocalRing();
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
-        public void FetchReleaseInfo()
+        public override void InvalidUpgradeRing()
         {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.Upgrader.SetFailOnAction(MockProductUpgrader.ActionType.FetchReleaseInfo);
-                },
-                expectedReturn: ReturnCode.GenericError,
-                expectedOutput: new List<string>
-                {
-                    "Error fetching upgrade release info."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Upgrade checks failed. Error fetching upgrade release info"
-                });
+            base.InvalidUpgradeRing();
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public override void FetchReleaseInfo()
+        {
+            base.FetchReleaseInfo();
         }
 
         [TestCase]

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -65,25 +65,35 @@ namespace GVFS.Upgrader
         public void Execute()
         {
             string error = null;
-            try
-            {
-                Version newVersion = null;
-                if (!this.TryRunUpgradeInstall(out newVersion, out error))
-                {
-                    this.ExitCode = ReturnCode.GenericError;
-                }
-            }
-            finally
-            {
-                string cleanUpError = null;
-                if (!this.TryRunCleanUp(out cleanUpError))
-                {
-                    error = string.IsNullOrEmpty(error) ? cleanUpError : error + Environment.NewLine + cleanUpError;
-                    this.ExitCode = ReturnCode.GenericError;
-                }
-            }
+            string finishMessage = null;
 
-            string finishMessage = "Finished upgrade";
+            if (this.upgrader.IsNoneRing())
+            {
+                finishMessage = "Upgrade ring set to None. No upgrade check was performed.";
+            }
+            else
+            {
+                try
+                {
+                    Version newVersion = null;
+                    if (!this.TryRunUpgradeInstall(out newVersion, out error))
+                    {
+                        this.ExitCode = ReturnCode.GenericError;
+                    }
+                }
+                finally
+                {
+                    string cleanUpError = null;
+                    if (!this.TryRunCleanUp(out cleanUpError))
+                    {
+                        error = string.IsNullOrEmpty(error) ? cleanUpError : error + Environment.NewLine + cleanUpError;
+                        this.ExitCode = ReturnCode.GenericError;
+                    }
+                }
+
+                finishMessage = "Finished upgrade";
+            }
+            
             if (this.ExitCode == ReturnCode.GenericError)
             {
                 finishMessage = "Upgrade finished with errors";

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -76,6 +76,15 @@ namespace GVFS.CommandLine
             string error = null;
             Version newestVersion = null;
             bool isInstallable = false;
+
+            if (this.upgrader.IsNoneRing())
+            {
+                string message = "Upgrade ring set to None. No upgrade check was performed.";
+                this.tracer.RelatedInfo($"{nameof(this.TryRunProductUpgrade)}: {message}");
+                this.ReportInfoToConsole(message);
+                return true;
+            }
+
             if (!this.TryRunUpgradeChecks(out newestVersion, out isInstallable, out error))
             {
                 this.Output.WriteLine($"{error}");


### PR DESCRIPTION
- No upgrade check when local ring is set to None.
- Cleanup - Moved common upgrade tests from Upgrade Verb and Tool to base class.