### PR TITLE
Added a multithreaded hydration functional test

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -41,7 +41,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                     {
                         readException = e;
                     }
-                } );
+                });
 
                 threads[i].Start();
             }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.FileSystemRunners;
 using GVFS.FunctionalTests.Should;
 using GVFS.Tests.Should;
 using NUnit.Framework;
@@ -14,8 +14,48 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [Category(Categories.Mac.M1)]
     public class MultithreadedReadWriteTests : TestsWithEnlistmentPerFixture
     {
-        [TestCase]
-        public void CanReadUnhydratedFileInParallelWithoutTearing()
+        [TestCase, Order(1)]
+        public void CanReadVirtualFileInParallel()
+        {
+            // Note: This test MUST go first, or else it needs to ensure that it is reading a unique path compared to the
+            // other tests in this class. That applies to every directory in the path, as well as the leaf file name.
+            // Otherwise, this test loses most of its value because there will be no races occurring on creating the
+            // placeholder directories, enumerating them, and then creating a placeholder file and hydrating it.
+            
+            string fileName = Path.Combine("GVFS", "GVFS.FunctionalTests", "Tests", "LongRunningEnlistment", "GitMoveRenameTests.cs");
+            string virtualPath = this.Enlistment.GetVirtualPathTo(fileName);
+
+            Exception readException = null;
+
+            Thread[] threads = new Thread[32];
+            for (int i = 0; i < threads.Length; ++i)
+            {
+                int myIndex = i;
+                threads[i] = new Thread(() =>
+                {
+                    try
+                    {
+                        FileSystemRunner.DefaultRunner.ReadAllText(virtualPath).ShouldBeNonEmpty();
+                    }
+                    catch (Exception e)
+                    {
+                        readException = e;
+                    }
+                } );
+
+                threads[i].Start();
+            }
+
+            for (int i = 0; i < threads.Length; ++i)
+            {
+                threads[i].Join();
+            }
+
+            readException.ShouldBeNull("At least one of the reads failed");
+        }
+
+        [TestCase, Order(2)]
+        public void CanReadHydratedPlaceholderInParallel()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
             string fileName = Path.Combine("GVFS", "GVFS.FunctionalTests", "Tests", "LongRunningEnlistment", "WorkingDirectoryTests.cs");
@@ -72,6 +112,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [Order(3)]
         public void CanReadWriteAFileInParallel(FileSystemRunner fileSystem)
         {
             string fileName = @"CanReadWriteAFileInParallel";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -15,6 +15,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public class MultithreadedReadWriteTests : TestsWithEnlistmentPerFixture
     {
         [TestCase, Order(1)]
+        [Category(Categories.Windows)]
         public void CanReadVirtualFileInParallel()
         {
             // Note: This test MUST go first, or else it needs to ensure that it is reading a unique path compared to the
@@ -30,7 +31,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             Thread[] threads = new Thread[32];
             for (int i = 0; i < threads.Length; ++i)
             {
-                int myIndex = i;
                 threads[i] = new Thread(() =>
                 {
                     try


### PR DESCRIPTION
There was a previously existing functional test, but it would hydrate a file on a single thread, and then attempt to repeatedly read from it from 4 parallel threads. That test was ensuring that it's possible to read from a hydrated placeholder, but it did not cover the races that we are currently investigating on Mac.

I added a new test that uses 32 threads to concurrently read from a path that was previously completely virtual, all the way to the root of the repo. On my MacBook Pro, this test has failed every single time with 32 threads (and about 80% with 16 threads, 50% with 4 threads). I'm posting the test now to ensure that it is failing on our build servers, and anyone else's machines if you have time to test it out.

Before completing this PR, I will need to either mark the test as Windows-only, or else fix the races on Mac, though I suspect that will take longer.