### PR TITLE
RepoRegistry: Properly log error from TryGetNormalizedPath

### DIFF
--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -248,10 +248,15 @@ namespace GVFS.Service
                                 {
                                     EventMetadata metadata = new EventMetadata();
                                     metadata.Add("registration.EnlistmentRoot", registration.EnlistmentRoot);
+                                    metadata.Add("NormalizedEnlistmentRootPath", normalizedEnlistmentRootPath);
+                                    metadata.Add("ErrorMessage", errorMessage);
                                     this.tracer.RelatedWarning(metadata, $"{nameof(ReadRegistry)}: Failed to get normalized path name for registed enlistment root");
                                 }
 
-                                allRepos[normalizedEnlistmentRootPath] = registration;
+                                if (normalizedEnlistmentRootPath != null)
+                                {
+                                    allRepos[normalizedEnlistmentRootPath] = registration;
+                                }
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
While investigating a user issue with auto mount registration, I noticed that their logs contained a failure from TryGetNormalizedPath, but did not log the error message. Add that message to the logs so we can properly diagnose the issue.

Further, the 'normalizedEnlistmentRootPath' parameter becomes null, so do not add it to the dictionary in that case. Instead, it should be logged by the RelatedWarning.

Signed-off-by: Derrick Stolee <dstolee@microsoft.com>