### PR TITLE
Add EnlistmentId and MountId to ETW data for correlation

### DIFF
--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -206,7 +206,7 @@ namespace FastFetch
                 Console.WriteLine("The ParentActivityId provided (" + this.ParentActivityId + ") is not a valid GUID.");
             }
 
-            using (JsonTracer tracer = new JsonTracer("Microsoft.Git.FastFetch", parentActivityId, "FastFetch", disableTelemetry: true))
+            using (JsonTracer tracer = new JsonTracer("Microsoft.Git.FastFetch", parentActivityId, "FastFetch", enlistmentId: null, mountId: null, disableTelemetry: true))
             {
                 if (this.Verbose)
                 {

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -50,7 +50,7 @@ namespace GVFS.Common
         public abstract bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error);
         public abstract bool TryInstallGitCommandHooks(GVFSContext context, string executingDirectory, string hookName, string commandHookPath, out string errorMessage);
 
-        public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName);
+        public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId);
 
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path);
 

--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -20,13 +20,17 @@ namespace GVFS.Common.Tracing
 
         private EventLevel startStopLevel;
         private Keywords startStopKeywords;
-
         public JsonTracer(string providerName, string activityName, bool disableTelemetry = false)
-            : this(providerName, Guid.Empty, activityName, disableTelemetry)
+            : this(providerName, Guid.Empty, activityName, enlistmentId: null, mountId: null, disableTelemetry: disableTelemetry)
         {
         }
 
-        public JsonTracer(string providerName, Guid providerActivityId, string activityName, bool disableTelemetry = false)
+        public JsonTracer(string providerName, string activityName, string enlistmentId, string mountId, bool disableTelemetry = false)
+            : this(providerName, Guid.Empty, activityName, enlistmentId, mountId, disableTelemetry)
+        {
+        }
+
+        public JsonTracer(string providerName, Guid providerActivityId, string activityName, string enlistmentId, string mountId, bool disableTelemetry = false)
             : this(
                   new List<InProcEventListener>(),
                   providerActivityId,
@@ -36,7 +40,7 @@ namespace GVFS.Common.Tracing
         {
             if (!disableTelemetry)
             {
-                InProcEventListener telemetryListener = GVFSPlatform.Instance.CreateTelemetryListenerIfEnabled(providerName);
+                InProcEventListener telemetryListener = GVFSPlatform.Instance.CreateTelemetryListenerIfEnabled(providerName, enlistmentId, mountId);
                 if (telemetryListener != null)
                 {
                     this.listeners.Add(telemetryListener);
@@ -252,7 +256,6 @@ namespace GVFS.Common.Tracing
         private void WriteEvent(string eventName, EventLevel level, Keywords keywords, EventMetadata metadata, EventOpcode opcode)
         {
             string jsonPayload = metadata != null ? JsonConvert.SerializeObject(metadata) : null;
-
             foreach (InProcEventListener listener in this.listeners)
             {
                 listener.RecordMessage(eventName, this.activityId, this.parentActivityId, level, keywords, opcode, jsonPayload);

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using GVFS.Common;
+using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Tracing;
 using System;
@@ -124,7 +125,23 @@ namespace GVFS.Mount
 
         private JsonTracer CreateTracer(GVFSEnlistment enlistment, EventLevel verbosity, Keywords keywords)
         {
-            JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSMount");
+            string enlistmentId = null;
+            string mountId = null;
+
+            GitProcess git = new GitProcess(enlistment);
+            GitProcess.Result configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
+            if (!configResult.HasErrors)
+            {
+                enlistmentId = configResult.Output.Trim();
+            }
+
+            configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
+            if (!configResult.HasErrors)
+            {
+                mountId = configResult.Output.Trim();
+            }
+
+            JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSMount", enlistmentId: enlistmentId, mountId: mountId);
             tracer.AddLogFileEventListener(
                 GVFSEnlistment.GetNewGVFSLogFileName(enlistment.GVFSLogsRoot, GVFSConstants.LogFileTypes.MountProcess),
                 verbosity,

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -75,7 +75,7 @@ namespace GVFS.Platform.Mac
             return pipe;
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return null;
         }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -69,11 +69,13 @@ namespace GVFS.Platform.Windows
             return true;
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return ETWTelemetryEventListener.CreateTelemetryListenerIfEnabled(
                 this.GitInstallation.GetInstalledGitBinPath(),
-                providerName);
+                providerName,
+                enlistmentId,
+                mountId);
         }
 
         public override void InitializeEnlistmentACLs(string enlistmentPath)

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -50,7 +50,7 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return new MockListener(EventLevel.Verbose, Keywords.Telemetry);
         }


### PR DESCRIPTION
When matching up data with ETW event there is an EnlistmentId and mountId that it tied to data about the enlistment and the mounted process.  Other events are not tied to this data so when an exception happens getting the mount data that corresponds to it is not directly correlated.

This adds the EnlistmentId and MountId to the ETW data so that the data can be correlated.
