### PR TITLE
Mac: Support basic projection changes and re-categorize functional tests

### DIFF
--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -206,7 +206,7 @@ namespace FastFetch
                 Console.WriteLine("The ParentActivityId provided (" + this.ParentActivityId + ") is not a valid GUID.");
             }
 
-            using (JsonTracer tracer = new JsonTracer("Microsoft.Git.FastFetch", parentActivityId, "FastFetch", disableTelemetry: true))
+            using (JsonTracer tracer = new JsonTracer("Microsoft.Git.FastFetch", parentActivityId, "FastFetch", enlistmentId: null, mountId: null, disableTelemetry: true))
             {
                 if (this.Verbose)
                 {

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -50,7 +50,7 @@ namespace GVFS.Common
         public abstract bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error);
         public abstract bool TryInstallGitCommandHooks(GVFSContext context, string executingDirectory, string hookName, string commandHookPath, out string errorMessage);
 
-        public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName);
+        public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId);
 
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path);
 

--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -20,13 +20,17 @@ namespace GVFS.Common.Tracing
 
         private EventLevel startStopLevel;
         private Keywords startStopKeywords;
-
         public JsonTracer(string providerName, string activityName, bool disableTelemetry = false)
-            : this(providerName, Guid.Empty, activityName, disableTelemetry)
+            : this(providerName, Guid.Empty, activityName, enlistmentId: null, mountId: null, disableTelemetry: disableTelemetry)
         {
         }
 
-        public JsonTracer(string providerName, Guid providerActivityId, string activityName, bool disableTelemetry = false)
+        public JsonTracer(string providerName, string activityName, string enlistmentId, string mountId, bool disableTelemetry = false)
+            : this(providerName, Guid.Empty, activityName, enlistmentId, mountId, disableTelemetry)
+        {
+        }
+
+        public JsonTracer(string providerName, Guid providerActivityId, string activityName, string enlistmentId, string mountId, bool disableTelemetry = false)
             : this(
                   new List<InProcEventListener>(),
                   providerActivityId,
@@ -36,7 +40,7 @@ namespace GVFS.Common.Tracing
         {
             if (!disableTelemetry)
             {
-                InProcEventListener telemetryListener = GVFSPlatform.Instance.CreateTelemetryListenerIfEnabled(providerName);
+                InProcEventListener telemetryListener = GVFSPlatform.Instance.CreateTelemetryListenerIfEnabled(providerName, enlistmentId, mountId);
                 if (telemetryListener != null)
                 {
                     this.listeners.Add(telemetryListener);
@@ -252,7 +256,6 @@ namespace GVFS.Common.Tracing
         private void WriteEvent(string eventName, EventLevel level, Keywords keywords, EventMetadata metadata, EventOpcode opcode)
         {
             string jsonPayload = metadata != null ? JsonConvert.SerializeObject(metadata) : null;
-
             foreach (InProcEventListener listener in this.listeners)
             {
                 listener.RecordMessage(eventName, this.activityId, this.parentActivityId, level, keywords, opcode, jsonPayload);

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
@@ -14,7 +14,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Windows)]
+    [Category(Categories.WindowsOnly)]
     public class DiskLayoutUpgradeTests : TestsWithEnlistmentPerTestCase
     {
         public const int CurrentDiskLayoutMajorVersion = 16;

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
@@ -13,7 +13,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Windows)]
+    [Category(Categories.WindowsOnly)]
     public class JunctionAndSubstTests : TestsWithEnlistmentPerFixture
     {
         private const string SubstDrive = "Q:";

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/ServiceTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/ServiceTests.cs
@@ -14,7 +14,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Windows)]
+    [Category(Categories.WindowsOnly)]
     public class ServiceTests : TestsWithEnlistmentPerFixture
     {
         private const string NativeLibPath = @"C:\Program Files\GVFS\ProjectedFSLib.dll";

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/SharedCacheUpgradeTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/SharedCacheUpgradeTests.cs
@@ -14,7 +14,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Windows)]
+    [Category(Categories.WindowsOnly)]
     public class SharedCacheUpgradeTests : TestsWithMultiEnlistment
     {
         private string localCachePath;

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
@@ -16,7 +16,7 @@ using System.Threading;
 namespace GVFS.FunctionalTests.Windows.Windows.Tests
 {
     [TestFixture]
-    [Category(Categories.Windows)]
+    [Category(Categories.WindowsOnly)]
     public class WindowsFileSystemTests : TestsWithEnlistmentPerFixture
     {
         private enum CreationDisposition

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,13 +6,17 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
-        public const string Windows = "Windows";
+        public const string WindowsOnly = "WindowsOnly";
+        public const string MacOnly = "MacOnly";
 
-        public static class Mac
+        public static class MacTODO
         {
-            public const string M1 = "M1_CloneAndMount";
+            // The FailsOnBuildAgent category is for tests that pass on dev
+            // machines but not on the build agents
+            public const string FailsOnBuildAgent = "FailsOnBuildAgent";
+
+            public const string NeedsLockHolder = "NeedsDotCoreLockHolder"; 
             public const string M2 = "M2_StaticViewGitCommands";
-            public const string M2TODO = "M2_StaticViewGitCommandsStillTODO";
             public const string M3 = "M3_AllGitCommands";
             public const string M4 = "M4_All";
         }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -60,17 +60,21 @@ namespace GVFS.FunctionalTests
 
             if (runner.HasCustomArg("--windows-only"))
             {
-                includeCategories.Add(Categories.Windows);
+                includeCategories.Add(Categories.WindowsOnly);
             }
 
-            if (runner.HasCustomArg("--mac-only"))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                includeCategories.Add(Categories.Mac.M1);
-                includeCategories.Add(Categories.Mac.M2);
-                excludeCategories.Add(Categories.Mac.M2TODO);
-                excludeCategories.Add(Categories.Mac.M3);
-                excludeCategories.Add(Categories.Mac.M4);
-                excludeCategories.Add(Categories.Windows);
+                excludeCategories.Add(Categories.MacTODO.NeedsLockHolder);
+                excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
+                excludeCategories.Add(Categories.MacTODO.M2);
+                excludeCategories.Add(Categories.MacTODO.M3);
+                excludeCategories.Add(Categories.MacTODO.M4);
+                excludeCategories.Add(Categories.WindowsOnly);
+            }
+            else
+            {
+                excludeCategories.Add(Categories.MacOnly);
             }
 
             GVFSTestConfig.RepoToClone =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -12,7 +12,6 @@ using System.Linq;
 namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
 {
     [TestFixture]
-    [Category(Categories.Mac.M1)]
     public class BasicFileSystemTests : TestsWithEnlistmentPerFixture
     {
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
@@ -75,7 +74,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void NewFileAttributesAreUpdated(string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "FileAttributesAreUpdated");
@@ -103,7 +102,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void NewFolderAttributesAreUpdated(string parentFolder)
         {
             string folderName = Path.Combine(parentFolder, "FolderAttributesAreUpdated");
@@ -130,7 +129,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void ExpandedFileAttributesAreUpdated()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -157,7 +156,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void UnhydratedFolderAttributesAreUpdated()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -423,8 +422,9 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             fileSystem.DeleteFile(filePath);
         }
 
+        // WindowsOnly due to differences between POSIX and Windows delete
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestCanDeleteFilesWhileTheyAreOpenRunners)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void CanDeleteFilesWhileTheyAreOpen(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "CanDeleteFilesWhileTheyAreOpen");
@@ -455,8 +455,9 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             filePath.ShouldNotExistOnDisk(fileSystem);
         }
 
+        // WindowsOnly due to differences between POSIX and Windows delete
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void CanDeleteHydratedFilesWhileTheyAreOpenForWrite()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -490,7 +491,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void ProjectedBlobFileTimesMatchHead()
         {
             // TODO: 467539 - Update all runners to support getting create/modify/access times
@@ -514,7 +515,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void ProjectedBlobFolderTimesMatchHead()
         {
             // TODO: 467539 - Update all runners to support getting create/modify/access times
@@ -784,7 +785,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-        [Category(Categories.Mac.M4)]
+        [Category(Categories.MacTODO.M4)]
         public void DeleteIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));
@@ -842,7 +843,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void CreateFileInheritsParentDirectoryAttributes(string parentFolder)
         {
             string parentDirectoryPath = this.Enlistment.GetVirtualPathTo(Path.Combine(parentFolder, "CreateFileInheritsParentDirectoryAttributes"));
@@ -859,7 +860,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void CreateDirectoryInheritsParentDirectoryAttributes(string parentFolder)
         {
             string parentDirectoryPath = this.Enlistment.GetVirtualPathTo(Path.Combine(parentFolder, "CreateDirectoryInheritsParentDirectoryAttributes"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CacheServerTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CacheServerTests.cs
@@ -6,7 +6,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Mac.M2)]
     public class CacheServerTests : TestsWithEnlistmentPerFixture
     {
         private const string CustomUrl = "https://myCache";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -7,7 +7,6 @@ using System.IO;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
-    [Category(Categories.Mac.M1)]
     public class CloneTests : TestsWithEnlistmentPerFixture
     {
         private const int GVFSGenericError = 3;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -11,6 +11,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class DehydrateTests : TestsWithEnlistmentPerFixture
     {
         private const int GVFSGenericError = 3;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
@@ -9,6 +9,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class DiagnoseTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Properties;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
@@ -31,19 +32,20 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M2)]
         public void GitCheckoutFailsOutsideLock()
         {
             const string BackupPrefix = "BACKUP_";
-            const string PreCommand = "pre-command.exe";
-            const string PostCommand = "post-command.exe";
+            string preCommand = "pre-command" + Settings.Default.BinaryFileNameExtension;
+            string postCommand = "post-command" + Settings.Default.BinaryFileNameExtension;
 
             string hooksBase = Path.Combine(this.Enlistment.RepoRoot, ".git", "hooks");
 
             try
             {
                 // Get hooks out of the way to simulate lock not being acquired as expected
-                this.fileSystem.MoveFile(Path.Combine(hooksBase, PreCommand), Path.Combine(hooksBase, BackupPrefix + PreCommand));
-                this.fileSystem.MoveFile(Path.Combine(hooksBase, PostCommand), Path.Combine(hooksBase, BackupPrefix + PostCommand));
+                this.fileSystem.MoveFile(Path.Combine(hooksBase, preCommand), Path.Combine(hooksBase, BackupPrefix + preCommand));
+                this.fileSystem.MoveFile(Path.Combine(hooksBase, postCommand), Path.Combine(hooksBase, BackupPrefix + postCommand));
 
                 ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "checkout FunctionalTests/20170510_minor");
                 result.Errors.ShouldContain("fatal: unable to write new index file");
@@ -57,27 +59,30 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             finally
             {
                 // Reset hooks for cleanup.
-                this.fileSystem.MoveFile(Path.Combine(hooksBase, BackupPrefix + PreCommand), Path.Combine(hooksBase, PreCommand));
-                this.fileSystem.MoveFile(Path.Combine(hooksBase, BackupPrefix + PostCommand), Path.Combine(hooksBase, PostCommand));
+                this.fileSystem.MoveFile(Path.Combine(hooksBase, BackupPrefix + preCommand), Path.Combine(hooksBase, preCommand));
+                this.fileSystem.MoveFile(Path.Combine(hooksBase, BackupPrefix + postCommand), Path.Combine(hooksBase, postCommand));
             }
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void LockPreventsRenameFromOutsideRootOnTopOfIndex()
         {
             this.OverwritingIndexShouldFail(Path.Combine(this.Enlistment.EnlistmentRoot, "LockPreventsRenameFromOutsideRootOnTopOfIndex.txt"));
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void LockPreventsRenameFromInsideWorkingTreeOnTopOfIndex()
         {
             this.OverwritingIndexShouldFail(this.Enlistment.GetVirtualPathTo("LockPreventsRenameFromInsideWorkingTreeOnTopOfIndex.txt"));
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void LockPreventsRenameOfIndexLockOnTopOfIndex()
         {
-            this.OverwritingIndexShouldFail(this.Enlistment.GetVirtualPathTo(".git\\index.lock"));
+            this.OverwritingIndexShouldFail(this.Enlistment.GetVirtualPathTo(".git", "index.lock"));
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
@@ -88,7 +93,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private void OverwritingIndexShouldFail(string testFilePath)
         {
-            string indexPath = this.Enlistment.GetVirtualPathTo(".git\\index");
+            string indexPath = this.Enlistment.GetVirtualPathTo(".git", "index");
 
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
             byte[] indexContents = File.ReadAllBytes(indexPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -12,7 +12,6 @@ using System.Threading;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2)]
     public class GitFilesTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;
@@ -66,12 +65,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(3)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.M2)]
         public void CreateFileInFolderTest()
         {
             string folderName = "folder2";
             string fileName = "file2.txt";
-            string filePath = folderName + "\\" + fileName;
+            string filePath = Path.Combine(folderName, fileName);
 
             this.Enlistment.GetVirtualPathTo(filePath).ShouldNotExistOnDisk(this.fileSystem);
             GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, filePath);
@@ -87,7 +86,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.M3)]
         public void RenameEmptyFolderTest()
         {
             string folderName = "folder3a";
@@ -108,7 +107,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.M2)]
         public void RenameFolderTest()
         {
             string folderName = "folder4a";
@@ -141,7 +140,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.M2)]
         public void CaseOnlyRenameOfNewFolderKeepsExcludeEntries()
         {
             string[] expectedModifiedPathsEntries =
@@ -189,9 +188,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, gitFileToCheck);
         }
 
-        // TODO(Mac): Enable this test once the LockHolder is converted to .NET Core
         [TestCase, Order(8)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void ModifiedFileWillGetAddedToModifiedPathsFile()
         {
             string gitFileToTest = "GVFS/GVFS.Common/RetryWrapper.cs";
@@ -337,7 +335,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(15)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.M2)]
         public void SupersededFileAddedToSparseCheckoutAndSkipWorktreeBitCleared()
         {
             string fileToSupersedeEntry = "GVFlt_FileOperationTest/WriteAndVerify.txt";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -12,7 +12,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
     [Category(Categories.GitCommands)]
-    [Category(Categories.Mac.M2)]
     public class GitMoveRenameTests : TestsWithEnlistmentPerFixture
     {
         private string testFileContents = "0123456789";
@@ -92,7 +91,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.Mac.M3)]
         public void GitStatusAndObjectAfterGitAdd()
         {
             string existingFilename = "test.cs";
@@ -128,7 +126,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
-        [Category(Categories.Mac.M3)]
         public void GitStatusAfterUnstage()
         {
             string existingFilename = "test.cs";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
@@ -22,7 +22,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(1)]
-        [Category(Categories.Mac.M2)]
         public void GitStatus()
         {
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
@@ -33,14 +32,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(2)]
-        [Category(Categories.Mac.M2)]
         public void GitLog()
         {
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "log -n1", "commit", "Author:", "Date:");
         }
 
         [TestCase, Order(3)]
-        [Category(Categories.Mac.M2)]
         public void GitBranch()
         {
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
@@ -51,6 +48,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitCommandWaitsWhileAnotherIsRunning()
         {
             int pid;
@@ -61,6 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitAliasNamedAfterKnownCommandAcquiresLock()
         {
             string alias = nameof(this.GitAliasNamedAfterKnownCommandAcquiresLock);
@@ -73,6 +72,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock()
         {
             string alias = nameof(this.GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock);
@@ -89,6 +89,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(7)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void ExternalLockHolderReportedWhenBackgroundTasksArePending()
         {
             int pid;
@@ -106,6 +107,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(8)]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void OrphanedGVFSLockIsCleanedUp()
         {
             int pid;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -14,7 +14,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Mac.M1)]
     public class MountTests : TestsWithEnlistmentPerFixture
     {
         private const int GVFSGenericError = 3;
@@ -41,7 +40,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void MountCopiesMissingReadObjectHook()
         {
             this.Enlistment.UnmountGVFS();
@@ -262,7 +260,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         // Ported from ProjFS's BugRegressionTest
         [TestCase]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void ProjFS_CMDHangNoneActiveInstance()
         {
             this.Enlistment.UnmountGVFS();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
@@ -10,7 +10,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2)]
     public class MoveRenameFileTests : TestsWithEnlistmentPerFixture
     {
         public const string TestFileContents =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
@@ -8,7 +8,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2)]
     public class MoveRenameFileTests_2 : TestsWithEnlistmentPerFixture
     {
         private const string TestFileFolder = "Test_EPF_MoveRenameFileTests_2";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2TODO)]
     public class MoveRenameFolderTests : TestsWithEnlistmentPerFixture
     {       
         private const string TestFileContents =
@@ -40,12 +39,14 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.fileSystem = fileSystem;
         }
 
+        // WindowsOnly because renames of partial folders are blocked only on Windows
         [TestCase]
+        [Category(Categories.WindowsOnly)]
         public void RenameFolderShouldFail()
         {
             string testFileName = "RenameFolderShouldFail.cpp";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\RenameFolderShouldFail\\source";
-            string newFolderName = "Test_EPF_MoveRenameFolderTests\\RenameFolderShouldFail\\sourcerenamed";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "RenameFolderShouldFail", "source");
+            string newFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "RenameFolderShouldFail", "sourcerenamed");
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
 
             this.fileSystem.MoveDirectory_RequestShouldNotBeSupported(this.Enlistment.GetVirtualPathTo(oldFolderName), this.Enlistment.GetVirtualPathTo(newFolderName));
@@ -57,13 +58,16 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(oldFolderName, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
+        // This test requires expansion on PreDelete to be implemented
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacTODO.M2)]
+        [Category(Categories.MacOnly)]
         public void ChangeUnhydratedFolderName()
         {
             string testFileName = "ChangeUnhydratedFolderName.cpp";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\ChangeUnhydratedFolderName\\source";
-            string newFolderName = "Test_EPF_MoveRenameFolderTests\\ChangeUnhydratedFolderName\\source_renamed";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "ChangeUnhydratedFolderName", "source");
+            string newFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "ChangeUnhydratedFolderName", "source_renamed");
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
 
             this.fileSystem.MoveDirectory(this.Enlistment.GetVirtualPathTo(oldFolderName), this.Enlistment.GetVirtualPathTo(newFolderName));
@@ -75,12 +79,15 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(newFolderName, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
+        // This test requires expansion on PreDelete to be implemented
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacTODO.M2)]
+        [Category(Categories.MacOnly)]
         public void MoveUnhydratedFolderToNewFolder()
         {
             string testFileName = "MoveUnhydratedFolderToVirtualNTFSFolder.cpp";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\MoveUnhydratedFolderToVirtualNTFSFolder";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "MoveUnhydratedFolderToVirtualNTFSFolder");
 
             string newFolderName = "NewPerFixtureParent";
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
@@ -97,14 +104,17 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(movedFolderPath, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
+        // This test requires expansion on PreDelete to be implemented
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacTODO.M2)]
+        [Category(Categories.MacOnly)]
         public void MoveUnhydratedFolderToFullFolderInDotGitFolder()
         {
             string testFileName = "MoveUnhydratedFolderToFullFolderInDotGitFolder.cpp";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\MoveUnhydratedFolderToFullFolderInDotGitFolder";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "MoveUnhydratedFolderToFullFolderInDotGitFolder");
 
-            string newFolderName = ".git\\NewPerFixtureParent";
+            string newFolderName = Path.Combine(".git", "NewPerFixtureParent");
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.CreateDirectory(this.Enlistment.GetVirtualPathTo(newFolderName));
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldBeADirectory(this.fileSystem);
@@ -119,7 +129,6 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void MoveFullFolderToFullFolderInDotGitFolder()
         {
             string fileContents = "Test contents for MoveFullFolderToFullFolderInDotGitFolder";
@@ -147,12 +156,15 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             Path.Combine(movedFolderPath, testFileName).ShouldBeAFile(this.fileSystem).WithContents(fileContents);
         }
 
+        // This test requires expansion on PreDelete to be implemented
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacTODO.M2)]
+        [Category(Categories.MacOnly)]
         public void MoveAndRenameUnhydratedFolderToNewFolder()
         {
             string testFileName = "MoveAndRenameUnhydratedFolderToNewFolder.cpp";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\MoveAndRenameUnhydratedFolderToNewFolder";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "MoveAndRenameUnhydratedFolderToNewFolder");
 
             string newFolderName = "NewPerTestCaseParent";
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
@@ -169,12 +181,15 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(movedFolderPath, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
+        // This test requires expansion on PreDelete to be implemented
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacTODO.M2)]
+        [Category(Categories.MacOnly)]
         public void MoveFolderWithUnhydratedAndFullContents()
         {
             string testFileName = "MoveFolderWithUnhydratedAndFullContents.cs";
-            string oldFolderName = "Test_EPF_MoveRenameFolderTests\\MoveFolderWithUnhydratedAndFullContents";
+            string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "MoveFolderWithUnhydratedAndFullContents");
 
             string newFile = "TestFile.txt";
             string newFileContents = "Contents of TestFile.txt";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -11,11 +11,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     // TODO 469238: Elaborate on these tests?
     [TestFixture]
-    [Category(Categories.Mac.M1)]
     public class MultithreadedReadWriteTests : TestsWithEnlistmentPerFixture
     {
         [TestCase, Order(1)]
-        [Category(Categories.Windows)]
+        [Category(Categories.WindowsOnly)]
         public void CanReadVirtualFileInParallel()
         {
             // Note: This test MUST go first, or else it needs to ensure that it is reading a unique path compared to the

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -29,8 +29,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(2)]
         public void PrefetchSpecificFiles()
         {
-            this.ExpectBlobCount(this.Enlistment.Prefetch(@"--files GVFS\GVFS\Program.cs"), 1);
-            this.ExpectBlobCount(this.Enlistment.Prefetch(@"--files GVFS\GVFS\Program.cs;GVFS\GVFS.FunctionalTests\GVFS.FunctionalTests.csproj"), 2);
+            this.ExpectBlobCount(this.Enlistment.Prefetch($"--files {Path.Combine("GVFS", "GVFS", "Program.cs")}"), 1);
+            this.ExpectBlobCount(this.Enlistment.Prefetch($"--files {Path.Combine("GVFS", "GVFS", "Program.cs")};{Path.Combine("GVFS", "GVFS.FunctionalTests", "GVFS.FunctionalTests.csproj")}"), 2);
         }
 
         [TestCase, Order(3)]
@@ -41,6 +41,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
+        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFileExtensionWithHydrate()
         {
             int expectedCount = 3;
@@ -50,10 +51,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
+        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFilesWithHydrateWhoseObjectsAreAlreadyDownloaded()
         {
             int expectedCount = 2;
-            string output = this.Enlistment.Prefetch(@"--files GVFS\GVFS\Program.cs;GVFS\GVFS.FunctionalTests\GVFS.FunctionalTests.csproj --hydrate");
+            string output = this.Enlistment.Prefetch(
+                $"--files {Path.Combine("GVFS", "GVFS", "Program.cs")};{Path.Combine("GVFS", "GVFS.FunctionalTests", "GVFS.FunctionalTests.csproj")} --hydrate");
             this.ExpectBlobCount(output, expectedCount);
             output.ShouldContain("Hydrated files:   " + expectedCount);
             output.ShouldContain("Downloaded:       0");
@@ -62,8 +65,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(6)]
         public void PrefetchFolders()
         {
-            this.ExpectBlobCount(this.Enlistment.Prefetch(@"--folders GVFS\GVFS"), 17);
-            this.ExpectBlobCount(this.Enlistment.Prefetch(@"--folders GVFS\GVFS;GVFS\GVFS.FunctionalTests"), 65);
+            this.ExpectBlobCount(this.Enlistment.Prefetch($"--folders {Path.Combine("GVFS", "GVFS")}"), 17);
+            this.ExpectBlobCount(this.Enlistment.Prefetch($"--folders {Path.Combine("GVFS", "GVFS")};{Path.Combine("GVFS", "GVFS.FunctionalTests")}"), 65);
         }
 
         [TestCase, Order(7)]
@@ -97,10 +100,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             this.ExpectBlobCount(this.Enlistment.Prefetch("--files *"), 494);
             this.ExpectBlobCount(this.Enlistment.Prefetch("--folders /"), 494);
-            this.ExpectBlobCount(this.Enlistment.Prefetch("--folders \\"), 494);
+            this.ExpectBlobCount(this.Enlistment.Prefetch($"--folders {Path.DirectorySeparatorChar}"), 494);
         }
 
+        // TODO(Mac): Handle that lock files are not deleted on Mac, they are simply unlocked
         [TestCase, Order(10)]
+        [Category(Categories.MacTODO.M4)]
         public void PrefetchCleansUpStalePrefetchLock()
         {
             this.Enlistment.Prefetch("--commits");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -11,6 +11,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class PrefetchVerbWithoutSharedCacheTests : TestsWithEnlistmentPerFixture
     {
         private const string PrefetchPackPrefix = "prefetch";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
@@ -34,6 +34,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void UnmountWaitsForLock()
         {
             ManualResetEventSlim lockHolder = GitHelpers.AcquireGVFSLock(this.Enlistment, out _);
@@ -50,6 +51,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void UnmountSkipLock()
         {
             ManualResetEventSlim lockHolder = GitHelpers.AcquireGVFSLock(this.Enlistment, out _, Timeout.Infinite, true);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UpdatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UpdatePlaceholderTests.cs
@@ -13,6 +13,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class UpdatePlaceholderTests : TestsWithEnlistmentPerFixture
     {
         private const string TestParentFolderName = "Test_EPF_UpdatePlaceholderTests";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -14,7 +14,6 @@ using System.Text;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-    [Category(Categories.Mac.M2)]
     public class WorkingDirectoryTests : TestsWithEnlistmentPerFixture
     {
         private const int CurrentPlaceholderVersion = 1;
@@ -393,7 +392,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
         [TestCase, Order(13)]
         [Category(Categories.GitCommands)]
-        [Category(Categories.Mac.M3)]
+        [Category(Categories.MacTODO.M3)]
         public void FolderContentsProjectedAfterFolderCreateAndCheckout()
         {
             string folderName = "GVFlt_MultiThreadTest";
@@ -419,7 +418,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
         [TestCase, Order(14)]
         [Category(Categories.GitCommands)]
-        [Category(Categories.Mac.M3)]
+        [Category(Categories.MacTODO.M3)]
         public void FolderContentsCorrectAfterCreateNewFolderRenameAndCheckoutCommitWithSameFolder()
         {
             // 3a55d3b760c87642424e834228a3408796501e7c is the commit prior to adding Test_EPF_MoveRenameFileTests
@@ -448,9 +447,8 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             (folder + @"\MoveUnhydratedFileToDotGitFolder\Program.cs").ShouldBeAFile(this.fileSystem).WithContents(MoveRenameFileTests.TestFileContents);
         }
 
-        // TODO(Mac) This *should* be working already, we need further investigation of why this test fails on build agents, but not on dev machines.
         [TestCase, Order(15)]
-        [Category(Categories.Mac.M2TODO)]
+        [Category(Categories.MacTODO.FailsOnBuildAgent)]
         public void FilterNonUTF8FileName()
         {
             string encodingFilename = "ريلٌأكتوبرûمارسأغسطسºٰٰۂْٗ۵ريلٌأك.txt";
@@ -499,7 +497,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
         // TODO(Mac): Figure out why git for Mac is not requesting a redownload of the truncated object
         [TestCase, Order(17)]
-        [Category(Categories.Mac.M3)]
+        [Category(Categories.MacTODO.M3)]
         public void TruncatedObjectRedownloaded()
         {
             GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "checkout " + this.Enlistment.Commitish);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/CaseOnlyFolderRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/CaseOnlyFolderRenameTests.cs
@@ -10,9 +10,17 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
     [TestFixture]
     public class CaseOnlyFolderRenameTests : TestsWithEnlistmentPerTestCase
     {
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-        [Ignore("Disabled until moving partial folders is supported")]
-        public void CaseRenameFoldersAndRemountAndReanmeAgain(FileSystemRunner fileSystem)
+        private FileSystemRunner fileSystem;
+
+        public CaseOnlyFolderRenameTests()
+        {
+            this.fileSystem = new BashRunner();
+        }
+
+        // MacOnly because renames of partial folders are blocked on Windows
+        [TestCase]
+        [Category(Categories.MacOnly)]
+        public void CaseRenameFoldersAndRemountAndRenameAgain()
         {
             // Projected folder without a physical folder
             string parentFolderName = "GVFS";
@@ -21,12 +29,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string newGVFSSubFolderName = "gvfs";
             string newGVFSSubFolderPath = Path.Combine(parentFolderName, newGVFSSubFolderName);
 
-            this.Enlistment.GetVirtualPathTo(oldGVFSSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(oldGVFSSubFolderName);
+            this.Enlistment.GetVirtualPathTo(oldGVFSSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(oldGVFSSubFolderName);
 
-            // Use NativeMethods rather than the runner as it supports case-only rename
-            NativeMethods.MoveFile(this.Enlistment.GetVirtualPathTo(oldGVFSSubFolderPath), this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath));
+            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(oldGVFSSubFolderPath), this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath));
 
-            this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(newGVFSSubFolderName);
+            this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(newGVFSSubFolderName);
 
             // Projected folder with a physical folder
             string oldTestsSubFolderName = "GVFS.FunctionalTests";
@@ -37,34 +44,33 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string fileToAdd = "NewFile.txt";
             string fileToAddContent = "This is new file text.";
             string fileToAddPath = this.Enlistment.GetVirtualPathTo(Path.Combine(oldTestsSubFolderPath, fileToAdd));
-            fileSystem.WriteAllText(fileToAddPath, fileToAddContent);
+            this.fileSystem.WriteAllText(fileToAddPath, fileToAddContent);
 
-            this.Enlistment.GetVirtualPathTo(oldTestsSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(oldTestsSubFolderName);
+            this.Enlistment.GetVirtualPathTo(oldTestsSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(oldTestsSubFolderName);
 
-            // Use NativeMethods rather than the runner as it supports case-only rename
-            NativeMethods.MoveFile(this.Enlistment.GetVirtualPathTo(oldTestsSubFolderPath), this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath));
+            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(oldTestsSubFolderPath), this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath));
 
-            this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(newTestsSubFolderName);
+            this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(newTestsSubFolderName);
 
             // Remount
             this.Enlistment.UnmountGVFS();
             this.Enlistment.MountGVFS();
 
-            this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(newGVFSSubFolderName);
-            this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(newTestsSubFolderName);
-            this.Enlistment.GetVirtualPathTo(Path.Combine(newTestsSubFolderPath, fileToAdd)).ShouldBeAFile(fileSystem).WithContents().ShouldEqual(fileToAddContent);
+            this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(newGVFSSubFolderName);
+            this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(newTestsSubFolderName);
+            this.Enlistment.GetVirtualPathTo(Path.Combine(newTestsSubFolderPath, fileToAdd)).ShouldBeAFile(this.fileSystem).WithContents().ShouldEqual(fileToAddContent);
 
             // Rename each folder again
             string finalGVFSSubFolderName = "gvFS";
             string finalGVFSSubFolderPath = Path.Combine(parentFolderName, finalGVFSSubFolderName);
-            NativeMethods.MoveFile(this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath), this.Enlistment.GetVirtualPathTo(finalGVFSSubFolderPath));
-            this.Enlistment.GetVirtualPathTo(finalGVFSSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(finalGVFSSubFolderName);
+            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(newGVFSSubFolderPath), this.Enlistment.GetVirtualPathTo(finalGVFSSubFolderPath));
+            this.Enlistment.GetVirtualPathTo(finalGVFSSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(finalGVFSSubFolderName);
 
             string finalTestsSubFolderName = "gvfs.FunctionalTESTS";
             string finalTestsSubFolderPath = Path.Combine(parentFolderName, finalTestsSubFolderName);
-            NativeMethods.MoveFile(this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath), this.Enlistment.GetVirtualPathTo(finalTestsSubFolderPath));
-            this.Enlistment.GetVirtualPathTo(finalTestsSubFolderPath).ShouldBeADirectory(fileSystem).WithCaseMatchingName(finalTestsSubFolderName);
-            this.Enlistment.GetVirtualPathTo(Path.Combine(finalTestsSubFolderPath, fileToAdd)).ShouldBeAFile(fileSystem).WithContents().ShouldEqual(fileToAddContent);
+            this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(newTestsSubFolderPath), this.Enlistment.GetVirtualPathTo(finalTestsSubFolderPath));
+            this.Enlistment.GetVirtualPathTo(finalTestsSubFolderPath).ShouldBeADirectory(this.fileSystem).WithCaseMatchingName(finalTestsSubFolderName);
+            this.Enlistment.GetVirtualPathTo(Path.Combine(finalTestsSubFolderPath, fileToAdd)).ShouldBeAFile(this.fileSystem).WithContents().ShouldEqual(fileToAddContent);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedModifiedPathsTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
     [TestFixture]
-    [Category(Categories.Mac.M2TODO)]
+    [Category(Categories.MacTODO.M2)]
     public class PersistedModifiedPathsTests : TestsWithEnlistmentPerTestCase
     {
         private static readonly string FileToAdd = Path.Combine("GVFS", "TestAddFile.txt");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
@@ -9,7 +9,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.Mac.M1)]
     public class PersistedWorkingDirectoryTests : TestsWithEnlistmentPerTestCase
     {
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
@@ -10,6 +10,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class RepairTests : TestsWithEnlistmentPerTestCase
     {
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -16,6 +16,7 @@ namespace GVFS.FunctionalTests.Tests
     [TestFixture]
     [Category(Categories.FastFetch)]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class FastFetchTests
     {
         private readonly string fastFetchRepoRoot = Settings.Default.FastFetchRoot;

--- a/GVFS/GVFS.FunctionalTests/Tests/GVFSVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GVFSVerbTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 namespace GVFS.FunctionalTests.Tests
 {
     [TestFixture]
-    [Category(Categories.Mac.M1)]
     public class GVFSVerbTests
     {
         public GVFSVerbTests()

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -1,12 +1,12 @@
 ﻿using GVFS.FunctionalTests.Tools;
 using NUnit.Framework;
+using System.IO;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.Mac.M3)]
     public class AddStageTests : GitRepoTests
     {
         public AddStageTests() : base(enlistmentPerTest: false)
@@ -14,25 +14,22 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase, Order(1)]
-        [Category(Categories.Mac.M2)]
         public void AddBasicTest()
         {
-            this.EditFile("Readme.md", "Some new content.");
+            this.EditFile("Some new content.", "Readme.md");
             this.ValidateGitCommand("add Readme.md");
             this.RunGitCommand("commit -m \"Changing the Readme.md\"");
         }
 
         [TestCase, Order(2)]
-        [Category(Categories.Mac.M2)]
         public void StageBasicTest()
         {
-            this.EditFile("AuthoringTests.md", "Some new content.");
+            this.EditFile("Some new content.", "AuthoringTests.md");
             this.ValidateGitCommand("stage AuthoringTests.md");
             this.RunGitCommand("commit -m \"Changing the AuthoringTests.md\"");
         }
 
         [TestCase, Order(3)]
-        [Category(Categories.Mac.M2)]
         public void AddAndStageHardLinksTest()
         {
             if (!this.FileSystem.SupportsHardlinkCreation)
@@ -52,18 +49,19 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase, Order(4)]
         public void AddAllowsPlaceholderCreation()
         {
-            this.CommandAllowsPlaceholderCreation("add", @"GVFS\GVFS\Program.cs");
+            this.CommandAllowsPlaceholderCreation("add", "GVFS", "GVFS", "Program.cs");
         }
 
         [TestCase, Order(5)]
         public void StageAllowsPlaceholderCreation()
         {
-            this.CommandAllowsPlaceholderCreation("stage", @"GVFS\GVFS\App.config");
+            this.CommandAllowsPlaceholderCreation("stage", "GVFS", "GVFS", "App.config");
         }
 
-        private void CommandAllowsPlaceholderCreation(string command, string fileToRead)
+        private void CommandAllowsPlaceholderCreation(string command, params string[] fileToReadPathParts)
         {
-            this.EditFile("Readme.md", $"Some new content for {command}.");
+            string fileToRead = Path.Combine(fileToReadPathParts);
+            this.EditFile($"Some new content for {command}.", "Readme.md");
             ManualResetEventSlim resetEvent = GitHelpers.RunGitCommandWithWaitAndStdIn(this.Enlistment, resetTimeout: 3000, command: $"{command} -p", stdinToQuit: "q", processId: out _);
             this.FileContentsShouldMatch(fileToRead);
             this.ValidateGitCommand("--no-optional-locks status");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -88,38 +88,41 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutNewBranchFromStartingPointTest()
         {
             // In commit 8df701986dea0a5e78b742d2eaf9348825b14d35 the CheckoutNewBranchFromStartingPointTest files were not present
             this.ValidateGitCommand("checkout 8df701986dea0a5e78b742d2eaf9348825b14d35");
-            this.ShouldNotExistOnDisk("GitCommandsTests\\CheckoutNewBranchFromStartingPointTest\\test1.txt");
-            this.ShouldNotExistOnDisk("GitCommandsTests\\CheckoutNewBranchFromStartingPointTest\\test2.txt");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "CheckoutNewBranchFromStartingPointTest", "test1.txt");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "CheckoutNewBranchFromStartingPointTest", "test2.txt");
 
             // In commit cd5c55fea4d58252bb38058dd3818da75aff6685 the CheckoutNewBranchFromStartingPointTest files were present
             this.ValidateGitCommand("checkout -b tests/functional/CheckoutNewBranchFromStartingPointTest cd5c55fea4d58252bb38058dd3818da75aff6685");
-            this.FileShouldHaveContents("GitCommandsTests\\CheckoutNewBranchFromStartingPointTest\\test1.txt", "TestFile1 \r\n");
-            this.FileShouldHaveContents("GitCommandsTests\\CheckoutNewBranchFromStartingPointTest\\test2.txt", "TestFile2 \r\n");
+            this.FileShouldHaveContents("TestFile1 \r\n", "GitCommandsTests", "CheckoutNewBranchFromStartingPointTest", "test1.txt");
+            this.FileShouldHaveContents("TestFile2 \r\n", "GitCommandsTests", "CheckoutNewBranchFromStartingPointTest", "test2.txt");
 
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutOrhpanBranchFromStartingPointTest()
         {
             // In commit 8df701986dea0a5e78b742d2eaf9348825b14d35 the CheckoutOrhpanBranchFromStartingPointTest files were not present
             this.ValidateGitCommand("checkout 8df701986dea0a5e78b742d2eaf9348825b14d35");
-            this.ShouldNotExistOnDisk("GitCommandsTests\\CheckoutOrhpanBranchFromStartingPointTest\\test1.txt");
-            this.ShouldNotExistOnDisk("GitCommandsTests\\CheckoutOrhpanBranchFromStartingPointTest\\test2.txt");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "CheckoutOrhpanBranchFromStartingPointTest", "test1.txt");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "CheckoutOrhpanBranchFromStartingPointTest", "test2.txt");
 
             // In commit 15a9676c9192448820bd243807f6dab1bac66680 the CheckoutOrhpanBranchFromStartingPointTest files were present
             this.ValidateGitCommand("checkout --orphan tests/functional/CheckoutOrhpanBranchFromStartingPointTest 15a9676c9192448820bd243807f6dab1bac66680");
-            this.FileShouldHaveContents("GitCommandsTests\\CheckoutOrhpanBranchFromStartingPointTest\\test1.txt", "TestFile1 \r\n");
-            this.FileShouldHaveContents("GitCommandsTests\\CheckoutOrhpanBranchFromStartingPointTest\\test2.txt", "TestFile2 \r\n");
+            this.FileShouldHaveContents("TestFile1 \r\n", "GitCommandsTests", "CheckoutOrhpanBranchFromStartingPointTest", "test1.txt");
+            this.FileShouldHaveContents("TestFile2 \r\n", "GitCommandsTests", "CheckoutOrhpanBranchFromStartingPointTest", "test2.txt");
 
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void MoveFileFromDotGitFolderToWorkingDirectoryAndAddAndCheckout()
         {
             string testFileContents = "Test file contents for MoveFileFromDotGitFolderToWorkingDirectoryAndAddAndCheckout";
@@ -135,8 +138,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout -b " + newBranchName);
 
             this.ShouldNotExistOnDisk(targetPath);
-            this.CreateFile(dotGitFilePath, testFileContents);
-            this.FileShouldHaveContents(dotGitFilePath, testFileContents);
+            this.CreateFile(testFileContents, dotGitFilePath);
+            this.FileShouldHaveContents(testFileContents, dotGitFilePath);
 
             // Move file to working directory
             this.MoveFile(dotGitFilePath, targetPath);
@@ -152,6 +155,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchNoCrashOnStatus()
         {
             this.ControlGitRepo.Fetch("FunctionalTests/20170331_git_crash");
@@ -160,6 +164,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutCommitWhereFileContentsChangeAfterRead()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -168,23 +173,24 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             // In commit db95d631e379d366d26d899523f8136a77441914 the initial files for the FunctionalTests/20170206_Conflict_Source branch were created
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\" + fileName);
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", fileName);
 
             // A read should not add the file to the modified paths
             GVFSHelpers.ModifiedPathsShouldNotContain(this.FileSystem, this.Enlistment.DotGVFSRoot, fileName);
 
             this.ValidateGitCommand("checkout FunctionalTests/20170206_Conflict_Source");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\" + fileName);
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", fileName);
             GVFSHelpers.ModifiedPathsShouldNotContain(this.FileSystem, this.Enlistment.DotGVFSRoot, fileName);
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutCommitWhereFileDeletedAfterRead()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
 
             string fileName = "DeleteInSource.txt";
-            string filePath = @"Test_ConflictTests\DeletedFiles\" + fileName;
+            string filePath = Path.Combine("Test_ConflictTests", "DeletedFiles", fileName);
 
             // In commit db95d631e379d366d26d899523f8136a77441914 the initial files for the FunctionalTests/20170206_Conflict_Source branch were created
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
@@ -199,6 +205,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchAfterReadingFileAndVerifyContentsCorrect()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -215,6 +222,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchAfterReadingAllFilesAndVerifyContentsCorrect()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -233,15 +241,16 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchThatHasFolderShouldGetDeleted()
         {
             // this.ControlGitRepo.Commitish should not have the folder Test_ConflictTests\AddedFiles
-            string testFolder = @"Test_ConflictTests\AddedFiles";
+            string testFolder = Path.Combine("Test_ConflictTests", "AddedFiles");
             this.ShouldNotExistOnDisk(testFolder);
 
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictSourceBranch);
-            string testFile = testFolder + @"\AddedByBothDifferentContent.txt";
+            string testFile = Path.Combine(testFolder, "AddedByBothDifferentContent.txt");
             this.FileContentsShouldMatch(testFile);
 
             // Move back to this.ControlGitRepo.Commitish where testFolder and testFile are not in the repo
@@ -259,16 +268,17 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchThatDoesNotHaveFolderShouldNotHaveFolder()
         {
             // this.ControlGitRepo.Commitish should not have the folder Test_ConflictTests\AddedFiles
-            string testFolder = @"Test_ConflictTests\AddedFiles";
+            string testFolder = Path.Combine("Test_ConflictTests", "AddedFiles");
             this.ShouldNotExistOnDisk(testFolder);
 
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictSourceBranch);
 
-            string testFile = testFolder + @"\AddedByBothDifferentContent.txt";
+            string testFile = Path.Combine(testFolder, "AddedByBothDifferentContent.txt");
             this.FileContentsShouldMatch(testFile);
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
             this.ShouldNotExistOnDisk(testFile);
@@ -284,19 +294,20 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void EditFileReadFileAndCheckoutConflict()
         {
             // editFilePath was changed on ConflictTargetBranch
-            string editFilePath = @"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt";
+            string editFilePath = Path.Combine("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
 
             // readFilePath has different contents on ConflictSourceBranch and ConflictTargetBranch
-            string readFilePath = @"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt";
+            string readFilePath = Path.Combine("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
 
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictTargetBranch);
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictSourceBranch);
 
-            this.EditFile(editFilePath, "New content");
+            this.EditFile("New content", editFilePath);
             this.FileContentsShouldMatch(readFilePath);
             string originalReadFileContents = this.Enlistment.GetVirtualPathTo(readFilePath).ShouldBeAFile(this.FileSystem).WithContents();
 
@@ -318,9 +329,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void MarkFileAsReadOnlyAndCheckoutCommitWhereFileIsDifferent()
         {
-            string filePath = @"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt";
+            string filePath = Path.Combine("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
 
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictTargetBranch);
@@ -333,9 +345,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void MarkFileAsReadOnlyAndCheckoutCommitWhereFileIsDeleted()
         {
-            string filePath = @"Test_ConflictTests\AddedFiles\AddedBySource.txt";
+            string filePath = Path.Combine("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
 
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictTargetBranch);
@@ -348,6 +361,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ModifyAndCheckoutFirstOfSeveralFilesWhoseNamesAppearBeforeDot()
         {
             // Commit cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47 has the files (a).txt and (z).txt 
@@ -356,15 +370,16 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string newContent = "content to append";
 
             this.ValidateGitCommand("checkout cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47");
-            this.EditFile("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(a).txt", newContent);
-            this.FileShouldHaveContents("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(a).txt", originalContent + newContent);
+            this.EditFile(newContent, "DeleteFileWithNameAheadOfDotAndSwitchCommits", "(a).txt");
+            this.FileShouldHaveContents(originalContent + newContent, "DeleteFileWithNameAheadOfDotAndSwitchCommits", "(a).txt");
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("checkout -- DeleteFileWithNameAheadOfDotAndSwitchCommits/(a).txt");
             this.ValidateGitCommand("status");
-            this.FileShouldHaveContents("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(a).txt", originalContent);
+            this.FileShouldHaveContents(originalContent, "DeleteFileWithNameAheadOfDotAndSwitchCommits", "(a).txt");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixedToCommitWithNewFileThenCheckoutNewBranchAndCheckoutCommitWithNewFile()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -386,6 +401,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         // ReadFileAfterTryingToReadFileAtCommitWhereFileDoesNotExist is meant to exercise the NegativePathCache and its
         // behavior when projections change
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ReadFileAfterTryingToReadFileAtCommitWhereFileDoesNotExist()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -398,38 +414,39 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
 
             // Files should not exist
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
 
             // Check a second time to exercise the ProjFS negative cache
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
 
             // Switch to commit where files should exist
             this.ValidateGitCommand("checkout 51d15f7584e81d59d44c1511ce17d7c493903390");
 
             // Confirm files exist
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
 
             // Switch to commit where files should not exist
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
 
             // Verify files do not not exist
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
 
             // Check a second time to exercise the ProjFS negative cache
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.ShouldNotExistOnDisk(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.ShouldNotExistOnDisk("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithOpenHandleBlockingRepoMetdataUpdate()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -479,6 +496,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithOpenHandleBlockingProjectionDeleteAndRepoMetdataUpdate()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -534,6 +552,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithStaleRepoMetadataTmpFileOnDisk()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -544,6 +563,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWhileOutsideToolDoesNotAllowDeleteOfOpenRepoMetadata()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -593,6 +613,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void CheckoutBranchWhileOutsideToolHasExclusiveReadHandleOnDatabasesFolder()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -650,6 +671,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixedTwiceThenCheckoutWithChanges()
         {
             this.ControlGitRepo.Fetch("FunctionalTests/20171219_MultipleFileEdits");
@@ -669,6 +691,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixedTwiceThenCheckoutWithRemovedFiles()
         {
             this.ControlGitRepo.Fetch("FunctionalTests/20180102_MultipleFileDeletes");
@@ -688,6 +711,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void DeleteFolderAndChangeBranchToFolderWithDifferentCase()
         {
             // 692765 - Recursive modified paths entries for folders should be case insensitive when
@@ -708,6 +732,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void SuccessfullyChecksOutDirectoryToFileToDirectory()
         {
             // This test switches between two branches and verifies specific transitions occured
@@ -726,16 +751,16 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             //   where a\a contains "file contents one"
             //   and b contains "file contents two"
             //   This tests two types of renames crossing into each other
-            this.FileShouldHaveContents("a\\a", "file contents one");
-            this.FileShouldHaveContents("b", "file contents two");
+            this.FileShouldHaveContents("file contents one", "a", "a");
+            this.FileShouldHaveContents("file contents two", "b");
 
             // Delta of interest - Check initial state
             // renamed:    c\c <-> d\c && d\d <-> c\d
             //   where c\c contains "file contents c"
             //   and d\d contains "file contents d"
             //   This tests two types of renames crossing into each other
-            this.FileShouldHaveContents("c\\c", "file contents c");
-            this.FileShouldHaveContents("d\\d", "file contents d");
+            this.FileShouldHaveContents("file contents c", "c", "c");
+            this.FileShouldHaveContents("file contents d", "d", "d");
 
             // Now switch to second branch, part2 and verify transitions
             this.ValidateGitCommand("checkout FunctionalTests/20171103_DirectoryFileTransitionsPart2");
@@ -746,15 +771,15 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             // Delta of interest - Verify change
             // renamed:    a\a <-> b && b <-> a
-            this.FileShouldHaveContents("a", "file contents two");
-            this.FileShouldHaveContents("b", "file contents one");
+            this.FileShouldHaveContents("file contents two", "a");
+            this.FileShouldHaveContents("file contents one", "b");
 
             // Delta of interest - Verify change
             // renamed:    c\c <-> d\c && d\d <-> c\d
-            this.FileShouldHaveContents("c\\d", "file contents d");
-            this.FileShouldHaveContents("d\\c", "file contents c");
-            this.ShouldNotExistOnDisk("c\\c");
-            this.ShouldNotExistOnDisk("d\\d");
+            this.FileShouldHaveContents("file contents d", "c", "d");
+            this.FileShouldHaveContents("file contents c", "d", "c");
+            this.ShouldNotExistOnDisk("c", "c");
+            this.ShouldNotExistOnDisk("d", "d");
 
             // And back again
             this.ValidateGitCommand("checkout FunctionalTests/20171103_DirectoryFileTransitionsPart1");
@@ -765,37 +790,39 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             // Delta of interest - Final validation
             // renamed:    a\a <-> b && b <-> a
-            this.FileShouldHaveContents("a\\a", "file contents one");
-            this.FileShouldHaveContents("b", "file contents two");
+            this.FileShouldHaveContents("file contents one", "a", "a");
+            this.FileShouldHaveContents("file contents two", "b");
 
             // Delta of interest - Final validation
             // renamed:    c\c <-> d\c && d\d <-> c\d
-            this.FileShouldHaveContents("c\\c", "file contents c");
-            this.FileShouldHaveContents("d\\d", "file contents d");
-            this.ShouldNotExistOnDisk("c\\d");
-            this.ShouldNotExistOnDisk("d\\c");
+            this.FileShouldHaveContents("file contents c", "c", "c");
+            this.FileShouldHaveContents("file contents d", "d", "d");
+            this.ShouldNotExistOnDisk("c", "d");
+            this.ShouldNotExistOnDisk("d", "c");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void DeleteFileThenCheckout()
         {
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\DeleteFileTests\\1", "#test");
-            this.DeleteFile("GitCommandsTests\\DeleteFileTests\\1\\#test");
-            this.FolderShouldExistAndBeEmpty("GitCommandsTests\\DeleteFileTests\\1");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "DeleteFileTests", "1", "#test");
+            this.DeleteFile("GitCommandsTests", "DeleteFileTests", "1", "#test");
+            this.FolderShouldExistAndBeEmpty("GitCommandsTests", "DeleteFileTests", "1");
 
             // Commit cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47 is before
             // the files in GitCommandsTests\DeleteFileTests were added
             this.ValidateGitCommand("checkout cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47");
 
-            this.ShouldNotExistOnDisk("GitCommandsTests\\DeleteFileTests\\1");
-            this.ShouldNotExistOnDisk("GitCommandsTests\\DeleteFileTests");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "DeleteFileTests", "1");
+            this.ShouldNotExistOnDisk("GitCommandsTests", "DeleteFileTests");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutEditCheckoutWithoutFolderThenCheckoutWithMultipleFiles()
         {
             // Edit the file to get the entry in the sparse-checkout file
-            this.EditFile("DeleteFileWithNameAheadOfDotAndSwitchCommits\\1", "Changing the content of one file");
+            this.EditFile("Changing the content of one file", "DeleteFileWithNameAheadOfDotAndSwitchCommits", "1");
             this.RunGitCommand("reset --hard -q HEAD");
 
             // This commit should remove the DeleteFileWithNameAheadOfDotAndSwitchCommits folder
@@ -805,6 +832,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CreateAFolderThenCheckoutBranchWithFolder()
         {
             this.FolderShouldExistAndHaveFile("DeleteFileWithNameAheadOfDotAndSwitchCommits", "1");
@@ -818,6 +846,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithDirectoryNameSameAsFile()
         {
             this.SetupForFileDirectoryTest();
@@ -825,24 +854,28 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithDirectoryNameSameAsFileEnumerate()
         {
             this.RunFileDirectoryEnumerateTest("checkout");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithDirectoryNameSameAsFileWithRead()
         {
             this.RunFileDirectoryReadTest("checkout");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithDirectoryNameSameAsFileWithWrite()
         {
             this.RunFileDirectoryWriteTest("checkout");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchDirectoryWithOneFile()
         {
             this.SetupForFileDirectoryTest(commandBranch: GitRepoTests.DirectoryWithDifferentFileAfterBranch);
@@ -850,18 +883,21 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchDirectoryWithOneFileEnumerate()
         {
             this.RunFileDirectoryEnumerateTest("checkout", commandBranch: GitRepoTests.DirectoryWithDifferentFileAfterBranch);
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchDirectoryWithOneFileRead()
         {
             this.RunFileDirectoryReadTest("checkout", commandBranch: GitRepoTests.DirectoryWithDifferentFileAfterBranch);
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchDirectoryWithOneFileWrite()
         {
             this.RunFileDirectoryWriteTest("checkout", commandBranch: GitRepoTests.DirectoryWithDifferentFileAfterBranch);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -4,6 +4,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class CherryPickConflictTests : GitRepoTests
     {
         public CherryPickConflictTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
@@ -6,6 +6,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M4)]
     public class DeleteEmptyFolderTests : GitRepoTests
     {
         public DeleteEmptyFolderTests() : base(enlistmentPerTest: true)
@@ -36,7 +37,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             ControlGitRepo.Fetch("FunctionalTests/20170202_RenameTestMergeTarget");
             this.ValidateGitCommand("checkout FunctionalTests/20170202_RenameTestMergeTarget");
-            this.DeleteFile("Test_EPF_GitCommandsTestOnlyFileFolder\\file.txt");
+            this.DeleteFile("Test_EPF_GitCommandsTestOnlyFileFolder", "file.txt");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m\"Delete only file.\"");
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
@@ -4,6 +4,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class EnumerationMergeTest : GitRepoTests
     {
         // Commit that found GvFlt Bug 12258777: Entries are sometimes skipped during 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -29,7 +29,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void VerifyTestFilesExist()
         {
             // Sanity checks to ensure that the test files we expect to be in our test repo are present
@@ -41,28 +40,24 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StatusTest()
         {
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StatusShortTest()
         {
             this.ValidateGitCommand("status -s");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void BranchTest()
         {
             this.ValidateGitCommand("branch");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void NewBranchTest()
         {
             this.ValidateGitCommand("branch tests/functional/NewBranchTest");
@@ -70,7 +65,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void DeleteBranchTest()
         {
             this.ValidateGitCommand("branch tests/functional/DeleteBranchTest");
@@ -88,56 +82,48 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void UntrackedFileTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "add .");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void UntrackedEmptyFileTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "add .");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void UntrackedFileAddAllTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "add --all");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void UntrackedEmptyFileAddAllTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "add --all");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StageUntrackedFileTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "stage .");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StageUntrackedEmptyFileTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "stage .");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StageUntrackedFileAddAllTest()
         {
             this.BasicCommit(this.CreateFile, addCommand: "stage --all");
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void StageUntrackedEmptyFileAddAllTest()
         {
             this.BasicCommit(this.CreateEmptyFile, addCommand: "stage --all");
@@ -210,8 +196,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             // 663045 - Confirm that folder can be deleted after deleting file then changing
             // branches
-            string deleteFolderPath = @"GVFlt_DeleteFolderTest\GVFlt_DeletePlaceholderNonEmptyFolder_DeleteOnClose\NonEmptyFolder";
-            string deleteFilePath = deleteFolderPath + @"\bar.txt";
+            string deleteFolderPath = Path.Combine("GVFlt_DeleteFolderTest", "GVFlt_DeletePlaceholderNonEmptyFolder_DeleteOnClose", "NonEmptyFolder");
+            string deleteFilePath = Path.Combine(deleteFolderPath, "bar.txt");
 
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: () => this.DeleteFile(deleteFilePath));
             this.DeleteFolder(deleteFolderPath);
@@ -220,54 +206,53 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase]
         public void DeleteFolderSwitchBranchTest()
         {
-            this.SwitchBranch(fileSystemAction: () => this.DeleteFolder(@"GVFlt_DeleteFolderTest\GVFlt_DeleteLocalEmptyFolder_DeleteOnClose"));
+            this.SwitchBranch(fileSystemAction: () => this.DeleteFolder("GVFlt_DeleteFolderTest", "GVFlt_DeleteLocalEmptyFolder_DeleteOnClose"));
         }
 
         [TestCase]
         public void DeleteFolderStageChangesSwitchBranchTest()
         {
-            this.StageChangesSwitchBranch(fileSystemAction: () => this.DeleteFolder(@"GVFlt_DeleteFolderTest\GVFlt_DeleteLocalEmptyFolder_SetDisposition"));
+            this.StageChangesSwitchBranch(fileSystemAction: () => this.DeleteFolder("GVFlt_DeleteFolderTest", "GVFlt_DeleteLocalEmptyFolder_SetDisposition"));
         }
 
         [TestCase]
         public void DeleteFolderCommitChangesSwitchBranchTest()
         {
-            this.CommitChangesSwitchBranch(fileSystemAction: () => this.DeleteFolder(@"GVFlt_DeleteFolderTest\GVFlt_DeleteNonRootVirtualFolder_DeleteOnClose"));
+            this.CommitChangesSwitchBranch(fileSystemAction: () => this.DeleteFolder("GVFlt_DeleteFolderTest", "GVFlt_DeleteNonRootVirtualFolder_DeleteOnClose"));
         }
 
         [TestCase]
         public void DeleteFolderCommitChangesSwitchBranchSwitchBackTest()
         {
-            this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: () => this.DeleteFolder(@"GVFlt_DeleteFolderTest\GVFlt_DeleteNonRootVirtualFolder_SetDisposition"));
+            this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: () => this.DeleteFolder("GVFlt_DeleteFolderTest", "GVFlt_DeleteNonRootVirtualFolder_SetDisposition"));
         }
 
         [TestCase]
-        [Category(Categories.Mac.M2)]
         public void DeleteFilesWithNameAheadOfDot()
         {
             string folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "1");
             this.FolderShouldExistAndHaveFile(folder, "#test");
-            this.DeleteFile(Path.Combine(folder, "#test"));
+            this.DeleteFile(folder, "#test");
             this.FolderShouldExistAndBeEmpty(folder);
 
             folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "2");
             this.FolderShouldExistAndHaveFile(folder, "$test");
-            this.DeleteFile(Path.Combine(folder, "$test"));
+            this.DeleteFile(folder, "$test");
             this.FolderShouldExistAndBeEmpty(folder);
 
             folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "3");
             this.FolderShouldExistAndHaveFile(folder, ")");
-            this.DeleteFile(Path.Combine(folder, ")"));
+            this.DeleteFile(folder, ")");
             this.FolderShouldExistAndBeEmpty(folder);
 
             folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "4");
             this.FolderShouldExistAndHaveFile(folder, "+.test");
-            this.DeleteFile(Path.Combine(folder, "+.test"));
+            this.DeleteFile(folder, "+.test");
             this.FolderShouldExistAndBeEmpty(folder);
 
             folder = Path.Combine("GitCommandsTests", "DeleteFileTests", "5");
             this.FolderShouldExistAndHaveFile(folder, "-.test");
-            this.DeleteFile(Path.Combine(folder, "-.test"));
+            this.DeleteFile(folder, "-.test");
             this.FolderShouldExistAndBeEmpty(folder);
 
             this.ValidateGitCommand("status");
@@ -276,20 +261,30 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase]
         public void RenameFilesWithNameAheadOfDot()
         {
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\RenameFileTests\\1", "#test");
-            this.MoveFile("GitCommandsTests\\RenameFileTests\\1\\#test", "GitCommandsTests\\RenameFileTests\\1\\#testRenamed");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "1", "#test");
+            this.MoveFile(
+                Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#testRenamed"));
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\RenameFileTests\\2", "$test");
-            this.MoveFile("GitCommandsTests\\RenameFileTests\\2\\$test", "GitCommandsTests\\RenameFileTests\\2\\$testRenamed");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "2", "$test");
+            this.MoveFile(
+                Path.Combine("GitCommandsTests", "RenameFileTests", "2", "$test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "2", "$testRenamed"));
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\RenameFileTests\\3", ")");
-            this.MoveFile("GitCommandsTests\\RenameFileTests\\3\\)", "GitCommandsTests\\RenameFileTests\\3\\)Renamed");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "3", ")");
+            this.MoveFile(
+                Path.Combine("GitCommandsTests", "RenameFileTests", "3", ")"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "3", ")Renamed"));
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\RenameFileTests\\4", "+.test");
-            this.MoveFile("GitCommandsTests\\RenameFileTests\\4\\+.test", "GitCommandsTests\\RenameFileTests\\4\\+.testRenamed");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "4", "+.test");
+            this.MoveFile(
+                Path.Combine("GitCommandsTests", "RenameFileTests", "4", "+.test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "4", "+.testRenamed"));
 
-            this.FolderShouldExistAndHaveFile("GitCommandsTests\\RenameFileTests\\5", "-.test");
-            this.MoveFile("GitCommandsTests\\RenameFileTests\\5\\-.test", "GitCommandsTests\\RenameFileTests\\5\\-.testRenamed");
+            this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "5", "-.test");
+            this.MoveFile(
+                Path.Combine("GitCommandsTests", "RenameFileTests", "5", "-.test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "5", "-.testRenamed"));
 
             this.ValidateGitCommand("status");
         }
@@ -297,10 +292,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase]
         public void DeleteFileWithNameAheadOfDotAndSwitchCommits()
         {
-            this.DeleteFile("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(1).txt");
+            string fileRelativePath = Path.Combine("DeleteFileWithNameAheadOfDotAndSwitchCommits", "(1).txt");
+            this.DeleteFile(fileRelativePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("checkout -- DeleteFileWithNameAheadOfDotAndSwitchCommits/(1).txt");
-            this.DeleteFile("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(1).txt");
+            this.DeleteFile(fileRelativePath);
             this.ValidateGitCommand("status");
 
             // 14cf226119766146b1fa5c5aa4cd0896d05f6b63 is the commit prior to creating (1).txt, it has two different files with
@@ -308,21 +304,22 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // (a).txt 
             // (z).txt 
             this.ValidateGitCommand("checkout 14cf226119766146b1fa5c5aa4cd0896d05f6b63");
-            this.DeleteFile("DeleteFileWithNameAheadOfDotAndSwitchCommits\\(a).txt");
+            this.DeleteFile("DeleteFileWithNameAheadOfDotAndSwitchCommits", "(a).txt");
             this.ValidateGitCommand("checkout -- DeleteFileWithNameAheadOfDotAndSwitchCommits/(a).txt");
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void AddFileAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack()
         {
             // 663045 - Confirm that folder can be deleted after adding a file then changing branches
-            string newFileParentFolderPath = @"GVFS\GVFS\CommandLine";
-            string newFilePath = newFileParentFolderPath + @"\testfile.txt";
+            string newFileParentFolderPath = Path.Combine("GVFS", "GVFS", "CommandLine");
+            string newFilePath = Path.Combine(newFileParentFolderPath, "testfile.txt");
             string newFileContents = "test contents";
 
             this.CommitChangesSwitchBranch(
-                fileSystemAction: () => this.CreateFile(newFilePath, newFileContents),
+                fileSystemAction: () => this.CreateFile(newFileContents, newFilePath),
                 test: "AddFileAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack");
 
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
@@ -332,20 +329,20 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout tests/functional/AddFileAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack");
 
             this.FolderShouldExist(newFileParentFolderPath);
-            this.FileShouldHaveContents(newFilePath, newFileContents);
+            this.FileShouldHaveContents(newFileContents, newFilePath);
         }
 
         [TestCase]
         public void OverwriteFileInSubfolderAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack()
         {
-            string overwrittenFileParentFolderPath = @"GVFlt_DeleteFolderTest\GVFlt_DeletePlaceholderNonEmptyFolder_SetDisposition";
+            string overwrittenFileParentFolderPath = Path.Combine("GVFlt_DeleteFolderTest", "GVFlt_DeletePlaceholderNonEmptyFolder_SetDisposition");
 
             // GVFlt_DeleteFolderTest\GVFlt_DeletePlaceholderNonEmptyFolder_SetDispositiontestfile.txt already exists in the repo as TestFile.txt
-            string fileToOverwritePath = overwrittenFileParentFolderPath + @"\testfile.txt";
+            string fileToOverwritePath = Path.Combine(overwrittenFileParentFolderPath, "testfile.txt");
             string newFileContents = "test contents";
 
             this.CommitChangesSwitchBranch(
-                fileSystemAction: () => this.CreateFile(fileToOverwritePath, newFileContents),
+                fileSystemAction: () => this.CreateFile(newFileContents, fileToOverwritePath),
                 test: "OverwriteFileInSubfolderAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack");
 
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
@@ -354,10 +351,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
             this.ValidateGitCommand("checkout tests/functional/OverwriteFileInSubfolderAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack");
 
-            string subFolderPath = @"GVFlt_DeleteFolderTest\GVFlt_DeletePlaceholderNonEmptyFolder_SetDisposition\NonEmptyFolder";
+            string subFolderPath = Path.Combine("GVFlt_DeleteFolderTest", "GVFlt_DeletePlaceholderNonEmptyFolder_SetDisposition", "NonEmptyFolder");
             this.ShouldNotExistOnDisk(subFolderPath);
             this.FolderShouldExist(overwrittenFileParentFolderPath);
-            this.FileShouldHaveContents(fileToOverwritePath, newFileContents);
+            this.FileShouldHaveContents(newFileContents, fileToOverwritePath);
         }
 
         [TestCase]
@@ -365,13 +362,13 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             // 663045 - Confirm that grandparent folder can be deleted after adding a (granchild) file
             // then changing branches
-            string newFileParentFolderPath = @"GVFlt_DeleteFolderTest\GVFlt_DeleteVirtualNonEmptyFolder_DeleteOnClose\NonEmptyFolder";
-            string newFileGrandParentFolderPath = @"GVFlt_DeleteFolderTest\GVFlt_DeleteVirtualNonEmptyFolder_DeleteOnClose";
-            string newFilePath = newFileParentFolderPath + @"\testfile.txt";
+            string newFileParentFolderPath = Path.Combine("GVFlt_DeleteFolderTest", "GVFlt_DeleteVirtualNonEmptyFolder_DeleteOnClose", "NonEmptyFolder");
+            string newFileGrandParentFolderPath = Path.Combine("GVFlt_DeleteFolderTest", "GVFlt_DeleteVirtualNonEmptyFolder_DeleteOnClose");
+            string newFilePath = Path.Combine(newFileParentFolderPath, "testfile.txt");
             string newFileContents = "test contents";
 
             this.CommitChangesSwitchBranch(
-                fileSystemAction: () => this.CreateFile(newFilePath, newFileContents),
+                fileSystemAction: () => this.CreateFile(newFileContents, newFilePath),
                 test: "AddFileInSubfolderAndCommitOnNewBranchSwitchDeleteFolderAndSwitchBack");
 
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
@@ -382,7 +379,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             this.FolderShouldExist(newFileParentFolderPath);
             this.FolderShouldExist(newFileGrandParentFolderPath);
-            this.FileShouldHaveContents(newFilePath, newFileContents);
+            this.FileShouldHaveContents(newFileContents, newFilePath);
         }
 
         [TestCase]
@@ -541,8 +538,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.RenameFile);
         }
 
+        // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
-        [Ignore("Disabled until moving partial folders is supported")]
+        [Category(Categories.MacOnly)]
+        [Category(Categories.MacTODO.M3)]
         public void MoveFolderCommitChangesSwitchBranchSwitchBackTest()
         {
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.MoveFolder);
@@ -553,8 +552,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndCommit_before");
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndCommit_after");
-            string filePath = @"GVFS\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine("GVFS", "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -572,8 +571,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         public void AddFileCommitThenDeleteAndResetSoft()
         {
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
-            string filePath = @"GVFS\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine("GVFS", "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -586,8 +585,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         public void AddFileCommitThenDeleteAndResetMixed()
         {
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
-            string filePath = @"GVFS\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine("GVFS", "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -602,8 +601,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
             string folderPath = "test_folder";
             this.CreateFolder(folderPath);
-            string filePath = folderPath + @"\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine(folderPath, "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -619,8 +618,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
             string folderPath = "test_folder";
             this.CreateFolder(folderPath);
-            string filePath = folderPath + @"\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine(folderPath, "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -636,8 +635,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
             string folderPath = "test_folder";
             this.CreateFolder(folderPath);
-            string filePath = folderPath + @"\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine(folderPath, "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -652,8 +651,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout -b tests/functional/AddFileCommitThenDeleteAndResetSoft");
             string folderPath = "test_folder";
             this.CreateFolder(folderPath);
-            string filePath = folderPath + @"\testfile.txt";
-            this.CreateFile(filePath, "Some new content for the file");
+            string filePath = Path.Combine(folderPath + "testfile.txt");
+            this.CreateFile("Some new content for the file", filePath);
             this.ValidateGitCommand("status");
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for AddFileCommitThenDeleteAndCommit\"");
@@ -669,28 +668,28 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             string topMostNewFolder = "AddFoldersAndFilesAndRenameFolder_Test";
             this.CreateFolder(topMostNewFolder);
-            this.CreateFile(topMostNewFolder + @"\top_level_test_file.txt", "test contents");
+            this.CreateFile("test contents", topMostNewFolder, "top_level_test_file.txt");
 
-            string testFolderLevel1 = topMostNewFolder + @"\TestFolderLevel1";
+            string testFolderLevel1 = Path.Combine(topMostNewFolder, "TestFolderLevel1");
             this.CreateFolder(testFolderLevel1);
-            this.CreateFile(testFolderLevel1 + @"\level_1_test_file.txt", "test contents");
+            this.CreateFile("test contents", testFolderLevel1, "level_1_test_file.txt");
 
-            string testFolderLevel2 = testFolderLevel1 + @"\TestFolderLevel2";
+            string testFolderLevel2 = Path.Combine(testFolderLevel1, "TestFolderLevel2");
             this.CreateFolder(testFolderLevel2);
-            this.CreateFile(testFolderLevel2 + @"\level_2_test_file.txt", "test contents");
+            this.CreateFile("test contents", testFolderLevel2, "level_2_test_file.txt");
 
-            string testFolderLevel3 = testFolderLevel2 + @"\TestFolderLevel3";
+            string testFolderLevel3 = Path.Combine(testFolderLevel2, "TestFolderLevel3");
             this.CreateFolder(testFolderLevel3);
-            this.CreateFile(testFolderLevel3 + @"\level_3_test_file.txt", "test contents");
+            this.CreateFile("test contents", testFolderLevel3, "level_3_test_file.txt");
             this.ValidateGitCommand("status");
 
-            this.MoveFolder(testFolderLevel3, testFolderLevel2 + @"\TestFolderLevel3Renamed");
+            this.MoveFolder(testFolderLevel3, Path.Combine(testFolderLevel2, "TestFolderLevel3Renamed"));
             this.ValidateGitCommand("status");
 
-            this.MoveFolder(testFolderLevel2, testFolderLevel1 + @"\TestFolderLevel2Renamed");
+            this.MoveFolder(testFolderLevel2, Path.Combine(testFolderLevel1, "TestFolderLevel2Renamed"));
             this.ValidateGitCommand("status");
 
-            this.MoveFolder(testFolderLevel1, topMostNewFolder + @"\TestFolderLevel1Renamed");
+            this.MoveFolder(testFolderLevel1, Path.Combine(topMostNewFolder, "TestFolderLevel1Renamed"));
             this.ValidateGitCommand("status");
 
             this.MoveFolder(topMostNewFolder, "AddFoldersAndFilesAndRenameFolder_TestRenamed");
@@ -706,11 +705,12 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string renamedFolder = "AddFileAfterFolderRename_TestRenamed";
             this.CreateFolder(folder);
             this.MoveFolder(folder, renamedFolder);
-            this.CreateFile(renamedFolder + @"\test_file.txt", "test contents");
+            this.CreateFile("test contents", renamedFolder, "test_file.txt");
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetSoft()
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetSoft");
@@ -718,6 +718,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixed()
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetMixed");
@@ -725,6 +726,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixed2()
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetMixed2");
@@ -735,11 +737,12 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         public void ManuallyModifyHead()
         {
             this.ValidateGitCommand("status");
-            this.ReplaceText(TestConstants.DotGit.Head, "f1bce402a7a980a8320f3f235cf8c8fdade4b17a");
+            this.ReplaceText("f1bce402a7a980a8320f3f235cf8c8fdade4b17a", TestConstants.DotGit.Head);
             this.ValidateGitCommand("status");
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetSoftTwice()
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetSoftTwice");
@@ -751,6 +754,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void ResetMixedTwice()
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetMixedTwice");
@@ -965,6 +969,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.FailsOnBuildAgent)]
         public void EditFileNeedingUtf8Encoding()
         {
             this.ValidateGitCommand("checkout -b tests/functional/EditFileNeedingUtf8Encoding");
@@ -980,8 +985,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             GVFSHelpers.ModifiedPathsShouldNotContain(this.FileSystem, this.Enlistment.DotGVFSRoot, EncodingFilename);
             this.ValidateGitCommand("status");
 
-            this.AppendAllText(virtualFile, ContentWhenEditingFile);
-            this.AppendAllText(controlFile, ContentWhenEditingFile);
+            this.AppendAllText(ContentWhenEditingFile, virtualFile);
+            this.AppendAllText(ContentWhenEditingFile, controlFile);
 
             this.ValidateGitCommand("status");
 
@@ -997,13 +1002,14 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RenameOnlyFileInFolder()
         {
             ControlGitRepo.Fetch("FunctionalTests/20170202_RenameTestMergeTarget");
             ControlGitRepo.Fetch("FunctionalTests/20170202_RenameTestMergeSource");
 
             this.ValidateGitCommand("checkout FunctionalTests/20170202_RenameTestMergeTarget");
-            this.FileSystem.ReadAllText(this.Enlistment.GetVirtualPathTo("Test_EPF_GitCommandsTestOnlyFileFolder\\file.txt"));
+            this.FileSystem.ReadAllText(this.Enlistment.GetVirtualPathTo("Test_EPF_GitCommandsTestOnlyFileFolder", "file.txt"));
             this.ValidateGitCommand("merge origin/FunctionalTests/20170202_RenameTestMergeSource");
         }
 
@@ -1073,12 +1079,12 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         private void CreateFile()
         {
-            this.CreateFile(Path.GetRandomFileName() + "tempFile.txt", "Some content here");
+            this.CreateFile("Some content here", Path.GetRandomFileName() + "tempFile.txt");
         }
 
         private void EditFile()
         {
-            this.AppendAllText(GitCommandsTests.EditFilePath, ContentWhenEditingFile);
+            this.AppendAllText(ContentWhenEditingFile, GitCommandsTests.EditFilePath);
         }
 
         private void DeleteFile()

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -191,8 +191,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.CreateEmptyFile(controlFile);
         }
 
-        protected void CreateFile(string filePath, string content)
+        protected void CreateFile(string content, params string[] filePathPaths)
         {
+            string filePath = Path.Combine(filePathPaths);
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             this.FileSystem.WriteAllText(virtualFile, content);
@@ -207,8 +208,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.CreateDirectory(controlFolder);
         }
 
-        protected void EditFile(string filePath, string content)
+        protected void EditFile(string content, params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             this.FileSystem.AppendAllText(virtualFile, content);
@@ -255,8 +257,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             controlFileTo.ShouldBeAFile(this.FileSystem);
         }
 
-        protected void DeleteFile(string filePath)
+        protected void DeleteFile(params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             this.FileSystem.DeleteFile(virtualFile);
@@ -265,8 +268,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             controlFile.ShouldNotExistOnDisk(this.FileSystem);
         }
 
-        protected void DeleteFolder(string folderPath)
+        protected void DeleteFolder(params string[] folderPathParts)
         {
+            string folderPath = Path.Combine(folderPathParts);
             string virtualFolder = Path.Combine(this.Enlistment.RepoRoot, folderPath);
             string controlFolder = Path.Combine(this.ControlGitRepo.RootPath, folderPath);
             this.FileSystem.DeleteDirectory(virtualFolder);
@@ -287,48 +291,57 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             controlFileFrom.ShouldNotExistOnDisk(this.FileSystem);
         }
 
-        protected void FolderShouldExist(string folderPath)
+        protected void FolderShouldExist(params string[] folderPathParts)
         {
+            string folderPath = Path.Combine(folderPathParts);
             string virtualFolder = Path.Combine(this.Enlistment.RepoRoot, folderPath);
             string controlFolder = Path.Combine(this.ControlGitRepo.RootPath, folderPath);
             virtualFolder.ShouldBeADirectory(this.FileSystem);
             controlFolder.ShouldBeADirectory(this.FileSystem);
         }
 
-        protected void FolderShouldExistAndHaveFile(string folderPath, string fileName)
+        protected void FolderShouldExistAndHaveFile(params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
+            string folderPath = Path.GetDirectoryName(filePath);
+            string fileName = Path.GetFileName(filePath);
+
             string virtualFolder = Path.Combine(this.Enlistment.RepoRoot, folderPath);
             string controlFolder = Path.Combine(this.ControlGitRepo.RootPath, folderPath);
             virtualFolder.ShouldBeADirectory(this.FileSystem).WithItems(fileName).Count().ShouldEqual(1);
             controlFolder.ShouldBeADirectory(this.FileSystem).WithItems(fileName).Count().ShouldEqual(1);
         }
 
-        protected void FolderShouldExistAndBeEmpty(string folderPath)
+        protected void FolderShouldExistAndBeEmpty(params string[] folderPathParts)
         {
+            string folderPath = Path.Combine(folderPathParts);
             string virtualFolder = Path.Combine(this.Enlistment.RepoRoot, folderPath);
             string controlFolder = Path.Combine(this.ControlGitRepo.RootPath, folderPath);
             virtualFolder.ShouldBeADirectory(this.FileSystem).WithNoItems();
             controlFolder.ShouldBeADirectory(this.FileSystem).WithNoItems();
         }
 
-        protected void ShouldNotExistOnDisk(string path)
+        protected void ShouldNotExistOnDisk(params string[] pathParts)
         {
+            string path = Path.Combine(pathParts);
             string virtualPath = Path.Combine(this.Enlistment.RepoRoot, path);
             string controlPath = Path.Combine(this.ControlGitRepo.RootPath, path);
             virtualPath.ShouldNotExistOnDisk(this.FileSystem);
             controlPath.ShouldNotExistOnDisk(this.FileSystem);
         }
 
-        protected void FileShouldHaveContents(string filePath, string contents)
+        protected void FileShouldHaveContents(string contents, params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
             string virtualFilePath = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFilePath = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             virtualFilePath.ShouldBeAFile(this.FileSystem).WithContents(contents);
             controlFilePath.ShouldBeAFile(this.FileSystem).WithContents(contents);
         }
 
-        protected void FileContentsShouldMatch(string filePath)
+        protected void FileContentsShouldMatch(params string[] filePathPaths)
         {
+            string filePath = Path.Combine(filePathPaths);
             string virtualFilePath = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFilePath = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             virtualFilePath.ShouldBeAFile(this.FileSystem).WithContents(controlFilePath.ShouldBeAFile(this.FileSystem).WithContents());
@@ -350,16 +363,18 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             controlFolderPath.ShouldBeADirectory(this.FileSystem).WithCaseMatchingName(caseSensitiveName);
         }
 
-        protected void AppendAllText(string filePath, string content)
+        protected void AppendAllText(string content, params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             this.FileSystem.AppendAllText(virtualFile, content);
             this.FileSystem.AppendAllText(controlFile, content);
         }
 
-        protected void ReplaceText(string filePath, string newContent)
+        protected void ReplaceText(string newContent, params string[] filePathParts)
         {
+            string filePath = Path.Combine(filePathParts);
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
             this.FileSystem.WriteAllText(virtualFile, newContent);
@@ -375,7 +390,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         protected void ValidateFileDirectoryTest(string command, string commandBranch = DirectoryWithFileAfterBranch)
         {
-            this.EditFile("Readme.md", "Change file");
+            this.EditFile("Change file", "Readme.md");
             this.ValidateGitCommand("add --all");
             this.RunGitCommand("commit -m \"Some change\"");
             this.ValidateGitCommand($"{command} {commandBranch}");
@@ -401,88 +416,88 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         protected void RunFileDirectoryWriteTest(string command, string commandBranch = DirectoryWithFileAfterBranch)
         {
             this.SetupForFileDirectoryTest(commandBranch);
-            this.EditFile("file.txt\\file.txt", "Change file");
+            this.EditFile("Change file", "file.txt", "file.txt");
             this.ValidateFileDirectoryTest(command, commandBranch);
         }
 
         protected void ReadConflictTargetFiles()
         {
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTargetDeleteInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SameChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SuccessfulMerge.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\DeletedFiles\DeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTargetDeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "DeletedFiles", "DeleteInSource.txt");
         }
 
         protected void FilesShouldMatchCheckoutOfTargetBranch()
         {
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\NoChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "NoChange.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\DeletedFiles\DeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "DeletedFiles", "DeleteInSource.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTargetDeleteInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SameChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SuccessfulMerge.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTargetDeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
         }
 
         protected void FilesShouldMatchCheckoutOfSourceBranch()
         {
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\NoChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "NoChange.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\DeletedFiles\DeleteInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "DeletedFiles", "DeleteInTarget.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSourceDeleteInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SameChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SuccessfulMerge.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSourceDeleteInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
         }
 
         protected void FilesShouldMatchAfterNoConflict()
         {
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\NoChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "NoChange.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTargetDeleteInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SameChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SuccessfulMerge.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTargetDeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
         }
 
         protected void FilesShouldMatchAfterConflict()
         {
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothDifferentContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByBothSameContent.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedBySource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\AddedByTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\AddedFiles\NoChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothDifferentContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByBothSameContent.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedBySource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "AddedByTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "AddedFiles", "NoChange.txt");
 
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInSourceDeleteInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTarget.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ChangeInTargetDeleteInSource.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\ConflictingChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SameChange.txt");
-            this.FileContentsShouldMatch(@"Test_ConflictTests\ModifiedFiles\SuccessfulMerge.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInSourceDeleteInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTarget.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ChangeInTargetDeleteInSource.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
+            this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -5,7 +5,8 @@ using NUnit.Framework;
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
-    [Category(Categories.Mac.M3)]
+    [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class HashObjectTests : GitRepoTests
     {
         public HashObjectTests() : base(enlistmentPerTest: false)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -6,6 +6,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class MergeConflictTests : GitRepoTests
     {
         public MergeConflictTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
@@ -4,6 +4,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class RebaseConflictTests : GitRepoTests
     {
         public RebaseConflictTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
@@ -3,6 +3,8 @@
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
+    [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class RebaseTests : GitRepoTests
     {
         public RebaseTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
+    [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class ResetHardTests : GitRepoTests
     {
         private const string ResetHardCommand = "reset --hard";

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -5,6 +5,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class ResetMixedTests : GitRepoTests
     {
         public ResetMixedTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
@@ -4,6 +4,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M3)]
     public class ResetSoftTests : GitRepoTests
     {
         public ResetSoftTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -10,7 +10,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
         }
 
+        // Mac(TODO): Something is triggering Readme.md to get created on disk before this
+        // test validates that it's not present
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void CanReadFileAfterGitRmDryRun()
         {
             this.ValidateGitCommand("status");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -24,6 +24,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]   
         public void ModifyingAndDeletingRepositoryExcludeFileInvalidatesCache()
         {
             string repositoryExcludeFile = Path.Combine(".git", "info", "exclude");
@@ -31,7 +32,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.RepositoryIgnoreTestSetup();
 
             // Add ignore pattern to existing exclude file
-            this.EditFile(repositoryExcludeFile, "*.ign");
+            this.EditFile("*.ign", repositoryExcludeFile);
 
             // The exclude file has been modified, verify this status
             // excludes the "test.ign" file as expected.
@@ -49,6 +50,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]  
         public void NewRepositoryExcludeFileInvalidatesCache()
         {
             string repositoryExcludeFileRelativePath = Path.Combine(".git", "info", "exclude");
@@ -61,7 +63,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             File.Exists(repositoryExcludeFilePath).ShouldBeFalse("Repository exclude path should not exist");
 
             // Create new exclude file with ignore pattern
-            this.CreateFile(repositoryExcludeFileRelativePath, "*.ign");
+            this.CreateFile("*.ign", repositoryExcludeFileRelativePath);
 
             // The exclude file has been modified, verify this status
             // excludes the "test.ign" file as expected.
@@ -69,6 +71,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]  
         public void ModifyingHeadSymbolicRefInvalidatesCache()
         {
             this.ValidateGitCommand("status");
@@ -84,6 +87,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]  
         public void ModifyingHeadRefInvalidatesCache()
         {
             this.ValidateGitCommand("status");
@@ -104,7 +108,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             File.Delete(statusCachePath);
 
             // Create a new file with an extension that will be ignored later in the test.
-            this.CreateFile("test.ign", "file to be ignored");
+            this.CreateFile("file to be ignored", "test.ign");
 
             this.WaitForStatusCacheToBeGenerated();
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
@@ -40,6 +40,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M4)]
         public void UpdateIndexRemoveAddFileOpenForWrite()
         {
             // TODO 940287: Remove this test and re-enable UpdateIndexRemoveFileOnDisk

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -3,6 +3,8 @@
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
+    [Category(Categories.GitCommands)]
+    [Category(Categories.MacTODO.M4)]
     public class UpdateRefTests : GitRepoTests
     {
         public UpdateRefTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
@@ -8,6 +8,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M4)]
     public class ServiceVerbTests : TestsWithMultiEnlistment
     {
         private static readonly string[] EmptyRepoList = new string[] { };

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -14,6 +14,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.MacTODO.M3)]
     public class SharedCacheTests : TestsWithMultiEnlistment
     {
         private const string WellKnownFile = "Readme.md";

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using GVFS.Common;
+using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Tracing;
 using System;
@@ -124,7 +125,23 @@ namespace GVFS.Mount
 
         private JsonTracer CreateTracer(GVFSEnlistment enlistment, EventLevel verbosity, Keywords keywords)
         {
-            JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSMount");
+            string enlistmentId = null;
+            string mountId = null;
+
+            GitProcess git = new GitProcess(enlistment);
+            GitProcess.Result configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
+            if (!configResult.HasErrors)
+            {
+                enlistmentId = configResult.Output.Trim();
+            }
+
+            configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
+            if (!configResult.HasErrors)
+            {
+                mountId = configResult.Output.Trim();
+            }
+
+            JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSMount", enlistmentId: enlistmentId, mountId: mountId);
             tracer.AddLogFileEventListener(
                 GVFSEnlistment.GetNewGVFSLogFileName(enlistment.GVFSLogsRoot, GVFSConstants.LogFileTypes.MountProcess),
                 verbosity,

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -14,6 +14,8 @@ namespace GVFS.Platform.Mac
 {
     public class MacFileSystemVirtualizer : FileSystemVirtualizer
     {
+        public static readonly byte[] PlaceholderVersionId = ToVersionIdByteArray(new byte[] { PlaceholderVersion });
+
         private VirtualizationInstance virtualizationInstance;
 
         public MacFileSystemVirtualizer(GVFSContext context, GVFSGitObjects gitObjects)
@@ -81,11 +83,18 @@ namespace GVFS.Platform.Mac
             out UpdateFailureReason failureReason)
         {
             UpdateFailureCause failureCause = UpdateFailureCause.NoFailure;
+
+            // TODO(Mac): Add functional tests that include:
+            //     - Mode + content changes between commits
+            //     - Mode only changes (without any change to content, see issue #223)
+            ushort fileMode = this.FileSystemCallbacks.GitIndexProjection.GetFilePathMode(relativePath);
+
             Result result = this.virtualizationInstance.UpdatePlaceholderIfNeeded(
                 relativePath,
-                GetPlaceholderVersionId(),
-                ConvertShaToContentId(shaContentId),
+                PlaceholderVersionId,
+                ToVersionIdByteArray(ConvertShaToContentId(shaContentId)),
                 (ulong)endOfFile,
+                fileMode,
                 (UpdateType)updateFlags,
                 out failureCause);
             failureReason = (UpdateFailureReason)failureCause;
@@ -397,7 +406,7 @@ namespace GVFS.Platform.Mac
                         projectedItems = this.FileSystemCallbacks.GitIndexProjection.GetProjectedItems(CancellationToken.None, blobSizesConnection, relativePath);
                     }
 
-                    result = this.CreateEnumerationPlaceholders(relativePath, projectedItems);
+                    result = this.CreatePlaceholders(relativePath, projectedItems, triggeringProcessName);
                 }
                 catch (SizesUnavailableException e)
                 {
@@ -422,37 +431,50 @@ namespace GVFS.Platform.Mac
             return Result.EIOError;
         }
 
-        private Result CreateEnumerationPlaceholders(string relativePath, IEnumerable<ProjectedFileInfo> projectedItems)
+        private Result CreatePlaceholders(string directoryRelativePath, IEnumerable<ProjectedFileInfo> projectedItems, string triggeringProcessName)
         {
             foreach (ProjectedFileInfo fileInfo in projectedItems)
             {
                 Result result;
+                string sha = null;
+                string childRelativePath = Path.Combine(directoryRelativePath, fileInfo.Name);
                 if (fileInfo.IsFolder)
                 {
-                    result = this.virtualizationInstance.WritePlaceholderDirectory(Path.Combine(relativePath, fileInfo.Name));
+                    result = this.virtualizationInstance.WritePlaceholderDirectory(childRelativePath);
                 }
                 else
                 {
                     // TODO(Mac): Add functional tests that validate file mode is set correctly
-                    string filePath = Path.Combine(relativePath, fileInfo.Name);
-                    ushort fileMode = this.FileSystemCallbacks.GitIndexProjection.GetFilePathMode(filePath);
+                    ushort fileMode = this.FileSystemCallbacks.GitIndexProjection.GetFilePathMode(childRelativePath);
+                    sha = fileInfo.Sha.ToString();
                     result = this.virtualizationInstance.WritePlaceholderFile(
-                        filePath,
-                        ToVersionIdByteArray(FileSystemVirtualizer.GetPlaceholderVersionId()),
-                        ToVersionIdByteArray(FileSystemVirtualizer.ConvertShaToContentId(fileInfo.Sha.ToString())),
+                        childRelativePath,
+                        PlaceholderVersionId,
+                        ToVersionIdByteArray(FileSystemVirtualizer.ConvertShaToContentId(sha)),
                         (ulong)fileInfo.Size,
                         fileMode);
                 }
 
                 if (result != Result.Success)
                 {
-                    EventMetadata metadata = this.CreateEventMetadata(relativePath);
+                    EventMetadata metadata = this.CreateEventMetadata(childRelativePath);
                     metadata.Add("fileInfo.Name", fileInfo.Name);
                     metadata.Add("fileInfo.Size", fileInfo.Size);
                     metadata.Add("fileInfo.IsFolder", fileInfo.IsFolder);
-                    this.Context.Tracer.RelatedError(metadata, $"{nameof(this.CreateEnumerationPlaceholders)}: Write placeholder failed");
+                    this.Context.Tracer.RelatedError(metadata, $"{nameof(this.CreatePlaceholders)}: Write placeholder failed");
 
                     return result;
+                }
+                else
+                {
+                    if (fileInfo.IsFolder)
+                    {
+                        this.FileSystemCallbacks.OnPlaceholderFolderCreated(childRelativePath);
+                    }
+                    else
+                    {
+                        this.FileSystemCallbacks.OnPlaceholderFileCreated(childRelativePath, sha, triggeringProcessName);
+                    }
                 }
             }
 

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -75,7 +75,7 @@ namespace GVFS.Platform.Mac
             return pipe;
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return null;
         }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -19,6 +19,12 @@ namespace GVFS.Platform.Windows
 {
     public class WindowsFileSystemVirtualizer : FileSystemVirtualizer
     {
+        /// <summary>
+        /// GVFS uses the first byte of the providerId field of placeholders to version
+        /// the data that it stores in the contentId (and providerId) fields of the placeholder
+        /// </summary>
+        public static readonly byte[] PlaceholderVersionId = new byte[] { PlaceholderVersion };
+
         private const string ClassName = nameof(WindowsFileSystemVirtualizer);
         private const int MaxBlobStreamBufferSize = 64 * 1024;
         private const int MinPrjLibThreads = 5;
@@ -131,7 +137,7 @@ namespace GVFS.Platform.Windows
                 fileAttributes,
                 endOfFile,
                 ConvertShaToContentId(shaContentId),
-                GetPlaceholderVersionId(),
+                PlaceholderVersionId,
                 (UpdateType)updateFlags,
                 out failureCause);
             failureReason = (UpdateFailureReason)failureCause;
@@ -757,7 +763,7 @@ namespace GVFS.Platform.Windows
                     endOfFile: fileInfo.Size,
                     isDirectory: fileInfo.IsFolder,
                     contentId: FileSystemVirtualizer.ConvertShaToContentId(sha),
-                    providerId: FileSystemVirtualizer.GetPlaceholderVersionId());
+                    providerId: PlaceholderVersionId);
 
                 if (result != HResult.Ok)
                 {
@@ -1094,7 +1100,11 @@ namespace GVFS.Platform.Windows
                         if (gitCommand.IsValidGitCommand)
                         {
                             string directoryPath = Path.Combine(this.Context.Enlistment.WorkingDirectoryRoot, virtualPath);
-                            HResult hr = this.virtualizationInstance.ConvertDirectoryToPlaceholder(directoryPath, ConvertShaToContentId(GVFSConstants.AllZeroSha), GetPlaceholderVersionId());
+                            HResult hr = this.virtualizationInstance.ConvertDirectoryToPlaceholder(
+                                directoryPath, 
+                                ConvertShaToContentId(GVFSConstants.AllZeroSha), 
+                                PlaceholderVersionId);
+                            
                             if (hr == HResult.Ok)
                             {
                                 this.FileSystemCallbacks.OnPlaceholderFolderCreated(virtualPath);

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -69,11 +69,13 @@ namespace GVFS.Platform.Windows
             return true;
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return ETWTelemetryEventListener.CreateTelemetryListenerIfEnabled(
                 this.GitInstallation.GetInstalledGitBinPath(),
-                providerName);
+                providerName,
+                enlistmentId,
+                mountId);
         }
 
         public override void InitializeEnlistmentACLs(string enlistmentPath)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
@@ -441,7 +441,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                     Guid enumerationGuid = Guid.NewGuid();
 
                     byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                    byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                    byte[] placeholderVersion = WindowsFileSystemVirtualizer.PlaceholderVersionId;
 
                     mockVirtualization.OnGetFileStream(
                         commandId: 1,
@@ -657,7 +657,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                     Guid enumerationGuid = Guid.NewGuid();
 
                     byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                    byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                    byte[] placeholderVersion = WindowsFileSystemVirtualizer.PlaceholderVersionId;
 
                     uint fileLength = 100;
                     MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;
@@ -709,7 +709,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                     Guid enumerationGuid = Guid.NewGuid();
 
                     byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                    byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                    byte[] placeholderVersion = WindowsFileSystemVirtualizer.PlaceholderVersionId;
 
                     MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;
 
@@ -760,7 +760,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 Guid enumerationGuid = Guid.NewGuid();
 
                 byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                byte[] placeholderVersion = WindowsFileSystemVirtualizer.PlaceholderVersionId;
 
                 uint fileLength = 100;
                 MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;
@@ -815,7 +815,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                     Guid enumerationGuid = Guid.NewGuid();
 
                     byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                    byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                    byte[] placeholderVersion = WindowsFileSystemVirtualizer.PlaceholderVersionId;
 
                     uint fileLength = 100;
                     MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -50,7 +50,7 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName)
+        public override InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId)
         {
             return new MockListener(EventLevel.Verbose, Keywords.Telemetry);
         }

--- a/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
@@ -84,6 +84,7 @@ namespace GVFS.UnitTests.Mock.Mac
             byte[] providerId,
             byte[] contentId,
             ulong fileSize,
+            ushort fileMode,
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
@@ -84,9 +84,23 @@ namespace GVFS.UnitTests.Platform.Mac
         [TestCase]
         public void UpdatePlaceholderIfNeeded()
         {
+            using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
+            using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
             using (MacFileSystemVirtualizer virtualizer = new MacFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects, mockVirtualization))
+            using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
+                this.Repo.Context,
+                this.Repo.GitObjects,
+                RepoMetadata.Instance,
+                new MockBlobSizes(),
+                gitIndexProjection,
+                backgroundTaskRunner,
+                virtualizer))
             {
+                gitIndexProjection.MockFileModes.TryAdd("test" + Path.DirectorySeparatorChar + "test.txt", FileMode644);
+                string error;
+                fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
+
                 UpdateFailureReason failureReason = UpdateFailureReason.NoFailure;
 
                 mockVirtualization.UpdatePlaceholderIfNeededResult = Result.Success;
@@ -142,6 +156,7 @@ namespace GVFS.UnitTests.Platform.Mac
                         out failureReason)
                     .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)mockVirtualization.UpdatePlaceholderIfNeededResult));
                 failureReason.ShouldEqual((UpdateFailureReason)mockVirtualization.UpdatePlaceholderIfNeededFailureCause);
+                fileSystemCallbacks.Stop();
             }
         }
 
@@ -273,7 +288,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
 
                 byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                byte[] placeholderVersion = MacFileSystemVirtualizer.PlaceholderVersionId;
 
                 uint fileLength = 100;
                 MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;
@@ -315,7 +330,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
 
                 byte[] contentId = FileSystemVirtualizer.ConvertShaToContentId("0123456789012345678901234567890123456789");
-                byte[] placeholderVersion = FileSystemVirtualizer.GetPlaceholderVersionId();
+                byte[] placeholderVersion = MacFileSystemVirtualizer.PlaceholderVersionId;
 
                 uint fileLength = 100;
                 MockGVFSGitObjects mockGVFSGitObjects = this.Repo.GitObjects as MockGVFSGitObjects;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -63,16 +63,6 @@ namespace GVFS.Virtualization.FileSystem
             return Encoding.Unicode.GetBytes(sha);
         }
 
-        /// <summary>
-        /// GVFS uses the first byte of the providerId field of placeholders to version
-        /// the data that it stores in the contentId (and providerId) fields of the placeholder
-        /// </summary>
-        /// <returns>Byte array to set as placeholder version Id</returns>
-        public static byte[] GetPlaceholderVersionId()
-        {
-            return new byte[] { PlaceholderVersion };
-        }
-
         public virtual bool TryStart(FileSystemCallbacks fileSystemCallbacks, out string error)
         {
             this.FileSystemCallbacks = fileSystemCallbacks;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -214,6 +214,7 @@ void KauthHandler_HandleKernelMessageResponse(uint64_t messageId, MessageType re
                 }
             }
             Mutex_Release(s_outstandingMessagesMutex);
+            break;
         }
         
         // The follow are not valid responses to kernel messages

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -31,6 +31,24 @@ namespace PrjFSLib.Mac.Interop
             byte[] contentId,
             ulong fileSize,
             ushort fileMode);
+        
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_UpdatePlaceholderFileIfNeeded")]
+            public static extern Result UpdatePlaceholderFileIfNeeded(
+            string relativePath,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] providerId,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] contentId,
+            ulong fileSize,
+            ushort fileMode,
+            UpdateType updateType,
+            ref UpdateFailureCause failureCause);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_DeleteFile")]
+        public static extern Result DeleteFile(
+            string relativePath,
+            UpdateType updateType,
+            ref UpdateFailureCause failureCause);
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WriteFileContents")]
         public static extern Result WriteFileContents(

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/UpdateType.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/UpdateType.cs
@@ -7,7 +7,6 @@ namespace PrjFSLib.Mac
     {
         Invalid         = 0x00000000,
 
-        AllowDirtyData  = 0x00000002,
         AllowReadOnly   = 0x00000020,
     }
 }

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -71,7 +71,14 @@ namespace PrjFSLib.Mac
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
-            throw new NotImplementedException();
+            UpdateFailureCause deleteFailureCause = UpdateFailureCause.NoFailure;
+            Result result = Interop.PrjFSLib.DeleteFile(
+                relativePath,
+                updateFlags,
+                ref deleteFailureCause);
+
+            failureCause = deleteFailureCause;
+            return result;
         }
 
         public virtual Result WritePlaceholderDirectory(
@@ -106,10 +113,28 @@ namespace PrjFSLib.Mac
             byte[] providerId,
             byte[] contentId,
             ulong fileSize,
+            ushort fileMode,
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
-            throw new NotImplementedException();
+            if (providerId.Length != Interop.PrjFSLib.PlaceholderIdLength ||
+                contentId.Length != Interop.PrjFSLib.PlaceholderIdLength)
+            {
+                throw new ArgumentException();
+            }
+
+            UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
+            Result result = Interop.PrjFSLib.UpdatePlaceholderFileIfNeeded(
+                relativePath,
+                providerId,
+                contentId,
+                fileSize,
+                fileMode,
+                updateFlags,
+                ref updateFailureCause);
+
+            failureCause = updateFailureCause;
+            return result;
         }
 
         public virtual Result CompleteCommand(

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -102,15 +102,16 @@ typedef enum
     
 } PrjFS_UpdateFailureCause;
 
-PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
+extern "C" PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
     _In_    const char*                             relativePath,
     _In_    unsigned char                           providerId[PrjFS_PlaceholderIdLength],
     _In_    unsigned char                           contentId[PrjFS_PlaceholderIdLength],
     _In_    unsigned long                           fileSize,
+    _In_    uint16_t                                fileMode,
     _In_    PrjFS_UpdateType                        updateFlags,
     _Out_   PrjFS_UpdateFailureCause*               failureCause);
 
-PrjFS_Result PrjFS_DeleteFile(
+extern "C" PrjFS_Result PrjFS_DeleteFile(
     _In_    const char*                             relativePath,
     _In_    PrjFS_UpdateType                        updateFlags,
     _Out_   PrjFS_UpdateFailureCause*               failureCause);

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -15,4 +15,4 @@ sudo mkdir /GVFS.FT
 sudo chown $USER /GVFS.FT
 
 $SRCDIR/ProjFS.Mac/Scripts/LoadPrjFSKext.sh
-$PUBLISHDIR/GVFS.FunctionalTests --full-suite --mac-only
+$PUBLISHDIR/GVFS.FunctionalTests --full-suite


### PR DESCRIPTION
**Summary of VFSForGit product changes**

- Added update\delete placeholder functionality to `ProjFS.Mac`
- Update VFSForGit (for Mac) to add files\folders to the placeholder list as they are created during enumeration
- Fixed bugs\issues in `MacFileSystemVirtualizer.UpdatePlaceholderIfNeeded`

With these changes *most* projection change scenarios are covered.  #219 has been filed for supporting projection changes where new files need to be created by VFSForGit (something not covered by the changes in this PR). 

**Summary of test changes**

- Eliminated `--mac-only` flag and replaced it with an OS check in the functional tests
- Switched from a allow-list of tests that should run on Mac to a deny-list of tests that should not run on Mac
- Fixed up Windows specific paths
- Enabled many more tests on Mac (283 now passing, up from 204)

```
 Test Run Summary
   Overall result: Warning
   Test Count: 286, Passed: 282, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 4
     Skipped Tests - Ignored: 4, Explicit: 0, Other: 0
     Start time: 2018-08-29 23:15:15Z
     End time: 2018-08-29 23:28:25Z
     Duration: 790.114 seconds
```

**Follow up work items**
#219 
#223 
#231 

Fixes #196 