### PR TITLE
Abort upgrade when GVFS.Service is not running

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -37,7 +37,7 @@ namespace GVFS.Common
 
         public abstract void StartBackgroundProcess(string programName, string[] args);
         public abstract bool IsProcessActive(int processId);
-
+        public abstract void IsServiceInstalledAndRunning(string name, out bool installed, out bool running);
         public abstract string GetNamedPipeName(string enlistmentRoot);
         public abstract NamedPipeServerStream CreatePipeByName(string pipeName);
 

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -147,14 +147,11 @@ namespace GVFS.Upgrader
             return GVFSPlatform.Instance.KernelDriver.IsGVFSUpgradeSupported();
         }
 
-        protected virtual bool FreshInstallOrServiceRunning()
+        protected virtual bool IsServiceInstalledAndNotRunning()
         {
-            bool isInstalled;
-            bool isRunning;
+            GVFSPlatform.Instance.IsServiceInstalledAndRunning(GVFSConstants.Service.ServiceName, out bool isInstalled, out bool isRunning);
 
-            GVFSPlatform.Instance.IsServiceInstalledAndRunning(GVFSConstants.Service.ServiceName, out isInstalled, out isRunning);
-
-            return isInstalled ? isRunning : true;
+            return isInstalled && !isRunning;
         }
 
         protected virtual bool IsUnattended()
@@ -258,7 +255,7 @@ namespace GVFS.Upgrader
                 return false;
             }
 
-            if (!this.FreshInstallOrServiceRunning())
+            if (this.IsServiceInstalledAndNotRunning())
             {
                 error = "GVFS Service is not running.\nStart \"GVFS.Service\" and run \"gvfs upgrade\" again.";
                 return false;

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -147,6 +147,16 @@ namespace GVFS.Upgrader
             return GVFSPlatform.Instance.KernelDriver.IsGVFSUpgradeSupported();
         }
 
+        protected virtual bool FreshInstallOrServiceRunning()
+        {
+            bool isInstalled;
+            bool isRunning;
+
+            GVFSPlatform.Instance.IsServiceInstalledAndRunning(GVFSConstants.Service.ServiceName, out isInstalled, out isRunning);
+
+            return isInstalled ? isRunning : true;
+        }
+
         protected virtual bool IsUnattended()
         {
             return GVFSEnlistment.IsUnattended(this.tracer);
@@ -245,6 +255,12 @@ namespace GVFS.Upgrader
             if (!this.IsProjFSInboxed())
             {
                 error = "Unsupported ProjFS configuration.\nCheck your team's documentation for how to upgrade.";
+                return false;
+            }
+
+            if (!this.FreshInstallOrServiceRunning())
+            {
+                error = "GVFS Service is not running.\nStart \"GVFS.Service\" and run \"gvfs upgrade\" again.";
                 return false;
             }
 

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -56,6 +56,11 @@ namespace GVFS.Platform.Mac
             return MacPlatform.IsProcessActiveImplementation(processId);
         }
 
+        public override void IsServiceInstalledAndRunning(string name, out bool installed, out bool running)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void StartBackgroundProcess(string programName, string[] args)
         {
             ProcessLauncher.StartBackgroundProcess(programName, args);

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -12,6 +12,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.ServiceProcess;
 using System.Text;
 
 namespace GVFS.Platform.Windows
@@ -166,6 +167,14 @@ namespace GVFS.Platform.Windows
         public override bool IsProcessActive(int processId)
         {
             return WindowsPlatform.IsProcessActiveImplementation(processId);
+        }
+
+        public override void IsServiceInstalledAndRunning(string name, out bool installed, out bool running)
+        {
+            ServiceController service = ServiceController.GetServices().FirstOrDefault(s => s.ServiceName.Equals(name, StringComparison.Ordinal));
+
+            installed = service != null;
+            running = service != null ? service.Status == ServiceControllerStatus.Running : false;
         }
 
         public override string GetNamedPipeName(string enlistmentRoot)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -32,7 +32,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             IsGitUpgradeAllowed = 0x20,
             UnMountRepos = 0x40,
             RemountRepos = 0x80,
-            IsFreshInstallOrServiceRunning = 0x100
+            IsServiceInstalledAndNotRunning = 0x100
         }
         
         public List<string> GVFSArgs { get; private set; } = new List<string>();
@@ -56,6 +56,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             this.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.IsDevelopmentVersion);
             this.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.UnattendedMode);
             this.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.BlockingProcessesRunning);
+            this.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.IsServiceInstalledAndNotRunning);
 
             this.GVFSArgs.Clear();
         }
@@ -67,10 +68,10 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             return true;
         }
 
-        protected override bool FreshInstallOrServiceRunning()
+        protected override bool IsServiceInstalledAndNotRunning()
         {
             this.SequenceTracker.RecordMethod("PreCheck_IsServiceRunning");
-            return this.FakedResultOfCheck(FailOnCheckType.IsFreshInstallOrServiceRunning);
+            return this.FakedResultOfCheck(FailOnCheckType.IsServiceInstalledAndNotRunning);
         }
 
         protected override bool IsElevated()

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -32,6 +32,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             IsGitUpgradeAllowed = 0x20,
             UnMountRepos = 0x40,
             RemountRepos = 0x80,
+            IsFreshInstallOrServiceRunning = 0x100
         }
         
         public List<string> GVFSArgs { get; private set; } = new List<string>();
@@ -64,6 +65,12 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             gitVersion = new GitVersion(2, 17, 1, "gvfs", 1, 4);
             error = null;
             return true;
+        }
+
+        protected override bool FreshInstallOrServiceRunning()
+        {
+            this.SequenceTracker.RecordMethod("PreCheck_IsServiceRunning");
+            return this.FakedResultOfCheck(FailOnCheckType.IsFreshInstallOrServiceRunning);
         }
 
         protected override bool IsElevated()

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
@@ -49,6 +49,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "PreCheck_DevelopmentVersion",
                     "PreCheck_Elevated",
                     "PreCheck_ProjFSInboxed",
+                    "PreCheck_IsServiceRunning",
                     "UnmountAll",
                     "PreCheck_BlockingProcessRunning",
                     "DownloadAsset_GVFS",

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -154,7 +154,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
-                    this.PrerunChecker.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.IsFreshInstallOrServiceRunning);
+                    this.PrerunChecker.SetReturnTrueOnCheck(MockInstallerPrerunChecker.FailOnCheckType.IsServiceInstalledAndNotRunning);
                 },
                 expectedReturn: ReturnCode.GenericError,
                 expectedOutput: new List<string>

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -149,6 +149,26 @@ namespace GVFS.UnitTests.Windows.Upgrader
         }
 
         [TestCase]
+        public void IsGVFSServiceRunningPreCheck()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.PrerunChecker.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.IsFreshInstallOrServiceRunning);
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    "GVFS Service is not running.",
+                    "Start \"GVFS.Service\" and run \"gvfs upgrade\" again."
+                },
+                expectedErrors: new List<string>
+                {
+                    "GVFS Service is not running."
+                });
+        }
+
+        [TestCase]
         public void ElevatedRunPreCheck()
         {
             this.ConfigureRunAndVerify(

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -90,6 +90,11 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
+        public override void IsServiceInstalledAndRunning(string name, out bool installed, out bool running)
+        {
+            throw new NotSupportedException();
+        }
+
         public override bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
         {
             throw new NotSupportedException();


### PR DESCRIPTION
- Adding precheck for GVFS.Service. If Service is not running, then upgrade will abort with error. 
- In case of fresh install, this check will not be performed.
- Added platform specific method to check Service status.
- Updated UT.