### PR TITLE
Mac: Fixed a bug that was preventing clone from running prefetch and mount

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -126,13 +126,6 @@ namespace GVFS.Common.NamedPipes
                     metadata.Add(TracingConstants.MessageKey.WarningMessage, "OnNewConnection: Connection broken");
                     this.tracer.RelatedEvent(EventLevel.Warning, "OnNewConnectionn_EndWaitForConnection_IOException", metadata);
                 }
-                catch (ObjectDisposedException)
-                {
-                    if (!this.isStopping)
-                    {
-                        throw;
-                    }
-                }
                 catch (Exception e)
                 {
                     this.LogErrorAndExit("OnNewConnection caught unhandled exception, exiting process", e);

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -87,7 +87,10 @@ namespace GVFS.Common.NamedPipes
 
         private void OnNewConnection(IAsyncResult ar)
         {
-            this.OnNewConnection(ar, createNewThreadIfSynchronous: true);
+            if (!this.isStopping)
+            {
+                this.OnNewConnection(ar, createNewThreadIfSynchronous: true);
+            }
         }
 
         private void OnNewConnection(IAsyncResult ar, bool createNewThreadIfSynchronous)

--- a/GVFS/GVFS.Common/Prefetch/CommitPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/CommitPrefetcher.cs
@@ -155,7 +155,7 @@ namespace GVFS.Common.Prefetch
                 {
                     tracer.RelatedWarning(
                         metadata: null,
-                        message: "Failed to connect to GVFS. Skipping post-fetch job request.",
+                        message: "Failed to connect to GVFS.Mount process. Skipping post-fetch job request.",
                         keywords: Keywords.Telemetry);
                     return false;
                 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -22,7 +22,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
         // the cache 
         public PrefetchVerbWithoutSharedCacheTests()
-            : base(forcePerRepoObjectCache: true)
+            : base(forcePerRepoObjectCache: true, skipPrefetchDuringClone: true)
         {
             this.fileSystem = new SystemIORunner();
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
@@ -7,10 +7,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public abstract class TestsWithEnlistmentPerFixture
     {
         private readonly bool forcePerRepoObjectCache;
+        private readonly bool skipPrefetchDuringClone;
         
-        public TestsWithEnlistmentPerFixture(bool forcePerRepoObjectCache = false)
+        public TestsWithEnlistmentPerFixture(bool forcePerRepoObjectCache = false, bool skipPrefetchDuringClone = false)
         {
             this.forcePerRepoObjectCache = forcePerRepoObjectCache;
+            this.skipPrefetchDuringClone = skipPrefetchDuringClone;
         }
 
         public GVFSFunctionalTestEnlistment Enlistment
@@ -23,7 +25,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             if (this.forcePerRepoObjectCache)
             {
-                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMountWithPerRepoCache(GVFSTestConfig.PathToGVFS);
+                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMountWithPerRepoCache(GVFSTestConfig.PathToGVFS, this.skipPrefetchDuringClone);
             }
             else
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
@@ -1,7 +1,6 @@
 ﻿using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
-using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 {

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
@@ -1,7 +1,6 @@
 ﻿using GVFS.FunctionalTests.Tools;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 {

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -157,7 +157,6 @@ namespace GVFS.FunctionalTests.Tools
         {
             this.gvfsProcess.Clone(this.RepoUrl, this.Commitish);
 
-            this.MountGVFS();
             GitProcess.Invoke(this.RepoRoot, "checkout " + this.Commitish);
             GitProcess.Invoke(this.RepoRoot, "branch --unset-upstream");
             GitProcess.Invoke(this.RepoRoot, "config core.abbrev 40");

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -82,11 +82,11 @@ namespace GVFS.FunctionalTests.Tools
             get; private set;
         }
 
-        public static GVFSFunctionalTestEnlistment CloneAndMountWithPerRepoCache(string pathToGvfs, string commitish = null)
+        public static GVFSFunctionalTestEnlistment CloneAndMountWithPerRepoCache(string pathToGvfs, bool skipPrefetch)
         {
             string enlistmentRoot = GVFSFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
             string localCache = GVFSFunctionalTestEnlistment.GetRepoSpecificLocalCacheRoot(enlistmentRoot);
-            return CloneAndMount(pathToGvfs, enlistmentRoot, commitish, localCache);
+            return CloneAndMount(pathToGvfs, enlistmentRoot, null, localCache, skipPrefetch);
         }
 
         public static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string commitish = null, string localCacheRoot = null)
@@ -153,9 +153,9 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
-        public void CloneAndMount()
+        public void CloneAndMount(bool skipPrefetch)
         {
-            this.gvfsProcess.Clone(this.RepoUrl, this.Commitish);
+            this.gvfsProcess.Clone(this.RepoUrl, this.Commitish, skipPrefetch);
 
             GitProcess.Invoke(this.RepoRoot, "checkout " + this.Commitish);
             GitProcess.Invoke(this.RepoRoot, "branch --unset-upstream");
@@ -264,7 +264,7 @@ namespace GVFS.FunctionalTests.Tools
                 objectHash.Substring(2));
         }
         
-        private static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string enlistmentRoot, string commitish, string localCacheRoot)
+        private static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string enlistmentRoot, string commitish, string localCacheRoot, bool skipPrefetch = false)
         {
             GVFSFunctionalTestEnlistment enlistment = new GVFSFunctionalTestEnlistment(
                 pathToGvfs,
@@ -275,7 +275,7 @@ namespace GVFS.FunctionalTests.Tools
 
             try
             {
-                enlistment.CloneAndMount();
+                enlistment.CloneAndMount(skipPrefetch);
             }
             catch (Exception e)
             {

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -21,7 +21,7 @@ namespace GVFS.FunctionalTests.Tools
         public void Clone(string repositorySource, string branchToCheckout)
         {
             string args = string.Format(
-                "clone \"{0}\" \"{1}\" --branch \"{2}\" --no-mount --no-prefetch --local-cache-path \"{3}\"",
+                "clone \"{0}\" \"{1}\" --branch \"{2}\" --local-cache-path \"{3}\"",
                 repositorySource,
                 this.enlistmentRoot,
                 branchToCheckout,

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -37,10 +37,8 @@ namespace GVFS.FunctionalTests.Tools
 
         public bool TryMount(out string output)
         {
-            string mountCommand = "mount \"" + this.enlistmentRoot + "\" --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
-
             this.IsEnlistmentMounted().ShouldEqual(false, "GVFS is already mounted");
-            output = this.CallGVFS(mountCommand);
+            output = this.CallGVFS("mount \"" + this.enlistmentRoot + "\"");
             return this.IsEnlistmentMounted();
         }
 
@@ -58,11 +56,7 @@ namespace GVFS.FunctionalTests.Tools
 
         public string Diagnose()
         {
-            string diagnoseArgs = string.Join(
-                " ",
-                "diagnose \"" + this.enlistmentRoot + "\"",
-                "--internal_use_only_service_name " + GVFSServiceProcess.TestServiceName);
-            return this.CallGVFS(diagnoseArgs);
+            return this.CallGVFS("diagnose \"" + this.enlistmentRoot + "\"");
         }
 
         public string Status()
@@ -79,11 +73,7 @@ namespace GVFS.FunctionalTests.Tools
         {
             if (this.IsEnlistmentMounted())
             {
-                string unmountArgs = string.Join(
-                    " ",
-                    "unmount \"" + this.enlistmentRoot + "\"",
-                    "--internal_use_only_service_name " + GVFSServiceProcess.TestServiceName);
-                string result = this.CallGVFS(unmountArgs, failOnError: true);
+                string result = this.CallGVFS("unmount \"" + this.enlistmentRoot + "\"", failOnError: true);
                 this.IsEnlistmentMounted().ShouldEqual(false, "GVFS did not unmount: " + result);
             }
         }
@@ -96,18 +86,14 @@ namespace GVFS.FunctionalTests.Tools
 
         public string RunServiceVerb(string argument)
         {
-            string serviceVerbArgs = string.Join(
-                " ",
-                "service " + argument,
-                "--internal_use_only_service_name " + GVFSServiceProcess.TestServiceName);
-            return this.CallGVFS(serviceVerbArgs, failOnError: true);
+            return this.CallGVFS("service " + argument, failOnError: true);
         }
 
         private string CallGVFS(string args, bool failOnError = false)
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
-            processInfo.Arguments = args;
+            processInfo.Arguments = args + " --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
 
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -1,7 +1,5 @@
 ﻿using GVFS.Tests.Should;
-using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tools
 {
@@ -18,14 +16,15 @@ namespace GVFS.FunctionalTests.Tools
             this.localCacheRoot = localCacheRoot;
         }
         
-        public void Clone(string repositorySource, string branchToCheckout)
+        public void Clone(string repositorySource, string branchToCheckout, bool skipPrefetch)
         {
             string args = string.Format(
-                "clone \"{0}\" \"{1}\" --branch \"{2}\" --local-cache-path \"{3}\"",
+                "clone \"{0}\" \"{1}\" --branch \"{2}\" --local-cache-path \"{3}\" {4}",
                 repositorySource,
                 this.enlistmentRoot,
                 branchToCheckout,
-                this.localCacheRoot);
+                this.localCacheRoot,
+                skipPrefetch ? "--no-prefetch" : string.Empty);
             this.CallGVFS(args, failOnError: true);
         }
 

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -7,7 +7,6 @@ using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security;

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -15,4 +15,4 @@ sudo mkdir /GVFS.FT
 sudo chown $USER /GVFS.FT
 
 $SRCDIR/ProjFS.Mac/Scripts/LoadPrjFSKext.sh
-$PUBLISHDIR/GVFS.FunctionalTests --full-suite
+$PUBLISHDIR/GVFS.FunctionalTests --full-suite $2


### PR DESCRIPTION
It turns out there are two underlying bugs here:
* When we dispose a `NamedPipeServerStream`, it immediately calls our callback, and then calling `EndWaitForConnection` seems to throw different exceptions on Windows than on Mac.
* The `SocketException` that gets thrown on Mac triggers the unhandled exception handler, however this was happening after the tracer was already disposed, and so our attempt to log the exception was a noop, making it easier for this exception to hide.

I updated the tracer to throw if you write to it after it is disposed, and also updated the callback to early exit if we've already disposed the `NamedPipeServer`.

Questions:
* Can we now remove the `ObjectDisposedException` handler that was previously there to handle this scenario on Windows?
  * Yes, with the new pattern we no longer see `ObjectDisposedException` on Windows. Removed that handler.
* Why are no functional tests failing? Our functional tests always call clone with `--no-prefetch --no-mount` flags, but even so clone should have been failing with a non-zero error code.
  * The reason is that this bug is caused by a race. If the gvfs process manages to exit cleanly before the async exception is thrown, which is what happens with the `--no-prefetch --no-mount` flags, then everything appears to have worked correctly. I updated the functional tests to no longer pass in those flags, confirmed that the tests fail without my named pipe fix, and then pass with the fix.

With the dispose fix, the output of clone now makes it clear that something went wrong:
```
... <normal clone outputs so far>
Cloning...Succeeded
Writing to disposed tracer
{"Area":"NamedPipeServer","Exception":"System.Net.Sockets.SocketException (89): Operation canceled\n   at System.IO.Pipes.NamedPipeServerStream.<WaitForConnectionAsync>g__WaitForConnectionAsyncCore|23_0()\n   at System.Threading.Tasks.TaskToApm.End(IAsyncResult asyncResult)\n   at System.IO.Pipes.NamedPipeServerStream.EndWaitForConnection(IAsyncResult asyncResult)\n   at GVFS.Common.NamedPipes.NamedPipeServer.OnNewConnection(IAsyncResult ar, Boolean createNewThreadIfSynchronous) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs:line 114","ErrorMessage":"OnNewConnection caught unhandled exception, exiting process"}

Unhandled Exception: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'JsonTracer'.
   at GVFS.Common.Tracing.JsonTracer.WriteEvent(String eventName, EventLevel level, Keywords keywords, EventMetadata metadata, EventOpcode opcode) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/Tracing/JsonTracer.cs:line 273
   at GVFS.Common.Tracing.JsonTracer.RelatedEvent(EventLevel level, String eventName, EventMetadata metadata, Keywords keyword) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/Tracing/JsonTracer.cs:line 118
   at GVFS.Common.Tracing.JsonTracer.RelatedError(EventMetadata metadata, String message, Keywords keywords) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/Tracing/JsonTracer.cs:line 160
   at GVFS.Common.Tracing.JsonTracer.RelatedError(EventMetadata metadata, String message) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/Tracing/JsonTracer.cs:line 153
   at GVFS.Common.NamedPipes.NamedPipeServer.LogErrorAndExit(String message, Exception e) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs:line 172
   at GVFS.Common.NamedPipes.NamedPipeServer.OnNewConnection(IAsyncResult ar, Boolean createNewThreadIfSynchronous) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs:line 135
   at GVFS.Common.NamedPipes.NamedPipeServer.OnNewConnection(IAsyncResult ar) in /Users/sanoursa/Repos/VFSForGit/src/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs:line 90
   at System.Threading.Tasks.TaskToApm.<>c__DisplayClass3_0.<InvokeCallbackWhenTaskCompletes>b__0()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.AwaitTaskContinuation.RunCallback(ContextCallback callback, Object state, Task& currentTask)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
Abort trap: 6
```

and with all of the fixes:
```
... <snip>
Cloning...Succeeded
Fetching commits and trees from origin (no cache server)...Succeeded
Validating repo...Succeeded
Mounting...Succeeded
```