### PR TITLE
Don't update ModifiedPaths.dat for hard links created outside of repo

### DIFF
--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -241,15 +241,18 @@ namespace GVFS.Virtualization.FileSystem
         {
             try
             {
-                bool pathInDotGit = FileSystemCallbacks.IsPathInsideDotGit(relativeNewLinkPath);
+                if (!string.IsNullOrEmpty(relativeNewLinkPath))
+                {
+                    bool pathInDotGit = FileSystemCallbacks.IsPathInsideDotGit(relativeNewLinkPath);
 
-                if (pathInDotGit)
-                {
-                    this.OnDotGitFileOrFolderChanged(relativeNewLinkPath);
-                }
-                else
-                {
-                    this.FileSystemCallbacks.OnFileHardLinkCreated(relativeNewLinkPath);
+                    if (pathInDotGit)
+                    {
+                        this.OnDotGitFileOrFolderChanged(relativeNewLinkPath);
+                    }
+                    else
+                    {
+                        this.FileSystemCallbacks.OnFileHardLinkCreated(relativeNewLinkPath);
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #257 

The issue was that ProjFS on Windows delivers notifications with a new link path of `""` when hard links are created outside of the repo to a file inside the repo.