### PR TITLE
Update PowerShellRunner to support hard link creation and enable more functional tests on Mac

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -47,11 +47,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             }
         }
 
-        public override bool SupportsHardlinkCreation
-        {
-            get { return true; }
-        }
-
         protected override string FileName
         {
             get

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -27,11 +27,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "The process cannot access the file because it is being used by another process"
         };
 
-        public override bool SupportsHardlinkCreation
-        {
-            get { return true; }
-        }
-
         protected override string FileName
         {
             get

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -47,11 +47,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             get { return defaultRunner; }
         }
 
-        public virtual bool SupportsHardlinkCreation 
-        { 
-            get { return false; } 
-        }
-
         // File methods
         public abstract bool FileExists(string path);       
         public abstract string MoveFile(string sourcePath, string targetPath);
@@ -74,11 +69,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public abstract void ReadAllText_FileShouldNotBeFound(string path);
 
         public abstract void CreateEmptyFile(string path);
-
-        public virtual void CreateHardLink(string newLinkFilePath, string existingFilePath)
-        {
-            Assert.Fail($"This runner does not support {nameof(this.CreateHardLink)}");
-        }
+        public abstract void CreateHardLink(string newLinkFilePath, string existingFilePath);
 
         /// <summary>
         /// Write the specified contents to the specified file.  By calling this method the caller is

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -32,6 +32,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "PermissionDenied"
         };
 
+        public override bool SupportsHardlinkCreation
+        {
+            get { return true; }
+        }
+
         protected override string FileName
         {
             get
@@ -103,6 +108,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void CreateEmptyFile(string path)
         {
             this.RunProcess(string.Format("-Command \"&{{ New-Item -ItemType file {0}}}\"", path));
+        }
+
+        public override void CreateHardLink(string newLinkFilePath, string existingFilePath)
+        {
+            this.RunProcess(string.Format("-Command \"&{{ New-Item -ItemType HardLink -Path {0} -Value {1}}}\"", newLinkFilePath, existingFilePath));
         }
 
         public override void WriteAllText(string path, string contents)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -32,11 +32,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "PermissionDenied"
         };
 
-        public override bool SupportsHardlinkCreation
-        {
-            get { return true; }
-        }
-
         protected override string FileName
         {
             get

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests.Should;
+using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -72,6 +73,18 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             using (FileStream fs = File.Create(path))
             {
+            }
+        }
+
+        public override void CreateHardLink(string newLinkFilePath, string existingFilePath)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                WindowsCreateHardLink(newLinkFilePath, existingFilePath, IntPtr.Zero).ShouldBeTrue($"Failed to create hard link: {Marshal.GetLastWin32Error()}");
+            }
+            else
+            {
+                MacCreateHardLink(existingFilePath, newLinkFilePath).ShouldEqual(0, $"Failed to create hard link: {Marshal.GetLastWin32Error()}");
             }
         }
 
@@ -177,6 +190,15 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         [DllImport("kernel32", SetLastError = true)]
         private static extern bool MoveFileEx(string existingFileName, string newFileName, int flags);
+
+        [DllImport("libc", EntryPoint = "link", SetLastError = true)]
+        private static extern int MacCreateHardLink(string oldPath, string newPath);
+
+        [DllImport("kernel32.dll", EntryPoint = "CreateHardLink", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool WindowsCreateHardLink(
+            string newLinkFileName,
+            string existingFileName,
+            IntPtr securityAttributes);
 
         private static void RetryOnException(Action action)
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -42,11 +42,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(2)]
         public void CreateHardLinkTest()
         {
-            if (!this.fileSystem.SupportsHardlinkCreation)
-            {
-                return;
-            }
-
             string existingFileName = "fileToLinkTo.txt";
             string existingFilePath = this.Enlistment.GetVirtualPathTo(existingFileName);
             GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, existingFileName);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -120,7 +120,7 @@ A Scripts/
             }
         }
 
-        [TestCaseSource(typeof(HardLinkRunners), HardLinkRunners.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
         public void ModifiedPathsCorrectAfterHardLinking(FileSystemRunner fileSystem)
         {
             const string ExpectedModifiedFilesContentsAfterHardlinks =
@@ -160,35 +160,6 @@ A LinkToFileOutsideSrc.txt
             using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {
                 reader.ReadToEnd().ShouldEqual(ExpectedModifiedFilesContentsAfterHardlinks);
-            }
-        }
-
-        private class HardLinkRunners
-        {
-            public const string TestRunners = "Runners";
-
-            public static object[] Runners
-            {
-                get
-                {
-                    List<object[]> hardLinkRunners = new List<object[]>();
-                    foreach (object[] runner in FileSystemRunner.Runners.ToList())
-                    {
-                        FileSystemRunner fileSystem = runner.ToList().First() as FileSystemRunner;
-                        if (fileSystem.SupportsHardlinkCreation)
-                        {
-                            hardLinkRunners.Add(new object[] { fileSystem });
-                        }
-                    }
-
-                    if (hardLinkRunners.Count > 0)
-                    {
-                        return hardLinkRunners.ToArray();
-                    }
-
-                    // Always return at least one runner that supports creating hard links
-                    return new[] { new object[] { new BashRunner() } };
-                }
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -3,9 +3,7 @@ using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -3,10 +3,9 @@ using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
-using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 {
@@ -172,15 +171,22 @@ A LinkToFileOutsideSrc.txt
             {
                 get
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    List<object[]> hardLinkRunners = new List<object[]>();
+                    foreach (object[] runner in FileSystemRunner.Runners.ToList())
                     {
-                        return new[]
+                        FileSystemRunner fileSystem = runner.ToList().First() as FileSystemRunner;
+                        if (fileSystem.SupportsHardlinkCreation)
                         {
-                            new object[] { new CmdRunner() },
-                            new object[] { new BashRunner() },
-                        };
+                            hardLinkRunners.Add(new object[] { fileSystem });
+                        }
                     }
 
+                    if (hardLinkRunners.Count > 0)
+                    {
+                        return hardLinkRunners.ToArray();
+                    }
+
+                    // Always return at least one runner that supports creating hard links
                     return new[] { new object[] { new BashRunner() } };
                 }
             }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -56,7 +56,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private void CommandAllowsPlaceholderCreation(string command, params string[] fileToReadPathParts)
         {
             string fileToRead = Path.Combine(fileToReadPathParts);
-            this.EditFile($"Some new content for {command}.", "Readme.md");
+            this.EditFile($"Some new content for {command}.", "Protocol.md");
             ManualResetEventSlim resetEvent = GitHelpers.RunGitCommandWithWaitAndStdIn(this.Enlistment, resetTimeout: 3000, command: $"{command} -p", stdinToQuit: "q", processId: out _);
             this.FileContentsShouldMatch(fileToRead);
             this.ValidateGitCommand("--no-optional-locks status");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -32,11 +32,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase, Order(3)]
         public void AddAndStageHardLinksTest()
         {
-            if (!this.FileSystem.SupportsHardlinkCreation)
-            {
-                return;
-            }
-
             this.CreateHardLink("ReadmeLink.md", "Readme.md");
             this.ValidateGitCommand("add ReadmeLink.md");
             this.RunGitCommand("commit -m \"Created ReadmeLink.md\"");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -251,7 +251,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchThatHasFolderShouldGetDeleted()
         {
             // this.ControlGitRepo.Commitish should not have the folder Test_ConflictTests\AddedFiles

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -802,6 +802,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ShouldNotExistOnDisk("d", "c");
         }
 
+        // TODO(Mac): This test needs the fix for issue #264
         [TestCase]
         [Category(Categories.MacTODO.M3)]
         public void DeleteFileThenCheckout()

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -224,14 +224,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string virtualNewLinkFile = Path.Combine(this.Enlistment.RepoRoot, newLinkFileName);
             string controlNewLinkFile = Path.Combine(this.ControlGitRepo.RootPath, newLinkFileName);
 
-            // GitRepoTests are only run with SystemIORunner (which does not support hardlink
-            // creation) so use a BashRunner instead.
-            this.FileSystem.SupportsHardlinkCreation.ShouldBeFalse(
-                "If this.FileSystem.SupportsHardlinkCreation is true, CreateHardLink no longer needs to create a BashRunner");
-            FileSystemRunner runner = new BashRunner();
-
-            runner.CreateHardLink(virtualNewLinkFile, virtualExistingFile);
-            runner.CreateHardLink(controlNewLinkFile, controlExistingFile);
+            this.FileSystem.CreateHardLink(virtualNewLinkFile, virtualExistingFile);
+            this.FileSystem.CreateHardLink(controlNewLinkFile, controlExistingFile);
         }
 
         protected void SetFileAsReadOnly(string filePath)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
@@ -4,7 +4,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.MacTODO.M3)]
     public class RebaseTests : GitRepoTests
     {
         public RebaseTests() : base(enlistmentPerTest: true)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -48,6 +48,7 @@ static bool TrySendRequestAndWaitForResponse(
     const VirtualizationRoot* root,
     MessageType messageType,
     const vnode_t vnode,
+    const char* vnodePath,
     int pid,
     const char* procname,
     int* kauthResult,
@@ -253,14 +254,23 @@ static int HandleVnodeOperation(
     vnode_t currentVnode =  reinterpret_cast<vnode_t>(arg1);
     // arg2 is the (vnode_t) parent vnode
     int* kauthError =       reinterpret_cast<int*>(arg3);
+    int kauthResult = KAUTH_RESULT_DEFER;
+
+    const char* vnodePath = nullptr;
+    char vnodePathBuffer[PrjFSMaxPath];
+    int vnodePathLength = PrjFSMaxPath;
 
     VirtualizationRoot* root = nullptr;
     vtype vnodeType;
     uint32_t currentVnodeFileFlags;
     int pid;
     char procname[MAXCOMLEN + 1];
-
-    int kauthResult = KAUTH_RESULT_DEFER;
+    
+    // TODO(Mac): Issue #271 - Reduce reliance on vn_getpath
+    if (0 == vn_getpath(currentVnode, vnodePathBuffer, &vnodePathLength))
+    {
+        vnodePath = vnodePathBuffer;
+    }
 
     if (!ShouldHandleVnodeOpEvent(
             context,
@@ -292,6 +302,7 @@ static int HandleVnodeOperation(
                         root,
                         MessageType_KtoU_EnumerateDirectory,
                         currentVnode,
+                        vnodePath,
                         pid,
                         procname,
                         &kauthResult,
@@ -308,6 +319,7 @@ static int HandleVnodeOperation(
                     root,
                     MessageType_KtoU_NotifyDirectoryPreDelete,
                     currentVnode,
+                    vnodePath,
                     pid,
                     procname,
                     &kauthResult,
@@ -325,6 +337,7 @@ static int HandleVnodeOperation(
                     root,
                     MessageType_KtoU_NotifyFilePreDelete,
                     currentVnode,
+                    vnodePath,
                     pid,
                     procname,
                     &kauthResult,
@@ -351,6 +364,7 @@ static int HandleVnodeOperation(
                         root,
                         MessageType_KtoU_HydrateFile,
                         currentVnode,
+                        vnodePath,
                         pid,
                         procname,
                         &kauthResult,
@@ -428,6 +442,7 @@ static int HandleFileOpOperation(
                 root,
                 messageType,
                 currentVnodeFromPath,
+                newPath,
                 pid,
                 procname,
                 &kauthResult,
@@ -439,7 +454,7 @@ static int HandleFileOpOperation(
     else if (KAUTH_FILEOP_CLOSE == action)
     {
         vnode_t currentVnode = reinterpret_cast<vnode_t>(arg0);
-        // arg1 is the (const char *) path
+        const char* path = (const char*)arg1;
         int closeFlags = static_cast<int>(arg2);
         
         if (vnode_isdir(currentVnode))
@@ -476,6 +491,7 @@ static int HandleFileOpOperation(
                     root,
                     MessageType_KtoU_NotifyFileModified,
                     currentVnode,
+                    path,
                     pid,
                     procname,
                     &kauthResult,
@@ -492,6 +508,7 @@ static int HandleFileOpOperation(
                     root,
                     MessageType_KtoU_NotifyFileCreated,
                     currentVnode,
+                    path,
                     pid,
                     procname,
                     &kauthResult,
@@ -647,6 +664,7 @@ static bool TrySendRequestAndWaitForResponse(
     const VirtualizationRoot* root,
     MessageType messageType,
     const vnode_t vnode,
+    const char* vnodePath,
     int pid,
     const char* procname,
     int* kauthResult,
@@ -657,11 +675,10 @@ static bool TrySendRequestAndWaitForResponse(
     OutstandingMessage message;
     message.receivedResponse = false;
     
-    char vnodePath[PrjFSMaxPath];
-    int vnodePathLength = PrjFSMaxPath;
-    if (vn_getpath(vnode, vnodePath, &vnodePathLength))
+    if (nullptr == vnodePath)
     {
-        KextLog_Error("Unable to resolve a vnode to its path");
+        // Default error code is EACCES. See errno.h for more codes.
+        *kauthError = EAGAIN;
         *kauthResult = KAUTH_RESULT_DENY;
         return false;
     }

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -267,6 +267,8 @@ static int HandleVnodeOperation(
     char procname[MAXCOMLEN + 1];
     
     // TODO(Mac): Issue #271 - Reduce reliance on vn_getpath
+    // Call vn_getpath first when the cache is hottest to increase the chances
+    // of successfully getting the path
     if (0 == vn_getpath(currentVnode, vnodePathBuffer, &vnodePathLength))
     {
         vnodePath = vnodePathBuffer;


### PR DESCRIPTION
Fixes #262 

- Added `CreateHardLink` implementation to `PowerShellRunner`
- Removed OS check from `ModifiedPathsTests` when building list of runners
- Enabled `CheckoutTests.CheckoutBranchThatHasFolderShouldGetDeleted` test on Mac
- Enabled `GitCommands.RebaseTests` on Mac