### PR TITLE
Mac: Prevent deletes of the index by non-git processes and enable related functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -114,7 +114,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             // BashRunner does nothing special when a failure is expected, so just confirm source file is still present
             this.MoveFile(sourcePath, targetPath);
-            this.FileExists(sourcePath).ShouldBeTrue();
+            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
         }
 
         public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -29,14 +29,12 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "Function not implemented"
         };
 
-        private static string[] permissionDeniedWindowsMessage = new string[]
+        private static string[] windowsPermissionDeniedMessage = new string[]
         {
             "Permission denied"
         };
 
-        // TODO(Mac): Update this message when the kext returns a more accurate
-        // error code
-        private static string[] permissionDeniedMacMessage = new string[]
+        private static string[] macPermissionDeniedMessage = new string[]
         {
             "Resource temporarily unavailable"
         };
@@ -116,7 +114,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             // BashRunner does nothing special when a failure is expected, so just confirm source file is still present
             this.MoveFile(sourcePath, targetPath);
-            this.FileExists(sourcePath).ShouldEqual(true);
+            this.FileExists(sourcePath).ShouldBeTrue();
         }
 
         public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)
@@ -254,14 +252,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                this.DeleteFile(path).ShouldContain(permissionDeniedWindowsMessage);
-            }
-            else
-            {
-                this.DeleteFile(path).ShouldContain(permissionDeniedMacMessage);
-            }
+            this.DeleteFile(path).ShouldContain(this.GetPermissionDeniedError());
+            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)
@@ -286,6 +278,16 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             bashPath = bashPath.Replace(":\\", "/");
             bashPath = bashPath.Replace('\\', '/');
             return bashPath;
+        }
+
+        private string[] GetPermissionDeniedError()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return windowsPermissionDeniedMessage;
+            }
+
+            return macPermissionDeniedMessage;
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -28,9 +29,16 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "Function not implemented"
         };
 
-        private static string[] permissionDeniedMessage = new string[]
+        private static string[] permissionDeniedWindowsMessage = new string[]
         {
             "Permission denied"
+        };
+
+        // TODO(Mac): Update this message when the kext returns a more accurate
+        // error code
+        private static string[] permissionDeniedMacMessage = new string[]
+        {
+            "Resource temporarily unavailable"
         };
 
         private readonly string pathToBash;
@@ -246,7 +254,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
-            this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                this.DeleteFile(path).ShouldContain(permissionDeniedWindowsMessage);
+            }
+            else
+            {
+                this.DeleteFile(path).ShouldContain(permissionDeniedMacMessage);
+            }
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -177,6 +177,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
             this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
+            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests.Should;
+using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -61,6 +62,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public override void DeleteFile_AccessShouldBeDenied(string path)
         {
             this.ShouldFail<Exception>(() => { this.DeleteFile(path); });
+            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
         }
 
         public override string ReadAllText(string path)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -785,7 +785,6 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
-        [Category(Categories.MacTODO.M4)]
         public void DeleteIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -81,14 +81,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.OverwritingIndexShouldFail(this.Enlistment.GetVirtualPathTo(".git", "index.lock"));
         }
 
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        private static extern bool MoveFileEx(
+        [DllImport("kernel32.dll", EntryPoint = "MoveFileEx", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool WindowsMoveFileEx(
             string existingFileName,
             string newFileName,
             uint flags);
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
-        private static extern int Rename(string oldPath, string newPath);
+        private static extern int MacRename(string oldPath, string newPath);
 
         private void OverwritingIndexShouldFail(string testFilePath)
         {
@@ -114,14 +114,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return MoveFileEx(
+                return WindowsMoveFileEx(
                     oldPath,
                     newPath,
                     (uint)(MoveFileFlags.MoveFileReplaceExisting | MoveFileFlags.MoveFileCopyAllowed));
             }
             else
             {
-                return Rename(oldPath, newPath) == 0;
+                return MacRename(oldPath, newPath) == 0;
             }
         }
     }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -34,13 +34,7 @@ namespace GVFS.Platform.Mac
             this.virtualizationInstance = virtualizationInstance ?? new VirtualizationInstance();
         }
 
-        protected override string EtwArea
-        {
-            get
-            {
-                return ClassName;
-            }
-        }
+        protected override string EtwArea => ClassName;
 
         public static FSResult ResultToFSResult(Result result)
         {
@@ -350,7 +344,6 @@ namespace GVFS.Platform.Mac
                             metadata.Add(TracingConstants.MessageKey.WarningMessage, "Blocked index delete outside the lock");
                             this.Context.Tracer.RelatedEvent(EventLevel.Warning, $"{nameof(OnPreDelete)}_BlockedIndexDelete", metadata);
 
-                            // TODO(Mac): Is this the correct Result to return?
                             return Result.EAccessDenied;
                         }
                     }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -16,6 +16,8 @@ namespace GVFS.Platform.Mac
     {
         public static readonly byte[] PlaceholderVersionId = ToVersionIdByteArray(new byte[] { PlaceholderVersion });
 
+        private const string ClassName = nameof(MacFileSystemVirtualizer);
+
         private VirtualizationInstance virtualizationInstance;
 
         public MacFileSystemVirtualizer(GVFSContext context, GVFSGitObjects gitObjects)
@@ -30,6 +32,14 @@ namespace GVFS.Platform.Mac
             : base(context, gitObjects)
         {
             this.virtualizationInstance = virtualizationInstance ?? new VirtualizationInstance();
+        }
+
+        protected override string EtwArea
+        {
+            get
+            {
+                return ClassName;
+            }
         }
 
         public static FSResult ResultToFSResult(Result result)
@@ -336,7 +346,7 @@ namespace GVFS.Platform.Mac
                         if (string.IsNullOrEmpty(lockedGitCommand))
                         {
                             EventMetadata metadata = new EventMetadata();
-                            metadata.Add("Area", EtwArea);
+                            metadata.Add("Area", this.EtwArea);
                             metadata.Add(TracingConstants.MessageKey.WarningMessage, "Blocked index delete outside the lock");
                             this.Context.Tracer.RelatedEvent(EventLevel.Warning, $"{nameof(OnPreDelete)}_BlockedIndexDelete", metadata);
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -55,13 +55,7 @@ namespace GVFS.Platform.Windows
             this.activeCommands = new ConcurrentDictionary<int, CancellationTokenSource>();
         }
 
-        protected override string EtwArea
-        {
-            get
-            {
-                return ClassName;
-            }
-        }
+        protected override string EtwArea => ClassName;
 
         /// <remarks>
         /// Public for unit testing


### PR DESCRIPTION
*Summary of changes*
- Block deletes of the index when the `GVFSLock` is not held by git
- Updated `BashRunner` to expect different messages on Windows and Mac when deletes are blocked
- Enabled `BasicFileSystemTests. DeleteIndexFileFails` test on Mac
- Enabled all `GVFSLockTests` tests on Mac

Closes #222 