### PR TITLE
Mac: Fix missing files due to auth cache

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -15,7 +15,6 @@
             // machines but not on the build agents
             public const string FailsOnBuildAgent = "FailsOnBuildAgent";
             public const string NeedsLockHolder = "NeedsDotCoreLockHolder";
-            public const string NeedsCachePoisonFix = "NeedsCachePoisonFix";
             public const string M2 = "M2_StaticViewGitCommands";
             public const string M3 = "M3_AllGitCommands";
             public const string M4 = "M4_All";

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -67,7 +67,6 @@ namespace GVFS.FunctionalTests
             {
                 excludeCategories.Add(Categories.MacTODO.NeedsLockHolder);
                 excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
-                excludeCategories.Add(Categories.MacTODO.NeedsCachePoisonFix);
                 excludeCategories.Add(Categories.MacTODO.M2);
                 excludeCategories.Add(Categories.MacTODO.M3);
                 excludeCategories.Add(Categories.MacTODO.M4);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -14,7 +14,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public class MultithreadedReadWriteTests : TestsWithEnlistmentPerFixture
     {
         [TestCase, Order(1)]
-        [Category(Categories.MacTODO.NeedsCachePoisonFix)]
         public void CanReadVirtualFileInParallel()
         {
             // Note: This test MUST go first, or else it needs to ensure that it is reading a unique path compared to the
@@ -27,7 +26,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             Exception readException = null;
 
-            Thread[] threads = new Thread[32];
+            Thread[] threads = new Thread[128];
             for (int i = 0; i < threads.Length; ++i)
             {
                 threads[i] = new Thread(() =>

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -88,7 +88,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsCachePoisonFix)]
         public void ReadDeepFilesAfterCheckout()
         {
             // In commit 8df701986dea0a5e78b742d2eaf9348825b14d35 the CheckoutNewBranchFromStartingPointTest files were not present
@@ -104,7 +103,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsCachePoisonFix)]
         public void CheckoutNewBranchFromStartingPointTest()
         {
             // In commit 8df701986dea0a5e78b742d2eaf9348825b14d35 the CheckoutNewBranchFromStartingPointTest files were not present
@@ -121,7 +119,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsCachePoisonFix)]
         public void CheckoutOrhpanBranchFromStartingPointTest()
         {
             // In commit 8df701986dea0a5e78b742d2eaf9348825b14d35 the CheckoutOrhpanBranchFromStartingPointTest files were not present
@@ -734,7 +731,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsCachePoisonFix)]
         public void SuccessfullyChecksOutDirectoryToFileToDirectory()
         {
             // This test switches between two branches and verifies specific transitions occured

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -105,7 +105,6 @@ int16_t VirtualizationRoots_LookupVnode(vnode_t vnode, vfs_context_t context)
         {
             // TODO: check xattr contents
             
-            
             char path[PrjFSMaxPath] = "";
             int pathLength = sizeof(path);
             vn_getpath(vnode, path, &pathLength);
@@ -281,6 +280,12 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
     if (NULLVP != virtualizationRootVNode)
     {
         vnode_put(virtualizationRootVNode);
+    }
+    
+    if (rootIndex >= 0)
+    {
+        VirtualizationRoot* root = &s_virtualizationRoots[rootIndex];
+        vfs_setauthcache_ttl(vnode_mount(root->rootVNode), 0);
     }
     
     vfs_context_rele(vfsContext);


### PR DESCRIPTION
The first commit re-enables all the tests that were hitting bugs with auth cache poison issues. The second commit fixes those issues by setting the auth cache TTL to 0.

With this fix, we no longer hit any missing file issues. Initial perf testing also demonstrates that there is very minimal overhead on non-virtualized paths, i.e. anything outside of a VFS for Git repo. For paths inside of a virtualization root, there is a bigger perf hit, but that is because our kext is now getting called on every kauth request, and any of our own perf issues are getting magnified. We will do more work to analyze that overhead and optimize it, but for now this fix makes our kext much more reliable.

Fixes #249 