### PR TITLE
Make LaunchPrefetchJobIfIdle thread safe and update it to exit when unhandled exceptions occur

### DIFF
--- a/GVFS/GVFS.UnitTests/Prefetch/BackgroundPrefetcherTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/BackgroundPrefetcherTests.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Prefetch
         {
             using (CommonRepoSetup setup = new CommonRepoSetup())
             {
-                BlockedDirectoryExistsFileSystem fileSystem = new BlockedDirectoryExistsFileSystem(setup.FileSystem.RootDirectory);
+                BlockedCreateDirectoryFileSystem fileSystem = new BlockedCreateDirectoryFileSystem(setup.FileSystem.RootDirectory);
                 using (BackgroundPrefetcher prefetcher = new BackgroundPrefetcher(
                     setup.Context.Tracer,
                     setup.Context.Enlistment,
@@ -49,31 +49,31 @@ namespace GVFS.UnitTests.Prefetch
                 {
                     prefetcher.LaunchPrefetchJobIfIdle().ShouldBeTrue();
                     prefetcher.LaunchPrefetchJobIfIdle().ShouldBeFalse();
-                    fileSystem.UnblockDirectoryExists();
+                    fileSystem.UnblockCreateDirectory();
                     prefetcher.WaitForPrefetchToFinish();
                 }
             }
         }
 
-        private class BlockedDirectoryExistsFileSystem : MockFileSystem
+        private class BlockedCreateDirectoryFileSystem : MockFileSystem
         {
-            private ManualResetEvent unblockDirectoryExists;
+            private ManualResetEvent unblockCreateDirectory;
 
-            public BlockedDirectoryExistsFileSystem(MockDirectory rootDirectory)
+            public BlockedCreateDirectoryFileSystem(MockDirectory rootDirectory)
                 : base(rootDirectory)
             {
-                this.unblockDirectoryExists = new ManualResetEvent(initialState: false);
+                this.unblockCreateDirectory = new ManualResetEvent(initialState: false);
             }
 
-            public void UnblockDirectoryExists()
+            public void UnblockCreateDirectory()
             {
-                this.unblockDirectoryExists.Set();
+                this.unblockCreateDirectory.Set();
             }
 
-            public override bool DirectoryExists(string path)
+            public override void CreateDirectory(string path)
             {
-                this.unblockDirectoryExists.WaitOne();
-                return base.DirectoryExists(path);
+                this.unblockCreateDirectory.WaitOne();
+                base.CreateDirectory(path);
             }
         }
     }

--- a/GVFS/GVFS.UnitTests/Prefetch/BackgroundPrefetcherTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/BackgroundPrefetcherTests.cs
@@ -1,7 +1,9 @@
 ﻿using GVFS.Common.Prefetch;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.FileSystem;
 using GVFS.UnitTests.Virtual;
 using NUnit.Framework;
+using System.Threading;
 
 namespace GVFS.UnitTests.Prefetch
 {
@@ -30,6 +32,48 @@ namespace GVFS.UnitTests.Prefetch
 
                 prefetcher.LaunchPrefetchJobIfIdle().ShouldBeTrue();
                 prefetcher.WaitForPrefetchToFinish();
+            }
+        }
+
+        [TestCase]
+        public void LaunchPrefetchJobIfIdleDoesNotLaunchSecondThreadIfFirstInProgress()
+        {
+            using (CommonRepoSetup setup = new CommonRepoSetup())
+            {
+                BlockedDirectoryExistsFileSystem fileSystem = new BlockedDirectoryExistsFileSystem(setup.FileSystem.RootDirectory);
+                using (BackgroundPrefetcher prefetcher = new BackgroundPrefetcher(
+                    setup.Context.Tracer,
+                    setup.Context.Enlistment,
+                    fileSystem,
+                    setup.GitObjects))
+                {
+                    prefetcher.LaunchPrefetchJobIfIdle().ShouldBeTrue();
+                    prefetcher.LaunchPrefetchJobIfIdle().ShouldBeFalse();
+                    fileSystem.UnblockDirectoryExists();
+                    prefetcher.WaitForPrefetchToFinish();
+                }
+            }
+        }
+
+        private class BlockedDirectoryExistsFileSystem : MockFileSystem
+        {
+            private ManualResetEvent unblockDirectoryExists;
+
+            public BlockedDirectoryExistsFileSystem(MockDirectory rootDirectory)
+                : base(rootDirectory)
+            {
+                this.unblockDirectoryExists = new ManualResetEvent(initialState: false);
+            }
+
+            public void UnblockDirectoryExists()
+            {
+                this.unblockDirectoryExists.Set();
+            }
+
+            public override bool DirectoryExists(string path)
+            {
+                this.unblockDirectoryExists.WaitOne();
+                return base.DirectoryExists(path);
             }
         }
     }

--- a/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
+++ b/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
@@ -34,14 +34,14 @@ namespace GVFS.UnitTests.Virtual
             enlistmentDirectory.CreateFile(Path.Combine(this.GitParentPath, ".git", "info", "always_exclude"), "always_exclude Contents", createDirectories: true);
             enlistmentDirectory.CreateDirectory(enlistment.GitPackRoot);
 
-            MockFileSystem fileSystem = new MockFileSystem(enlistmentDirectory);
+            this.FileSystem = new MockFileSystem(enlistmentDirectory);
             this.Repository = new MockGitRepo(
                 tracer, 
                 enlistment,
-                fileSystem);
+                this.FileSystem);
             CreateStandardGitTree(this.Repository);
 
-            this.Context = new GVFSContext(tracer, fileSystem, this.Repository, enlistment);
+            this.Context = new GVFSContext(tracer, this.FileSystem, this.Repository, enlistment);
 
             this.HttpObjects = new MockHttpGitObjects(tracer, enlistment);
             this.GitObjects = new MockGVFSGitObjects(this.Context, this.HttpObjects);
@@ -56,6 +56,7 @@ namespace GVFS.UnitTests.Virtual
 
         public MockGitRepo Repository { get; private set; }
         public MockHttpGitObjects HttpObjects { get; private set; }
+        public MockFileSystem FileSystem { get; private set; }
         
         public void Dispose()
         {


### PR DESCRIPTION
Fixes #277 

**Changes**
- Made `LaunchPrefetchJobIfIdle` thread safe
- Updated `LaunchPrefetchJobIfIdle` to force the process to exit if an unhandled exception occurs