### PR TITLE
Catch and log exceptions thrown by TryPrepareFolderForCallbacks

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common.Tracing;
+using System;
 
 namespace GVFS.Common.FileSystem
 {
@@ -8,7 +9,7 @@ namespace GVFS.Common.FileSystem
         string DriverLogFolderName { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         string FlushDriverLogs();
-        bool TryPrepareFolderForCallbacks(string folderPath, out string error);
+        bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -1,5 +1,4 @@
 ﻿using GVFS.Common.Tracing;
-using System;
 
 namespace GVFS.Common.FileSystem
 {
@@ -9,7 +8,7 @@ namespace GVFS.Common.FileSystem
         string DriverLogFolderName { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         string FlushDriverLogs();
-        bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
+        bool TryPrepareFolderForCallbacks(string folderPath, out string error);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
     }
 }

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -46,8 +46,9 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public bool TryPrepareFolderForCallbacks(string folderPath, out string error)
+        public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)
         {
+            exception = null;
             error = string.Empty;
             Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(folderPath);
             if (result != Result.Success)

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -46,9 +46,8 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)
+        public bool TryPrepareFolderForCallbacks(string folderPath, out string error)
         {
-            exception = null;
             error = string.Empty;
             Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(folderPath);
             if (result != Result.Success)

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -30,7 +30,6 @@ namespace GVFS.Platform.Windows
         private const string FilterLoggerSessionName = "Microsoft-Windows-ProjFS-Filter-Log";
 
         private const string ProjFSNativeLibFileName = "ProjectedFSLib.dll";
-        private const string ProjFSManagedLibFileName = "ProjectedFSLib.Managed.dll";
 
         private const uint OkResult = 0;
         private const uint NameCollisionErrorResult = 0x801F0012;
@@ -321,40 +320,14 @@ namespace GVFS.Platform.Windows
             return sb.ToString();
         }
 
-        public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)
+        public bool TryPrepareFolderForCallbacks(string folderPath, out string error)
         {
-            exception = null;
             error = string.Empty;
             Guid virtualizationInstanceGuid = Guid.NewGuid();
-
-            try
+            HResult result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(virtualizationInstanceGuid, folderPath);
+            if (result != HResult.Ok)
             {
-                HResult result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(virtualizationInstanceGuid, folderPath);
-                if (result != HResult.Ok)
-                {
-                    error = "Failed to prepare \"" + folderPath + "\" for callbacks, error: " + result.ToString("F");
-                    return false;
-                }
-            }
-            catch (FileNotFoundException e)
-            {
-                exception = e;
-
-                if (e.FileName.Equals(ProjFSManagedLibFileName, StringComparison.OrdinalIgnoreCase))
-                {
-                    error = $"Failed to load {ProjFSManagedLibFileName}. Ensure that ProjFS is installed and enabled";
-                }
-                else
-                {
-                    error = $"FileNotFoundException while trying to prepare \"{folderPath}\" for callbacks: {e.Message}";
-                }
-
-                return false;
-            }
-            catch (Exception e)
-            {
-                exception = e;
-                error = $"Exception while trying to prepare \"{folderPath}\" for callbacks: {e.Message}";
+                error = "Failed to prepare \"" + folderPath + "\" for callbacks, error: " + result.ToString("F");
                 return false;
             }
 

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -609,22 +609,29 @@ namespace GVFS.CommandLine
             }
 
             // Prepare the working directory folder for GVFS last to ensure that gvfs mount will fail if gvfs clone has failed
-            Exception exception;
-            string prepFileSystemError;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out prepFileSystemError, out exception))
+            Result prepForCallbacksResult = new Result(true);
+            try
+            {
+                string prepFileSystemError;
+                if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out prepFileSystemError))
+                {
+                    prepForCallbacksResult = new Result(prepFileSystemError);
+                }
+            }
+            catch (Exception e)
             {
                 EventMetadata metadata = new EventMetadata();
-                metadata.Add(nameof(prepFileSystemError), prepFileSystemError);
-                if (exception != null)
-                {
-                    metadata.Add("Exception", exception.ToString());
-                }
-
+                metadata.Add("Exception", e.ToString());
                 tracer.RelatedError(metadata, $"{nameof(this.CreateClone)}: TryPrepareFolderForCallbacks failed");
-                return new Result(prepFileSystemError);
+                prepForCallbacksResult = new Result($"Failed to prepare \"{enlistment.WorkingDirectoryRoot}\" for callbacks, exception: {e.Message}");
             }
 
-            return new Result(true);
+            if (!prepForCallbacksResult.Success)
+            {
+                tracer.RelatedError($"TryPrepareFolderForCallbacks failed, error: {prepForCallbacksResult.ErrorMessage}");
+            }
+
+            return prepForCallbacksResult;
         }
 
         private void CreateGitScript(GVFSEnlistment enlistment)

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -609,10 +609,18 @@ namespace GVFS.CommandLine
             }
 
             // Prepare the working directory folder for GVFS last to ensure that gvfs mount will fail if gvfs clone has failed
+            Exception exception;
             string prepFileSystemError;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out prepFileSystemError))
+            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out prepFileSystemError, out exception))
             {
-                tracer.RelatedError(prepFileSystemError);
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add(nameof(prepFileSystemError), prepFileSystemError);
+                if (exception != null)
+                {
+                    metadata.Add("Exception", exception.ToString());
+                }
+
+                tracer.RelatedError(metadata, $"{nameof(this.CreateClone)}: TryPrepareFolderForCallbacks failed");
                 return new Result(prepFileSystemError);
             }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -221,9 +221,18 @@ of your enlistment's src folder.
 
         private void PrepareSrcFolder(ITracer tracer, GVFSEnlistment enlistment)
         {
+            Exception exception;
             string error;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error))
+            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error, out exception))
             {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add(nameof(error), error);
+                if (exception != null)
+                {
+                    metadata.Add("Exception", exception.ToString());
+                }
+
+                tracer.RelatedError(metadata, $"{nameof(this.PrepareSrcFolder)}: TryPrepareFolderForCallbacks failed");
                 this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + error);
             }
         }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -221,19 +221,23 @@ of your enlistment's src folder.
 
         private void PrepareSrcFolder(ITracer tracer, GVFSEnlistment enlistment)
         {
-            Exception exception;
-            string error;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error, out exception))
+            try
+            {
+                string error;
+                if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error))
+                {
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add(nameof(error), error);
+                    tracer.RelatedError(metadata, $"{nameof(this.PrepareSrcFolder)}: TryPrepareFolderForCallbacks failed");
+                    this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + error);
+                }
+            }
+            catch (Exception e)
             {
                 EventMetadata metadata = new EventMetadata();
-                metadata.Add(nameof(error), error);
-                if (exception != null)
-                {
-                    metadata.Add("Exception", exception.ToString());
-                }
-
+                metadata.Add("Exception", e.ToString());
                 tracer.RelatedError(metadata, $"{nameof(this.PrepareSrcFolder)}: TryPrepareFolderForCallbacks failed");
-                this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + error);
+                this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + e.Message);
             }
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -221,23 +221,19 @@ of your enlistment's src folder.
 
         private void PrepareSrcFolder(ITracer tracer, GVFSEnlistment enlistment)
         {
-            try
-            {
-                string error;
-                if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error))
-                {
-                    EventMetadata metadata = new EventMetadata();
-                    metadata.Add(nameof(error), error);
-                    tracer.RelatedError(metadata, $"{nameof(this.PrepareSrcFolder)}: TryPrepareFolderForCallbacks failed");
-                    this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + error);
-                }
-            }
-            catch (Exception e)
+            Exception exception;
+            string error;
+            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryRoot, out error, out exception))
             {
                 EventMetadata metadata = new EventMetadata();
-                metadata.Add("Exception", e.ToString());
+                metadata.Add(nameof(error), error);
+                if (exception != null)
+                {
+                    metadata.Add("Exception", exception.ToString());
+                }
+
                 tracer.RelatedError(metadata, $"{nameof(this.PrepareSrcFolder)}: TryPrepareFolderForCallbacks failed");
-                this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + e.Message);
+                this.ReportErrorAndExit(tracer, "Failed to recreate the virtualization root: " + error);
             }
         }
 


### PR DESCRIPTION
Fixes #278 

`TryPrepareFolderForCallbacks ` can throw a `FileNotFoundException` if ProjFS is not properly installed\enabled.  Prior to these changes, when an exception occurred the exception would not be logged and the full call stack would be displayed to the user on the console.

With these changes any exceptions thrown by `TryPrepareFolderForCallbacks` will be caught and recorded to the log file.