### PR TITLE
Mac kext performance tracing

### DIFF
--- a/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/xcschemes/PrjFS.xcscheme
+++ b/ProjFS.Mac/PrjFS.xcworkspace/xcshareddata/xcschemes/PrjFS.xcscheme
@@ -92,7 +92,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Profiling(Release)"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4AC1D7C12091FA0400786861 /* PrjFSProviderUserClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4AC1D7BF2091FA0400786861 /* PrjFSProviderUserClient.hpp */; };
 		4AC1D7C52091FBFC00786861 /* PrjFSLogUserClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1D7C32091FBFC00786861 /* PrjFSLogUserClient.cpp */; };
 		4AC1D7C62091FBFC00786861 /* PrjFSLogUserClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4AC1D7C42091FBFC00786861 /* PrjFSLogUserClient.hpp */; };
+		4AE187A821203A890026AC68 /* PerformanceTracing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AE187A721203A890026AC68 /* PerformanceTracing.cpp */; };
 		C6BDD366208BC60400CB7E58 /* VirtualizationRoots.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C6BDD364208BC60400CB7E58 /* VirtualizationRoots.hpp */; };
 		C6BDD367208BC60400CB7E58 /* VirtualizationRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6BDD365208BC60400CB7E58 /* VirtualizationRoots.cpp */; };
 		C6BDD36A208BC99100CB7E58 /* Locks.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C6BDD368208BC99100CB7E58 /* Locks.hpp */; };
@@ -38,6 +39,7 @@
 		4A9D139C208F675500376182 /* PrjFSService.hpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.h; path = PrjFSService.hpp; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		4AA0BA9920A4500600F33D1C /* vnode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vnode.h; sourceTree = "<group>"; };
 		4ABB733020B85DA500DC0D17 /* mount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mount.h; sourceTree = "<group>"; };
+		4ABB734320B867E000DC0D17 /* PerformanceTracing.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PerformanceTracing.hpp; sourceTree = "<group>"; };
 		4ABB734520BED11500DC0D17 /* PrjFSLogClientShared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrjFSLogClientShared.h; sourceTree = "<group>"; };
 		4ABB734C20C1A65B00DC0D17 /* PrjFSProviderClientShared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrjFSProviderClientShared.h; sourceTree = "<group>"; };
 		4AC1D7BE2091FA0400786861 /* PrjFSProviderUserClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSProviderUserClient.cpp; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 		4AC1D7C22091FA2300786861 /* PrjFSClasses.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSClasses.hpp; sourceTree = "<group>"; };
 		4AC1D7C32091FBFC00786861 /* PrjFSLogUserClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSLogUserClient.cpp; sourceTree = "<group>"; };
 		4AC1D7C42091FBFC00786861 /* PrjFSLogUserClient.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrjFSLogUserClient.hpp; sourceTree = "<group>"; };
+		4AE187A721203A890026AC68 /* PerformanceTracing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PerformanceTracing.cpp; sourceTree = "<group>"; };
 		C6BDD364208BC60400CB7E58 /* VirtualizationRoots.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRoots.hpp; sourceTree = "<group>"; };
 		C6BDD365208BC60400CB7E58 /* VirtualizationRoots.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VirtualizationRoots.cpp; sourceTree = "<group>"; };
 		C6BDD368208BC99100CB7E58 /* Locks.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Locks.hpp; sourceTree = "<group>"; };
@@ -124,6 +127,8 @@
 				C6C780CB207FD02400E7E054 /* KextLog.hpp */,
 				C6C780CC207FD02400E7E054 /* KextLog.cpp */,
 				C6C780B5207FC67200E7E054 /* Info.plist */,
+				4ABB734320B867E000DC0D17 /* PerformanceTracing.hpp */,
+				4AE187A721203A890026AC68 /* PerformanceTracing.cpp */,
 				C6E9E116208BBB62004A5725 /* KauthHandler.hpp */,
 				C6E9E117208BBB62004A5725 /* KauthHandler.cpp */,
 				C6BDD364208BC60400CB7E58 /* VirtualizationRoots.hpp */,
@@ -253,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6BDD36B208BC99100CB7E58 /* Locks.cpp in Sources */,
+				4AE187A821203A890026AC68 /* PerformanceTracing.cpp in Sources */,
 				C6BDD367208BC60400CB7E58 /* VirtualizationRoots.cpp in Sources */,
 				C6BDD374208C033200CB7E58 /* Memory.cpp in Sources */,
 				4AC1D7C52091FBFC00786861 /* PrjFSLogUserClient.cpp in Sources */,

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
@@ -275,6 +275,96 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		4A91E087215FA5FF0079FE1B /* Profiling(Release) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "PRJFS_PERFORMANCE_TRACING_ENABLE=1";
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MODULE_START = PrjFSKext_Start;
+				MODULE_STOP = PrjFSKext_Stop;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SYMROOT = "$(SRCROOT)/../../../BuildOutput/ProjFS.Mac/Native";
+				WARNING_CFLAGS = (
+					"-Werror=undefined-internal",
+					"-Werror=missing-prototypes",
+				);
+			};
+			name = "Profiling(Release)";
+		};
+		4A91E088215FA5FF0079FE1B /* Profiling(Release) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MACH_ASSERT=1",
+					"$(inherited)",
+				);
+				GCC_WARN_SHADOW = YES;
+				INFOPLIST_FILE = PrjFSKext/Info.plist;
+				MODULE_NAME = io.gvfs.PrjFSKext;
+				MODULE_START = PrjFSKext_Start;
+				MODULE_STOP = PrjFSKext_Stop;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.gvfs.PrjFSKext;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = (
+					"-Werror",
+					"-Werror=undefined-internal",
+					"-Werror=missing-prototypes",
+					"-Werror=format",
+				);
+				WRAPPER_EXTENSION = kext;
+			};
+			name = "Profiling(Release)";
+		};
 		C6C780B6207FC67200E7E054 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -467,6 +557,7 @@
 			buildConfigurations = (
 				C6C780B6207FC67200E7E054 /* Debug */,
 				C6C780B7207FC67200E7E054 /* Release */,
+				4A91E087215FA5FF0079FE1B /* Profiling(Release) */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -476,6 +567,7 @@
 			buildConfigurations = (
 				C6C780B9207FC67200E7E054 /* Debug */,
 				C6C780BA207FC67200E7E054 /* Release */,
+				4A91E088215FA5FF0079FE1B /* Profiling(Release) */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.cpp
@@ -1,0 +1,59 @@
+#include "PerformanceTracing.hpp"
+#include <sys/types.h>
+#include <stdatomic.h>
+#include <IOKit/IOUserClient.h>
+
+PerfTracingProbe profile_probes[Probe_Count];
+
+void PerfTracing_Init()
+{
+    for (size_t i = 0; i < Probe_Count; ++i)
+    {
+        PerfTracing_ProbeInit(&profile_probes[i]);
+    }
+}
+
+void PerfTracing_ProbeInit(PerfTracingProbe* probe)
+{
+    *probe = PerfTracingProbe{ .min = UINT64_MAX };
+}
+
+IOReturn PerfTracing_ExportDataUserClient(IOExternalMethodArguments* arguments)
+{
+    if (arguments->structureOutput == nullptr || arguments->structureOutputSize != sizeof(profile_probes))
+    {
+        return kIOReturnBadArgument;
+    }
+    
+    memcpy(arguments->structureOutput, profile_probes, sizeof(profile_probes));
+    return kIOReturnSuccess;
+}
+
+void PerfTracing_RecordSample(PerfTracingProbe* probe, uint64_t startTime, uint64_t endTime)
+{
+    uint64_t interval = endTime - startTime;
+    
+    atomic_fetch_add(&probe->numSamples1, 1);
+    atomic_fetch_add(&probe->sum, interval);
+    
+    __uint128_t intervalSquared = interval;
+    intervalSquared *= intervalSquared;
+    atomic_fetch_add(&probe->sumSquares, intervalSquared);
+    
+    // Update minimum sample if necessary
+    {
+        uint64_t oldMin = atomic_load(&probe->min);
+        while (interval < oldMin && !atomic_compare_exchange_weak(&probe->min, &oldMin, interval))
+        {}
+    }
+
+    // Update maximum sample if necessary
+    {
+        uint64_t oldMax = atomic_load(&probe->max);
+        while (interval > oldMax && !atomic_compare_exchange_weak(&probe->max, &oldMax, interval))
+        {}
+    }
+
+    atomic_fetch_add(&probe->numSamples2, 1);
+}
+

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.cpp
@@ -20,6 +20,7 @@ void PerfTracing_ProbeInit(PerfTracingProbe* probe)
 
 IOReturn PerfTracing_ExportDataUserClient(IOExternalMethodArguments* arguments)
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     if (arguments->structureOutput == nullptr || arguments->structureOutputSize != sizeof(profile_probes))
     {
         return kIOReturnBadArgument;
@@ -27,6 +28,9 @@ IOReturn PerfTracing_ExportDataUserClient(IOExternalMethodArguments* arguments)
     
     memcpy(arguments->structureOutput, profile_probes, sizeof(profile_probes));
     return kIOReturnSuccess;
+#else
+    return kIOReturnUnsupported;
+#endif
 }
 
 void PerfTracing_RecordSample(PerfTracingProbe* probe, uint64_t startTime, uint64_t endTime)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.hpp
@@ -94,10 +94,12 @@ class ProfileSample
     ProfileSample(const ProfileSample&) = delete;
     ProfileSample() = delete;
 
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     const uint64_t startTimestamp;
     PrjFS_PerfCounter wholeSampleProbe;
     PrjFS_PerfCounter finalSplitProbe;
     uint64_t splitTimestamp;
+#endif
 
 public:
     inline ProfileSample(PrjFS_PerfCounter defaultProbe);
@@ -110,6 +112,7 @@ public:
 
 ProfileSample::~ProfileSample()
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     uint64_t endTimestamp = mach_absolute_time();
     if (this->wholeSampleProbe != Probe_None)
     {
@@ -120,36 +123,49 @@ ProfileSample::~ProfileSample()
     {
         PerfTracing_RecordSample(&profile_probes[this->finalSplitProbe], this->splitTimestamp, endTimestamp);
     }
+#endif
 };
 
 void ProfileSample::TakeSplitSample(PrjFS_PerfCounter splitProbe)
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     uint64_t newSplitTimestamp = mach_absolute_time();
     PerfTracing_RecordSample(&profile_probes[splitProbe], this->splitTimestamp, newSplitTimestamp);
     this->splitTimestamp = newSplitTimestamp;
+#endif
 }
 
 void ProfileSample::TakeSplitSample(PrjFS_PerfCounter splitProbe, PrjFS_PerfCounter newFinalSplitProbe)
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     this->TakeSplitSample(splitProbe);
     this->finalSplitProbe = newFinalSplitProbe;
+#endif
 }
 
 void ProfileSample::SetFinalSplitProbe(PrjFS_PerfCounter newFinalSplitProbe)
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     this->finalSplitProbe = newFinalSplitProbe;
+#endif
 }
 
-ProfileSample::ProfileSample(PrjFS_PerfCounter defaultProbe) :
+
+ProfileSample::ProfileSample(PrjFS_PerfCounter defaultProbe)
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
+    :
     startTimestamp(mach_absolute_time()),
     wholeSampleProbe(defaultProbe),
     finalSplitProbe(Probe_None),
     splitTimestamp(this->startTimestamp)
+#endif
 {
 }
 
 void ProfileSample::SetProbe(PrjFS_PerfCounter probe)
 {
+#if PRJFS_PERFORMANCE_TRACING_ENABLE
     this->wholeSampleProbe = probe;
+#endif
 }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PerformanceTracing.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include "PrjFSCommon.h"
+
+#include <mach/mach_time.h>
+#include <IOKit/IOReturn.h>
+
+void PerfTracing_Init();
+void PerfTracing_ProbeInit(PerfTracingProbe* probe);
+void PerfTracing_RecordSample(PerfTracingProbe* probe, uint64_t startTime, uint64_t endTime);
+
+struct IOExternalMethodArguments;
+IOReturn PerfTracing_ExportDataUserClient(IOExternalMethodArguments* arguments);
+
+extern PerfTracingProbe profile_probes[Probe_Count];
+// A scope-based manual instrumentation profiling mechanism.
+// In the simplest case, the time between construction and destruction of the ProfileSample
+// is measured and registered with the probe specified during construction:
+//
+// void MyFunction()
+// {
+//    ProfileSample functionSample(Probe_MyFunction);
+//     // ... The code for which we're measuring the runtime ...
+// } // <-- functionSample goes out of scope here, so that's when timing ends
+//
+//
+// To allow runtimes different code paths in the same scope to be recorded separately, the
+// probe identity can be modified using SetProbe():
+//
+// void MyFunction()
+// {
+//     ProfileSample functionSample(Probe_MyFunction);
+//     // ... The code for which we're measuring the runtime ...
+//     if (specialCase)
+//     {
+//         // We want to be able to distinguish between the runtimes of MyFunction for this
+//         // special case vs "normal" runs.
+//         functionSample.SetProbe(Probe_MyFunctionSpecialCase);
+//         // ... do something potentially expensive here ...
+//     }
+//     // ... more code ...
+// } // <-- Runtime to here will be recorded either under Probe_MyFunction or Probe_MyFunctionSpecialCase
+//
+//
+// For tracing sub-sections of code, such as the special case logic above, in isolation,
+// we have 2 options: taking additional scoped samples, or split timings. Scoped samples are
+// easier to understand:
+//
+// void MyFunction()
+// {
+//     ProfileSample functionSample(Probe_MyFunction);
+//     // ...
+//     if (specialCase)
+//     {
+//         // Measure only the special case code on its own:
+//         ProfileSample specialCaseSample(Probe_MyFunctionSpecialCase);
+//         // ... do something potentially expensive here ...
+//     } // <-- scope of specialCaseSample ends here
+//     // ... more code ...
+// } // <-- end of Probe_MyFunction in all cases
+//
+// In the above example, the runtimes of all MyFunction() calls are recorded under Probe_MyFunction,
+// while the special case code on its own is recorded in Probe_MyFunctionSpecialCase.
+//
+// Taking split timings meanwhile allows us to carve up scoped samples into constituent sub-samples,
+// useful for drilling down to find the source of performance issues:
+//
+// void MyFunction()
+// {
+//     ProfileSample functionSample(Probe_MyFunction);
+//     // ...
+//     // The time from the creation of functionSample to this point is recorded as Probe_MyFunctionPart1.
+//     functionSample.TakeSplitSample(Probe_MyFunctionPart1, Probe_MyFunctionRemainder);
+//     if (specialCase)
+//     {
+//         // ... do something potentially expensive here ...
+//         functionSample.TakeSplitSample(Probe_MyFunctionSpecialCase); // This measures time since the Part1 split
+//     } // <-- scope of specialCaseSample ends here
+//     // ... more code ...
+// } // <-- end of Probe_MyFunction in all cases; the time since the last split (Probe_MyFunctionPart1
+//   // or Probe_MyFunctionSpecialCase depending on code path) is recorded as Probe_MyFunctionRemainder.
+//
+// The end time stamp for a split is taken as the start of the next split, and the overall start and end
+// stamps of the scoped sample are alse the start and end of the first and last (remainder) split,
+// respectively.
+// So in this case, the sum total runtime of all samples of Probe_MyFunction is exactly equal to the sum of
+// Probe_MyFunctionPart1 + Probe_MyFunctionSpecialCase + Probe_MyFunctionRemainder.
+// Note that Probe_MyFunctionSpecialCase may have a lower sample count.
+// Note also that the "remainder" split is optional - if only the 1-argument version of TakeSplitSample
+// is used, the split time to the end of scope is not recorded. (And like the scoped sample, it can be changed,
+// in this case using SetFinalSplitProbe())
+class ProfileSample
+{
+    ProfileSample(const ProfileSample&) = delete;
+    ProfileSample() = delete;
+
+    const uint64_t startTimestamp;
+    PrjFS_PerfCounter wholeSampleProbe;
+    PrjFS_PerfCounter finalSplitProbe;
+    uint64_t splitTimestamp;
+
+public:
+    inline ProfileSample(PrjFS_PerfCounter defaultProbe);
+    inline void SetProbe(PrjFS_PerfCounter probe);
+    inline void TakeSplitSample(PrjFS_PerfCounter splitProbe);
+    inline void TakeSplitSample(PrjFS_PerfCounter splitProbe, PrjFS_PerfCounter newFinalSplitProbe);
+    inline void SetFinalSplitProbe(PrjFS_PerfCounter newFinalSplitProbe);
+    inline ~ProfileSample();
+};
+
+ProfileSample::~ProfileSample()
+{
+    uint64_t endTimestamp = mach_absolute_time();
+    if (this->wholeSampleProbe != Probe_None)
+    {
+        PerfTracing_RecordSample(&profile_probes[this->wholeSampleProbe], this->startTimestamp, endTimestamp);
+    }
+    
+    if (this->finalSplitProbe != Probe_None)
+    {
+        PerfTracing_RecordSample(&profile_probes[this->finalSplitProbe], this->splitTimestamp, endTimestamp);
+    }
+};
+
+void ProfileSample::TakeSplitSample(PrjFS_PerfCounter splitProbe)
+{
+    uint64_t newSplitTimestamp = mach_absolute_time();
+    PerfTracing_RecordSample(&profile_probes[splitProbe], this->splitTimestamp, newSplitTimestamp);
+    this->splitTimestamp = newSplitTimestamp;
+}
+
+void ProfileSample::TakeSplitSample(PrjFS_PerfCounter splitProbe, PrjFS_PerfCounter newFinalSplitProbe)
+{
+    this->TakeSplitSample(splitProbe);
+    this->finalSplitProbe = newFinalSplitProbe;
+}
+
+void ProfileSample::SetFinalSplitProbe(PrjFS_PerfCounter newFinalSplitProbe)
+{
+    this->finalSplitProbe = newFinalSplitProbe;
+}
+
+ProfileSample::ProfileSample(PrjFS_PerfCounter defaultProbe) :
+    startTimestamp(mach_absolute_time()),
+    wholeSampleProbe(defaultProbe),
+    finalSplitProbe(Probe_None),
+    splitTimestamp(this->startTimestamp)
+{
+}
+
+void ProfileSample::SetProbe(PrjFS_PerfCounter probe)
+{
+    this->wholeSampleProbe = probe;
+}
+

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSKext.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSKext.cpp
@@ -5,12 +5,15 @@
 #include "KauthHandler.hpp"
 #include "Locks.hpp"
 #include "Memory.hpp"
+#include "PerformanceTracing.hpp"
 
 extern "C" kern_return_t PrjFSKext_Start(kmod_info_t* ki, void* d);
 extern "C" kern_return_t PrjFSKext_Stop(kmod_info_t* ki, void* d);
 
 kern_return_t PrjFSKext_Start(kmod_info_t* ki, void* d)
 {
+    PerfTracing_Init();
+    
     if (Locks_Init())
     {
         goto CleanupAndFail;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSLogUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSLogUserClient.hpp
@@ -26,5 +26,18 @@ public:
     virtual IOReturn clientMemoryForType(UInt32 type, IOOptionBits* options, IOMemoryDescriptor** memory) override;
     virtual IOReturn registerNotificationPort(mach_port_t port, UInt32 type, io_user_reference_t refCon) override;
     
+    virtual IOReturn externalMethod(
+        uint32_t selector,
+        IOExternalMethodArguments* arguments,
+        IOExternalMethodDispatch* dispatch = nullptr,
+        OSObject* target = nullptr,
+        void* reference = nullptr) override;
+
+    
+    static IOReturn fetchProfilingData(
+        OSObject* target,
+        void* reference,
+        IOExternalMethodArguments* arguments);
+    
     void sendLogMessage(KextLog_MessageHeader* message, uint32_t size);
 };

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
@@ -30,9 +30,9 @@ public:
     virtual IOReturn externalMethod(
         uint32_t selector,
         IOExternalMethodArguments* arguments,
-        IOExternalMethodDispatch* dispatch = 0,
-        OSObject* target = 0,
-        void* reference = 0) override;
+        IOExternalMethodDispatch* dispatch = nullptr,
+        OSObject* target = nullptr,
+        void* reference = nullptr) override;
     virtual IOReturn clientMemoryForType(
         UInt32 type,
         IOOptionBits* options,

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -37,6 +37,24 @@ enum PrjFS_PerfCounter : int32_t
 {
     // Note: ensure that any changes to this list are reflected in the PerfCounterNames array of strings
     
+    Probe_VnodeOp = 0,
+    Probe_FileOp,
+    Probe_Op_EarlyOut,
+    Probe_Op_NoVirtualizationRootFlag,
+    Probe_Op_EmptyFlag,
+    Probe_Op_DenyCrawler,
+    Probe_Op_Offline,
+    Probe_Op_Provider,
+    Probe_VnodeOp_PopulatePlaceholderDirectory,
+    Probe_VnodeOp_HydratePlaceholderFile,
+    
+    Probe_Op_IdentifySplit,
+    Probe_Op_VirtualizationRootFindSplit,
+        
+    Probe_ReadFileFlags,
+    
+    Probe_VirtualizationRoot_Find,
+    Probe_VirtualizationRoot_FindIteration,
     
     Probe_Count,
     

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -33,4 +33,29 @@ enum PrjFSServiceUserClientType
     UserClientType_Log,
 };
 
+enum PrjFS_PerfCounter : int32_t
+{
+    // Note: ensure that any changes to this list are reflected in the PerfCounterNames array of strings
+    
+    
+    Probe_Count,
+    
+    Probe_None = -1
+};
+
+struct PerfTracingProbe
+{
+    _Atomic uint64_t numSamples1;
+    _Atomic uint64_t numSamples2;
+    // Units: Mach absolute time (squared for sumSquares)
+    // Sum of measured sample intervals
+    _Atomic uint64_t sum;
+    // Smallest encountered interval
+    _Atomic uint64_t min;
+    // Largest encountered interval
+    _Atomic uint64_t max;
+    // Sum-of-squares of measured time intervals (for stddev)
+    _Atomic __uint128_t sumSquares;
+};
+
 #endif /* PrjFSCommon_h */

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
@@ -2,6 +2,14 @@
 
 #include <stdint.h>
 
+// External method selectors for log user clients
+enum PrjFSLogUserClientSelector
+{
+    LogSelector_Invalid = 0,
+    
+    LogSelector_FetchProfilingData,
+};
+
 enum PrjFSLogUserClientMemoryType
 {
     LogMemoryType_Invalid = 0,

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4A440DDE2093AD3300AADA76 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A440DDD2093AD3300AADA76 /* IOKit.framework */; };
 		4A8A1BEE20A0D5940024BC10 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8A1BED20A0D5940024BC10 /* CoreFoundation.framework */; };
+		4A91E086215E76A90079FE1B /* kext-perf-tracing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A91E084215E76A90079FE1B /* kext-perf-tracing.cpp */; };
 		C6C780D120816BDC00E7E054 /* PrjFSLib.h in Headers */ = {isa = PBXBuildFile; fileRef = C6C780CF20816BDC00E7E054 /* PrjFSLib.h */; };
 		C6C780D220816BDC00E7E054 /* PrjFSLib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6C780D020816BDC00E7E054 /* PrjFSLib.cpp */; };
 		D308478120B4431200F69E92 /* prjfs-log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D308478020B4431200F69E92 /* prjfs-log.cpp */; };
@@ -34,6 +35,8 @@
 /* Begin PBXFileReference section */
 		4A440DDD2093AD3300AADA76 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		4A8A1BED20A0D5940024BC10 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		4A91E084215E76A90079FE1B /* kext-perf-tracing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "kext-perf-tracing.cpp"; sourceTree = "<group>"; };
+		4A91E085215E76A90079FE1B /* kext-perf-tracing.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = "kext-perf-tracing.hpp"; sourceTree = "<group>"; };
 		C6C780C4207FC6AB00E7E054 /* libPrjFSLib.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libPrjFSLib.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6C780CF20816BDC00E7E054 /* PrjFSLib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrjFSLib.h; sourceTree = "<group>"; };
 		C6C780D020816BDC00E7E054 /* PrjFSLib.cpp */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSLib.cpp; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
@@ -103,6 +106,8 @@
 			isa = PBXGroup;
 			children = (
 				D308478020B4431200F69E92 /* prjfs-log.cpp */,
+				4A91E085215E76A90079FE1B /* kext-perf-tracing.hpp */,
+				4A91E084215E76A90079FE1B /* kext-perf-tracing.cpp */,
 			);
 			path = "prjfs-log";
 			sourceTree = "<group>";
@@ -207,6 +212,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D308478920B4432500F69E92 /* PrjFSUser.cpp in Sources */,
+				4A91E086215E76A90079FE1B /* kext-perf-tracing.cpp in Sources */,
 				D308478120B4431200F69E92 /* prjfs-log.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -1,0 +1,65 @@
+#include "kext-perf-tracing.hpp"
+#include "../../PrjFSKext/public/PrjFSCommon.h"
+#include "../../PrjFSKext/public/PrjFSLogClientShared.h"
+#include <mach/mach_time.h>
+#include <dispatch/dispatch.h>
+#include <IOKit/IOKitLib.h>
+#include <cstdio>
+#include <cmath>
+
+static mach_timebase_info_data_t s_machTimebase;
+
+static uint64_t nanosecondsFromAbsoluteTime(uint64_t machAbsoluteTime)
+{
+    return static_cast<__uint128_t>(machAbsoluteTime) * s_machTimebase.numer / s_machTimebase.denom;
+}
+
+static const char* const PerfCounterNames[Probe_Count] =
+{
+};
+
+bool PrjFSLog_FetchAndPrintKextProfilingData(io_connect_t connection)
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mach_timebase_info(&s_machTimebase);
+    });
+    
+    PerfTracingProbe probes[Probe_Count];
+    size_t out_size = sizeof(probes);
+    IOReturn ret = IOConnectCallStructMethod(connection, LogSelector_FetchProfilingData, nullptr, 0, probes, &out_size);
+    if (ret == kIOReturnUnsupported)
+    {
+        return false;
+    }
+    else if (ret == kIOReturnSuccess)
+    {
+        for (unsigned i = 0; i < Probe_Count; ++i)
+        {
+            double samples = probes[i].numSamples1;
+            double sum_abs = probes[i].sum;
+            double stddev_abs = samples > 1 ? sqrt((samples * probes[i].sumSquares - sum_abs * sum_abs) / (samples * (samples - 1))) : 0.0;
+
+            double sum_ns = nanosecondsFromAbsoluteTime(sum_abs);
+            double stddev_ns = nanosecondsFromAbsoluteTime(stddev_abs);
+            double mean_ns = samples > 0 ? sum_ns / samples : 0;
+            printf("%2u %40s  %8llu [%8llu] samples, total time: %15.0f ns, mean: %10.2f ns +/- %11.2f",
+                i, PerfCounterNames[i], probes[i].numSamples1, probes[i].numSamples2, sum_ns, mean_ns, stddev_ns);
+            if (probes[i].min != UINT64_MAX)
+            {
+                printf(", min: %7llu ns, max: %10llu ns\n",  nanosecondsFromAbsoluteTime(probes[i].min), nanosecondsFromAbsoluteTime(probes[i].max));
+            }
+            else
+            {
+                printf("\n");
+            }
+        }
+    }
+    else
+    {
+        fprintf(stderr, "fetching profiling data from kernel failed: 0x%x\n", ret);
+        return false;
+    }
+    fflush(stdout);
+    return true;
+}

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -16,6 +16,23 @@ static uint64_t nanosecondsFromAbsoluteTime(uint64_t machAbsoluteTime)
 
 static const char* const PerfCounterNames[Probe_Count] =
 {
+    [Probe_VnodeOp] = "VnodeOp",
+    [Probe_FileOp] = "FileOp",
+    [Probe_Op_EarlyOut] = "Op_EarlyOut",
+    [Probe_Op_NoVirtualizationRootFlag] = "Op_NoVirtualizationRootFlag",
+    [Probe_Op_EmptyFlag] = "Op_EmptyFlag",
+    [Probe_Op_DenyCrawler] = "Op_DenyCrawler",
+    [Probe_Op_Offline] = "Op_Offline",
+    [Probe_Op_Provider] = "Op_Provider",
+    [Probe_VnodeOp_PopulatePlaceholderDirectory] = "VnodeOp_PopulatePlaceholderDirectory",
+    [Probe_VnodeOp_HydratePlaceholderFile] = "VnodeOp_HydratePlaceholderFile",
+    
+    [Probe_Op_IdentifySplit] = "Op_IdentifySplit",
+    [Probe_Op_VirtualizationRootFindSplit] = "Op_VirtualizationRootFindSplit",
+    
+    [Probe_ReadFileFlags] = "Probe_ReadFileFlags",
+    [Probe_VirtualizationRoot_Find] = "VirtualizationRoot_Find",
+    [Probe_VirtualizationRoot_FindIteration] = "VirtualizationRoot_FindIteration",
 };
 
 bool PrjFSLog_FetchAndPrintKextProfilingData(io_connect_t connection)

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.hpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <IOKit/IOTypes.h>
+
+bool PrjFSLog_FetchAndPrintKextProfilingData(io_connect_t connection);


### PR DESCRIPTION
Adds a simple mechanism for tracing the runtime of code paths in the kext.

This is an updated and reworked version of the kext performance tracing code I wrote ages ago. The [original PR (pre-github)](https://dev.azure.com/mseng/VSOnline/_git/GVFS/pullrequest/348922?_a=overview) was never merged due to the derived works licensing issue. This new PR no longer imports any external libraries.

Example output:

```
 0                                  VnodeOp    324663 [  324663] samples, total time:      2183224415 ns, mean:    6724.59 ns +/-   165772.00, min:     552 ns, max:   63021858 ns
 1                         VnodeOp_EarlyOut     14065 [   14065] samples, total time:          919921 ns, mean:      65.40 ns +/-      148.00, min:      10 ns, max:      10823 ns
 2         VnodeOp_NoVirtualizationRootFlag   1053931 [ 1053931] samples, total time:       324526160 ns, mean:     307.92 ns +/-      851.00, min:     131 ns, max:     506253 ns
 3                        VnodeOp_EmptyFlag         0 [       0] samples, total time:               0 ns, mean:       0.00 ns +/-        0.00
 4                      VnodeOp_DenyCrawler      6211 [    6211] samples, total time:         2723004 ns, mean:     438.42 ns +/-      199.00, min:     208 ns, max:       5000 ns
 5                          VnodeOp_Offline     13787 [   13787] samples, total time:       128897126 ns, mean:    9349.18 ns +/-    22885.00, min:    1476 ns, max:    1960524 ns
 6                         VnodeOp_Provider     33311 [   33311] samples, total time:       165406431 ns, mean:    4965.52 ns +/-     3066.00, min:     712 ns, max:     192446 ns
 7     VnodeOp_PopulatePlaceholderDirectory       405 [     405] samples, total time:      1679875615 ns, mean: 4147841.02 ns +/- 11614989.00, min:  229834 ns, max:  169771434 ns
 8           VnodeOp_HydratePlaceholderFile      3711 [    3711] samples, total time:      2797867855 ns, mean:  753939.06 ns +/-  9880228.00, min:  101931 ns, max:  599370787 ns
 9                    VnodeOp_IdentifySplit    375877 [  375877] samples, total time:       346696712 ns, mean:     922.37 ns +/-   153833.00, min:     193 ns, max:   63019327 ns
10      VnodeOp_VirtualizationRootFindSplit    375877 [  375877] samples, total time:      2087201093 ns, mean:    5552.88 ns +/-     9195.00, min:     299 ns, max:    1948646 ns
11                            ReadFileFlags   1436019 [ 1436019] samples, total time:       214778997 ns, mean:     149.57 ns +/-      599.00, min:      58 ns, max:     505953 ns
12                  VirtualizationRoot_Find    375877 [  375877] samples, total time:      2024552898 ns, mean:    5386.21 ns +/-     9150.00, min:     201 ns, max:    1948488 ns
13         VirtualizationRoot_FindIteration   1369038 [ 1369038] samples, total time:      1894929183 ns, mean:    1384.13 ns +/-     4698.00, min:      95 ns, max:    1945764 ns

```

The main functionality is built around a scoped time measurement class, and an enum of probe indices. Each index corresponds to a struct of aggregate data from samples. (total runtime, sum-of-squares for standard deviation calculation, minimum, maximum, number of samples)

The logging user client is extended by a method for extracting the data, and the sample user space logging tool pulls and outputs that data periodically.

The second commit places a bunch of probes throughout the kext, and the final 2 commits ensure that the instrumentation normally compiles down to nothing, and add a profiling build configuration where it's enabled.
