### PR TITLE
Allow MirrorProvider to handle/hydrate Read only files in the mirrored path

### DIFF
--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -81,7 +81,7 @@ namespace MirrorProvider
                 return FileSystemResult.EFileNotFound;
             }
 
-            using (FileStream fs = new FileStream(fullPathInMirror, FileMode.Open))
+            using (FileStream fs = new FileStream(fullPathInMirror, FileMode.Open, FileAccess.Read))
             {
                 long remainingData = fs.Length;
                 byte[] buffer = new byte[bufferSize];


### PR DESCRIPTION
If a file in the path that is being mirrored is read only (think in the context of it being a Perforce enlistment), the mirror provider will fail on hydration as it will try opening with Read/Write permission. Let's explicitly open with FileAccess.Read to avoid this issue since we don't need Write permission on the parent file.