### PR TITLE
Allow functional tests to be started from VS for Mac

### DIFF
--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests
 {
@@ -16,14 +17,23 @@ namespace GVFS.FunctionalTests
 
         public static bool ReplaceInboxProjFS { get; set; }
 
+        public static bool StartedFromDebugger { get; set; }
+
         public static string PathToGVFS
         {
             get
             {
-                return
-                    TestGVFSOnPath ? 
-                    Properties.Settings.Default.PathToGVFS : 
-                    Path.Combine(Properties.Settings.Default.CurrentDirectory, Properties.Settings.Default.PathToGVFS);
+                if (TestGVFSOnPath)
+                {
+                    return Properties.Settings.Default.PathToGVFS;
+                }
+
+                if (StartedFromDebugger && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    return Path.Combine(Properties.Settings.Default.CurrentDirectory, "..", "..", "..", "..", "..", "..", "Publish", Properties.Settings.Default.PathToGVFS);
+                }
+
+                return Path.Combine(Properties.Settings.Default.CurrentDirectory, Properties.Settings.Default.PathToGVFS);
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -13,6 +13,8 @@ namespace GVFS.FunctionalTests
     {
         public static void Main(string[] args)
         {
+            GVFSTestConfig.StartedFromDebugger = Debugger.IsAttached;
+            
             Properties.Settings.Default.Initialize();
             NUnitRunner runner = new NUnitRunner(args);
 


### PR DESCRIPTION
The issue was that the functional tests need to look in the Publish directory for `gvfs`.

To fix this, the functional tests will check if they were started from the debugger on Mac and adjust the path to `gvfs` as needed.

With these changes I am able to run the tests by right-clicking on the`GVFS.FunctionalTests` project and selecting "Start Debugging Item".

Note that it's still required to manually load the ProjFS kext before starting the tests in VS.