### PR TITLE
Add GCM_URL_OVERRIDE support for "git credential fill"

### DIFF
--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -26,7 +26,7 @@ namespace GVFS.UnitTests.Mock.Git
             this.expectedCommandInfos.Add(commandInfo);
         }
 
-        protected override Result InvokeGitImpl(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, Action<StreamWriter> writeStdIn, Action<string> parseStdOutLine, int timeoutMs)
+        protected override Result InvokeGitImpl(string command, string repoUrl, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, Action<StreamWriter> writeStdIn, Action<string> parseStdOutLine, int timeoutMs)
         {
             if (this.ShouldFail)
             {


### PR DESCRIPTION
GCM_URL_OVERRIDE is required for new DevOps urls to authenticate in Git Credential Manager, when command line arguments are not available.