### PR TITLE
Update multi-pack-index to use upstream version

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181012.4</GitPackageVersion>
+    <GitPackageVersion>2.20181018.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -155,33 +155,13 @@ namespace GVFS.Common.Git
             using (ITracer activity = tracer.StartActivity(nameof(this.TryWriteMultiPackIndex), EventLevel.Informational, Keywords.Telemetry, metadata: null))
             {
                 GitProcess process = new GitProcess(enlistment);
-                GitProcess.Result result = process.WriteMultiPackIndex(enlistment.GitPackRoot);
+                GitProcess.Result result = process.WriteMultiPackIndex(enlistment.GitObjectsRoot);
 
-                if (!result.HasErrors)
-                {
-                    string midxHash = result.Output.Trim();
-                    activity.RelatedInfo("Updated midx-head to hash {0}", midxHash);
-
-                    string expectedMidxHead = Path.Combine(enlistment.GitPackRoot, "midx-" + midxHash + ".midx");
-
-                    List<string> midxFiles = new List<string>();
-
-                    midxFiles.AddRange(fileSystem.GetFiles(enlistment.GitPackRoot, "midx-*.midx"));
-                    midxFiles.AddRange(fileSystem.GetFiles(enlistment.GitPackRoot, "tmp_midx_*"));
-
-                    foreach (string midxFile in midxFiles)
-                    {
-                        if (!midxFile.Equals(expectedMidxHead, StringComparison.OrdinalIgnoreCase) && !fileSystem.TryDeleteFile(midxFile))
-                        {
-                            activity.RelatedWarning("Failed to delete MIDX file {0}", midxFile);
-                        }
-                    }
-                }
-                else
+                if (result.HasErrors)
                 {
                     EventMetadata errorMetadata = new EventMetadata();
                     errorMetadata.Add("Operation", nameof(this.TryWriteMultiPackIndex));
-                    errorMetadata.Add("packDir", enlistment.GitPackRoot);
+                    errorMetadata.Add("objectDir", enlistment.GitObjectsRoot);
                     errorMetadata.Add("Errors", result.Errors);
                     errorMetadata.Add("Output", result.Output.Length > 1024 ? result.Output.Substring(1024) : result.Output);
                     activity.RelatedError(errorMetadata, result.Errors, Keywords.Telemetry);

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -359,14 +359,12 @@ namespace GVFS.Common.Git
         /// <summary>
         /// Write a new multi-pack-index (MIDX) in the specified pack directory.
         /// 
-        /// This will update the midx-head file to point to the new MIDX file.
-        /// 
         /// If no new packfiles are found, then this is a no-op.
         /// </summary>
-        public Result WriteMultiPackIndex(string packDir)
+        public Result WriteMultiPackIndex(string objectDir)
         {
             // We override the config settings so we keep writing the MIDX file even if it is disabled for reads.
-            return this.InvokeGitAgainstDotGitFolder("-c core.midx=true midx --write --update-head --pack-dir \"" + packDir + "\"");
+            return this.InvokeGitAgainstDotGitFolder("-c core.multiPackIndex=true multi-pack-index write --object-dir=\"" + objectDir + "\"");
         }
 
         public Result RemoteAdd(string remoteName, string url)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -137,9 +137,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
             while (this.fileSystem.FileExists(postFetchLock));
 
-            ProcessResult midxResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "midx --read --pack-dir=\"" + objectDir + "/pack\"");
+            ProcessResult midxResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "multi-pack-index verify --object-dir=\"" + objectDir + "\"");
             midxResult.ExitCode.ShouldEqual(0);
-            midxResult.Output.ShouldContain("4d494458"); // Header from midx file.
 
             ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph read --object-dir=\"" + objectDir + "\"");
             graphResult.ExitCode.ShouldEqual(0);

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -430,7 +430,7 @@ namespace GVFS.Hooks
                 case "ls-files":
                 case "ls-tree":
                 case "merge-base":
-                case "midx":
+                case "multi-pack-index":
                 case "name-rev":
                 case "push":
                 case "remote":

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -546,6 +546,9 @@ namespace GVFS.Mount
 
             this.heartbeat = new HeartbeatThread(this.tracer, this.fileSystemCallbacks);
             this.heartbeat.Start();
+
+            // Launch a background job to compute the multi-pack-index. Will do nothing if up-to-date.
+            this.fileSystemCallbacks.LaunchPostFetchJob(packIndexes: new List<string>());
         }
 
         private void UnmountAndStopWorkingDirectoryCallbacks()

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -568,7 +568,7 @@ namespace GVFS.Virtualization
                     {
                         this.context.Tracer.RelatedWarning(
                             metadata: null,
-                            message: PostFetchTelemetryKey + ": Failed to generate midx for new packfiles",
+                            message: PostFetchTelemetryKey + ": Failed to generate multi-pack-index for new packfiles",
                             keywords: Keywords.Telemetry);
                     }
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -198,7 +198,11 @@ namespace GVFS.Virtualization
             lock (this.postFetchJobLock)
             {
                 // TODO(Mac): System.PlatformNotSupportedException: Thread abort is not supported on this platform
-                this.postFetchJobThread?.Abort();
+
+                if (!GVFSPlatform.Instance.IsUnderConstruction)
+                {
+                    this.postFetchJobThread?.Abort();
+                }
             }
 
             // Shutdown the GitStatusCache before other

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -81,7 +81,7 @@ namespace GVFS.CommandLine
                 { "core.commitGraph", "true" },
                 { "core.fscache", "true" },
                 { "core.gvfs", "true" },
-                { "core.midx", "true" },
+                { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },
                 { "core.safecrlf", "false" },
                 { "core.untrackedCache", "false" },


### PR DESCRIPTION
Resolves #294.

Update GitForWindows to use upstream multi-pack-index code instead of our private version. See [the PR in Microsoft/git](https://github.com/Microsoft/git/pull/24) for more info on the Git change (and don't merge this until that is final).

This does the following:

- Update the command-line interactions that update the multi-pack-index.
- On mount, launch the post-fetch background job to ensure a multi-pack-index is calculated. (Very low cost if it already exists.)
- Since we have the multi-pack-index in more cases than before, we discover that we need to delete the multi-pack-index when deleting bad pack-files during prefetch.
- Since we trigger the post-fetch job on every mount, we now need to purposefully care about platform before shutting down the background thread. More work is required and tracked by #409.