### PR TITLE
Set config to useHttpPath=true

### DIFF
--- a/GVFS/GVFS.Common/Git/GitConfigSetting.cs
+++ b/GVFS/GVFS.Common/Git/GitConfigSetting.cs
@@ -6,6 +6,7 @@ namespace GVFS.Common.Git
     {
         public const string CoreVirtualizeObjectsName = "core.virtualizeobjects";
         public const string CoreVirtualFileSystemName = "core.virtualfilesystem";
+        public const string CredentialUseHttpPath = "credential.useHttpPath";
 
         public GitConfigSetting(string name, params string[] values)
         {

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -112,7 +112,7 @@ namespace GVFS.Common.Git
             using (ITracer activity = tracer.StartActivity("TryGetCredentials", EventLevel.Informational))
             {
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
-                    "credential fill",
+                    "-c " + GitConfigSetting.CredentialUseHttpPath + "=true credential fill",
                     stdin => stdin.Write("url=" + repoUrl + "\n\n"),
                     parseStdOutLine: null);
 

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -194,7 +194,7 @@ namespace GVFS.UnitTests.Git
 
             int revocations = 0;
             gitProcess.SetExpectedCommandResult(
-                "credential fill",
+                "-c credential.useHttpPath=true credential fill",
                 () => new GitProcess.Result("username=username\r\npassword=password" + revocations + "\r\n", string.Empty, GitProcess.Result.SuccessCode));
 
             gitProcess.SetExpectedCommandResult(

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -92,6 +92,7 @@ namespace GVFS.CommandLine
                 { GitConfigSetting.CoreVirtualizeObjectsName, "true" },
                 { GitConfigSetting.CoreVirtualFileSystemName, Paths.ConvertPathToGitFormat(GVFSConstants.DotGit.Hooks.VirtualFileSystemPath) },
                 { "core.hookspath", expectedHooksPath },
+                { GitConfigSetting.CredentialUseHttpPath, "true" },
                 { "credential.validate", "false" },
                 { "diff.autoRefreshIndex", "false" },
                 { "gc.auto", "0" },


### PR DESCRIPTION
Hostname is no longer sufficient for VSTS authentication. VSTS now requires dev.azure.com/account to determine the tenant.

By setting useHttpPath, credential managers will get the path which contains the account as the first parameter. They can then use this information for auth appropriately.

Please note this may require a reauth of the repository once as it move the token storage to include path.