### PR TITLE
Add new GVFS Config verb

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -33,7 +33,7 @@ namespace GVFS.Common
             public const string HooksPrefix = GitConfig.GVFSPrefix + "clone.default-";
             public const string GVFSTelemetryId = GitConfig.GVFSPrefix + "telemetry-id";
             public const string HooksExtension = ".hooks";
-            public const string UpgradeRing = GVFSPrefix + "upgrade-ring";
+            public const string UpgradeRing = "upgrade-ring";
         }
 
         public static class GitStatusCache
@@ -227,7 +227,7 @@ namespace GVFS.Common
             public const string GVFSUpgradeOptionalConfirm = "`gvfs upgrade [--confirm]`";
             public const string NoneRingConsoleAlert = "Upgrade ring set to \"None\". No upgrade check was performed.";
             public const string InvalidRingConsoleAlert = "Upgrade ring is not set. No upgrade check was performed.";
-            public const string SetUpgradeRingCommand = "To set or change upgrade ring, run `git config --global " + GitConfig.UpgradeRing + " [\"Fast\"|\"Slow\"|\"None\"] from a command prompt.";
+            public const string SetUpgradeRingCommand = "To set or change upgrade ring, run `gvfs config " + GitConfig.UpgradeRing + " [\"Fast\"|\"Slow\"|\"None\"] from an elevated command prompt.";
             public const string ReminderNotification = "A new version of GVFS is available. Run " + UpgradeVerbMessages.GVFSUpgrade + " to start the upgrade.";
             public const string UnmountRepoWarning = "The upgrade process will unmount all GVFS repositories for several minutes and remount them when it is complete. Ensure you are at a stopping point prior to upgrading.";
             public const string UpgradeInstallAdvice = "When you are ready, run " + UpgradeVerbMessages.GVFSUpgradeConfirm + " from an elevated command prompt.";

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -32,8 +32,12 @@ namespace GVFS.Common
             public const string DeprecatedCacheEndpointSuffix = ".cache-server-url";
             public const string HooksPrefix = GitConfig.GVFSPrefix + "clone.default-";
             public const string GVFSTelemetryId = GitConfig.GVFSPrefix + "telemetry-id";
-            public const string HooksExtension = ".hooks";
-            public const string UpgradeRing = "upgrade-ring";
+            public const string HooksExtension = ".hooks";            
+        }
+
+        public static class LocalGVFSConfig
+        {
+            public const string UpgradeRing = "upgrade.ring";
         }
 
         public static class GitStatusCache
@@ -227,7 +231,7 @@ namespace GVFS.Common
             public const string GVFSUpgradeOptionalConfirm = "`gvfs upgrade [--confirm]`";
             public const string NoneRingConsoleAlert = "Upgrade ring set to \"None\". No upgrade check was performed.";
             public const string InvalidRingConsoleAlert = "Upgrade ring is not set. No upgrade check was performed.";
-            public const string SetUpgradeRingCommand = "To set or change upgrade ring, run `gvfs config " + GitConfig.UpgradeRing + " [\"Fast\"|\"Slow\"|\"None\"] from an elevated command prompt.";
+            public const string SetUpgradeRingCommand = "To set or change upgrade ring, run `gvfs config " + LocalGVFSConfig.UpgradeRing + " [\"Fast\"|\"Slow\"|\"None\"] from a command prompt.";
             public const string ReminderNotification = "A new version of GVFS is available. Run " + UpgradeVerbMessages.GVFSUpgrade + " to start the upgrade.";
             public const string UnmountRepoWarning = "The upgrade process will unmount all GVFS repositories for several minutes and remount them when it is complete. Ensure you are at a stopping point prior to upgrading.";
             public const string UpgradeInstallAdvice = "When you are ready, run " + UpgradeVerbMessages.GVFSUpgradeConfirm + " from an elevated command prompt.";

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -87,6 +87,11 @@ namespace GVFS.Common.Git
             return new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --system " + settingName);
         }
 
+        public static Result GetFromFileConfig(string gitBinPath, string configFile, string settingName)
+        {
+            return new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --file " + configFile + " " + settingName);
+        }
+
         public static bool TryGetVersion(out GitVersion gitVersion, out string error)
         {
             string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
@@ -199,6 +204,16 @@ namespace GVFS.Common.Git
         {
             return this.InvokeGitAgainstDotGitFolder(string.Format(
                 "config --local --add {0} {1}",
+                 settingName,
+                 value));
+        }
+
+        public Result SetInFileConfig(string configFile, string settingName, string value, bool replaceAll = false)
+        {
+            return this.InvokeGitOutsideEnlistment(string.Format(
+                "config --file {0} {1} \"{2}\" \"{3}\"",
+                 configFile,
+                 replaceAll ? "--replace-all " : string.Empty,
                  settingName,
                  value));
         }

--- a/GVFS/GVFS.Common/Http/CacheServerResolver.cs
+++ b/GVFS/GVFS.Common/Http/CacheServerResolver.cs
@@ -39,7 +39,7 @@ namespace GVFS.Common.Http
 
         public bool TryResolveUrlFromRemote(
             string cacheServerName,
-            GVFSConfig gvfsConfig,
+            ServerGVFSConfig serverGVFSConfig,
             out CacheServerInfo cacheServer,
             out string error)
         {
@@ -54,12 +54,12 @@ namespace GVFS.Common.Http
             if (cacheServerName.Equals(CacheServerInfo.ReservedNames.Default, StringComparison.OrdinalIgnoreCase))
             {
                 cacheServer =
-                    gvfsConfig.CacheServers.FirstOrDefault(cache => cache.GlobalDefault)
+                    serverGVFSConfig.CacheServers.FirstOrDefault(cache => cache.GlobalDefault)
                     ?? this.CreateNone();
             }
             else
             {
-                cacheServer = gvfsConfig.CacheServers.FirstOrDefault(cache =>
+                cacheServer = serverGVFSConfig.CacheServers.FirstOrDefault(cache =>
                     cache.Name.Equals(cacheServerName, StringComparison.OrdinalIgnoreCase));
 
                 if (cacheServer == null)
@@ -74,7 +74,7 @@ namespace GVFS.Common.Http
 
         public CacheServerInfo ResolveNameFromRemote(
             string cacheServerUrl,
-            GVFSConfig gvfsConfig)
+            ServerGVFSConfig serverGVFSConfig)
         {
             if (string.IsNullOrWhiteSpace(cacheServerUrl))
             {
@@ -87,7 +87,7 @@ namespace GVFS.Common.Http
             }
 
             return
-                gvfsConfig.CacheServers.FirstOrDefault(cache => cache.Url.Equals(cacheServerUrl, StringComparison.OrdinalIgnoreCase))
+                serverGVFSConfig.CacheServers.FirstOrDefault(cache => cache.Url.Equals(cacheServerUrl, StringComparison.OrdinalIgnoreCase))
                 ?? new CacheServerInfo(cacheServerUrl, CacheServerInfo.ReservedNames.UserDefined);
         }
 

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -44,15 +44,15 @@ namespace GVFS.Common
 
         public bool TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers(
             ITracer tracer, 
-            GVFSConfig gvfsConfig,
+            ServerGVFSConfig serverGVFSConfig,
             CacheServerInfo currentCacheServer, 
             string localCacheRoot,
             out string localCacheKey, 
             out string errorMessage)
         {
-            if (gvfsConfig == null)
+            if (serverGVFSConfig == null)
             {
-                throw new ArgumentNullException(nameof(gvfsConfig));
+                throw new ArgumentNullException(nameof(serverGVFSConfig));
             }
 
             localCacheKey = null;
@@ -115,7 +115,7 @@ namespace GVFS.Common
                                 metadata.Add("currentCacheServer", currentCacheServer.ToString());
 
                                 string getLocalCacheKeyError;
-                                if (this.TryGetLocalCacheKeyFromRemoteCacheServers(tracer, gvfsConfig, currentCacheServer, mappingFile, out localCacheKey, out getLocalCacheKeyError))
+                                if (this.TryGetLocalCacheKeyFromRemoteCacheServers(tracer, serverGVFSConfig, currentCacheServer, mappingFile, out localCacheKey, out getLocalCacheKeyError))
                                 {
                                     metadata.Add("localCacheKey", localCacheKey);
                                     metadata.Add(TracingConstants.MessageKey.InfoMessage, nameof(this.TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers) + ": Generated new local cache key");
@@ -192,7 +192,7 @@ namespace GVFS.Common
 
         private bool TryGetLocalCacheKeyFromRemoteCacheServers(
             ITracer tracer,
-            GVFSConfig gvfsConfig,
+            ServerGVFSConfig serverGVFSConfig,
             CacheServerInfo currentCacheServer, 
             FileBasedDictionary<string, string> mappingFile, 
             out string localCacheKey,
@@ -203,7 +203,7 @@ namespace GVFS.Common
 
             try
             { 
-                if (this.TryFindExistingLocalCacheKey(mappingFile, gvfsConfig.CacheServers, out localCacheKey))
+                if (this.TryFindExistingLocalCacheKey(mappingFile, serverGVFSConfig.CacheServers, out localCacheKey))
                 {
                     EventMetadata metadata = CreateEventMetadata();
                     metadata.Add("currentCacheServer", currentCacheServer.ToString());
@@ -233,7 +233,7 @@ namespace GVFS.Common
                     mappingFileUpdates.Add(new KeyValuePair<string, string>(this.ToMappingKey(currentCacheServer.Url), localCacheKey));
                 }
 
-                foreach (CacheServerInfo cacheServer in gvfsConfig.CacheServers)
+                foreach (CacheServerInfo cacheServer in serverGVFSConfig.CacheServers)
                 {
                     string persistedLocalCacheKey;
                     if (mappingFile.TryGetValue(this.ToMappingKey(cacheServer.Url), out persistedLocalCacheKey))

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -1,0 +1,99 @@
+﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using System;
+using System.IO;
+
+namespace GVFS.Common
+{
+    public class LocalGVFSConfig
+    {
+        private const string FileName = "local_config.dat";
+        private string configFile;
+        private string gitPath;
+        private PhysicalFileSystem fileSystem;
+
+        public LocalGVFSConfig(string gitPath)
+        {
+            string servicePath = Paths.GetServiceDataRoot(GVFSConstants.Service.ServiceName);
+            string gvfsDirectory = Path.GetDirectoryName(servicePath);
+
+            this.configFile = Path.Combine(gvfsDirectory, FileName);
+            this.gitPath = gitPath;
+            this.fileSystem = new PhysicalFileSystem();
+        }
+
+        public bool TryGetValueForKey(string key, out string value, out string error)
+        {
+            return this.TryGetConfig(this.KeyWithGVFSSectionPrefix(key), out value, out error);
+        }
+
+        public bool TrySetValueForKey(string key, string value, out string error)
+        {
+            return this.TrySetConfig(this.KeyWithGVFSSectionPrefix(key), value, out error);
+        }
+
+        private bool TryGetConfig(string key, out string value, out string error)
+        {
+            if (!this.fileSystem.FileExists(this.configFile))
+            {
+                error = $"Error reading {key}. Config file({this.configFile}) does not exist.";
+                value = null;
+                return false;
+            }
+
+            GitProcess.Result result = GitProcess.GetFromFileConfig(this.gitPath, this.configFile, key);
+            if (!result.HasErrors && !string.IsNullOrEmpty(result.Output))
+            {
+                error = null;
+                value = result.Output.TrimEnd('\r', '\n');
+                return true;
+            }
+            else
+            {
+                error = string.IsNullOrEmpty(result.Errors) ? $"Error reading \"{key}\" from file {this.configFile}." : result.Errors;
+                value = null;
+                return false;
+            }
+        }
+
+        private bool TrySetConfig(string key, string value, out string error)
+        {
+            if (!this.fileSystem.FileExists(this.configFile) && !this.TryCreateConfigFile(out error))
+            {
+                error = $"Error setting config value {key}: {value}. {error}";
+                return false;
+            }
+
+            GitProcess git = new GitProcess(this.gitPath, workingDirectoryRoot: null, gvfsHooksRoot: null);
+            GitProcess.Result result = git.SetInFileConfig(this.configFile, key, value, replaceAll: true);
+            if (result.HasErrors)
+            {
+                error = string.IsNullOrEmpty(result.Errors) ? $"Error setting config value {key}: {value}. Config file {this.configFile}." : result.Errors;
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        private bool TryCreateConfigFile(out string error)
+        {
+            Exception exception = null;
+            if (!this.fileSystem.TryWriteTempFileAndRename(this.configFile, string.Empty, out exception))
+            {
+                error = $"Could not create config file {this.configFile}. {exception.Message}";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        private string KeyWithGVFSSectionPrefix(string key)
+        {
+            const string GVFSSectionName = "gvfs";
+
+            return string.Join(".", GVFSSectionName, key);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -245,13 +245,14 @@ namespace GVFS.Common
         public virtual bool TryLoadRingConfig(out string error)
         {
             string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            GitProcess.Result result = GitProcess.GetFromGlobalConfig(gitPath, GVFSConstants.GitConfig.UpgradeRing);
-            if (!result.HasErrors && !string.IsNullOrEmpty(result.Output))
+            LocalGVFSConfig localConfig = new LocalGVFSConfig(gitPath);
+
+            string ringConfig = null;
+            if (localConfig.TryGetValueForKey(GVFSConstants.GitConfig.UpgradeRing, out ringConfig, out error))
             {
-                string ringConfig = result.Output.TrimEnd('\r', '\n');
                 RingType ringType;
 
-                if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) && 
+                if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) &&
                     Enum.IsDefined(typeof(RingType), ringType) &&
                     ringType != RingType.Invalid)
                 {
@@ -261,14 +262,10 @@ namespace GVFS.Common
                 }
                 else
                 {
-                    error = "Invalid upgrade ring `" + ringConfig + "` specified in Git config.";                    
+                    error = "Invalid upgrade ring `" + ringConfig + "` specified in Git config.";
                 }
             }
-            else
-            {
-                error = string.IsNullOrEmpty(result.Errors) ? "Unable to determine upgrade ring." : result.Errors;                
-            }
-
+            
             error += Environment.NewLine + GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
             this.Ring = RingType.Invalid;
             return false;

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -245,10 +245,10 @@ namespace GVFS.Common
         public virtual bool TryLoadRingConfig(out string error)
         {
             string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            LocalGVFSConfig localConfig = new LocalGVFSConfig(gitPath);
+            LocalGVFSConfig localConfig = new LocalGVFSConfig();
 
             string ringConfig = null;
-            if (localConfig.TryGetValueForKey(GVFSConstants.GitConfig.UpgradeRing, out ringConfig, out error))
+            if (localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error, this.tracer))
             {
                 RingType ringType;
 
@@ -262,7 +262,7 @@ namespace GVFS.Common
                 }
                 else
                 {
-                    error = "Invalid upgrade ring `" + ringConfig + "` specified in Git config.";
+                    error = "Invalid upgrade ring `" + ringConfig + "` specified in gvfs config.";
                 }
             }
             

--- a/GVFS/GVFS.Common/ServerGVFSConfig.cs
+++ b/GVFS/GVFS.Common/ServerGVFSConfig.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace GVFS.Common
 {
-    public class GVFSConfig
+    public class ServerGVFSConfig
     {
         public IEnumerable<VersionRange> AllowedGVFSClientVersions { get; set; }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
@@ -107,7 +107,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
             if (this.LocalRingConfig == RingType.Invalid)
             {
-                error = "Invalid upgrade ring `Invalid` specified in Git config.";
+                error = "Invalid upgrade ring `Invalid` specified in gvfs config.";
                 return false;
             }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -56,7 +56,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
         [TestCase]
         public virtual void InvalidUpgradeRing()
         {
-            string errorString = "Invalid upgrade ring `Invalid` specified in Git config.";
+            string errorString = "Invalid upgrade ring `Invalid` specified in gvfs config.";
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {

--- a/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
@@ -204,9 +204,9 @@ namespace GVFS.UnitTests.Common
             return new MockGVFSEnlistment(gitProcess);
         }
 
-        private GVFSConfig CreateGVFSConfig()
+        private ServerGVFSConfig CreateGVFSConfig()
         {
-            return new GVFSConfig
+            return new ServerGVFSConfig
             {
                 CacheServers = new[]
                 {
@@ -215,9 +215,9 @@ namespace GVFS.UnitTests.Common
             };
         }
 
-        private GVFSConfig CreateDefaultDeserializedGVFSConfig()
+        private ServerGVFSConfig CreateDefaultDeserializedGVFSConfig()
         {
-            return JsonConvert.DeserializeObject<GVFSConfig>("{}");
+            return JsonConvert.DeserializeObject<ServerGVFSConfig>("{}");
         }
 
         private CacheServerResolver CreateResolver(MockGVFSEnlistment enlistment = null)

--- a/GVFS/GVFS/CommandLine/CacheServerVerb.cs
+++ b/GVFS/GVFS/CommandLine/CacheServerVerb.cs
@@ -42,7 +42,7 @@ namespace GVFS.CommandLine
 
             using (ITracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "CacheVerb"))
             {
-                GVFSConfig gvfsConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
+                ServerGVFSConfig serverGVFSConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
 
                 CacheServerResolver cacheServerResolver = new CacheServerResolver(tracer, enlistment);
                 string error = null;
@@ -50,7 +50,7 @@ namespace GVFS.CommandLine
                 if (this.CacheToSet != null)
                 {
                     CacheServerInfo cacheServer = cacheServerResolver.ParseUrlOrFriendlyName(this.CacheToSet);
-                    cacheServer = this.ResolveCacheServer(tracer, cacheServer, cacheServerResolver, gvfsConfig);
+                    cacheServer = this.ResolveCacheServer(tracer, cacheServer, cacheServerResolver, serverGVFSConfig);
 
                     if (!cacheServerResolver.TrySaveUrlToLocalConfig(cacheServer, out error))
                     {
@@ -61,7 +61,7 @@ namespace GVFS.CommandLine
                 }
                 else if (this.ListCacheServers)
                 {
-                    List<CacheServerInfo> cacheServers = gvfsConfig.CacheServers.ToList();
+                    List<CacheServerInfo> cacheServers = serverGVFSConfig.CacheServers.ToList();
 
                     if (cacheServers != null && cacheServers.Any())
                     {
@@ -80,7 +80,7 @@ namespace GVFS.CommandLine
                 else
                 {
                     string cacheServerUrl = CacheServerResolver.GetUrlFromConfig(enlistment);
-                    CacheServerInfo cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServerUrl, gvfsConfig);
+                    CacheServerInfo cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServerUrl, serverGVFSConfig);
 
                     this.Output.WriteLine("Using cache server: " + cacheServer);
                 }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -119,7 +119,7 @@ namespace GVFS.CommandLine
                 Result cloneResult = new Result(false);
 
                 CacheServerInfo cacheServer = null;
-                GVFSConfig gvfsConfig = null;
+                ServerGVFSConfig serverGVFSConfig = null;
 
                 using (JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSClone"))
                 {
@@ -178,19 +178,19 @@ namespace GVFS.CommandLine
                         }
 
                         RetryConfig retryConfig = this.GetRetryConfig(tracer, enlistment, TimeSpan.FromMinutes(RetryConfig.FetchAndCloneTimeoutMinutes));
-                        gvfsConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
+                        serverGVFSConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
 
-                        cacheServer = this.ResolveCacheServer(tracer, cacheServer, cacheServerResolver, gvfsConfig);
+                        cacheServer = this.ResolveCacheServer(tracer, cacheServer, cacheServerResolver, serverGVFSConfig);
 
                         if (!GVFSPlatform.Instance.IsUnderConstruction)
                         {
-                            this.ValidateClientVersions(tracer, enlistment, gvfsConfig, showWarnings: true);
+                            this.ValidateClientVersions(tracer, enlistment, serverGVFSConfig, showWarnings: true);
                         }
                        
                         this.ShowStatusWhileRunning(
                             () =>
                             {
-                                cloneResult = this.TryClone(tracer, enlistment, cacheServer, retryConfig, gvfsConfig, resolvedLocalCacheRoot);
+                                cloneResult = this.TryClone(tracer, enlistment, cacheServer, retryConfig, serverGVFSConfig, resolvedLocalCacheRoot);
                                 return cloneResult.Success;
                             },
                             "Cloning",
@@ -214,7 +214,7 @@ namespace GVFS.CommandLine
                                 verb.Commits = true;
                                 verb.SkipVersionCheck = true;
                                 verb.ResolvedCacheServer = cacheServer;
-                                verb.GVFSConfig = gvfsConfig;
+                                verb.ServerGVFSConfig = serverGVFSConfig;
                             });
 
                         if (result != ReturnCode.Success)
@@ -238,7 +238,7 @@ namespace GVFS.CommandLine
                                 verb.SkipMountedCheck = true;
                                 verb.SkipVersionCheck = true;
                                 verb.ResolvedCacheServer = cacheServer;
-                                verb.DownloadedGVFSConfig = gvfsConfig;
+                                verb.DownloadedGVFSConfig = serverGVFSConfig;
                             });
                     }
                 }
@@ -323,7 +323,7 @@ namespace GVFS.CommandLine
             GVFSEnlistment enlistment, 
             CacheServerInfo cacheServer, 
             RetryConfig retryConfig, 
-            GVFSConfig gvfsConfig,
+            ServerGVFSConfig serverGVFSConfig,
             string resolvedLocalCacheRoot)
         {
             Result pipeResult;
@@ -372,7 +372,7 @@ namespace GVFS.CommandLine
                     }
 
                     string localCacheError;
-                    if (!this.TryDetermineLocalCacheAndInitializePaths(tracer, enlistment, gvfsConfig, cacheServer, resolvedLocalCacheRoot, out localCacheError))
+                    if (!this.TryDetermineLocalCacheAndInitializePaths(tracer, enlistment, serverGVFSConfig, cacheServer, resolvedLocalCacheRoot, out localCacheError))
                     {
                         tracer.RelatedError(localCacheError);
                         return new Result(localCacheError);
@@ -460,7 +460,7 @@ namespace GVFS.CommandLine
         private bool TryDetermineLocalCacheAndInitializePaths(
             ITracer tracer,
             GVFSEnlistment enlistment,
-            GVFSConfig gvfsConfig,
+            ServerGVFSConfig serverGVFSConfig,
             CacheServerInfo currentCacheServer,
             string localCacheRoot,
             out string errorMessage)
@@ -472,7 +472,7 @@ namespace GVFS.CommandLine
             string localCacheKey;
             if (!localCacheResolver.TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers(
                 tracer,
-                gvfsConfig,
+                serverGVFSConfig,
                 currentCacheServer,
                 localCacheRoot,
                 localCacheKey: out localCacheKey,

--- a/GVFS/GVFS/CommandLine/ConfigVerb.cs
+++ b/GVFS/GVFS/CommandLine/ConfigVerb.cs
@@ -1,0 +1,61 @@
+﻿using CommandLine;
+using GVFS.Common;
+using System;
+
+namespace GVFS.CommandLine
+{
+    [Verb(ConfigVerbName, HelpText = "Set and Get GVFS config settings.")]
+    public class ConfigVerb : GVFSVerb
+    {
+        private const string ConfigVerbName = "config";
+        private LocalGVFSConfig localConfig;
+
+        public override string EnlistmentRootPathParameter { get; set; }
+
+        protected override string VerbName
+        {
+            get { return ConfigVerbName; }
+        }
+
+        public override void Execute()
+        {
+            string[] args = Environment.GetCommandLineArgs();
+            if (args.Length < 3 || args.Length > 4)
+            {
+                string usageString = string.Join(
+                    Environment.NewLine,
+                    "Error: wrong number of arguments.",
+                    "Usage: gvfs config <config> <value>");
+                this.ReportErrorAndExit(usageString);
+            }
+
+            this.localConfig = new LocalGVFSConfig(GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath());
+
+            string key = args[2];
+            string value = null;
+            string error = null;
+            bool isRead = args.Length == 3;
+
+            key = args[2];
+            if (isRead)
+            {
+                if (this.localConfig.TryGetValueForKey(key, out value, out error))
+                {
+                    Console.WriteLine(value);
+                }
+                else
+                {
+                    this.ReportErrorAndExit(error);
+                }
+            }
+            else
+            {
+                value = args[3];
+                if (!this.localConfig.TrySetValueForKey(key, value, out error))
+                {
+                    this.ReportErrorAndExit(error);
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/ConfigVerb.cs
+++ b/GVFS/GVFS/CommandLine/ConfigVerb.cs
@@ -5,7 +5,7 @@ using System;
 namespace GVFS.CommandLine
 {
     [Verb(ConfigVerbName, HelpText = "Get and set GVFS options.")]
-    public class ConfigVerb : GVFSVerb.NonRepoVerb
+    public class ConfigVerb : GVFSVerb.ForNoEnlistment
     {
         private const string ConfigVerbName = "config";
         private LocalGVFSConfig localConfig;

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -104,7 +104,7 @@ of your enlistment's src folder.
                 }
 
                 // Local cache and objects paths are required for TryDownloadGitObjects
-                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, gvfsConfig: null, cacheServer: null);
+                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig: null, cacheServer: null);
 
                 if (this.TryBackupFiles(tracer, enlistment, backupRoot))
                 {

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -1039,6 +1039,19 @@ You can specify a URL, a name of a configured cache server, or the special names
             }
         }
 
+        public abstract class NonRepoVerb : GVFSVerb
+        {
+            public NonRepoVerb(bool validateOrigin = true) : base(validateOrigin)
+            {
+            }
+
+            public override string EnlistmentRootPathParameter
+            {
+                get { throw new InvalidOperationException(); }
+                set { throw new InvalidOperationException(); }
+            }
+        }
+
         public class VerbAbortedException : Exception
         {
             public VerbAbortedException(GVFSVerb verb)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -1039,9 +1039,9 @@ You can specify a URL, a name of a configured cache server, or the special names
             }
         }
 
-        public abstract class NonRepoVerb : GVFSVerb
+        public abstract class ForNoEnlistment : GVFSVerb
         {
-            public NonRepoVerb(bool validateOrigin = true) : base(validateOrigin)
+            public ForNoEnlistment(bool validateOrigin = true) : base(validateOrigin)
             {
             }
 

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -37,7 +37,7 @@ namespace GVFS.CommandLine
         public bool SkipMountedCheck { get; set; }
         public bool SkipVersionCheck { get; set; }
         public CacheServerInfo ResolvedCacheServer { get; set; }
-        public GVFSConfig DownloadedGVFSConfig { get; set; }
+        public ServerGVFSConfig DownloadedGVFSConfig { get; set; }
 
         protected override string VerbName
         {
@@ -128,7 +128,7 @@ namespace GVFS.CommandLine
                 }
 
                 RetryConfig retryConfig = null;
-                GVFSConfig gvfsConfig = this.DownloadedGVFSConfig;
+                ServerGVFSConfig serverGVFSConfig = this.DownloadedGVFSConfig;
                 if (!this.SkipVersionCheck)
                 {
                     string authErrorMessage = null;
@@ -140,24 +140,24 @@ namespace GVFS.CommandLine
                         this.Output.WriteLine("    Mount will proceed, but new files cannot be accessed until GVFS can authenticate.");
                     }
 
-                    if (gvfsConfig == null)
+                    if (serverGVFSConfig == null)
                     {
                         if (retryConfig == null)
                         {
                             retryConfig = this.GetRetryConfig(tracer, enlistment);
                         }
 
-                        gvfsConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
+                        serverGVFSConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
                     }
 
-                    this.ValidateClientVersions(tracer, enlistment, gvfsConfig, showWarnings: true);
+                    this.ValidateClientVersions(tracer, enlistment, serverGVFSConfig, showWarnings: true);
 
                     CacheServerResolver cacheServerResolver = new CacheServerResolver(tracer, enlistment);
-                    cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServer.Url, gvfsConfig);
+                    cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServer.Url, serverGVFSConfig);
                     this.Output.WriteLine("Configured cache server: " + cacheServer);
                 }
 
-                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, gvfsConfig, cacheServer);
+                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig, cacheServer);
 
                 if (!this.ShowStatusWhileRunning(
                     () => { return this.PerformPreMountValidation(tracer, enlistment, out mountExecutableLocation, out errorMessage); },

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -70,7 +70,7 @@ namespace GVFS.CommandLine
 
         public bool SkipVersionCheck { get; set; }
         public CacheServerInfo ResolvedCacheServer { get; set; }
-        public GVFSConfig GVFSConfig { get; set; }
+        public ServerGVFSConfig ServerGVFSConfig { get; set; }
 
         protected override string VerbName
         {
@@ -100,7 +100,7 @@ namespace GVFS.CommandLine
                 RetryConfig retryConfig = this.GetRetryConfig(tracer, enlistment, TimeSpan.FromMinutes(RetryConfig.FetchAndCloneTimeoutMinutes));
 
                 CacheServerInfo cacheServer = this.ResolvedCacheServer;
-                GVFSConfig gvfsConfig = this.GVFSConfig;
+                ServerGVFSConfig serverGVFSConfig = this.ServerGVFSConfig;
                 if (!this.SkipVersionCheck)
                 {
                     string authErrorMessage;
@@ -111,23 +111,23 @@ namespace GVFS.CommandLine
                         this.ReportErrorAndExit(tracer, "Unable to prefetch because authentication failed");
                     }
 
-                    if (gvfsConfig == null)
+                    if (serverGVFSConfig == null)
                     {
-                        gvfsConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
+                        serverGVFSConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
                     }
 
                     if (cacheServer == null)
                     {
                         CacheServerResolver cacheServerResolver = new CacheServerResolver(tracer, enlistment);
-                        cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServerUrl, gvfsConfig);
+                        cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServerUrl, serverGVFSConfig);
                     }
 
-                    this.ValidateClientVersions(tracer, enlistment, gvfsConfig, showWarnings: false);
+                    this.ValidateClientVersions(tracer, enlistment, serverGVFSConfig, showWarnings: false);
 
                     this.Output.WriteLine("Configured cache server: " + cacheServer);
                 }
 
-                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, gvfsConfig, cacheServer);
+                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig, cacheServer);
 
                 try
                 {

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace GVFS.CommandLine
 {
     [Verb(ServiceVerbName, HelpText = "Runs commands for the GVFS service.")]
-    public class ServiceVerb : GVFSVerb
+    public class ServiceVerb : GVFSVerb.NonRepoVerb
     {
         private const string ServiceVerbName = "service";
 
@@ -34,12 +34,6 @@ namespace GVFS.CommandLine
             Required = false,
             HelpText = "Prints a list of all mounted repos")]
         public bool List { get; set; }
-
-        public override string EnlistmentRootPathParameter
-        {
-            get { throw new InvalidOperationException(); }
-            set { throw new InvalidOperationException(); }
-        }
 
         protected override string VerbName
         {

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace GVFS.CommandLine
 {
     [Verb(ServiceVerbName, HelpText = "Runs commands for the GVFS service.")]
-    public class ServiceVerb : GVFSVerb.NonRepoVerb
+    public class ServiceVerb : GVFSVerb.ForNoEnlistment
     {
         private const string ServiceVerbName = "service";
 

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace GVFS.CommandLine
 {
     [Verb(UpgradeVerbName, HelpText = "Checks for new GVFS release, downloads and installs it when available.")]
-    public class UpgradeVerb : GVFSVerb
+    public class UpgradeVerb : GVFSVerb.NonRepoVerb
     {
         private const string UpgradeVerbName = "upgrade";
         private ITracer tracer;
@@ -43,8 +43,6 @@ namespace GVFS.CommandLine
             Required = false,
             HelpText = "Pass in this flag to actually install the newest release")]
         public bool Confirmed { get; set; }
-
-        public override string EnlistmentRootPathParameter { get; set; }
 
         protected override string VerbName
         {

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace GVFS.CommandLine
 {
     [Verb(UpgradeVerbName, HelpText = "Checks for new GVFS release, downloads and installs it when available.")]
-    public class UpgradeVerb : GVFSVerb.NonRepoVerb
+    public class UpgradeVerb : GVFSVerb.ForNoEnlistment
     {
         private const string UpgradeVerbName = "upgrade";
         private ITracer tracer;

--- a/GVFS/GVFS/GVFS.Windows.csproj
+++ b/GVFS/GVFS/GVFS.Windows.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\ProjFS.props" />
@@ -74,6 +74,7 @@
     </Compile>
     <Compile Include="CommandLine\CacheServerVerb.cs" />
     <Compile Include="CommandLine\CloneVerb.cs" />
+    <Compile Include="CommandLine\ConfigVerb.cs" />
     <Compile Include="CommandLine\DehydrateVerb.cs" />
     <Compile Include="CommandLine\DiagnoseVerb.cs" />
     <Compile Include="CommandLine\GVFSVerb.cs" />

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -74,7 +74,7 @@ namespace GVFS
                             clone.Execute();
                             Environment.Exit((int)ReturnCode.Success);
                         })
-                    .WithParsed<GVFSVerb.NonRepoVerb>(
+                    .WithParsed<GVFSVerb.ForNoEnlistment>(
                         verb =>
                         {
                             verb.Execute();

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -28,7 +28,7 @@ namespace GVFS
                 typeof(StatusVerb),
                 typeof(UnmountVerb),
                 typeof(UpgradeVerb),
-                typeof(ConfigVerb)
+                typeof(ConfigVerb),
             };
 
             int consoleWidth = 80;
@@ -74,26 +74,10 @@ namespace GVFS
                             clone.Execute();
                             Environment.Exit((int)ReturnCode.Success);
                         })
-                    .WithParsed<ServiceVerb>(
-                        service =>
+                    .WithParsed<GVFSVerb.NonRepoVerb>(
+                        verb =>
                         {
-                            // The service verb doesn't operate on a repo, so it doesn't use the enlistment
-                            // path at all.
-                            service.Execute();
-                            Environment.Exit((int)ReturnCode.Success);
-                        })
-                    .WithParsed<UpgradeVerb>(
-                        upgrade =>
-                        {
-                            // The upgrade verb doesn't operate on a repo, so it doesn't use the enlistment
-                            // path at all.
-                            upgrade.Execute();
-                            Environment.Exit((int)ReturnCode.Success);
-                        })
-                    .WithParsed<ConfigVerb>(
-                        config =>
-                        {
-                            config.Execute();
+                            verb.Execute();
                             Environment.Exit((int)ReturnCode.Success);
                         })
                     .WithParsed<GVFSVerb>(

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -27,7 +27,8 @@ namespace GVFS
                 typeof(ServiceVerb),
                 typeof(StatusVerb),
                 typeof(UnmountVerb),
-                typeof(UpgradeVerb)
+                typeof(UpgradeVerb),
+                typeof(ConfigVerb)
             };
 
             int consoleWidth = 80;
@@ -87,6 +88,12 @@ namespace GVFS
                             // The upgrade verb doesn't operate on a repo, so it doesn't use the enlistment
                             // path at all.
                             upgrade.Execute();
+                            Environment.Exit((int)ReturnCode.Success);
+                        })
+                    .WithParsed<ConfigVerb>(
+                        config =>
+                        {
+                            config.Execute();
                             Environment.Exit((int)ReturnCode.Success);
                         })
                     .WithParsed<GVFSVerb>(


### PR DESCRIPTION
#### Summary
- New ConfigVerb.
- Usage gvfs config <key> <value>
- Renamed GVFSConfig.cs to ServerGVFSConfig.cs.
- New LocalGVFSConfig.cs file. It writes config key value pairs into a config file.
- Updated ProductUpgrader.cs to use the new LocalGVFSConfig class to read ring config.
- Cleanup - renamed all occurances of gvfsConfig to serverGVFSConfig.

#### File Format
Config file is a simple dictionary file stored at path C:\ProgramData\GVFS\local_config.dat. 

#### Command usage and messaging:
```
PS M:\Work\gvfs\VFSForGit_Ameen> gvfs config upgrade.ring "Fast"
PS M:\Work\gvfs\VFSForGit_Ameen> gvfs config upgrade.ring
Fast
```