### PR TITLE
Fix a flaky test involving the background prefetch thread

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -131,10 +131,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string objectDir = this.Enlistment.GetObjectRoot(this.fileSystem);
             string postFetchLock = Path.Combine(objectDir, "post-fetch.lock");
 
-            while (this.fileSystem.FileExists(postFetchLock))
+            // Wait first, to hopefully ensure the background thread has
+            // started before we check for the lock file.
+            do
             {
                 Thread.Sleep(500);
             }
+            while (this.fileSystem.FileExists(postFetchLock));
 
             ProcessResult midxResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "midx --read --pack-dir=\"" + objectDir + "/pack\"");
             midxResult.ExitCode.ShouldEqual(0);


### PR DESCRIPTION
The functional test `PrefetchCleansUpStalePrefetchLock` intends to check the multi-pack-index and commit-graph are completely written after a prefetch. However, this can fail if the test is faster than the background thread in the mount process.

This change introduces a 500ms pause in the test to ensure we give adequate time to the mount process before verifying the background thread did its work.