### PR TITLE
CloneVerb: Force download of commit and trees on failed initial checkout

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -96,7 +96,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
             enlistment1.Status().ShouldContain("Mount status: Ready");
             enlistment2.Status().ShouldContain("Mount status: Ready");
         }
-        
+
         [TestCase]
         public void ParallelReadsInASharedCache()
         {
@@ -265,7 +265,30 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
             newObjectsRoot.ShouldContain(newCacheKey);
             newObjectsRoot.ShouldBeADirectory(this.fileSystem);
 
-            this.AlternatesFileShouldHaveGitObjectsRoot(enlistment);            
+            this.AlternatesFileShouldHaveGitObjectsRoot(enlistment);
+        }
+        
+        [TestCase]
+        public void SecondCloneSucceedsWithMissingTrees()
+        {
+            string newCachePath = Path.Combine(this.localCacheParentPath, ".customGvfsCache2");
+            GVFSFunctionalTestEnlistment enlistment1 = this.CreateNewEnlistment(localCacheRoot: newCachePath);
+            File.ReadAllText(Path.Combine(enlistment1.RepoRoot, WellKnownFile));
+
+            this.AlternatesFileShouldHaveGitObjectsRoot(enlistment1);
+
+            string packDir = Path.Combine(enlistment1.GetObjectRoot(this.fileSystem), "pack");
+            string[] packDirFiles = Directory.EnumerateFiles(packDir, "*", SearchOption.AllDirectories).ToArray();
+            for (int i = 0; i < packDirFiles.Length; i++)
+            {
+                this.fileSystem.DeleteFile(Path.Combine(packDir, packDirFiles[i]));
+            }
+
+            // Enumerate the root directory, populating the tip commit and root tree
+            this.fileSystem.EnumerateDirectory(enlistment1.RepoRoot);
+
+            GVFSFunctionalTestEnlistment enlistment2 = this.CreateNewEnlistment(localCacheRoot: newCachePath);
+            this.fileSystem.EnumerateDirectory(enlistment2.RepoRoot);
         }
 
         // Override OnTearDownEnlistmentsDeleted rathern than using [TearDown] as the enlistments need to be unmounted before

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -572,7 +572,7 @@ namespace GVFS.CommandLine
                 // It is possible to have the above TryDownloadCommit() fail because we
                 // already have the commit and root tree we intend to check out, but
                 // don't have a tree further down the working directory. If we fail
-                // checkout here, it may be due to not having these trees and the
+                // checkout here, its' because we don't have these trees and the
                 // read-object hook is not available yet. Force downloading the commit
                 // again and retry the checkout.
 
@@ -583,7 +583,7 @@ namespace GVFS.CommandLine
                     gitObjects,
                     gitRepo,
                     out errorMessage,
-                    ignoreIfRootExists: false))
+                    checkLocalObjectCache: false))
                 {
                     return new Result(errorMessage);
                 }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -567,6 +567,30 @@ namespace GVFS.CommandLine
             }
 
             GitProcess.Result forceCheckoutResult = git.ForceCheckout(branch);
+            if (forceCheckoutResult.HasErrors && forceCheckoutResult.Errors.IndexOf("unable to read tree") > 0)
+            {
+                // It is possible to have the above TryDownloadCommit() fail because we
+                // already have the commit and root tree we intend to check out, but
+                // don't have a tree further down the working directory. If we fail
+                // checkout here, it may be due to not having these trees and the
+                // read-object hook is not available yet. Force downloading the commit
+                // again and retry the checkout.
+
+                if (!this.TryDownloadCommit(
+                    refs.GetTipCommitId(branch),
+                    enlistment,
+                    objectRequestor,
+                    gitObjects,
+                    gitRepo,
+                    out errorMessage,
+                    ignoreIfRootExists: false))
+                {
+                    return new Result(errorMessage);
+                }
+
+                forceCheckoutResult = git.ForceCheckout(branch);
+            }
+
             if (forceCheckoutResult.HasErrors)
             {
                 string[] errorLines = forceCheckoutResult.Errors.Split('\n');

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -176,15 +176,15 @@ namespace GVFS.CommandLine
         }
 
         protected bool ShowStatusWhileRunning(
-            Func<bool> action, 
-            string message, 
+            Func<bool> action,
+            string message,
             bool suppressGvfsLogMessage = false)
         {
             string gvfsLogEnlistmentRoot = null;
             if (!suppressGvfsLogMessage)
             {
                 string errorMessage;
-                GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(this.EnlistmentRootPathParameter, out gvfsLogEnlistmentRoot, out errorMessage);                
+                GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(this.EnlistmentRootPathParameter, out gvfsLogEnlistmentRoot, out errorMessage);
             }
 
             return this.ShowStatusWhileRunning(action, message, gvfsLogEnlistmentRoot);
@@ -261,7 +261,7 @@ namespace GVFS.CommandLine
             }
 
             return gvfsConfig;
-        }        
+        }
 
         protected void ValidateClientVersions(ITracer tracer, GVFSEnlistment enlistment, GVFSConfig gvfsConfig, bool showWarnings)
         {
@@ -401,9 +401,10 @@ You can specify a URL, a name of a configured cache server, or the special names
             GitObjectsHttpRequestor objectRequestor,
             GVFSGitObjects gitObjects,
             GitRepo repo,
-            out string error)
+            out string error,
+            bool ignoreIfRootExists = true)
         {
-            if (!repo.CommitAndRootTreeExists(commitId))
+            if (!ignoreIfRootExists || !repo.CommitAndRootTreeExists(commitId))
             {
                 if (!gitObjects.TryDownloadCommit(commitId))
                 {
@@ -740,7 +741,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 MetaName = "Enlistment Root Path",
                 HelpText = "Full or relative path to the GVFS enlistment root")]
             public override string EnlistmentRootPathParameter { get; set; }
-            
+
             public sealed override void Execute()
             {
                 this.ValidatePathParameter(this.EnlistmentRootPathParameter);
@@ -855,7 +856,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                     if (File.Exists(alternatesFilePath))
                     {
                         try
-                        {                            
+                        {
                             using (Stream stream = fileSystem.OpenFileStream(
                                 alternatesFilePath,
                                 FileMode.Open,
@@ -922,7 +923,7 @@ You can specify a URL, a name of a configured cache server, or the special names
 
                         gvfsConfig = this.QueryGVFSConfig(tracer, enlistment, retryConfig);
                     }
-                    
+
                     string localCacheKey;
                     LocalCacheResolver localCacheResolver = new LocalCacheResolver(enlistment);
                     if (!localCacheResolver.TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers(
@@ -1009,7 +1010,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 if (GVFSPlatform.Instance.IsUnderConstruction)
                 {
                     hooksPath = "hooksUnderConstruction";
-                }                
+                }
                 else
                 {
                     hooksPath = ProcessHelper.WhereDirectory(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
@@ -1017,8 +1018,8 @@ You can specify a URL, a name of a configured cache server, or the special names
                     {
                         this.ReportErrorAndExit("Could not find " + GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
                     }
-                }             
-                
+                }
+
                 GVFSEnlistment enlistment = null;
                 try
                 {
@@ -1030,7 +1031,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                     {
                         enlistment = GVFSEnlistment.CreateWithoutRepoUrlFromDirectory(enlistmentRootPath, gitBinPath, hooksPath);
                     }
-                    
+
                     if (enlistment == null)
                     {
                         this.ReportErrorAndExit(

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -402,9 +402,9 @@ You can specify a URL, a name of a configured cache server, or the special names
             GVFSGitObjects gitObjects,
             GitRepo repo,
             out string error,
-            bool ignoreIfRootExists = true)
+            bool checkLocalObjectCache = true)
         {
-            if (!ignoreIfRootExists || !repo.CommitAndRootTreeExists(commitId))
+            if (!checkLocalObjectCache || !repo.CommitAndRootTreeExists(commitId))
             {
                 if (!gitObjects.TryDownloadCommit(commitId))
                 {


### PR DESCRIPTION
On Clone, we need to create the `.git/index` file during a checkout, which requires having all trees reachable from the root tree of the tip commit. To ensure we have all of the objects, we call `TryDownloadCommit()`. However, this method doesn't actually try downloading a pack of trees if we already have the commit and root tree.

Due to the shared object cache, we may have these objects for a few reasons:

1. A recent fetch included a ref update that points to that commit, and we downloaded the commit and tree as loose objects.
2. A background prefetch downloaded a prefetch pack containing that commit and tree, but some of the reachable trees are missing due to clock skew between cache servers.

This fixes the issue by forcibly downloading the packfile if the checkout fails and trying again.

Resolves #306.