### PR TITLE
LockData: Limit number of '|' chars that split the message

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
@@ -283,8 +283,10 @@ namespace GVFS.Common.NamedPipes
             {
                 if (!string.IsNullOrEmpty(body))
                 {
-                    // This mesage is stored using the MessageSeperator delimitor for performance reasons
-                    string[] dataParts = body.Split(MessageSeparator);
+                    // This mesage is stored using the MessageSeperator delimitor for performance reasons.
+                    // The final part is free-text, so could include the delimiter. Limit our count to the
+                    // number of controlled parts.
+                    string[] dataParts = body.Split(new char[] { MessageSeparator }, count: 5);
                     int pid;
                     bool isElevated = false;
                     bool checkAvailabilityOnly = false;

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
@@ -36,6 +36,9 @@ namespace GVFS.UnitTests.Common
             this.ValidateError("1|1|true|10|git status", "Invalid lock message. Expected bool for isElevated, got: 1 from message: '1|1|true|10|git status'");
             this.ValidateError("1|true|true|true|git status", "Invalid lock message. Expected command length, got: true from message: '1|true|true|true|git status'");
             this.ValidateError("1|true|true|5|git status", "Invalid lock message. The parsedCommand is an unexpected length, got: 5 from message: '1|true|true|5|git status'");
+
+            LockData data = LockData.FromBody("1|true|true|35|git commit -m \"Pipes|in|my|message\"");
+            data.ParsedCommand.ShouldEqual("git commit -m \"Pipes|in|my|message\"");
         }
 
         private void ValidateError(string body, string exceptionMessage)


### PR DESCRIPTION
We send multiple data fields in our lock request and use the pipe symbol '|' to split these fields. However, the final field is free-text, so could include that symbol. We then complain when the length doesn't match.

Limit our splitting to be the expected number of fields, removing this issue. Add a simple unit test that verifies this behavior.