### PR TITLE
Mac kext: Virtualisation root refactoring & array resizing

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 					"$(inherited)",
 					"MACH_ASSERT=1",
 				);
+				GCC_WARN_SHADOW = YES;
 				INFOPLIST_FILE = PrjFSKext/Info.plist;
 				MODULE_NAME = io.gvfs.PrjFSKext;
 				MODULE_START = PrjFSKext_Start;
@@ -430,7 +431,11 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				GCC_PREPROCESSOR_DEFINITIONS = "MACH_ASSERT=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MACH_ASSERT=1",
+					"$(inherited)",
+				);
+				GCC_WARN_SHADOW = YES;
 				INFOPLIST_FILE = PrjFSKext/Info.plist;
 				MODULE_NAME = io.gvfs.PrjFSKext;
 				MODULE_START = PrjFSKext_Start;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -42,11 +42,9 @@ static inline bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 
 static bool IsFileSystemCrawler(char* procname);
 
-static const char* GetRelativePath(const char* path, const char* root);
-
 static void Sleep(int seconds, void* channel);
 static bool TrySendRequestAndWaitForResponse(
-    const VirtualizationRoot* root,
+    VirtualizationRootHandle root,
     MessageType messageType,
     const vnode_t vnode,
     const FsidInode& vnodeFsidInode,
@@ -65,7 +63,7 @@ static bool ShouldHandleVnodeOpEvent(
     kauth_action_t action,
 
     // Out params:
-    VirtualizationRoot** root,
+    VirtualizationRootHandle* root,
     vtype* vnodeType,
     uint32_t* vnodeFileFlags,
     FsidInode* vnodeFsidInode,
@@ -80,7 +78,7 @@ static bool ShouldHandleFileOpEvent(
     kauth_action_t action,
 
     // Out params:
-    VirtualizationRoot** root,
+    VirtualizationRootHandle* root,
     FsidInode* vnodeFsidInode,
     int* pid);
 
@@ -277,7 +275,7 @@ static int HandleVnodeOperation(
     char vnodePathBuffer[PrjFSMaxPath];
     int vnodePathLength = PrjFSMaxPath;
 
-    VirtualizationRoot* root = nullptr;
+    VirtualizationRootHandle root = RootHandle_None;
     vtype vnodeType;
     uint32_t currentVnodeFileFlags;
     FsidInode vnodeFsidInode;
@@ -435,7 +433,7 @@ static int HandleFileOpOperation(
             goto CleanupAndReturn;
         }
         
-        VirtualizationRoot* root = nullptr;
+        VirtualizationRootHandle root = RootHandle_None;
         FsidInode vnodeFsidInode;
         int pid;
         if (!ShouldHandleFileOpEvent(
@@ -495,7 +493,7 @@ static int HandleFileOpOperation(
             goto CleanupAndReturn;
         }
             
-        VirtualizationRoot* root = nullptr;
+        VirtualizationRootHandle root = RootHandle_None;
         FsidInode vnodeFsidInode;
         int pid;
         if (!ShouldHandleFileOpEvent(
@@ -571,7 +569,7 @@ static bool ShouldHandleVnodeOpEvent(
     kauth_action_t action,
 
     // Out params:
-    VirtualizationRoot** root,
+    VirtualizationRootHandle* root,
     vtype* vnodeType,
     uint32_t* vnodeFileFlags,
     FsidInode* vnodeFsidInode,
@@ -579,8 +577,8 @@ static bool ShouldHandleVnodeOpEvent(
     char procname[MAXCOMLEN + 1],
     int* kauthResult)
 {
-    *root = nullptr;
     *kauthResult = KAUTH_RESULT_DEFER;
+    *root = RootHandle_None;
     
     if (!VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode))
     {
@@ -626,19 +624,22 @@ static bool ShouldHandleVnodeOpEvent(
     }
     
     *vnodeFsidInode = Vnode_GetFsidAndInode(vnode, context);
-    *root = VirtualizationRoots_FindForVnode(vnode, *vnodeFsidInode);
+    *root = VirtualizationRoot_FindForVnode(vnode, *vnodeFsidInode);
     
-    if (nullptr == *root)
+    if (RootHandle_ProviderTemporaryDirectory == *root)
+    {
+        *kauthResult = KAUTH_RESULT_DEFER;
+        return false;
+    }
+    else if (RootHandle_None == *root)
     {
         KextLog_FileNote(vnode, "No virtualization root found for file with set flag.");
         
         *kauthResult = KAUTH_RESULT_DEFER;
         return false;
     }
-    else if (nullptr == (*root)->providerUserClient)
+    else if (!VirtualizationRoot_IsOnline(*root))
     {
-        // There is no registered provider for this root
-        
         // TODO(Mac): Protect files in the worktree from modification (and prevent
         // the creation of new files) when the provider is offline
         
@@ -647,7 +648,7 @@ static bool ShouldHandleVnodeOpEvent(
     }
     
     // If the calling process is the provider, we must exit right away to avoid deadlocks
-    if (*pid == (*root)->providerPid)
+    if (VirtualizationRoot_PIDMatchesProvider(*root, *pid))
     {
         *kauthResult = KAUTH_RESULT_DEFER;
         return false;
@@ -663,10 +664,12 @@ static bool ShouldHandleFileOpEvent(
     kauth_action_t action,
 
     // Out params:
-    VirtualizationRoot** root,
+    VirtualizationRootHandle* root,
     FsidInode* vnodeFsidInode,
     int* pid)
 {
+    *root = RootHandle_None;
+
     vtype vnodeType = vnode_vtype(vnode);
     if (ShouldIgnoreVnodeType(vnodeType, vnode))
     {
@@ -674,21 +677,17 @@ static bool ShouldHandleFileOpEvent(
     }
     
     *vnodeFsidInode = Vnode_GetFsidAndInode(vnode, context);
-    *root = VirtualizationRoots_FindForVnode(vnode, *vnodeFsidInode);
-    if (nullptr == *root)
+    *root = VirtualizationRoot_FindForVnode(vnode, *vnodeFsidInode);
+    if (!VirtualizationRoot_IsValidRootHandle(*root))
     {
-        return false;
-    }
-    else if (nullptr == (*root)->providerUserClient)
-    {
-        // There is no registered provider for this root
+        // This VNode is not part of a root
         return false;
     }
     
-    // If the calling process is the provider, we must exit right away to avoid deadlocks
     *pid = GetPid(context);
-    if (*pid == (*root)->providerPid)
+    if (VirtualizationRoot_PIDMatchesProvider(*root, *pid))
     {
+        // If the calling process is the provider, we must exit right away to avoid deadlocks
         return false;
     }
     
@@ -696,7 +695,7 @@ static bool ShouldHandleFileOpEvent(
 }
 
 static bool TrySendRequestAndWaitForResponse(
-    const VirtualizationRoot* root,
+    VirtualizationRootHandle root,
     MessageType messageType,
     const vnode_t vnode,
     const FsidInode& vnodeFsidInode,
@@ -719,7 +718,7 @@ static bool TrySendRequestAndWaitForResponse(
         return false;
     }
     
-    const char* relativePath = GetRelativePath(vnodePath, root->path);
+    const char* relativePath = VirtualizationRoot_GetRootRelativePath(root, vnodePath);
     
     int nextMessageId = OSIncrementAtomic(&s_nextMessageId);
     
@@ -748,7 +747,7 @@ static bool TrySendRequestAndWaitForResponse(
     
     // TODO(Mac): Should we pass in the root directly, rather than root->index?
     //            The index seems more like a private implementation detail.
-    if (!isShuttingDown && 0 != ActiveProvider_SendMessage(root->index, messageSpec))
+    if (!isShuttingDown && 0 != ActiveProvider_SendMessage(root, messageSpec))
     {
         // TODO: appropriately handle unresponsive providers
         
@@ -883,19 +882,6 @@ static bool IsFileSystemCrawler(char* procname)
     }
     
     return false;
-}
-
-static const char* GetRelativePath(const char* path, const char* root)
-{
-    assert(strlen(path) >= strlen(root));
-    
-    const char* relativePath = path + strlen(root);
-    if (relativePath[0] == '/')
-    {
-        relativePath++;
-    }
-    
-    return relativePath;
 }
 
 static bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -425,7 +425,7 @@ static int HandleFileOpOperation(
         KAUTH_FILEOP_LINK == action)
     {
         // arg0 is the (const char *) fromPath (or the file being linked to)
-        const char* newPath = (const char*)arg1;
+        const char* newPath = reinterpret_cast<const char*>(arg1);
         
         // TODO(Mac): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
         // it's possible that we'll miss notifications
@@ -481,7 +481,7 @@ static int HandleFileOpOperation(
     else if (KAUTH_FILEOP_CLOSE == action)
     {
         vnode_t currentVnode = reinterpret_cast<vnode_t>(arg0);
-        const char* path = (const char*)arg1;
+        const char* path = reinterpret_cast<const char*>(arg1);
         int closeFlags = static_cast<int>(arg2);
         
         if (vnode_isdir(currentVnode))

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Memory.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Memory.hpp
@@ -7,4 +7,17 @@ kern_return_t Memory_Cleanup();
 void* Memory_Alloc(uint32_t size);
 void Memory_Free(void* buffer, uint32_t size);
 
+template <typename T>
+T* Memory_AllocArray(uint32_t arrayLength)
+{
+    size_t allocBytes = arrayLength * sizeof(T);
+    if (allocBytes > UINT32_MAX)
+    {
+        return nullptr;
+    }
+    
+    return static_cast<T*>(Memory_Alloc(static_cast<uint32_t>(allocBytes)));
+}
+
+
 #endif /* Memory_h */

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
@@ -3,6 +3,7 @@
 #include "PrjFSClasses.hpp"
 #include "Locks.hpp"
 #include "Message.h"
+#include "VirtualizationRoots.hpp"
 #include <IOKit/IOUserClient.h>
 
 struct MessageHeader;
@@ -18,8 +19,8 @@ private:
     Mutex dataQueueWriterMutex;
 public:
     pid_t pid;
-    // The root for which this is the provider; -1 prior to registration
-    int32_t virtualizationRootIndex;
+    // The root for which this is the provider; RootHandle_None prior to registration
+    VirtualizationRootHandle virtualizationRootHandle;
     
     // IOUserClient methods:
     virtual bool initWithTask(

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
@@ -4,42 +4,37 @@
 #include "PrjFSClasses.hpp"
 #include "kernel-header-wrappers/vnode.h"
 
-struct VirtualizationRoot
-{
-    bool                        inUse;
-    // If this is a nullptr, there is no active provider for this virtualization root (offline root)
-    PrjFSProviderUserClient*    providerUserClient;
-    int                         providerPid;
-    // For an active root, this is retained (vnode_get), for an offline one, it is not, so it may be stale (check the vid)
-    vnode_t                     rootVNode;
-    uint32_t                    rootVNodeVid;
-    
-    // Mount point ID + persistent, on-disk ID for the root directory, so we can
-    // identify it if the vnode of an offline root gets recycled.
-    fsid_t                      rootFsid;
-    uint64_t                    rootInode;
-    
-    // TODO(Mac): this should eventually be entirely diagnostic and not used for decisions
-    char                        path[PrjFSMaxPath];
+typedef int16_t VirtualizationRootHandle;
 
-    int32_t                     index;
+// Zero and positive values indicate a handle for a valid virtualization
+// root. Other values have special meanings:
+enum VirtualizationRootSpecialHandle : VirtualizationRootHandle
+{
+    // Not in a virtualization root.
+    RootHandle_None                       = -1,
+    // Root/non-root state not known. Useful reset value for invalidating cached state.
+    RootHandle_Indeterminate              = -2,
+    // Vnode is not in a virtualization root, but below a provider's registered temp directory
+    RootHandle_ProviderTemporaryDirectory = -3,
 };
 
 kern_return_t VirtualizationRoots_Init(void);
 kern_return_t VirtualizationRoots_Cleanup(void);
 
-VirtualizationRoot* VirtualizationRoots_FindForVnode(vnode_t vnode, const FsidInode& vnodeFsidInode);
+VirtualizationRootHandle VirtualizationRoot_FindForVnode(vnode_t vnode, const FsidInode& vnodeFsidInode);
 
 struct VirtualizationRootResult
 {
     errno_t error;
-    int32_t rootIndex;
+    VirtualizationRootHandle root;
 };
 VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProviderUserClient* userClient, pid_t clientPID, const char* virtualizationRootPath);
-void ActiveProvider_Disconnect(int32_t rootIndex);
+void ActiveProvider_Disconnect(VirtualizationRootHandle rootHandle);
 
 struct Message;
-errno_t ActiveProvider_SendMessage(int32_t rootIndex, const Message message);
+errno_t ActiveProvider_SendMessage(VirtualizationRootHandle rootHandle, const Message message);
 bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode_t vnode);
-
-int16_t VirtualizationRoots_LookupVnode(vnode_t vnode, vfs_context_t context, const FsidInode& vnodeFsidInode);
+bool VirtualizationRoot_IsOnline(VirtualizationRootHandle rootHandle);
+bool VirtualizationRoot_PIDMatchesProvider(VirtualizationRootHandle rootHandle, pid_t pid);
+bool VirtualizationRoot_IsValidRootHandle(VirtualizationRootHandle rootHandle);
+const char* VirtualizationRoot_GetRootRelativePath(VirtualizationRootHandle rootHandle, const char* path);


### PR DESCRIPTION
The way the `VirtualizationRoot` struct has been used in the ProjFS kext has been rather messy so far - sometimes by index, sometimes by pointer, often non-threadsafe (although the risks have been fairly small).

The ultimate goals of this PR are:
 * Lift the limit on number of virtualisation roots.
 * Fix the thread safety issues.

The reason I made the virtualisation root array a fixed size initially was because allowing resizes means the pointers will become invalid unless you introduce some fairly strict locking requirements. Locking the root array for near enough the entire duration of a vnode/fileop callback could cause some significant contention though and would furthermore raise issues with performing vnode I/O and acquiring other locks while holding the vroot lock.

This PR approaches the issue a different way: consistently only expose vroot indices in the API, never pointers to the struct itself, and provide accessor functions which ensure thread safety as needed. As long as indices stay linked to root identities, it's safe to drop the lock while holding a root index.

To get there, I made a bunch of other smaller preparatory and in some cases only tangentially related changes; **all the changes are in logically distinct git commits, so when reviewing you may wish to review one commit at a time** - you'll have an easier ride that way.

Quick commit summary:

1. <s>*Don't assert/KP on attribute reading failure.* The assertion on getting vnode attributes successfully failed a few times during development & testing. It's not entirely clear why yet, but the assert doesn't give much clue as to the reason, so I've changed this to a soft failure with some extra logging. If you encounter instances of this error while testing etc., please do send me --reports.</s>
2. *Handle named streams.* Relatedly, I've logged I/O errors on a bunch of other operations, and quite a number of them originated in vnodes corresponding to resource forks. (You'll recognise these by their path, which looks something like `/path/to/a/regular/file/..namedfork/rsrc`.) These aren't standalone files, but alternate data streams/forks on a regular file. For the most part, they are uninteresting to VFS for Git, but they behave oddly when querying things like xattrs, and we really should be applying the logic according to their underlying file. So this changes the vnode op callback handler to operate on that underlying file when encountering a named stream.
3. *Replaces some C-style casts with C++ style.* We've been fairly consistent with using C++ style casts (`static_cast`, `const_cast`, `reinterpret_cast`) in the kext, but I stumbled across some C-style casts that crept in. This changes them to C++ style.
4. *Enables warnings for shadowed variables.* Activates another compiler warning - shadowing variables is rarely what we want, and more frequently is a bug. (I made just such a mistake while refactoring the `VirtualizationRoot` API and spent half an hour chasing it, if you must know.)
5. *Adds typed array memory allocation function*. This adds a helper function that wraps our memory allocator with a typed array-based one, which make for slightly more readable and less error prone code. (Particularly with regard to overflow on size calculations.)
6. *Use only `VirtualizationRoot` indices, not direct pointers.* This rejigs the `VirtualizationRoot.hpp` API to never leak pointers, and indeed moves the struct definition to the `.cpp` file. It also adds accessor functions for situations where previously pointers were dereferenced, and wraps them with locks so access is threadsafe.
7. *Dynamically alloc virtualisation root array & resize when full.* This finally gets rid of the nasty assertion failure when our virtualisation root array is full and grows it instead!