### PR TITLE
WIP: Windows: Use a faster comparison when enumeration filter strings don't have wildcards

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -6,10 +6,11 @@ namespace GVFS.Platform.Windows
 {
     public class ActiveEnumeration
     {
-        private static FileNamePatternMatcher doesPatternMatch = null;
+        private static FileNamePatternMatcher wildcardPatternMatcher = null;
 
         // Use our own enumerator to avoid having to dispose anything
         private ProjectedFileInfoEnumerator fileInfoEnumerator;
+        private FileNamePatternMatcher patternMatcher;
 
         private string filterString = null;
 
@@ -36,12 +37,13 @@ namespace GVFS.Platform.Windows
         }
 
         /// <summary>
-        /// Sets the pattern matching delegate that will be used for file name comparisons
+        /// Sets the pattern matching delegate that will be used for file name comparisons when the filter
+        /// contains wildcards.
         /// </summary>
         /// <param name="patternMatcher">FileNamePatternMatcher to be used by ActiveEnumeration</param>
-        public static void SetPatternMatcher(FileNamePatternMatcher patternMatcher)
+        public static void SetWildcardPatternMatcher(FileNamePatternMatcher patternMatcher)
         {
-            doesPatternMatch = patternMatcher;
+            wildcardPatternMatcher = patternMatcher;
         }
 
         /// <summary>
@@ -107,15 +109,31 @@ namespace GVFS.Platform.Windows
             return this.filterString;
         }
 
+        private static bool NameMatchsNoWildcardFilter(string name, string filter)
+        {
+            return string.Equals(name, filter, System.StringComparison.OrdinalIgnoreCase);
+        }
+
         private void SaveFilter(string filter)
         {
             if (string.IsNullOrEmpty(filter))
             {
                 this.filterString = string.Empty;
+                this.patternMatcher = null;
             }
             else
             {
                 this.filterString = filter;
+
+                if (ProjFS.Utils.DoesNameContainWildCards(this.filterString))
+                {
+                    this.patternMatcher = wildcardPatternMatcher;
+                }
+                else
+                {
+                    this.patternMatcher = NameMatchsNoWildcardFilter;
+                }
+
                 if (this.IsCurrentValid && this.IsCurrentHidden())
                 {
                     this.MoveNext();
@@ -125,7 +143,12 @@ namespace GVFS.Platform.Windows
 
         private bool IsCurrentHidden()
         {
-            return !doesPatternMatch(this.Current.Name, this.GetFilterString());
+            if (this.patternMatcher == null)
+            {
+                return false;
+            }
+
+            return !this.patternMatcher(this.Current.Name, this.GetFilterString());
         }
 
         private void ResetEnumerator()

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -272,11 +272,11 @@ namespace GVFS.Platform.Windows
 
             if (projFSPatternMatchingWorks)
             {
-                ActiveEnumeration.SetPatternMatcher(Utils.IsFileNameMatch);
+                ActiveEnumeration.SetWildcardPatternMatcher(Utils.IsFileNameMatch);
             }
             else
             {
-                ActiveEnumeration.SetPatternMatcher(InternalFileNameMatchesFilter);
+                ActiveEnumeration.SetWildcardPatternMatcher(InternalFileNameMatchesFilter);
             }
 
             this.Context.Tracer.RelatedEvent(

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
@@ -23,7 +23,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
 
         public ActiveEnumerationTests(PatternMatcherWrapper wrapper)
         {
-            ActiveEnumeration.SetPatternMatcher(wrapper.Matcher);
+            ActiveEnumeration.SetWildcardPatternMatcher(wrapper.Matcher);
         }
 
         public static object[] Runners


### PR DESCRIPTION
Update `ActiveEnumeration` to use `string.Equals` rather than `Utils.IsFileNameMatch` when the enumeration filter string does not have wildcards (first commit), and to exit early when the filter does not have wildcards (second commit).

Times with scenario provided by @kyle-rader 

  | Baseline Times (sec) | First commit (sec) | Second commit (sec)
-- | -- | -- | --
  | 48.23 | 9.83 | 8.6
  | 41.16 | 9.37 | 8.75
  | 44.49 | 10.76 | 9.06
  | 41.18 | 10.35 | 8.99
Average | 43.77 | 10.08 | 8.85







