### PR TITLE
Windows: Use a faster comparison when enumeration filter strings don't have wildcards

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -6,10 +6,11 @@ namespace GVFS.Platform.Windows
 {
     public class ActiveEnumeration
     {
-        private static FileNamePatternMatcher doesPatternMatch = null;
+        private static FileNamePatternMatcher wildcardPatternMatcher = null;
 
         // Use our own enumerator to avoid having to dispose anything
         private ProjectedFileInfoEnumerator fileInfoEnumerator;
+        private FileNamePatternMatcher patternMatcher;
 
         private string filterString = null;
 
@@ -36,12 +37,13 @@ namespace GVFS.Platform.Windows
         }
 
         /// <summary>
-        /// Sets the pattern matching delegate that will be used for file name comparisons
+        /// Sets the pattern matching delegate that will be used for file name comparisons when the filter
+        /// contains wildcards.
         /// </summary>
         /// <param name="patternMatcher">FileNamePatternMatcher to be used by ActiveEnumeration</param>
-        public static void SetPatternMatcher(FileNamePatternMatcher patternMatcher)
+        public static void SetWildcardPatternMatcher(FileNamePatternMatcher patternMatcher)
         {
-            doesPatternMatch = patternMatcher;
+            wildcardPatternMatcher = patternMatcher;
         }
 
         /// <summary>
@@ -107,15 +109,31 @@ namespace GVFS.Platform.Windows
             return this.filterString;
         }
 
+        private static bool NameMatchsNoWildcardFilter(string name, string filter)
+        {
+            return string.Equals(name, filter, System.StringComparison.OrdinalIgnoreCase);
+        }
+
         private void SaveFilter(string filter)
         {
             if (string.IsNullOrEmpty(filter))
             {
                 this.filterString = string.Empty;
+                this.patternMatcher = null;
             }
             else
             {
                 this.filterString = filter;
+
+                if (ProjFS.Utils.DoesNameContainWildCards(this.filterString))
+                {
+                    this.patternMatcher = wildcardPatternMatcher;
+                }
+                else
+                {
+                    this.patternMatcher = NameMatchsNoWildcardFilter;
+                }
+
                 if (this.IsCurrentValid && this.IsCurrentHidden())
                 {
                     this.MoveNext();
@@ -125,7 +143,12 @@ namespace GVFS.Platform.Windows
 
         private bool IsCurrentHidden()
         {
-            return !doesPatternMatch(this.Current.Name, this.GetFilterString());
+            if (this.patternMatcher == null)
+            {
+                return false;
+            }
+
+            return !this.patternMatcher(this.Current.Name, this.GetFilterString());
         }
 
         private void ResetEnumerator()

--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -6,11 +6,11 @@ namespace GVFS.Platform.Windows
 {
     public class ActiveEnumeration
     {
-        private static FileNamePatternMatcher wildcardPatternMatcher = null;
+        private static FileNamePatternMatcher doesWildcardPatternMatch = null;
 
         // Use our own enumerator to avoid having to dispose anything
         private ProjectedFileInfoEnumerator fileInfoEnumerator;
-        private FileNamePatternMatcher patternMatcher;
+        private FileNamePatternMatcher doesPatternMatch;
 
         private string filterString = null;
 
@@ -43,7 +43,7 @@ namespace GVFS.Platform.Windows
         /// <param name="patternMatcher">FileNamePatternMatcher to be used by ActiveEnumeration</param>
         public static void SetWildcardPatternMatcher(FileNamePatternMatcher patternMatcher)
         {
-            wildcardPatternMatcher = patternMatcher;
+            doesWildcardPatternMatch = patternMatcher;
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace GVFS.Platform.Windows
             return this.filterString;
         }
 
-        private static bool NameMatchsNoWildcardFilter(string name, string filter)
+        private static bool NameMatchesNoWildcardFilter(string name, string filter)
         {
             return string.Equals(name, filter, System.StringComparison.OrdinalIgnoreCase);
         }
@@ -119,7 +119,7 @@ namespace GVFS.Platform.Windows
             if (string.IsNullOrEmpty(filter))
             {
                 this.filterString = string.Empty;
-                this.patternMatcher = null;
+                this.doesPatternMatch = null;
             }
             else
             {
@@ -127,11 +127,11 @@ namespace GVFS.Platform.Windows
 
                 if (ProjFS.Utils.DoesNameContainWildCards(this.filterString))
                 {
-                    this.patternMatcher = wildcardPatternMatcher;
+                    this.doesPatternMatch = doesWildcardPatternMatch;
                 }
                 else
                 {
-                    this.patternMatcher = NameMatchsNoWildcardFilter;
+                    this.doesPatternMatch = NameMatchesNoWildcardFilter;
                 }
 
                 if (this.IsCurrentValid && this.IsCurrentHidden())
@@ -143,12 +143,12 @@ namespace GVFS.Platform.Windows
 
         private bool IsCurrentHidden()
         {
-            if (this.patternMatcher == null)
+            if (this.doesPatternMatch == null)
             {
                 return false;
             }
 
-            return !this.patternMatcher(this.Current.Name, this.GetFilterString());
+            return !this.doesPatternMatch(this.Current.Name, this.GetFilterString());
         }
 
         private void ResetEnumerator()

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -272,11 +272,11 @@ namespace GVFS.Platform.Windows
 
             if (projFSPatternMatchingWorks)
             {
-                ActiveEnumeration.SetPatternMatcher(Utils.IsFileNameMatch);
+                ActiveEnumeration.SetWildcardPatternMatcher(Utils.IsFileNameMatch);
             }
             else
             {
-                ActiveEnumeration.SetPatternMatcher(InternalFileNameMatchesFilter);
+                ActiveEnumeration.SetWildcardPatternMatcher(InternalFileNameMatchesFilter);
             }
 
             this.Context.Tracer.RelatedEvent(

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
@@ -23,7 +23,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
 
         public ActiveEnumerationTests(PatternMatcherWrapper wrapper)
         {
-            ActiveEnumeration.SetPatternMatcher(wrapper.Matcher);
+            ActiveEnumeration.SetWildcardPatternMatcher(wrapper.Matcher);
         }
 
         public static object[] Runners


### PR DESCRIPTION
Update `ActiveEnumeration` to use `string.Equals` rather than `Utils.IsFileNameMatch` when the enumeration filter string does not have wildcards.

Times with scenario provided by @kyle-rader 

  | Baseline Times (sec) | PR Changes (sec)
-- | -- | --
  | 48.23 | 9.83
  | 41.16 | 9.37 
  | 44.49 | 10.76 
  | 41.18 | 10.35 
Average | 43.77 | 10.08 