### PR TITLE
GitProcess: allow GIT_TRACE to point to full path

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/StatusVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/StatusVerbTests.cs
@@ -1,0 +1,28 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class StatusVerbTests : TestsWithEnlistmentPerFixture
+    {
+        [TestCase]
+        public void GitTrace()
+        {
+            Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
+
+            this.Enlistment.Status(trace: "1");
+            this.Enlistment.Status(trace: "2");
+
+            string logPath = Path.Combine(this.Enlistment.RepoRoot, "log-file.txt");
+            this.Enlistment.Status(trace: logPath);
+
+            FileSystemRunner fileSystem = new SystemIORunner();
+            fileSystem.FileExists(logPath).ShouldBeTrue();
+            string.IsNullOrWhiteSpace(fileSystem.ReadAllText(logPath)).ShouldBeFalse();
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -211,9 +211,9 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.Diagnose();
         }
 
-        public string Status()
+        public string Status(string trace = null)
         {
-            return this.gvfsProcess.Status();
+            return this.gvfsProcess.Status(trace);
         }
 
         public bool WaitForBackgroundOperations(int maxWaitMilliseconds = DefaultMaxWaitMSForStatusCheck)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -8,14 +8,14 @@ namespace GVFS.FunctionalTests.Tools
         private readonly string pathToGVFS;
         private readonly string enlistmentRoot;
         private readonly string localCacheRoot;
-        
+
         public GVFSProcess(string pathToGVFS, string enlistmentRoot, string localCacheRoot)
         {
             this.pathToGVFS = pathToGVFS;
             this.enlistmentRoot = enlistmentRoot;
             this.localCacheRoot = localCacheRoot;
         }
-        
+
         public void Clone(string repositorySource, string branchToCheckout, bool skipPrefetch)
         {
             string args = string.Format(
@@ -60,9 +60,9 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("diagnose \"" + this.enlistmentRoot + "\"");
         }
 
-        public string Status()
+        public string Status(string trace = null)
         {
-            return this.CallGVFS("status " + this.enlistmentRoot);
+            return this.CallGVFS("status " + this.enlistmentRoot, trace: trace);
         }
 
         public string CacheServer(string args)
@@ -90,7 +90,7 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
-        private string CallGVFS(string args, bool failOnError = false)
+        private string CallGVFS(string args, bool failOnError = false, string trace = null)
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
@@ -99,6 +99,11 @@ namespace GVFS.FunctionalTests.Tools
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
+
+            if (trace != null)
+            {
+                processInfo.EnvironmentVariables["GIT_TRACE"] = trace;
+            }
 
             using (Process process = Process.Start(processInfo))
             {


### PR DESCRIPTION
The GIT_TRACE variable can be helpful for diagnosing problems during Git commands. However, there are many places in VFS for Git that require parsing the Git output. Using `GIT_TRACE=1` sends the output to stdout, which messes up this parsing. In the past, we have blocked that variable for this reason.

It would still be helpful to allow logging the trace output. Git allows a fully-qualified path as the value of `GIT_TRACE` and will append to that file instead. This is how we would like users to use `GIT_TRACE` when investigating issues. Unblock that type of setting.

Resolves #276