### PR TITLE
Use correct repoUrl for credential

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
@@ -14,6 +14,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
     public class RepairTests : TestsWithEnlistmentPerTestCase
     {
         [TestCase]
+        public void NoFixesNeeded()
+        {
+            this.Enlistment.UnmountGVFS();
+
+            this.Enlistment.Repair();
+        }
+
+        [TestCase]
         public void FixesCorruptHeadSha()
         {
             this.Enlistment.UnmountGVFS();

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -45,6 +45,7 @@ namespace GVFS.RepairJobs
 
             // At this point, we've confirmed that the repo url can be gotten, so we have to 
             // reinitialize the GitProcess with a valid repo url for 'git credential fill'
+            string repoUrl = null;
             try
             {
                 GVFSEnlistment enlistment = GVFSEnlistment.CreateFromDirectory(
@@ -52,6 +53,7 @@ namespace GVFS.RepairJobs
                     this.Enlistment.GitBinPath,
                     this.Enlistment.GVFSHooksRoot);
                 git = new GitProcess(enlistment);
+                repoUrl = enlistment.RepoUrl;
             }
             catch (InvalidRepoException)
             {
@@ -61,7 +63,7 @@ namespace GVFS.RepairJobs
 
             string username;
             string password;
-            if (!git.TryGetCredentials(this.Tracer, this.Enlistment.RepoUrl, out username, out password))
+            if (!git.TryGetCredentials(this.Tracer, repoUrl, out username, out password))
             {
                 messages.Add("Authentication failed. Run 'gvfs log' for more info.");
                 messages.Add(".git\\config is valid and remote 'origin' is set, but may have a typo:");


### PR DESCRIPTION
This change allows us to reinitialize the GitProcess with valid repository information and pass it correctly to the credential call.

The bug was caused by the refactor [here](https://dev.azure.com/mseng/AzureDevOps/_git/GVFS/commit/cec8bb00b1a4954329fd5a6e5dd6243f47fe381e?refName=refs%2Fheads%2Fmaster&_a=compare&path=%2FGVFS%2FGVFS.CLI%2FRepairJobs%2FGitConfigRepairJob.cs).  
- Previously, we used the repoUrl from the enlistment on GitProcess creation.
- Now, we use the url passed in on  TryGetCredentials.

A new unit test was added that exposed the failure.

#289 


