### PR TITLE
Show "None" message in diagnose instead of invalid url

### DIFF
--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -13,7 +13,6 @@ namespace GVFS.Common
         public const string BlobSizesCacheName = "blobSizes";
 
         private const string GitObjectCacheName = "gitObjects";
-        private const string InvalidRepoUrl = "invalid://repoUrl";
 
         private string gitVersion;
         private string gvfsVersion;
@@ -90,7 +89,7 @@ namespace GVFS.Common
                     return null;
                 }
 
-                return new GVFSEnlistment(enlistmentRoot, InvalidRepoUrl, gitBinRoot, gvfsHooksRoot);
+                return new GVFSEnlistment(enlistmentRoot, string.Empty, gitBinRoot, gvfsHooksRoot);
             }
 
             return null;

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -53,7 +53,7 @@ namespace GVFS.CommandLine
                 this.WriteMessage(GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath());
                 this.WriteMessage(string.Empty);
                 this.WriteMessage("Enlistment root: " + enlistment.EnlistmentRoot);
-                this.WriteMessage("Cache Server: " + CacheServerResolver.GetUrlFromConfig(enlistment));
+                this.WriteMessage("Cache Server: " + CacheServerResolver.GetCacheServerFromConfig(enlistment));
 
                 string localCacheRoot;
                 string gitObjectsRoot;


### PR DESCRIPTION
When a cache server is not set up we shouldn't be showing the invalid default url.  

Instead let's show a helpful message to the user.

#289