### PR TITLE
Remove SharedCacheTests.SecondCloneSucceedsWithMissingTrees

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -267,29 +267,6 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 
             this.AlternatesFileShouldHaveGitObjectsRoot(enlistment);
         }
-        
-        [TestCase]
-        public void SecondCloneSucceedsWithMissingTrees()
-        {
-            string newCachePath = Path.Combine(this.localCacheParentPath, ".customGvfsCache2");
-            GVFSFunctionalTestEnlistment enlistment1 = this.CreateNewEnlistment(localCacheRoot: newCachePath);
-            File.ReadAllText(Path.Combine(enlistment1.RepoRoot, WellKnownFile));
-
-            this.AlternatesFileShouldHaveGitObjectsRoot(enlistment1);
-
-            string packDir = Path.Combine(enlistment1.GetObjectRoot(this.fileSystem), "pack");
-            string[] packDirFiles = Directory.EnumerateFiles(packDir, "*", SearchOption.AllDirectories).ToArray();
-            for (int i = 0; i < packDirFiles.Length; i++)
-            {
-                this.fileSystem.DeleteFile(Path.Combine(packDir, packDirFiles[i]));
-            }
-
-            // Enumerate the root directory, populating the tip commit and root tree
-            this.fileSystem.EnumerateDirectory(enlistment1.RepoRoot);
-
-            GVFSFunctionalTestEnlistment enlistment2 = this.CreateNewEnlistment(localCacheRoot: newCachePath);
-            this.fileSystem.EnumerateDirectory(enlistment2.RepoRoot);
-        }
 
         // Override OnTearDownEnlistmentsDeleted rathern than using [TearDown] as the enlistments need to be unmounted before
         // localCacheParentPath can be deleted (as the SQLite blob sizes database cannot be deleted while GVFS is mounted) 


### PR DESCRIPTION
This test attempted to cover a rare scenario, but is flaky due to something holding a handle on the pack-files we are trying to delete.

The test did these things:

1. Clone in `enlistment1`.
2. Delete all packfiles.
3. Download the tip commit and root tree as loose objects.
4. Clone in `enlistment2`, hitting the new retry logic.

However, the pack-file delete can fail due to something holding on to the packfiles. This failed on one PR build already. Stop it from failing on others.