### PR TITLE
Mac: Prevent double hydration and directory expansion

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		263E066C21667C11005F756A /* FsidInode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FsidInode.h; sourceTree = "<group>"; };
 		4A08829C20D80B8300E17FEE /* PrjFSXattrs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrjFSXattrs.h; sourceTree = "<group>"; };
 		4A63CB0B20AB009000157B95 /* VnodeUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VnodeUtilities.cpp; sourceTree = "<group>"; };
 		4A63CB0C20AB009000157B95 /* VnodeUtilities.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VnodeUtilities.hpp; sourceTree = "<group>"; };
@@ -90,6 +91,7 @@
 				4ABB734C20C1A65B00DC0D17 /* PrjFSProviderClientShared.h */,
 				4A08829C20D80B8300E17FEE /* PrjFSXattrs.h */,
 				C6BDD37A208C2FD700CB7E58 /* Message.h */,
+				263E066C21667C11005F756A /* FsidInode.h */,
 			);
 			path = public;
 			sourceTree = "<group>";

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Message_Kernel.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Message_Kernel.cpp
@@ -6,12 +6,14 @@ void Message_Init(
     MessageHeader* header,
     uint64_t messageId,
     MessageType messageType,
+    const FsidInode& fsidInode,
     int32_t pid,
     const char* procname,
     const char* path)
 {
     header->messageId = messageId;
     header->messageType = messageType;
+    header->fsidInode = fsidInode;
     header->pid = pid;
     
     if (nullptr != procname)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "FsidInode.h"
 #include "PrjFSClasses.hpp"
 #include "kernel-header-wrappers/vnode.h"
 
@@ -27,7 +28,7 @@ struct VirtualizationRoot
 kern_return_t VirtualizationRoots_Init(void);
 kern_return_t VirtualizationRoots_Cleanup(void);
 
-VirtualizationRoot* VirtualizationRoots_FindForVnode(vnode_t vnode);
+VirtualizationRoot* VirtualizationRoots_FindForVnode(vnode_t vnode, const FsidInode& vnodeFsidInode);
 
 struct VirtualizationRootResult
 {
@@ -41,4 +42,4 @@ struct Message;
 errno_t ActiveProvider_SendMessage(int32_t rootIndex, const Message message);
 bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode_t vnode);
 
-int16_t VirtualizationRoots_LookupVnode(vnode_t vnode, vfs_context_t context);
+int16_t VirtualizationRoots_LookupVnode(vnode_t vnode, vfs_context_t context, const FsidInode& vnodeFsidInode);

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.cpp
@@ -5,7 +5,7 @@
 
 extern "C" int mac_vnop_getxattr(struct vnode *, const char *, char *, size_t, size_t *);
 
-VnodeFsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t context)
+FsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t context)
 {
     vnode_attr attrs;
     VATTR_INIT(&attrs);

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VnodeUtilities.hpp
@@ -2,6 +2,7 @@
 
 #include <sys/kernel_types.h>
 #include <sys/_types/_fsid_t.h>
+#include "FsidInode.h"
 
 struct SizeOrError
 {
@@ -10,10 +11,4 @@ struct SizeOrError
 };
 
 SizeOrError Vnode_ReadXattr(vnode_t vnode, const char* xattrName, void* buffer, size_t bufferSize, vfs_context_t context);
-
-struct VnodeFsidInode
-{
-    fsid_t fsid;
-    uint64_t inode;
-};
-VnodeFsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t context);
+FsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t context);

--- a/ProjFS.Mac/PrjFSKext/public/FsidInode.h
+++ b/ProjFS.Mac/PrjFSKext/public/FsidInode.h
@@ -1,0 +1,20 @@
+//
+//  FsidInode.h
+//  PrjFSKext
+//
+//  Created by William Baker on 10/4/18.
+//  Copyright © 2018 GVFS. All rights reserved.
+//
+
+#ifndef FsidInode_h
+#define FsidInode_h
+
+#include <sys/_types/_fsid_t.h>
+
+struct FsidInode
+{
+    fsid_t fsid;
+    uint64_t inode;
+};
+
+#endif /* FsidInode_h */

--- a/ProjFS.Mac/PrjFSKext/public/FsidInode.h
+++ b/ProjFS.Mac/PrjFSKext/public/FsidInode.h
@@ -1,11 +1,3 @@
-//
-//  FsidInode.h
-//  PrjFSKext
-//
-//  Created by William Baker on 10/4/18.
-//  Copyright © 2018 GVFS. All rights reserved.
-//
-
 #ifndef FsidInode_h
 #define FsidInode_h
 

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -3,6 +3,7 @@
 
 #include <sys/param.h>
 #include "PrjFSCommon.h"
+#include "FsidInode.h"
 
 typedef enum
 {
@@ -39,6 +40,9 @@ struct MessageHeader
     // The message type indicates the type of request or response
     uint32_t            messageType; // values of type MessageType
     
+    // fsid and inode of the file
+    FsidInode           fsidInode;
+    
     // For messages from kernel to user mode, indicates the PID of the process that initiated the I/O
     int32_t             pid;
     char                procname[MAXCOMLEN + 1];
@@ -59,6 +63,7 @@ void Message_Init(
     MessageHeader* header,
     uint64_t messageId,
     MessageType messageType,
+    const FsidInode& fsidInode,
     int32_t pid,
     const char* procname,
     const char* path);

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -9,8 +9,9 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <queue>
-#include <unordered_map>
+#include <memory>
 #include <set>
+#include <map>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/IODataQueueClient.h>
 #include <mach/mach_port.h>
@@ -35,14 +36,16 @@ using std::hex;
 using std::is_pod;
 using std::lock_guard;
 using std::make_pair;
+using std::make_shared;
+using std::map;
 using std::move;
 using std::mutex;
 using std::oct;
 using std::pair;
 using std::queue;
 using std::set;
+using std::shared_ptr;
 using std::string;
-using std::unordered_map;
 
 typedef lock_guard<mutex> mutex_lock;
 
@@ -69,7 +72,7 @@ static void CombinePaths(const char* root, const char* relative, char (&combined
 static errno_t SendKernelMessageResponse(uint64_t messageId, MessageType responseType);
 static errno_t RegisterVirtualizationRootPath(const char* path);
 
-static void HandleKernelRequest(Message requestSpec, void* messageMemory);
+static void HandleKernelRequest(void* messageMemory, uint32_t messageSize);
 static PrjFS_Result HandleEnumerateDirectoryRequest(const MessageHeader* request, const char* path);
 static PrjFS_Result HandleRecursivelyEnumerateDirectoryRequest(const MessageHeader* request, const char* path);
 static PrjFS_Result HandleHydrateFileRequest(const MessageHeader* request, const char* path);
@@ -94,10 +97,27 @@ static PrjFS_Callbacks s_callbacks;
 static dispatch_queue_t s_messageQueueDispatchQueue;
 static dispatch_queue_t s_kernelRequestHandlingConcurrentQueue;
 
-// Map of relative path -> set of pending message IDs for that path, plus mutex to protect it.
-static unordered_map<string, set<uint64_t>> s_PendingRequestMessageIDs;
-static mutex s_PendingRequestMessageMutex;
+struct CaseInsensitiveStringCompare
+{
+    bool operator() (const std::string& lhs, const std::string& rhs) const
+    {
+        return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
+    }
+};
 
+struct MutexAndUseCount
+{
+    shared_ptr<mutex> mutex;
+    int useCount;
+};
+
+// Map of relative path -> MutexAndUseCount for that path, plus mutex to protect the map itself.
+typedef map<string, MutexAndUseCount, CaseInsensitiveStringCompare> PathToMutexMap;
+PathToMutexMap s_inProgressExpansions;
+mutex s_inProgressExpansionsMutex;
+
+static shared_ptr<mutex> CheckoutPathMutex(const string& fullPath);
+static void ReturnPathMutex(const string& fullPath, const shared_ptr<mutex>& mutex);
 
 // The full API is defined in the header, but only the minimal set of functions needed
 // for the initial MirrorProvider implementation are listed here. Calling any other function
@@ -192,37 +212,11 @@ PrjFS_Result PrjFS_StartVirtualizationInstance(
                 cerr << "Unexpected result dequeueing message - result 0x" << hex << result << " dequeued " << dequeuedSize << "/" << messageSize << " bytes\n";
                 abort();
             }
-            
-            Message message = ParseMessageMemory(messageMemory, messageSize);
-            
-            // At the moment, we expect all messages to include a path
-            assert(message.path != nullptr);
-
-            // Ensure we don't run more than one request handler at once for the same file
-            {
-                mutex_lock lock(s_PendingRequestMessageMutex);
-                typedef unordered_map<string, set<uint64_t>>::iterator PendingMessageIterator;
-                    PendingMessageIterator file_messages_found = s_PendingRequestMessageIDs.find(message.path);
-                if (file_messages_found == s_PendingRequestMessageIDs.end())
-                {
-                    // Not handling this file/dir yet
-                    pair<PendingMessageIterator, bool> inserted =
-                        s_PendingRequestMessageIDs.insert(make_pair(string(message.path), set<uint64_t>{ message.messageHeader->messageId }));
-                    assert(inserted.second);
-                }
-                else
-                {
-                    // Already a handler running for this path, don't handle it again.
-                    file_messages_found->second.insert(message.messageHeader->messageId);
-                    continue;
-                }
-            }
-            
 
             dispatch_async(
                 s_kernelRequestHandlingConcurrentQueue,
                 ^{
-                    HandleKernelRequest(message, messageMemory);
+                    HandleKernelRequest(messageMemory, messageSize);
                 });
         }
     });
@@ -436,6 +430,7 @@ PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
        return result;
     }
 
+    // TODO(Mac): Ensure that races with hydration are handled properly
     return PrjFS_WritePlaceholderFile(relativePath, providerId, contentId, fileSize, fileMode);
 }
 
@@ -482,6 +477,7 @@ PrjFS_Result PrjFS_DeleteFile(
         return PrjFS_Result_EInvalidArgs;
     }
 
+    // TODO(Mac): Ensure that races with hydration are handled properly
     // TODO(Mac): Ensure file is not full before proceeding
     
     char fullPath[PrjFSMaxPath];
@@ -554,9 +550,14 @@ static Message ParseMessageMemory(const void* messageMemory, uint32_t size)
     return Message { header, path };
 }
 
-static void HandleKernelRequest(Message request, void* messageMemory)
+static void HandleKernelRequest(void* messageMemory, uint32_t messageSize)
 {
     PrjFS_Result result = PrjFS_Result_EIOError;
+    
+    Message request = ParseMessageMemory(messageMemory, messageSize);
+    
+    // At the moment, we expect all messages to include a path
+    assert(request.path != nullptr);
     
     const MessageHeader* requestHeader = request.messageHeader;
     switch (requestHeader->messageType)
@@ -621,21 +622,8 @@ static void HandleKernelRequest(Message request, void* messageMemory)
             PrjFS_Result_Success == result
             ? MessageType_Response_Success
             : MessageType_Response_Fail;
-
-        set<uint64_t> messageIDs;
-
-        {
-            mutex_lock lock(s_PendingRequestMessageMutex);
-            unordered_map<string, set<uint64_t>>::iterator fileMessageIDsFound = s_PendingRequestMessageIDs.find(request.path);
-            assert(fileMessageIDsFound != s_PendingRequestMessageIDs.end());
-            messageIDs = move(fileMessageIDsFound->second);
-            s_PendingRequestMessageIDs.erase(fileMessageIDsFound);
-        }
-
-        for (uint64_t messageID : messageIDs)
-        {
-            SendKernelMessageResponse(messageID, responseType);
-        }
+        
+            SendKernelMessageResponse(requestHeader->messageId, responseType);
     }
     
     free(messageMemory);
@@ -647,26 +635,44 @@ static PrjFS_Result HandleEnumerateDirectoryRequest(const MessageHeader* request
     cout << "PrjFSLib.HandleEnumerateDirectoryRequest: " << path << endl;
 #endif
     
-    PrjFS_Result callbackResult = s_callbacks.EnumerateDirectory(
-        0 /* commandId */,
-        path,
-        request->pid,
-        request->procname);
-    
-    if (PrjFS_Result_Success == callbackResult)
+    char fullPath[PrjFSMaxPath];
+    CombinePaths(s_virtualizationRootFullPath.c_str(), path, fullPath);
+    if (!IsBitSetInFileFlags(fullPath, FileFlags_IsEmpty))
     {
-        char fullPath[PrjFSMaxPath];
-        CombinePaths(s_virtualizationRootFullPath.c_str(), path, fullPath);
-        
-        if (!SetBitInFileFlags(fullPath, FileFlags_IsEmpty, false))
-        {
-            // TODO(Mac): how should we handle this scenario where the provider thinks it succeeded, but we were unable to
-            // update placeholder metadata?
-            return PrjFS_Result_EIOError;
-        }
+        return PrjFS_Result_Success;
     }
     
-    return callbackResult;
+    PrjFS_Result result;
+    shared_ptr<mutex> expansionMutex = CheckoutPathMutex(fullPath);
+    {
+        mutex_lock lock(*expansionMutex);
+        if (!IsBitSetInFileFlags(fullPath, FileFlags_IsEmpty))
+        {
+            result = PrjFS_Result_Success;
+            goto CleanupAndReturn;
+        }
+    
+        result = s_callbacks.EnumerateDirectory(
+            0 /* commandId */,
+            path,
+            request->pid,
+            request->procname);
+        
+        if (PrjFS_Result_Success == result)
+        {
+            if (!SetBitInFileFlags(fullPath, FileFlags_IsEmpty, false))
+            {
+                // TODO(Mac): how should we handle this scenario where the provider thinks it succeeded, but we were unable to
+                // update placeholder metadata?
+                result = PrjFS_Result_EIOError;
+            }
+        }
+    }
+
+CleanupAndReturn:
+    ReturnPathMutex(fullPath, expansionMutex);
+
+    return result;
 }
 
 static PrjFS_Result HandleRecursivelyEnumerateDirectoryRequest(const MessageHeader* request, const char* path)
@@ -689,13 +695,10 @@ static PrjFS_Result HandleRecursivelyEnumerateDirectoryRequest(const MessageHead
         
         CombinePaths(s_virtualizationRootFullPath.c_str(), directoryRelativePath.c_str(), pathBuffer);
     
-        if (IsBitSetInFileFlags(pathBuffer, FileFlags_IsEmpty))
+        PrjFS_Result result = HandleEnumerateDirectoryRequest(request, directoryRelativePath.c_str());
+        if (result != PrjFS_Result_Success)
         {
-            PrjFS_Result result = HandleEnumerateDirectoryRequest(request, directoryRelativePath.c_str());
-            if (result != PrjFS_Result_Success)
-            {
-                goto CleanupAndReturn;
-            }
+            goto CleanupAndReturn;
         }
         
         DIR* directory = opendir(pathBuffer);
@@ -744,59 +747,81 @@ static PrjFS_Result HandleHydrateFileRequest(const MessageHeader* request, const
         return PrjFS_Result_EIOError;
     }
     
+    if (!IsBitSetInFileFlags(fullPath, FileFlags_IsEmpty))
+    {
+        return PrjFS_Result_Success;
+    }
+    
+    PrjFS_Result result;
     PrjFS_FileHandle fileHandle;
     
-    // Mode "rb+" means:
-    //  - The file must already exist
-    //  - The handle is opened for reading and writing
-    //  - We are allowed to seek to somewhere other than end of stream for writing
-    fileHandle.file = fopen(fullPath, "rb+");
-    if (nullptr == fileHandle.file)
+    shared_ptr<mutex> hydrationMutex = CheckoutPathMutex(fullPath);
+    
     {
-        return PrjFS_Result_EIOError;
-    }
-    
-    // Seek back to the beginning so the provider can overwrite the empty contents
-    if (fseek(fileHandle.file, 0, 0))
-    {
-        fclose(fileHandle.file);
-        return PrjFS_Result_EIOError;
-    }
-    
-    PrjFS_Result callbackResult = s_callbacks.GetFileStream(
-        0 /* comandId */,
-        path,
-        xattrData.providerId,
-        xattrData.contentId,
-        request->pid,
-        request->procname,
-        &fileHandle);
-    
-    // TODO: once we support async callbacks, we'll need to save off the fileHandle if the result is Pending
-    
-    if (fclose(fileHandle.file))
-    {
-        // TODO: under what conditions can fclose fail? How do we recover?
-        return PrjFS_Result_EIOError;
-    }
-    
-    if (PrjFS_Result_Success == callbackResult)
-    {
-        // TODO: validate that the total bytes written match the size that was reported on the placeholder in the first place
-        // Potential bugs if we don't:
-        //  * The provider writes fewer bytes than expected. The hydrated is left with extra padding up to the original reported size.
-        //  * The provider writes more bytes than expected. The write succeeds, but whatever tool originally opened the file may have already
-        //    allocated the originally reported size, and now the contents appear truncated.
-        
-        if (!SetBitInFileFlags(fullPath, FileFlags_IsEmpty, false))
+        mutex_lock lock(*hydrationMutex);
+        if (!IsBitSetInFileFlags(fullPath, FileFlags_IsEmpty))
         {
-            // TODO: how should we handle this scenario where the provider thinks it succeeded, but we were unable to
-            // update placeholder metadata?
-            return PrjFS_Result_EIOError;
+            result = PrjFS_Result_Success;
+            goto CleanupAndReturn;
+        }
+        
+        // Mode "rb+" means:
+        //  - The file must already exist
+        //  - The handle is opened for reading and writing
+        //  - We are allowed to seek to somewhere other than end of stream for writing
+        fileHandle.file = fopen(fullPath, "rb+");
+        if (nullptr == fileHandle.file)
+        {
+            result = PrjFS_Result_EIOError;
+            goto CleanupAndReturn;
+        }
+        
+        // Seek back to the beginning so the provider can overwrite the empty contents
+        if (fseek(fileHandle.file, 0, 0))
+        {
+            fclose(fileHandle.file);
+            result = PrjFS_Result_EIOError;
+            goto CleanupAndReturn;
+        }
+        
+        result = s_callbacks.GetFileStream(
+            0 /* comandId */,
+            path,
+            xattrData.providerId,
+            xattrData.contentId,
+            request->pid,
+            request->procname,
+            &fileHandle);
+        
+        // TODO: once we support async callbacks, we'll need to save off the fileHandle if the result is Pending
+        
+        if (fclose(fileHandle.file))
+        {
+            // TODO: under what conditions can fclose fail? How do we recover?
+            result = PrjFS_Result_EIOError;
+            goto CleanupAndReturn;
+        }
+        
+        if (PrjFS_Result_Success == result)
+        {
+            // TODO: validate that the total bytes written match the size that was reported on the placeholder in the first place
+            // Potential bugs if we don't:
+            //  * The provider writes fewer bytes than expected. The hydrated is left with extra padding up to the original reported size.
+            //  * The provider writes more bytes than expected. The write succeeds, but whatever tool originally opened the file may have already
+            //    allocated the originally reported size, and now the contents appear truncated.
+            
+            if (!SetBitInFileFlags(fullPath, FileFlags_IsEmpty, false))
+            {
+                // TODO: how should we handle this scenario where the provider thinks it succeeded, but we were unable to
+                // update placeholder metadata?
+                result = PrjFS_Result_EIOError;
+            }
         }
     }
-    
-    return callbackResult;
+
+CleanupAndReturn:
+    ReturnPathMutex(fullPath, hydrationMutex);
+    return result;
 }
 
 static PrjFS_Result HandleFileNotification(
@@ -1031,3 +1056,34 @@ static const char* NotificationTypeToString(PrjFS_NotificationType notificationT
     }
 }
 #endif
+
+static shared_ptr<mutex> CheckoutPathMutex(const string& fullPath)
+{
+    mutex_lock lock(s_inProgressExpansionsMutex);
+    PathToMutexMap::iterator iter = s_inProgressExpansions.find(fullPath);
+    if (iter == s_inProgressExpansions.end())
+    {
+        pair<PathToMutexMap::iterator, bool> newEntry = s_inProgressExpansions.insert(
+            PathToMutexMap::value_type(fullPath, { make_shared<mutex>(), 1 }));
+        assert(newEntry.second);
+        return newEntry.first->second.mutex;
+    }
+    else
+    {
+        iter->second.useCount++;
+        return iter->second.mutex;
+    }
+}
+
+static void ReturnPathMutex(const string& fullPath, const shared_ptr<mutex>& mutex)
+{
+    mutex_lock lock(s_inProgressExpansionsMutex);
+    PathToMutexMap::iterator iter = s_inProgressExpansions.find(fullPath);
+    assert(iter != s_inProgressExpansions.end());
+    assert(iter->second.mutex.get() == mutex.get());
+    iter->second.useCount--;
+    if (iter->second.useCount == 0)
+    {
+        s_inProgressExpansions.erase(iter);
+    }
+}


### PR DESCRIPTION
Fixes #315 

There were a few issues in the ProjFS for Mac user-mode library:

- All messages from the kernel would be coalesced into a single callback to the provider, meaning it was possible that notifications could get lost.

- The path comparisons when deciding if messages should be collapsed were case sensitive.

- When messages were collapsed, the library was leaking the memory allocated for any of the collapsed messages.

- The hydrate\enumerate code was not checking if the file\directory had already been expanded.  As a result, if two requests came in sequentially, it's possible that with the right timing they would both run and problems would occur when trying to expand the file\directory a second time.

This PR addresses these issues with the following changes:

- Messages are no longer collapsed

- There is a new per-path collection of mutexes to ensure that two threads don't expand the same path at the same time.

- The hydration\enumeration handles check if the path is expanded prior to asking the provider to expand it. 