### PR TITLE
SecondCloneSucceedsWithMissingTrees: Attempt 2

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -21,7 +21,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 
         // This branch and commit sha should point to the same place.
         private const string WellKnownBranch = "FunctionalTests/20170602";
-        private const string WellKnownCommitSha = "79dc4233df4d9a7e053662bff95df498f640022e";
+        private const string WellKnownCommitSha = "42eb6632beffae26893a3d6e1a9f48d652327c6f";
 
         private string localCachePath;
         private string localCacheParentPath;

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
@@ -28,9 +28,16 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         {
         }
 
-        protected GVFSFunctionalTestEnlistment CreateNewEnlistment(string localCacheRoot = null, string branch = null)
+        protected GVFSFunctionalTestEnlistment CreateNewEnlistment(
+            string localCacheRoot = null,
+            string branch = null,
+            bool skipPrefetch = false)
         {
-            GVFSFunctionalTestEnlistment output = GVFSFunctionalTestEnlistment.CloneAndMount(GVFSTestConfig.PathToGVFS, branch, localCacheRoot);
+            GVFSFunctionalTestEnlistment output = GVFSFunctionalTestEnlistment.CloneAndMount(
+                GVFSTestConfig.PathToGVFS,
+                branch,
+                localCacheRoot,
+                skipPrefetch);
             this.enlistmentsToDelete.Add(output);
             return output;
         }

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -89,10 +89,14 @@ namespace GVFS.FunctionalTests.Tools
             return CloneAndMount(pathToGvfs, enlistmentRoot, null, localCache, skipPrefetch);
         }
 
-        public static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string commitish = null, string localCacheRoot = null)
+        public static GVFSFunctionalTestEnlistment CloneAndMount(
+            string pathToGvfs,
+            string commitish = null,
+            string localCacheRoot = null,
+            bool skipPrefetch = false)
         {
             string enlistmentRoot = GVFSFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
-            return CloneAndMount(pathToGvfs, enlistmentRoot, commitish, localCacheRoot);
+            return CloneAndMount(pathToGvfs, enlistmentRoot, commitish, localCacheRoot, skipPrefetch);
         }
 
         public static GVFSFunctionalTestEnlistment CloneAndMountEnlistmentWithSpacesInPath(string pathToGvfs, string commitish = null)


### PR DESCRIPTION
The previous approach to this test relied on deleting packfiles from the shared object cache. That failed on Windows because the .idx files have restrictive permissions that cause the delete to fail.

Instead, use the loose object downloads to hydrate the commit and root tree for the WellKnownBranch and then do a clone pointing at that branch. This should trigger the failure case.

Resolves #330