### PR TITLE
Pass all required components to vswhere in BuildGVFSForWindows.bat

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,6 @@ If you'd like to build your own VFS for Git Windows installer:
     * .NET Core cross-platform development
   * Include the following additional components:
     * .NET Core runtime
-    * C++/CLI support
     * Windows 10 SDK (10.0.10240.0)
 * Install the .NET Core 2.1 SDK (https://www.microsoft.com/net/download/dotnet-core/2.1)
 * Create a folder to clone into, e.g. `C:\Repos\VFSForGit`

--- a/Scripts/BuildGVFSForWindows.bat
+++ b/Scripts/BuildGVFSForWindows.bat
@@ -19,14 +19,20 @@ SET vswhere=%~dp0..\..\packages\vswhere.%vswherever%\tools\vswhere.exe
 
 :: Use vswhere to find the latest VS installation (including prerelease installations) with the msbuild component.
 :: See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.Component.NetFX.Core.Runtime Microsoft.VisualStudio.Component.Windows10SDK.10240 -property installationPath`) do (
   set VsInstallDir=%%i
+)
+
+IF NOT DEFINED VsInstallDir (
+  echo ERROR: Could not locate a Visual Studio installation with required components.
+  echo Refer to Readme.md for a list of the required Visual Studio components.
+  exit /b 10
 )
 
 SET msbuild="%VsInstallDir%\MSBuild\15.0\Bin\amd64\msbuild.exe"
 IF NOT EXIST %msbuild% (
-	echo Error: Could not find msbuild
-	exit /b 1
+  echo ERROR: Could not find msbuild
+  exit /b 1
 )
 
 %msbuild% %~dp0\..\GVFS.sln /p:GVFSVersion=%GVFSVersion% /p:Configuration=%SolutionConfiguration% /p:Platform=x64 || exit /b 1


### PR DESCRIPTION
When installing new versions of Visual Studio for testing, I often do not install all the workloads. This PR makes vswhere smarter about choosing the latest version of VS that can actually build VFS for Git, rather than the latest version of VS period.