### PR TITLE
Update NamedPipeStreamReader to handle multiple sequential messages

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -10,13 +10,13 @@ namespace GVFS.Common.NamedPipes
     /// The server side of a Named Pipe used for interprocess communication.
     ///
     /// Named Pipe protocol:
-    ///    The client / server process send a "message" (or line) of data as a
+    ///    The client / server process sends a "message" (or line) of data as a
     ///    sequence of bytes terminated by a 0x3 byte (ASCII control code for
     ///    End of text). Text is encoded as UTF-8 to be sent as bytes across the wire.
     ///
     /// This format was chosen so that
     ///   1) A reasonable range of values can be transmitted across the pipe,
-    ///      including including null and bytes that represent newline characters,
+    ///      including null and bytes that represent newline characters,
     ///   2) It would be easy to implement in multiple places 
     ///      (we have managed and native implementations).
     /// </summary>

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -6,6 +6,22 @@ using System.Threading;
 
 namespace GVFS.Common.NamedPipes
 {
+    /// <summary>
+    /// The server side of a Named Pipe used for interprocess communication.
+    ///
+    /// Named Pipe protocol:
+    ///    The client / server process send a "message" (or line) of data as a
+    ///    sequence of bytes terminated by a 0x3 byte (ASCII control code for
+    ///    End of text). The sender of a message must wait for a response from
+    ///    the other side before sending another message. Text is encoded as
+    ///    UTF-8 to be sent as bytes across the wire.
+    ///
+    /// This format was chosen so that
+    ///   1) A reasonable range of values can be transmitted across the pipe,
+    ///      including including null and bytes that represent newline characters,
+    ///   2) It would be easy to implement in multiple places 
+    ///      (we have managed and native implementations).
+    /// </summary>
     public class NamedPipeServer : IDisposable
     {
         // TODO(Mac) the limit is much shorter on macOS

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -12,9 +12,7 @@ namespace GVFS.Common.NamedPipes
     /// Named Pipe protocol:
     ///    The client / server process send a "message" (or line) of data as a
     ///    sequence of bytes terminated by a 0x3 byte (ASCII control code for
-    ///    End of text). The sender of a message must wait for a response from
-    ///    the other side before sending another message. Text is encoded as
-    ///    UTF-8 to be sent as bytes across the wire.
+    ///    End of text). Text is encoded as UTF-8 to be sent as bytes across the wire.
     ///
     /// This format was chosen so that
     ///   1) A reasonable range of values can be transmitted across the pipe,

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
@@ -86,6 +86,39 @@ namespace GVFS.UnitTests.Common
             this.TestTransmitMessage(messageWithNewLines);
         }
 
+        [Test]
+        [Description("Verify that we can transmit message multiple messages in the same buffer")]
+        [Ignore("Demonstrate failing behavior")]
+        public void CanSendMultipleMessagesIntheSameBuffer()
+        {
+            string[] messages = new string[]
+            {
+                "This is a new message",
+                "This is another message",
+                "This is the third message in a series of messages"
+            };
+
+            this.TestTransmitMessages(messages);
+        }
+
+        [Test]
+        [Description("Verify that we can handle messages that are chunked at different points")]
+        [Ignore("Demonstrate failing behavior")]
+        public void CanHandleMultipleChunkedMessagesInTheSameBuffer()
+        {
+            string chunkedMessage = new string('T', BufferSize + (BufferSize / 2));
+
+            // Verify that we corrently handle messages 
+            string[] messages = new string[]
+            {
+                chunkedMessage,
+                "This is another message",
+                chunkedMessage
+            };
+
+            this.TestTransmitMessages(messages);
+        }
+
         private void TestTransmitMessage(string message)
         {
             long pos = this.ReadStreamPosition();
@@ -95,6 +128,24 @@ namespace GVFS.UnitTests.Common
 
             string readMessage = this.streamReader.ReadMessage();
             readMessage.ShouldEqual(message, "The message read from the stream reader is not the same as the message that was sent.");
+        }
+        
+        private void TestTransmitMessages(string[] messages)
+        {
+            long pos = this.ReadStreamPosition();
+
+            foreach (string message in messages)
+            {
+                this.streamWriter.WriteMessage(message);
+            }
+            
+            this.SetStreamPosition(pos);
+
+            foreach (string message in messages)
+            {
+                string readMessage = this.streamReader.ReadMessage();
+                readMessage.ShouldEqual(message, "The message read from the stream reader is not the same as the message that was sent.");
+            }
         }
 
         private long ReadStreamPosition()

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
@@ -24,7 +24,6 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can transmit multiple messages")]
         public void CanWriteAndReadMessages()
         {
             string firstMessage = @"This is a new message";
@@ -41,7 +40,6 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can transmit a message that contains content that is the size of a NamedPipeStreamReader's buffer")]
         public void CanSendBufferSizedContent()
         {
             string longMessage = new string('T', BufferSize);
@@ -49,7 +47,6 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can transmit message that is the same size a NamedPipeStreamReader's buffer")]
         public void CanSendBufferSizedMessage()
         {
             int numBytesInMessageTerminator = 1;
@@ -58,7 +55,6 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that the expected exception is thrown if message is not terminated with expected byte.")]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ReadingPartialMessgeThrows()
         {
@@ -71,7 +67,6 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can transmit message that is larger than the buffer")]
         public void CanSendMultiBufferSizedMessage()
         {
             string longMessage = new string('T', BufferSize * 3);
@@ -79,15 +74,13 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can transmit message that newline characters")]
-        public void CanSendNewLines()
+        public void CanSendMessagesWithNewLines()
         {
             string messageWithNewLines = "This is a \nstringwith\nnewlines";
             this.TestTransmitMessage(messageWithNewLines);
         }
 
         [Test]
-        [Description("Verify that we can transmit message multiple messages in the same buffer")]
         public void CanSendMultipleMessagesIntheSameBuffer()
         {
             string[] messages = new string[]
@@ -101,12 +94,10 @@ namespace GVFS.UnitTests.Common
         }
 
         [Test]
-        [Description("Verify that we can handle messages that are chunked at different points")]
         public void CanHandleMultipleChunkedMessagesInTheSameBuffer()
         {
             string chunkedMessage = new string('T', BufferSize + (BufferSize / 2));
 
-            // Verify that we corrently handle messages 
             string[] messages = new string[]
             {
                 chunkedMessage,

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
@@ -88,7 +88,6 @@ namespace GVFS.UnitTests.Common
 
         [Test]
         [Description("Verify that we can transmit message multiple messages in the same buffer")]
-        [Ignore("Demonstrate failing behavior")]
         public void CanSendMultipleMessagesIntheSameBuffer()
         {
             string[] messages = new string[]
@@ -103,7 +102,6 @@ namespace GVFS.UnitTests.Common
 
         [Test]
         [Description("Verify that we can handle messages that are chunked at different points")]
-        [Ignore("Demonstrate failing behavior")]
         public void CanHandleMultipleChunkedMessagesInTheSameBuffer()
         {
             string chunkedMessage = new string('T', BufferSize + (BufferSize / 2));


### PR DESCRIPTION
Originally, the NamedPipeStreamReader assumed that only a single message would be sent over the pipe at a time. This allowed for some simplifications to the `NamedPipeStreamReader`. However, this assumption does not hold for and results in incorrect behavior when multiple messages are sent (see #333).

This series of commits adds test cases demonstrating this issue and updates the NamedPipeStreamReader to handle multiple sequential messages on the NamedPipe stream.

Fixes #333 
