### PR TITLE
Simplify the logic for `NamedPipeStreamReader` and fix handling of multiple sequential messages

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -6,6 +6,22 @@ using System.Threading;
 
 namespace GVFS.Common.NamedPipes
 {
+    /// <summary>
+    /// The server side of a Named Pipe used for interprocess communication.
+    ///
+    /// Named Pipe protocol:
+    ///    The client / server process sends a "message" (or line) of data as a
+    ///    sequence of bytes terminated by a 0x3 byte (ASCII control code for
+    ///    End of text). The sender of a message must wait for a response from
+    ///    the other side before sending another message. Text is encoded as
+    ///    UTF-8 to be sent as bytes across the wire.
+    ///
+    /// This format was chosen so that:
+    ///   1) A reasonable range of values can be transmitted across the pipe,
+    ///      including null and bytes that represent newline characters.
+    ///   2) It would be easy to implement in multiple places, as we
+    ///      have managed and native implementations.
+    /// </summary>
     public class NamedPipeServer : IDisposable
     {
         // TODO(Mac) the limit is much shorter on macOS

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -12,9 +12,7 @@ namespace GVFS.Common.NamedPipes
     /// Named Pipe protocol:
     ///    The client / server process sends a "message" (or line) of data as a
     ///    sequence of bytes terminated by a 0x3 byte (ASCII control code for
-    ///    End of text). The sender of a message must wait for a response from
-    ///    the other side before sending another message. Text is encoded as
-    ///    UTF-8 to be sent as bytes across the wire.
+    ///    End of text). Text is encoded as UTF-8 to be sent as bytes across the wire.
     ///
     /// This format was chosen so that:
     ///   1) A reasonable range of values can be transmitted across the pipe,

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeStreamReader.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeStreamReader.cs
@@ -11,23 +11,16 @@ namespace GVFS.Common.NamedPipes
     /// </summary>
     public class NamedPipeStreamReader
     {
-        private const int DefaultBufferSize = 1024;
+        private const int InitialListSize = 1024;
         private const byte TerminatorByte = 0x3;
+        private readonly byte[] buffer;
 
-        private int bufferSize;
-        private byte[] buffer;
         private Stream stream;
 
-        public NamedPipeStreamReader(Stream stream, int bufferSize)
+        public NamedPipeStreamReader(Stream stream)
         {
             this.stream = stream;
-            this.bufferSize = bufferSize;
-            this.buffer = new byte[this.bufferSize];
-        }
-
-        public NamedPipeStreamReader(Stream stream)
-            : this(stream, DefaultBufferSize)
-        {
+            this.buffer = new byte[1];
         }
 
         /// <summary>
@@ -36,38 +29,23 @@ namespace GVFS.Common.NamedPipes
         /// <returns>The message read from the stream, or null if the end of the input stream has been reached. </returns>
         public string ReadMessage()
         {
-            int bytesRead = this.Read();
-            if (bytesRead == 0)
+            byte currentByte;
+
+            bool streamOpen = this.TryReadByte(out currentByte);
+            if (!streamOpen)
             {
                 // The end of the stream has been reached - return null to indicate this.
                 return null;
             }
 
-            // If we have read in the entire message in the first read (mainline scenario),
-            // then just process the data directly from the buffer.
-            if (this.buffer[bytesRead - 1] == TerminatorByte)
+            List<byte> bytes = new List<byte>(InitialListSize);
+
+            do
             {
-                return Encoding.UTF8.GetString(this.buffer, 0, bytesRead - 1);
-            }
+                bytes.Add(currentByte);
+                streamOpen = this.TryReadByte(out currentByte);
 
-            // We need to process multiple chunks - collect data from multiple chunks
-            // into a single list
-            List<byte> bytes = new List<byte>(this.bufferSize * 2);
-
-            while (true)
-            {
-                bool encounteredTerminatorByte = this.buffer[bytesRead - 1] == TerminatorByte;
-                int lengthToCopy = encounteredTerminatorByte ? bytesRead - 1 : bytesRead;
-
-                bytes.AddRange(new ArraySegment<byte>(this.buffer, 0, lengthToCopy));
-                if (encounteredTerminatorByte)
-                {
-                    break;
-                }
-
-                bytesRead = this.Read();
-
-                if (bytesRead == 0)
+                if (!streamOpen)
                 {
                     // We have read a partial message (the last byte received does not indicate that
                     // this was the end of the message), but the stream has been closed. Throw an exception
@@ -76,17 +54,24 @@ namespace GVFS.Common.NamedPipes
                     throw new IOException("Incomplete message read from stream. The end of the stream was reached without the expected terminating byte.");
                 }
             }
+            while (currentByte != TerminatorByte);
 
             return Encoding.UTF8.GetString(bytes.ToArray());
         }
 
         /// <summary>
-        /// Read the next chunk of bytes from the stream.
+        /// Read a byte from the stream.
         /// </summary>
-        /// <returns>The number of bytes read.</returns>
-        private int Read()
+        /// <param name="readByte">The byte read from the stream</param>
+        /// <returns>True if byte read, false if end of stream has been reached</returns>
+        private bool TryReadByte(out byte readByte)
         {
-            return this.stream.Read(this.buffer, 0, this.buffer.Length);
+            this.buffer[0] = 0;
+
+            int numBytesRead = this.stream.Read(this.buffer, 0, 1);
+            readByte = this.buffer[0];
+
+            return numBytesRead == 1;
         }
     }
 }


### PR DESCRIPTION
Update the `NamedPipeStreamReader` to read individual bytes from the underlying stream. This avoids complexity associated with reading a larger chunk of bytes and handling the different cases associated with that approach. This change also fixes handling of multiple sequential messages (#333)