### PR TITLE
Mac: Update MoveAndOverwriteFile to use native API

### DIFF
--- a/GVFS/GVFS.Common/NativeMethods.Shared.cs
+++ b/GVFS/GVFS.Common/NativeMethods.Shared.cs
@@ -143,6 +143,11 @@ namespace GVFS.Common
             }
         }
 
+        public static void ThrowLastWin32Exception(string message)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), message);
+        }
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern SafeFileHandle OpenProcess(
             ProcessAccessFlags processAccess,
@@ -152,11 +157,6 @@ namespace GVFS.Common
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetExitCodeProcess(SafeFileHandle hProcess, out uint lpExitCode);
-
-        private static void ThrowLastWin32Exception(string message)
-        {
-            throw new Win32Exception(Marshal.GetLastWin32Error(), message);
-        }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern SafeFileHandle CreateFile(

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.FileSystem;
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -15,13 +16,10 @@ namespace GVFS.Platform.Mac
 
         public void MoveAndOverwriteFile(string sourceFileName, string destinationFilename)
         {
-            // TODO(Mac): Use native API
-            if (File.Exists(destinationFilename))
+            if (Rename(sourceFileName, destinationFilename) != 0)
             {
-                File.Delete(destinationFilename);
+                NativeMethods.ThrowLastWin32Exception($"Failed to renname {sourceFileName} to {destinationFilename}");
             }
-
-            File.Move(sourceFileName, destinationFilename);
         }
 
         public void CreateHardLink(string newFileName, string existingFileName)
@@ -42,5 +40,8 @@ namespace GVFS.Platform.Mac
 
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
         private static extern int Chmod(string pathname, int mode);
+
+        [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
+        private static extern int Rename(string oldPath, string newPath);
     }
 }


### PR DESCRIPTION
Fixes #342.

The initial `MoveAndOverwriteFile` could result in a missing file (if `File.Delete` succeeded and `File.Move` failed).

Switch to the atomic `rename` function.

```
DESCRIPTION
     The rename() system call causes the link named old to be renamed as new.  If new exists, it is first removed.  Both old and new must be of the same type (that is, both must be either direc-
     tories or non-directories) and must reside on the same file system.

     The rename() system call guarantees that an instance of new will always exist, even if the system should crash in the middle of the operation.
```