### PR TITLE
Mac: Unblock 'gvfs prefetch --hydrate'

### DIFF
--- a/GVFS/GVFS.Common/Prefetch/Jobs/ReadFilesJob.cs
+++ b/GVFS/GVFS.Common/Prefetch/Jobs/ReadFilesJob.cs
@@ -60,11 +60,8 @@ namespace GVFS.Common.Prefetch.Jobs
                         {
                             using (FileStream filestream = new FileStream(path, FileMode.Open, FileAccess.Read))
                             {
-                                int thisByte = filestream.ReadByte();
-                                if (thisByte != -1)
-                                {
-                                    succeeded = true;
-                                }
+                                filestream.ReadByte();
+                                succeeded = true;
                             }
                         }
 

--- a/GVFS/GVFS.Common/Prefetch/Jobs/ReadFilesJob.cs
+++ b/GVFS/GVFS.Common/Prefetch/Jobs/ReadFilesJob.cs
@@ -46,7 +46,7 @@ namespace GVFS.Common.Prefetch.Jobs
                         bool succeeded = false;
 
                         // TODO(Mac): Replace this with a native method as opposed to a slow .NET method
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        if (!GVFSPlatform.Instance.IsUnderConstruction)
                         {
                             using (SafeFileHandle handle = NativeFileReader.Open(path))
                             {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -42,7 +42,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
-        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFileExtensionWithHydrate()
         {
             int expectedCount = 3;
@@ -52,7 +51,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFilesWithHydrateWhoseObjectsAreAlreadyDownloaded()
         {
             int expectedCount = 2;


### PR DESCRIPTION
Unblock 'gvfs prefetch --hydrate' by going for a cheap, inefficient .NET implementation that will force a hydration on each prefetched file. This should be replaced with an efficient native version down the line. I turned the tests for this behavior on while I was here.

This 'fixes' #243 by implementing a quick .NET solution, but we'll keep the issue open to track the real fix.