### PR TITLE
UpgradeVerb cleanups for release

### DIFF
--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -15,10 +15,10 @@ namespace GVFS.Common
             ITracer tracer,
             PhysicalFileSystem fileSystem, 
             string dataFilePath, 
-            IEqualityComparer<TKey> keyComparer = null) 
+            IEqualityComparer<TKey> keyComparer) 
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: false)
         {
-            this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer ?? EqualityComparer<TKey>.Default);
+            this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer);
         }
 
         public static bool TryCreate(
@@ -29,7 +29,12 @@ namespace GVFS.Common
             out string error,
             IEqualityComparer<TKey> keyComparer = null)
         {
-            output = new FileBasedDictionary<TKey, TValue>(tracer, fileSystem, dictionaryPath, keyComparer);
+            output = new FileBasedDictionary<TKey, TValue>(
+                tracer, 
+                fileSystem, 
+                dictionaryPath, 
+                keyComparer ?? EqualityComparer<TKey>.Default);
+
             if (!output.TryLoadFromDisk<TKey, TValue>(
                 output.TryParseAddLine,
                 output.TryParseRemoveLine,

--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -11,14 +11,28 @@ namespace GVFS.Common
     {
         private ConcurrentDictionary<TKey, TValue> data = new ConcurrentDictionary<TKey, TValue>();
 
-        private FileBasedDictionary(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath) 
+        private FileBasedDictionary(
+            ITracer tracer,
+            PhysicalFileSystem fileSystem, 
+            string dataFilePath, 
+            IEqualityComparer<TKey> keyComparer = null) 
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: false)
         {
+            if (keyComparer != null)
+            {
+                this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer);
+            }
         }
 
-        public static bool TryCreate(ITracer tracer, string dictionaryPath, PhysicalFileSystem fileSystem, out FileBasedDictionary<TKey, TValue> output, out string error)
+        public static bool TryCreate(
+            ITracer tracer, 
+            string dictionaryPath, 
+            PhysicalFileSystem fileSystem,
+            out FileBasedDictionary<TKey, TValue> output, 
+            out string error,
+            IEqualityComparer<TKey> keyComparer = null)
         {
-            output = new FileBasedDictionary<TKey, TValue>(tracer, fileSystem, dictionaryPath);
+            output = new FileBasedDictionary<TKey, TValue>(tracer, fileSystem, dictionaryPath, keyComparer);
             if (!output.TryLoadFromDisk<TKey, TValue>(
                 output.TryParseAddLine,
                 output.TryParseRemoveLine,

--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -9,7 +9,7 @@ namespace GVFS.Common
 {
     public class FileBasedDictionary<TKey, TValue> : FileBasedCollection
     {
-        private ConcurrentDictionary<TKey, TValue> data = new ConcurrentDictionary<TKey, TValue>();
+        private ConcurrentDictionary<TKey, TValue> data;
 
         private FileBasedDictionary(
             ITracer tracer,
@@ -18,10 +18,7 @@ namespace GVFS.Common
             IEqualityComparer<TKey> keyComparer = null) 
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: false)
         {
-            if (keyComparer != null)
-            {
-                this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer);
-            }
+            this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer ?? EqualityComparer<TKey>.Default);
         }
 
         public static bool TryCreate(

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -83,12 +83,12 @@ namespace GVFS.Common
             public const string Dehydrate = "dehydrate";
             public const string MountVerb = MountPrefix + "_verb";
             public const string MountProcess = MountPrefix + "_process";
+            public const string MountUpgrade = MountPrefix + "_repoupgrade";
             public const string Prefetch = "prefetch";
             public const string Repair = "repair";
             public const string Service = "service";
             public const string UpgradeVerb = UpgradePrefix + "_verb";
-            public const string UpgradeProcess = UpgradePrefix + "_process";
-            public const string MountUpgrade = MountPrefix + "_repoupgrade";
+            public const string UpgradeProcess = UpgradePrefix + "_process";            
         }
 
         public static class DotGVFS
@@ -228,7 +228,6 @@ namespace GVFS.Common
         {
             public const string GVFSUpgrade = "`gvfs upgrade`";
             public const string GVFSUpgradeConfirm = "`gvfs upgrade --confirm`";
-            public const string GVFSUpgradeOptionalConfirm = "`gvfs upgrade [--confirm]`";
             public const string NoUpgradeCheckPerformed = "No upgrade check was performed.";
             public const string NoneRingConsoleAlert = "Upgrade ring set to \"None\". " + NoUpgradeCheckPerformed;
             public const string NoRingConfigConsoleAlert = "Upgrade ring is not set. " + NoUpgradeCheckPerformed;

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -92,30 +92,21 @@ namespace GVFS.Common.Git
             return new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --file " + configFile + " " + settingName);
         }
 
-        public static bool TryGetVersion(out GitVersion gitVersion, out string error)
+        public static bool TryGetVersion(string gitBinPath, out GitVersion gitVersion, out string error)
         {
-            string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            if (gitPath != null)
-            {
-                GitProcess gitProcess = new GitProcess(gitPath, null, null);
-                Result result = gitProcess.InvokeGitOutsideEnlistment("--version");
-                string version = result.Output;
+            GitProcess gitProcess = new GitProcess(gitBinPath, null, null);
+            Result result = gitProcess.InvokeGitOutsideEnlistment("--version");
+            string version = result.Output;
 
-                if (!GitVersion.TryParseGitVersionCommandResult(version, out gitVersion))
-                {
-                    error = "Unable to determine installed git version. " + version;
-                    return false;
-                }
-
-                error = null;
-                return true;
-            }
-            else
+            if (result.HasErrors || !GitVersion.TryParseGitVersionCommandResult(version, out gitVersion))
             {
                 gitVersion = null;
-                error = "Unable to determine installed git path.";
+                error = "Unable to determine installed git version. " + version;
                 return false;
             }
+
+            error = null;
+            return true;
         }
 
         public virtual void RevokeCredential(string repoUrl)

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
+using System;
 using System.IO;
 
 namespace GVFS.Common
@@ -35,7 +36,7 @@ namespace GVFS.Common
                         
             try
             {
-                this.allSettings.TryGetValue(this.KeyFromConfigName(name), out value);
+                this.allSettings.TryGetValue(name, out value);
                 error = null;
                 return true;
             }
@@ -67,7 +68,7 @@ namespace GVFS.Common
 
             try
             {
-                this.allSettings.SetValueAndFlush(this.KeyFromConfigName(name), value);
+                this.allSettings.SetValueAndFlush(name, value);
                 error = null;
                 return true;
             }
@@ -85,11 +86,6 @@ namespace GVFS.Common
             }
         }
 
-        private string KeyFromConfigName(string configName)
-        {
-            return configName.ToUpperInvariant();
-        }
-
         private bool TryLoadSettings(ITracer tracer, out string error)
         {
             if (this.allSettings == null)
@@ -100,7 +96,8 @@ namespace GVFS.Common
                     dictionaryPath: this.configFile,
                     fileSystem: this.fileSystem,
                     output: out config,
-                    error: out error))
+                    error: out error,
+                    keyComparer: StringComparer.OrdinalIgnoreCase))
                 {
                     this.allSettings = config;
                     return true;

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -21,21 +21,21 @@ namespace GVFS.Common
         }
 
         public bool TryGetConfig(
-            string key, 
+            string name, 
             out string value, 
             out string error,
             ITracer tracer)
         {
             if (!this.TryLoadSettings(tracer, out error))
             {
-                error = $"Error getting config value {key}. {error}";
+                error = $"Error getting config value {name}. {error}";
                 value = null;
                 return false;
             }
                         
             try
             {
-                this.allSettings.TryGetValue(key.ToUpper(), out value);
+                this.allSettings.TryGetValue(this.KeyFromConfigName(name), out value);
                 error = null;
                 return true;
             }
@@ -44,30 +44,30 @@ namespace GVFS.Common
                 const string ErrorFormat = "Error getting config value for {0}. Config file {1}. {2}";
                 if (tracer != null)
                 {
-                    tracer.RelatedError(ErrorFormat, key, this.configFile, exception.ToString());
+                    tracer.RelatedError(ErrorFormat, name, this.configFile, exception.ToString());
                 }
 
-                error = string.Format(ErrorFormat, key, this.configFile, exception.Message);
+                error = string.Format(ErrorFormat, name, this.configFile, exception.Message);
                 value = null;
                 return false;
             }
         }
 
         public bool TrySetConfig(
-            string key, 
+            string name, 
             string value, 
             out string error,
             ITracer tracer)
         {
             if (!this.TryLoadSettings(tracer, out error))
             {
-                error = $"Error setting config value {key}: {value}. {error}";
+                error = $"Error setting config value {name}: {value}. {error}";
                 return false;
             }
 
             try
             {
-                this.allSettings.SetValueAndFlush(key.ToUpper(), value);
+                this.allSettings.SetValueAndFlush(this.KeyFromConfigName(name), value);
                 error = null;
                 return true;
             }
@@ -76,13 +76,18 @@ namespace GVFS.Common
                 const string ErrorFormat = "Error setting config value {0}: {1}. Config file {2}. {3}";
                 if (tracer != null)
                 {
-                    tracer.RelatedError(ErrorFormat, key, value, this.configFile, exception.ToString());
+                    tracer.RelatedError(ErrorFormat, name, value, this.configFile, exception.ToString());
                 }
 
-                error = string.Format(ErrorFormat, key, value, this.configFile, exception.Message);
+                error = string.Format(ErrorFormat, name, value, this.configFile, exception.Message);
                 value = null;
                 return false;
             }
+        }
+
+        private string KeyFromConfigName(string configName)
+        {
+            return configName.ToUpperInvariant();
         }
 
         private bool TryLoadSettings(ITracer tracer, out string error)

--- a/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
@@ -14,12 +14,11 @@ namespace GVFS.Common
         private const string GVFSInstallerFileNamePrefix = "SetupGVFS";
         private const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
 
-        public static bool IsLocalUpgradeAvailable(string[] installerExtensions)
+        public static bool IsLocalUpgradeAvailable(string installerExtension)
         {
             string downloadDirectory = GetAssetDownloadsPath();
             if (Directory.Exists(downloadDirectory))
             {
-                HashSet<string> extensions = new HashSet<string>(installerExtensions, StringComparer.OrdinalIgnoreCase);
                 HashSet<string> installerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
                     GVFSInstallerFileNamePrefix,
@@ -30,7 +29,9 @@ namespace GVFS.Common
                 {
                     string[] components = Path.GetFileName(file).Split('.');
                     int length = components.Length;
-                    if (length >= 2 && installerNames.Contains(components[0]) && extensions.Contains(components[length - 1]))
+                    if (length >= 2 && 
+                        installerNames.Contains(components[0]) && 
+                        installerExtension.Equals(components[length - 1], StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
                     }

--- a/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -13,24 +14,21 @@ namespace GVFS.Common
         private const string GVFSInstallerFileNamePrefix = "SetupGVFS";
         private const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
 
-        public static bool IsLocalUpgradeAvailable()
+        public static bool IsLocalUpgradeAvailable(string[] installerExtensions)
         {
             string downloadDirectory = GetAssetDownloadsPath();
             if (Directory.Exists(downloadDirectory))
             {
-                // This method is used Only by Git hooks. Git hooks does not have access
-                // to GVFSPlatform to read platform specific file extensions. That is the
-                // reason possible installer file extensions are defined here.
-                HashSet<string> extensions = new HashSet<string>() { "EXE", "DMG", "RPM", "DEB" };
-                HashSet<string> installerNames = new HashSet<string>()
+                HashSet<string> extensions = new HashSet<string>(installerExtensions, StringComparer.OrdinalIgnoreCase);
+                HashSet<string> installerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    GVFSInstallerFileNamePrefix.ToUpperInvariant(),
-                    VFSForGitInstallerFileNamePrefix.ToUpperInvariant()
+                    GVFSInstallerFileNamePrefix,
+                    VFSForGitInstallerFileNamePrefix
                 };
 
                 foreach (string file in Directory.EnumerateFiles(downloadDirectory, "*", SearchOption.TopDirectoryOnly))
                 {
-                    string[] components = Path.GetFileName(file).ToUpperInvariant().Split('.');
+                    string[] components = Path.GetFileName(file).Split('.');
                     int length = components.Length;
                     if (length >= 2 && installerNames.Contains(components[0]) && extensions.Contains(components[length - 1]))
                     {

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
@@ -4,7 +4,7 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
-        public static string InstallerExtension()
+        public static string GetInstallerExtension()
         {
             return MacPlatform.InstallerExtension;
         }

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
@@ -4,9 +4,9 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
-        public static string[] InstallerExtensions()
+        public static string InstallerExtension()
         {
-            return MacPlatform.InstallerExtensions;
+            return MacPlatform.InstallerExtension;
         }
 
         public static bool IsElevated()

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
@@ -4,6 +4,11 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
+        public static string[] InstallerExtensions()
+        {
+            return MacPlatform.InstallerExtensions;
+        }
+
         public static bool IsElevated()
         {
             return MacPlatform.IsElevatedImplementation();

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
@@ -4,6 +4,11 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
+        public static string[] InstallerExtensions()
+        {
+            return WindowsPlatform.InstallerExtensions;
+        }
+
         public static bool IsElevated()
         {
             return WindowsPlatform.IsElevatedImplementation();

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
@@ -4,9 +4,9 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
-        public static string[] InstallerExtensions()
+        public static string InstallerExtension()
         {
-            return WindowsPlatform.InstallerExtensions;
+            return WindowsPlatform.InstallerExtension;
         }
 
         public static bool IsElevated()

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
@@ -4,7 +4,7 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static class GVFSHooksPlatform
     {
-        public static string InstallerExtension()
+        public static string GetInstallerExtension()
         {
             return WindowsPlatform.InstallerExtension;
         }

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -109,7 +109,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable(GVFSHooksPlatform.InstallerExtension()))
+            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable(GVFSHooksPlatform.GetInstallerExtension()))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
             }

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -109,7 +109,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable(GVFSHooksPlatform.InstallerExtensions()))
+            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable(GVFSHooksPlatform.InstallerExtension()))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
             }

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -109,7 +109,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable())
+            if (randomValue <= reminderFrequency && ProductUpgrader.IsLocalUpgradeAvailable(GVFSHooksPlatform.InstallerExtensions()))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
             }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -5,6 +5,8 @@ namespace GVFS.Platform.Mac
 {
     public partial class MacPlatform
     {
+        public static readonly string[] InstallerExtensions = { "dmg" };
+
         public static bool IsElevatedImplementation()
         {
             // TODO(Mac): Implement proper check

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -5,7 +5,7 @@ namespace GVFS.Platform.Mac
 {
     public partial class MacPlatform
     {
-        public static readonly string[] InstallerExtensions = { "dmg" };
+        public static readonly string InstallerExtension = "dmg";
 
         public static bool IsElevatedImplementation()
         {

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -5,7 +5,7 @@ namespace GVFS.Platform.Mac
 {
     public partial class MacPlatform
     {
-        public static readonly string InstallerExtension = "dmg";
+        public const string InstallerExtension = "dmg";
 
         public static bool IsElevatedImplementation()
         {

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -8,7 +8,7 @@ namespace GVFS.Platform.Windows
 {
     public partial class WindowsPlatform
     {
-        public static readonly string[] InstallerExtensions = { "exe" };
+        public static readonly string InstallerExtension = "exe";
 
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -8,7 +8,7 @@ namespace GVFS.Platform.Windows
 {
     public partial class WindowsPlatform
     {
-        public static readonly string InstallerExtension = "exe";
+        public const string InstallerExtension = "exe";
 
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -8,6 +8,8 @@ namespace GVFS.Platform.Windows
 {
     public partial class WindowsPlatform
     {
+        public static readonly string[] InstallerExtensions = { "exe" };
+
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
 
         private enum StdHandle

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -414,9 +414,8 @@ namespace GVFS.Upgrader
 
             GitVersion installedGitVersion = null;
             string error = null;
-            if (GitProcess.TryGetVersion(
-                out installedGitVersion,
-                out error))
+            string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+            if (!string.IsNullOrEmpty(gitPath) && GitProcess.TryGetVersion(gitPath, out installedGitVersion, out error))
             {
                 metadata.Add(nameof(installedGitVersion), installedGitVersion.ToString());
             }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -50,9 +50,10 @@ namespace GVFS.CommandLine
                 this.WriteMessage(string.Empty);
                 this.WriteMessage("gvfs version " + ProcessHelper.GetCurrentProcessVersion());
 
-                GitVersion gitVersion;
-                string error;
-                if (GitProcess.TryGetVersion(out gitVersion, out error))
+                GitVersion gitVersion = null;
+                string error = null;
+                string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+                if (!string.IsNullOrEmpty(gitPath) && GitProcess.TryGetVersion(gitPath, out gitVersion, out error))
                 {
                     this.WriteMessage("git version " + gitVersion.ToString());
                 }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -52,8 +52,7 @@ namespace GVFS.CommandLine
 
                 GitVersion gitVersion = null;
                 string error = null;
-                string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-                if (!string.IsNullOrEmpty(gitPath) && GitProcess.TryGetVersion(gitPath, out gitVersion, out error))
+                if (!string.IsNullOrEmpty(enlistment.GitBinPath) && GitProcess.TryGetVersion(enlistment.GitBinPath, out gitVersion, out error))
                 {
                     this.WriteMessage("git version " + gitVersion.ToString());
                 }
@@ -62,7 +61,7 @@ namespace GVFS.CommandLine
                     this.WriteMessage("Could not determine git version. " + error);
                 }
 
-                this.WriteMessage(GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath());
+                this.WriteMessage(enlistment.GitBinPath);
                 this.WriteMessage(string.Empty);
                 this.WriteMessage("Enlistment root: " + enlistment.EnlistmentRoot);
                 this.WriteMessage("Cache Server: " + CacheServerResolver.GetCacheServerFromConfig(enlistment));

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -619,8 +619,9 @@ You can specify a URL, a name of a configured cache server, or the special names
 
         private void CheckGitVersion(ITracer tracer, GVFSEnlistment enlistment, out string version)
         {
-            GitVersion gitVersion;
-            if (!GitProcess.TryGetVersion(out gitVersion, out string _))
+            string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+            GitVersion gitVersion = null;
+            if (string.IsNullOrEmpty(gitPath) || !GitProcess.TryGetVersion(gitPath, out gitVersion, out string _))
             {
                 this.ReportErrorAndExit(tracer, "Error: Unable to retrieve the git version");
             }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -619,9 +619,8 @@ You can specify a URL, a name of a configured cache server, or the special names
 
         private void CheckGitVersion(ITracer tracer, GVFSEnlistment enlistment, out string version)
         {
-            string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
             GitVersion gitVersion = null;
-            if (string.IsNullOrEmpty(gitPath) || !GitProcess.TryGetVersion(gitPath, out gitVersion, out string _))
+            if (string.IsNullOrEmpty(enlistment.GitBinPath) || !GitProcess.TryGetVersion(enlistment.GitBinPath, out gitVersion, out string _))
             {
                 this.ReportErrorAndExit(tracer, "Error: Unable to retrieve the git version");
             }

--- a/Scripts/UninstallGVFS.bat
+++ b/Scripts/UninstallGVFS.bat
@@ -17,6 +17,6 @@ for /F "delims=" %%f in ('dir "c:\Program Files\GVFS\unins*.exe" /B /S /O:-D') d
 :deleteGVFS
 rmdir /q/s "c:\Program Files\GVFS"
 
-rmdir /q/s "C:\ProgramData\GVFS\GVFS.Upgrade"
+if exist "C:\ProgramData\GVFS\GVFS.Upgrade" rmdir /q/s "C:\ProgramData\GVFS\GVFS.Upgrade"
 
 :end


### PR DESCRIPTION
- Removed wildcard matching while searching for downloaded installers
- Updated FileBasedDictionary to support custom Key Comparators to enable case-insensitive lookups
- Fixed partial failure in build caused by UninstallGVFS.bat script.
- Updated TryGetVersion in GitProcess to accept git path as input argument.