### PR TITLE
Mac kext: Adds check to only handle fileops on allowed filesystems

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -670,6 +670,11 @@ static bool ShouldHandleFileOpEvent(
 {
     *root = RootHandle_None;
 
+    if (!VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode))
+    {
+        return false;
+    }
+
     vtype vnodeType = vnode_vtype(vnode);
     if (ShouldIgnoreVnodeType(vnodeType, vnode))
     {


### PR DESCRIPTION
The vnode handler was already performing this check, but the fileop handler previously skipped it. This means we were running our logic and vnode I/O on files that weren't on a supported file system.

This is part 1 of a fix for KP bug report #340. Potentially also removes some sources of I/O errors causing failed assertions (#328).
