### PR TITLE
RFC: Enhance automount to wait for volume to be available

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -8,5 +8,42 @@
         void CreateHardLink(string newLinkFileName, string existingFileName);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);
         void ChangeMode(string path, int mode);
+
+        /// <summary>
+        /// Check if a path exists as a subpath of the specified directory.
+        /// </summary>
+        /// <param name="directoryPath">Directory path.</param>
+        /// <param name="path">Path to query.</param>
+        /// <returns>True if <see cref="path"/> exists as a subpath of <see cref="directoryPath"/>, false otherwise.</returns>
+        bool IsPathUnderDirectory(string directoryPath, string path);
+
+        /// <summary>
+        /// Get the path to the volume root that the given path.
+        /// </summary>
+        /// <param name="path">File path to find the volume for.</param>
+        /// <returns>Path to the root of the volume.</returns>
+        string GetVolumeRoot(string path);
+
+        /// <summary>
+        /// Check if the volume for the given path is available and ready for use.
+        /// </summary>
+        /// <param name="path">Path to any directory or file on a volume.</param>
+        /// <remarks>
+        /// A volume might be unavailable for multiple reasons, including:
+        /// <para/>
+        ///  - the volume resides on a removable device which is not present
+        /// <para/>
+        ///  - the volume is not mounted in the operating system
+        /// <para/>
+        ///  - the volume is encrypted or locked
+        /// </remarks>
+        /// <returns>True if the volume is available, false otherwise.</returns>
+        bool IsVolumeAvailable(string path);
+
+        /// <summary>
+        /// Create an <see cref="IVolumeStateWatcher"/> which monitors for changes to the state of volumes on the system.
+        /// </summary>
+        /// <returns>Volume watcher</returns>
+        IVolumeStateWatcher CreateVolumeStateWatcher();
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IVolumeStateWatcher.cs
+++ b/GVFS/GVFS.Common/FileSystem/IVolumeStateWatcher.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace GVFS.Common.FileSystem
+{
+    /// <summary>
+    /// Monitors the system for changes to the state of any disk volume, notifying subscribers when a change occurs.
+    /// </summary>
+    public interface IVolumeStateWatcher : IDisposable
+    {
+        /// <summary>
+        /// Raised when the state of a volume has changed, such as becoming available.
+        /// </summary>
+        event EventHandler<VolumeStateChangedEventArgs> VolumeStateChanged;
+
+        /// <summary>
+        /// Start watching for changes to the states of volumes on the system.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stop watching for changes to the states of volumes on the system.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/GVFS/GVFS.Common/FileSystem/VolumeStateChangedEventArgs.cs
+++ b/GVFS/GVFS.Common/FileSystem/VolumeStateChangedEventArgs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace GVFS.Common.FileSystem
+{
+    public enum VolumeStateChangeType
+    {
+        /// <summary>
+        /// The volume is now available and ready to use.
+        /// </summary>
+        VolumeAvailable,
+
+        /// <summary>
+        /// The volume is no longer available.
+        /// </summary>
+        VolumeUnavailable,
+    }
+
+    public class VolumeStateChangedEventArgs : EventArgs
+    {
+        public VolumeStateChangedEventArgs(string volumePath, VolumeStateChangeType changeType)
+        {
+            this.VolumePath = volumePath;
+            this.ChangeType = changeType;
+        }
+
+        /// <summary>
+        /// Path to the root of the volume that has changed.
+        /// </summary>
+        public string VolumePath { get; }
+
+        /// <summary>
+        /// Type of change.
+        /// </summary>
+        public VolumeStateChangeType ChangeType { get; }
+    }
+}

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -300,6 +300,8 @@ namespace GVFS.Common.NamedPipes
             {
                 public List<string> RepoList { get; set; }
 
+                public List<string> InvalidRepoList { get; set; }
+
                 public static Response FromMessage(Message message)
                 {
                     return JsonConvert.DeserializeObject<Response>(message.Body);

--- a/GVFS/GVFS.Common/NativeMethods.cs
+++ b/GVFS/GVFS.Common/NativeMethods.cs
@@ -164,6 +164,13 @@ namespace GVFS.Common
             return DateTime.Now - uptime;
         }
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetVolumePathName(
+            string volumeName,
+            StringBuilder volumePathName,
+            uint bufferLength);
+
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern bool MoveFileEx(
             string existingFileName,

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -1,5 +1,6 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Common.FileSystem;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -31,6 +32,32 @@ namespace GVFS.Platform.Mac
         public void ChangeMode(string path, int mode)
         {
            Chmod(path, mode);
+        }
+
+        public bool IsPathUnderDirectory(string directoryPath, string path)
+        {
+            // TODO(Mac): Check if the user has set HFS+/APFS to case sensitive
+            // TODO(Mac): Normalize paths
+            // Note: this may be called with paths or volumes which do not exist/are not mounted
+            return path.StartsWith(directoryPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public string GetVolumeRoot(string path)
+        {
+            // TODO(Mac): Query the volume mount points and check if the path is under any of those
+            // For now just assume everything is under the system root.
+            return "/";
+        }
+
+        public bool IsVolumeAvailable(string path)
+        {
+            // TODO(Mac): Perform any additional checks for locked or encrypted volumes
+            return Directory.Exists(path) || File.Exists(path);
+        }
+
+        public IVolumeStateWatcher CreateVolumeStateWatcher()
+        {
+            return new MacVolumeStateWatcher();
         }
 
         public bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)

--- a/GVFS/GVFS.Platform.Mac/MacVolumeStateWatcher.cs
+++ b/GVFS/GVFS.Platform.Mac/MacVolumeStateWatcher.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using GVFS.Common.FileSystem;
+
+namespace GVFS.Platform.Mac
+{
+    public class MacVolumeStateWatcher : IVolumeStateWatcher
+    {
+        public event EventHandler<VolumeStateChangedEventArgs> VolumeStateChanged;
+
+        public void Start()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        protected void RaiseVolumeStateChanged(string volumePath, VolumeStateChangeType changeType)
+        {
+            this.VolumeStateChanged?.Invoke(this, new VolumeStateChangedEventArgs(volumePath, changeType));
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.Windows/BitLockerHelpers.cs
+++ b/GVFS/GVFS.Platform.Windows/BitLockerHelpers.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using System.Management;
+
+namespace GVFS.Platform.Windows
+{
+    internal static class BitLockerHelpers
+    {
+        public const string VolumeEncryptionNamespace = @"root\cimv2\security\MicrosoftVolumeEncryption";
+
+        public static bool TryGetVolumeLockStatus(string driveName, out bool isLocked)
+        {
+            string queryString = $"SELECT * FROM Win32_EncryptableVolume WHERE DriveLetter = '{driveName}'";
+
+            using (var searcher = new ManagementObjectSearcher(VolumeEncryptionNamespace, queryString))
+            {
+                ManagementObjectCollection results = searcher.Get();
+                ManagementObject mo = results.OfType<ManagementObject>().FirstOrDefault();
+                if (mo != null)
+                {
+                    // Check the protection status
+                    // ProtectionStatus == 0 means the drive is not protected by BitLocker and therefore cannot be locked
+                    if (mo.Properties["ProtectionStatus"].Value is uint protectedInt && protectedInt == 0)
+                    {
+                        isLocked = false;
+                        return true;
+                    }
+
+                    // Check the lock status
+                    // Lock status is not a property and must be retrieved by the GetLockStatus method
+                    var args = new object[1];
+                    if (TryInvokeMethod(mo, "GetLockStatus", args) && args[0] is uint lockedInt)
+                    {
+                        // Unlocked
+                        if (lockedInt == 0)
+                        {
+                            isLocked = false;
+                            return true;
+                        }
+
+                        // Locked
+                        if (lockedInt == 1)
+                        {
+                            isLocked = true;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            isLocked = false;
+            return false;
+        }
+
+        private static bool TryInvokeMethod(ManagementObject mo, string methodName, object[] args)
+        {
+            try
+            {
+                return mo.InvokeMethod(methodName, args) is uint result && result == 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -72,6 +72,7 @@
     <Compile Include="$(BuildOutputDir)\CommonAssemblyVersion.cs">
       <Link>CommonAssemblyVersion.cs</Link>
     </Compile>
+    <Compile Include="BitLockerHelpers.cs" />
     <Compile Include="DiskLayoutUpgrades\DiskLayout10to11Upgrade_NewOperationType.cs" />
     <Compile Include="DiskLayoutUpgrades\DiskLayout11to12Upgrade_SharedLocalCache.cs" />
     <Compile Include="DiskLayoutUpgrades\DiskLayout12to13Upgrade_FolderPlaceholder.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="WindowsPlatform.cs" />
     <Compile Include="WindowsPlatform.Shared.cs" />
     <Compile Include="WindowsFileSystem.cs" />
+    <Compile Include="WindowsVolumeStateWatcher.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -53,7 +53,7 @@ namespace GVFS.Platform.Windows
             try
             {
                 StringBuilder volumePathName = new StringBuilder(GVFSConstants.MaxPath);
-                if (!NativeMethods.GetVolumePathName(enlistmentRoot, volumePathName, GVFSConstants.MaxPath))
+                if (!Common.NativeMethods.GetVolumePathName(enlistmentRoot, volumePathName, GVFSConstants.MaxPath))
                 {
                     errorMessage = "Could not get volume path name";
                     tracer.RelatedError($"{nameof(TryAttach)}:{errorMessage}");
@@ -626,13 +626,6 @@ namespace GVFS.Platform.Windows
                 string instanceName,
                 uint createdInstanceNameLength = 0,
                 string createdInstanceName = null);
-
-            [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool GetVolumePathName(
-                string volumeName,
-                StringBuilder volumePathName,
-                uint bufferLength);
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -1,4 +1,6 @@
-﻿using GVFS.Common;
+﻿using System;
+using System.Text;
+using GVFS.Common;
 using GVFS.Common.FileSystem;
 
 namespace GVFS.Platform.Windows
@@ -27,6 +29,39 @@ namespace GVFS.Platform.Windows
 
         public void ChangeMode(string path, int mode)
         {
+        }
+
+        public bool IsPathUnderDirectory(string directoryPath, string path)
+        {
+            // TODO: Normalize paths
+            // We can't use the existing TryGetNormalizedPathImplementation method
+            // because it relies on actual calls to the disk to check if directories exist.
+            // This may be called with paths or volumes which do not actually exist.
+            return path.StartsWith(directoryPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public string GetVolumeRoot(string path)
+        {
+            var volumePathName = new StringBuilder(GVFSConstants.MaxPath);
+            if (NativeMethods.GetVolumePathName(path, volumePathName, GVFSConstants.MaxPath))
+            {
+                return volumePathName.ToString();
+            }
+
+            return null;
+        }
+
+        public bool IsVolumeAvailable(string path)
+        {
+            // No paths 'exist' on locked BitLocker volumes so it is sufficent to just
+            // check if the directory/file exists using the framework APIs.
+            return System.IO.Directory.Exists(path) || System.IO.File.Exists(path);
+        }
+
+        public IVolumeStateWatcher CreateVolumeStateWatcher()
+        {
+            // TODO: Extract the polling interval to a configuration value?
+            return new WindowsVolumeStateWatcher(TimeSpan.FromSeconds(15));
         }
 
         public bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)

--- a/GVFS/GVFS.Platform.Windows/WindowsVolumeStateWatcher.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsVolumeStateWatcher.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Management;
+using GVFS.Common.FileSystem;
+
+namespace GVFS.Platform.Windows
+{
+    public class WindowsVolumeStateWatcher : IVolumeStateWatcher
+    {
+        private readonly ManagementEventWatcher volumeWatcher;
+        private readonly ManagementEventWatcher cryptoVolumeWatcher;
+        private readonly IDictionary<string, bool> cryptoVolumeLockStatuses =
+            new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        public WindowsVolumeStateWatcher(TimeSpan pollingInterval)
+        {
+            int intervalSeconds = (int)pollingInterval.TotalSeconds;
+
+            // Watch for mount and unmount of volumes
+            string volumeQuery = $"SELECT * FROM Win32_VolumeChangeEvent WITHIN {intervalSeconds}";
+            this.volumeWatcher = new ManagementEventWatcher(volumeQuery);
+            this.volumeWatcher.EventArrived += this.OnVolumeEvent;
+
+            // Watch for changes to BitLocker-protected volume states (unlock, lock, etc)
+            string cryptoVolumeQuery = $"SELECT * FROM __InstanceModificationEvent WITHIN {intervalSeconds} WHERE TargetInstance ISA 'Win32_EncryptableVolume'";
+            this.cryptoVolumeWatcher = new ManagementEventWatcher(BitLockerHelpers.VolumeEncryptionNamespace, cryptoVolumeQuery);
+            this.cryptoVolumeWatcher.EventArrived += this.OnCryptoVolumeEvent;
+        }
+
+        public event EventHandler<VolumeStateChangedEventArgs> VolumeStateChanged;
+
+        public void Start()
+        {
+            this.volumeWatcher.Start();
+            this.cryptoVolumeWatcher.Start();
+        }
+
+        public void Stop()
+        {
+            this.cryptoVolumeWatcher.Stop();
+            this.volumeWatcher.Stop();
+        }
+
+        public void Dispose()
+        {
+            this.Stop();
+
+            this.volumeWatcher.EventArrived -= this.OnVolumeEvent;
+            this.volumeWatcher.Dispose();
+
+            this.cryptoVolumeWatcher.EventArrived -= this.OnCryptoVolumeEvent;
+            this.cryptoVolumeWatcher.Dispose();
+        }
+
+        protected void RaiseVolumeStateChanged(string volumePath, VolumeStateChangeType changeType)
+        {
+            this.VolumeStateChanged?.Invoke(this, new VolumeStateChangedEventArgs(volumePath, changeType));
+        }
+
+        private void OnVolumeEvent(object sender, EventArrivedEventArgs e)
+        {
+            ManagementBaseObject mbo = e.NewEvent;
+
+            var driveName = (string)mbo["DriveName"];
+            var eventType = (ushort)mbo["EventType"];
+
+            string volumePath = $@"{driveName}\";
+
+            if (eventType == 2)
+            {
+                // Device Arrival
+                // Check if the volume is not left locked by BitLocker on mount
+                if (BitLockerHelpers.TryGetVolumeLockStatus(driveName, out bool isLocked) && !isLocked)
+                {
+                    this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeAvailable);
+                }
+            }
+            else if (eventType == 3)
+            {
+                // Device Removal
+                this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeUnavailable);
+            }
+        }
+
+        private void OnCryptoVolumeEvent(object sender, EventArrivedEventArgs e)
+        {
+            ManagementBaseObject mbo = e.NewEvent;
+            var targetMbo = (ManagementBaseObject)mbo["TargetInstance"];
+
+            var driveName = (string)targetMbo?["DriveLetter"];
+            if (driveName == null)
+            {
+                return;
+            }
+
+            string volumePath = $@"{driveName}\";
+
+            // Get the new lock status of the volume
+            // Note: we can only invoke the required "GetLockStatus" method on instances of type
+            // ManagementObject, but management events only return instances of ManagementBaseObject.
+            if (!BitLockerHelpers.TryGetVolumeLockStatus(driveName, out bool newLockStatus))
+            {
+                return;
+            }
+
+            // Get previous lock status
+            // We only want to raise the 'VolumeStateChanged' event if the lock status has changed, but this event could
+            // be raised for any modification to the BitLocker volume's configuration such as auto unlock on/off.
+            // We track the previously seen lock statuses for all volumes so that we can detect changes to the locked status
+            // and only raise the 'VolumeStateChanged' event in those cases.
+            if (this.cryptoVolumeLockStatuses.TryGetValue(driveName, out bool prevLockStatus))
+            {
+                if (prevLockStatus && !newLockStatus)
+                {
+                    // Locked -> Unlocked
+                    this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeAvailable);
+                }
+                else if (!prevLockStatus && newLockStatus)
+                {
+                    // Unlocked -> Locked
+                    this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeUnavailable);
+                }
+            }
+            else
+            {
+                // We've never seen this volume before (must have just been mounted).. report the current locked state as an event
+                if (!newLockStatus)
+                {
+                    // Unlocked
+                    this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeAvailable);
+                }
+                else
+                {
+                    // Locked
+                    this.RaiseVolumeStateChanged(volumePath, VolumeStateChangeType.VolumeUnavailable);
+                }
+            }
+
+            // Update new lock status
+            this.cryptoVolumeLockStatuses[driveName] = newLockStatus;
+        }
+    }
+}

--- a/GVFS/GVFS.Service/GVFS.Service.csproj
+++ b/GVFS/GVFS.Service/GVFS.Service.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\GVFS.cs.props" />
@@ -74,9 +74,10 @@
     <Compile Include="ProductUpgradeTimer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepoAutoMounter.cs" />
     <Compile Include="RepoRegistration.cs" />
     <Compile Include="RepoRegistry.cs" />
-    <Compile Include="GVFSMountProcess.cs" />
+    <Compile Include="GVFSMountProcessManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj">

--- a/GVFS/GVFS.Service/GVFSMountProcessManager.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcessManager.cs
@@ -6,13 +6,13 @@ using System;
 
 namespace GVFS.Service
 {
-    public class GVFSMountProcess : IDisposable
+    public class GVFSMountProcessManager : IDisposable
     {
         private const string ParamPrefix = "--";
 
         private readonly ITracer tracer;
 
-        public GVFSMountProcess(ITracer tracer, int sessionId)
+        public GVFSMountProcessManager(ITracer tracer, int sessionId)
         {
             this.tracer = tracer;
             this.CurrentUser = new CurrentUser(this.tracer, sessionId);
@@ -20,20 +20,20 @@ namespace GVFS.Service
 
         public CurrentUser CurrentUser { get; private set; }
 
-        public bool Mount(string repoRoot)
+        public bool StartMount(string repoRoot)
         {
             if (!ProjFSFilter.IsServiceRunning(this.tracer))
             {
                 string error;
                 if (!EnableAndAttachProjFSHandler.TryEnablePrjFlt(this.tracer, out error))
                 {
-                    this.tracer.RelatedError($"{nameof(this.Mount)}: Unable to start the GVFS.exe process: {error}");
+                    this.tracer.RelatedError($"{nameof(this.StartMount)}: Unable to start the GVFS.exe process: {error}");
                 }
             }
 
             if (!this.CallGVFSMount(repoRoot))
             {
-                this.tracer.RelatedError($"{nameof(this.Mount)}: Unable to start the GVFS.exe process.");
+                this.tracer.RelatedError($"{nameof(this.StartMount)}: Unable to start the GVFS.exe process.");
                 return false;
             }
 

--- a/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
@@ -32,6 +32,7 @@ namespace GVFS.Service.Handlers
             NamedPipeMessages.GetActiveRepoListRequest.Response response = new NamedPipeMessages.GetActiveRepoListRequest.Response();
             response.State = NamedPipeMessages.CompletionState.Success;
             response.RepoList = new List<string>();
+            response.InvalidRepoList = new List<string>();
 
             List<RepoRegistration> repos;
             if (this.registry.TryGetActiveRepos(out repos, out errorMessage))
@@ -42,14 +43,7 @@ namespace GVFS.Service.Handlers
                 {
                     if (!this.IsValidRepo(repoRoot))
                     {
-                        if (!this.registry.TryRemoveRepo(repoRoot, out errorMessage))
-                        {
-                            this.tracer.RelatedInfo("Removing an invalid repo failed with error: " + response.ErrorMessage);
-                        }
-                        else
-                        {
-                            this.tracer.RelatedInfo("Removed invalid repo entry from registry: " + repoRoot);
-                        }
+                        response.InvalidRepoList.Add(repoRoot);
                     }
                     else
                     {

--- a/GVFS/GVFS.Service/RepoAutoMounter.cs
+++ b/GVFS/GVFS.Service/RepoAutoMounter.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
+using GVFS.Service.Handlers;
+
+namespace GVFS.Service
+{
+    public class RepoAutoMounter : IDisposable
+    {
+        private readonly ITracer tracer;
+        private readonly RepoRegistry repoRegistry;
+        private readonly int sessionId;
+        private readonly GVFSMountProcessManager mountProcessManager;
+        private readonly string userSid;
+
+        private IVolumeStateWatcher volumeWatcher;
+
+        public RepoAutoMounter(ITracer tracer, RepoRegistry repoRegistry, int sessionId)
+        {
+            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            this.repoRegistry = repoRegistry ?? throw new ArgumentNullException(nameof(repoRegistry));
+            this.sessionId = sessionId;
+
+            // Create a mount process factory for this session/user
+            this.mountProcessManager = new GVFSMountProcessManager(this.tracer, sessionId);
+            this.userSid = this.mountProcessManager.CurrentUser.Identity.User?.Value;
+        }
+
+        public void Start()
+        {
+            this.tracer.RelatedInfo("Starting auto mounter for session {0}", this.sessionId);
+
+            // Try mounting all the user's active repo straight away
+            this.tracer.RelatedInfo("Attempting to mount all known repos for user {0}", this.userSid);
+            this.MountAll();
+
+            // Start watching for changes to volume availability
+            this.volumeWatcher = GVFSPlatform.Instance.FileSystem.CreateVolumeStateWatcher();
+            this.volumeWatcher.VolumeStateChanged += this.OnVolumeStateChanged;
+            this.volumeWatcher.Start();
+        }
+
+        public void Stop()
+        {
+            this.tracer.RelatedInfo("Stopping auto mounter for session {0}", this.sessionId);
+
+            // Stop watching for changes to volume availability
+            if (this.volumeWatcher != null)
+            {
+                this.volumeWatcher.Stop();
+                this.volumeWatcher.VolumeStateChanged -= this.OnVolumeStateChanged;
+                this.volumeWatcher.Dispose();
+                this.volumeWatcher = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Stop();
+            this.mountProcessManager?.Dispose();
+        }
+
+        private void MountAll(string rootPath = null)
+        {
+            if (this.repoRegistry.TryGetActiveReposForUser(this.userSid, out var activeRepos, out string errorMessage))
+            {
+                foreach (RepoRegistration repo in activeRepos)
+                {
+                    if (rootPath == null || GVFSPlatform.Instance.FileSystem.IsPathUnderDirectory(rootPath, repo.EnlistmentRoot))
+                    {
+                        this.Mount(repo.EnlistmentRoot);
+                    }
+                }
+            }
+            else
+            {
+                this.tracer.RelatedError("Could not get repos to auto mount for user. Error: " + errorMessage);
+            }
+        }
+
+        private void Mount(string enlistmentRoot)
+        {
+            var metadata = new EventMetadata
+            {
+                ["EnlistmentRoot"] = enlistmentRoot
+            };
+
+            using (var activity = this.tracer.StartActivity("AutoMount", EventLevel.Informational, metadata))
+            {
+                string volumeRoot = GVFSPlatform.Instance.FileSystem.GetVolumeRoot(enlistmentRoot);
+                if (GVFSPlatform.Instance.FileSystem.IsVolumeAvailable(volumeRoot))
+                {
+                    // TODO #1043088: We need to respect the elevation level of the original mount
+                    if (this.mountProcessManager.StartMount(enlistmentRoot))
+                    {
+                        this.SendNotification("GVFS AutoMount", "The following GVFS repo is now mounted:\n{0}", enlistmentRoot);
+                        activity.RelatedInfo("Auto mount was successful for '{0}'", enlistmentRoot);
+                    }
+                    else
+                    {
+                        this.SendNotification("GVFS AutoMount", "The following GVFS repo failed to mount:\n{0}", enlistmentRoot);
+                        activity.RelatedError("Failed to auto mount '{0}'", enlistmentRoot);
+                    }
+                }
+                else
+                {
+                    activity.RelatedInfo("Cannot auto mount '{0}' because the volume '{1}' not available.", enlistmentRoot, volumeRoot);
+                }
+            }
+        }
+
+        private void OnVolumeStateChanged(object sender, VolumeStateChangedEventArgs e)
+        {
+            var metadata = new EventMetadata
+            {
+                ["State"] = e.ChangeType.ToString(),
+                ["Volume"] = e.VolumePath,
+            };
+
+            this.tracer.RelatedEvent(EventLevel.Informational, "VolumeStateChange", metadata);
+
+            switch (e.ChangeType)
+            {
+                case VolumeStateChangeType.VolumeAvailable:
+                    this.MountAll(rootPath: e.VolumePath);
+                    break;
+                case VolumeStateChangeType.VolumeUnavailable:
+                    // There is no need to do anything here to stop any potentially orphaned mount processes
+                    // since they will self-terminate if the volume is removed.
+                    break;
+                default:
+                    this.tracer.RelatedWarning("Unknown volume state change type: {0}", e.ChangeType);
+                    break;
+            }
+        }
+
+        private void SendNotification(string title, string format, params object[] args)
+        {
+            var request = new NamedPipeMessages.Notification.Request
+            {
+                Title = title,
+                Message = string.Format(format, args)
+            };
+
+            NotificationHandler.Instance.SendNotification(this.tracer, this.sessionId, request);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -27,6 +27,26 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
+        public bool IsPathUnderDirectory(string directoryPath, string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetVolumeRoot(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVolumeAvailable(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IVolumeStateWatcher CreateVolumeStateWatcher()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)
         {
             errorMessage = null;


### PR DESCRIPTION
_**Not ready for merge. Just a draft/RFC to get some initial feedback on the approach.**_

_(there are still some TODOs in the code, and a lack of tests! These will follow later :smile:)_

Enhance the auto-mounting logic to watch for new volumes to be attached (such as external drives), and to wait for BitLocker drives to be unlocked before mounting.

This changes the notion of 'auto mount' from a single action that runs on logon to an on-going process of mounting repositories as they become 'available'. At first logon we still attempt to mount all registered repositories as before.

I've used the term 'available'/'unavailable' in this change as it captures both the missing external drive case, as well as the encypted volume cases (such as BitLocker on Windows and any equivalents on macOS). I've used the term 'volume' rather than 'drive' as you can also mount drives as NTFS folder paths on Windows, and in macOS where volumes can be mounted anywhere under "/".

Added ability to list the state of all known repositories using the cmd: `gvfs service --list-all`, to compliment the existing `gvfs service --list-mounted` option which lists only the mounted repositories.

Open questions:
1. We can now detect when a volume is removed. Currently if you remove a volume the mount process continues to run and is reported as 'mounted' (this is the existing behaviour).
Should we try and kill the mount processes for repositories on volumes that have been removed/locked? Should the mount process itself be responsible for killing itself or should the service send a "kill" message?

    1.1. If we kill the process on `VolumeUnavilable`, and then you quickly lock and then unlock a volume (or plug/unplug an external drive) then do we want the removal to be considered a 'transient'; should we wait a fixed time (10 seconds) before killing the mount process?

    1.2. We can't send the 'unmount' message because this does two things we don't want: a) unregister the repository, b) read/write from disk! it's too late to unmount.. we can only 'die quickly'.

2. Currently if a repository does not exist and we're trying to mount it (at logon) we remove it from the repo-registry file (assuming it's been deleted). This might not be the case if a volume is locked, or has not been mounted yet. In this PR I've removed the 'remove repo on missing path' code, but this might lead to lots of redundant entries over time with no clean-up.
We could consider a heuristic that if the _volume_ of the repository does not exist then do NOT remove the registration, but if the volume _does_ exist and the enlistment does _not_ then it has likely been deleted and should be unregistered.

3. The only way to watch for BitLocker lock/unlock events is using the `ManagementEventWatcher`, which polls WMI. What polling interval should be used (I picked 10 seconds arbitrarily)? Too short and you end up using CPU. Too long and we increase the gap between the volume being unlocked and the call to `gvfs mount`.

4. [Future]: Users might want to select some repositories to not auto-mount. Currently they can do this by expliclty running `gvfs unmount` which sets "IsActive" to false in the registration - we don't ever try and auto-mount it.

