### PR TITLE
Fix missing untracked files when created in subfolder 

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20180814.4</GitPackageVersion>
+    <GitPackageVersion>2.20181011.3</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -155,6 +155,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");
 
             GVFSHelpers.ModifiedPathsShouldContain(this.fileSystem, this.Enlistment.DotGVFSRoot, "Folder/");
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.fileSystem, this.Enlistment.DotGVFSRoot, "Folder/testfile");
 
             this.fileSystem.RenameDirectory(this.Enlistment.RepoRoot, "Folder", "folder");
             this.Enlistment.WaitForBackgroundOperations().ShouldEqual(true, "Background operations failed to complete.");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -16,6 +16,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private const string EncodingFilename = "ريلٌأكتوبرûمارسأغسطسºٰٰۂْٗ۵ريلٌأك.txt";
         private const string ContentWhenEditingFile = "// Adding a comment to the file";
         private const string UnknownTestName = "Unknown";
+        private const string TopLevelFolderToCreate = "level1";
+        private const string SubFolderToCreate = "level2";
 
         private static readonly string EditFilePath = Path.Combine("GVFS", "GVFS.Common", "GVFSContext.cs");
         private static readonly string DeleteFilePath = Path.Combine("GVFS", "GVFS", "Program.cs");
@@ -1088,6 +1090,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private void CreateFile()
         {
             this.CreateFile("Some content here", Path.GetRandomFileName() + "tempFile.txt");
+            this.CreateFolder(TopLevelFolderToCreate);
+            this.CreateFolder(Path.Combine(TopLevelFolderToCreate, SubFolderToCreate));
+            this.CreateFile("File in new folder", Path.Combine(TopLevelFolderToCreate, SubFolderToCreate, Path.GetRandomFileName() + "folderFile.txt"));
         }
 
         private void EditFile()

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -117,7 +117,7 @@ namespace GVFS.FunctionalTests.Tools
             string[] modifedPathLines = modifedPathsContents.Split(new[] { ModifiedPathsNewLine }, StringSplitOptions.None);
             foreach (string gitPath in gitPaths)
             {
-                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath));
+                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath, StringComparison.OrdinalIgnoreCase));
             }
         }
 


### PR DESCRIPTION
Add to the test to create multiple level of folders and files in those folder to make sure they show up as untracked files.

Update the git for windows version that has the fix.

Fixes #358