### PR TITLE
Mac: Turn on 'gvfs prefetch --hydrate' 

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -8,5 +8,6 @@
         void CreateHardLink(string newLinkFileName, string existingFileName);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);
         void ChangeMode(string path, int mode);
+        bool HydrateFile(string fileName, byte[] buffer);
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -42,7 +42,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
-        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFileExtensionWithHydrate()
         {
             int expectedCount = 3;
@@ -52,7 +51,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.MacTODO.M4)]
         public void PrefetchByFilesWithHydrateWhoseObjectsAreAlreadyDownloaded()
         {
             int expectedCount = 2;

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -38,10 +38,44 @@ namespace GVFS.Platform.Mac
             return MacFileSystem.TryGetNormalizedPathImplementation(path, out normalizedPath, out errorMessage);
         }
 
+        public bool HydrateFile(string fileName, byte[] buffer)
+        {
+            return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
+        }
+
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
         private static extern int Chmod(string pathname, int mode);
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
         private static extern int Rename(string oldPath, string newPath);
+
+        private class NativeFileReader
+        {
+            private const int ReadOnly = 0x0000;
+
+            public static bool TryReadFirstByteOfFile(string fileName, byte[] buffer)
+            {
+                int fileDescriptor = Open(fileName, ReadOnly);
+                return TryReadOneByte(fileDescriptor, buffer);
+            }
+
+            private static bool TryReadOneByte(int fileDescriptor, byte[] buffer)
+            {
+                int numBytes = Read(fileDescriptor, buffer, 1);
+
+                if (numBytes == -1)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+            private static extern int Open(string path, int flag);
+
+            [DllImport("libc", EntryPoint = "read", SetLastError = true)]
+            private static extern int Read(int fd, [Out] byte[] buf, int count);
+        }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -1,5 +1,8 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace GVFS.Platform.Windows
 {
@@ -32,6 +35,59 @@ namespace GVFS.Platform.Windows
         public bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)
         {
             return WindowsFileSystem.TryGetNormalizedPathImplementation(path, out normalizedPath, out errorMessage);
+        }
+
+        public bool HydrateFile(string fileName, byte[] buffer)
+        {
+            return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
+        }
+
+        private class NativeFileReader
+        {
+            private const uint GenericRead = 0x80000000;
+            private const uint OpenExisting = 3;
+
+            public static bool TryReadFirstByteOfFile(string fileName, byte[] buffer)
+            {
+                using (SafeFileHandle handle = Open(fileName))
+                {
+                    if (!handle.IsInvalid)
+                    {
+                        return ReadOneByte(handle, buffer);
+                    }
+                }
+
+                return false;
+            }
+
+            private static SafeFileHandle Open(string fileName)
+            {
+                return CreateFile(fileName, GenericRead, (uint)(FileShare.ReadWrite | FileShare.Delete), 0, OpenExisting, 0, 0);
+            }
+
+            private static bool ReadOneByte(SafeFileHandle handle, byte[] buffer)
+            {
+                int bytesRead = 0;
+                return ReadFile(handle, buffer, 1, ref bytesRead, 0);
+            }
+
+            [DllImport("kernel32", SetLastError = true, ThrowOnUnmappableChar = true, CharSet = CharSet.Unicode)]
+            private static extern SafeFileHandle CreateFile(
+                string fileName,
+                uint desiredAccess,
+                uint shareMode,
+                uint securityAttributes,
+                uint creationDisposition,
+                uint flagsAndAttributes,
+                int hemplateFile);
+
+            [DllImport("kernel32", SetLastError = true)]
+            private static extern bool ReadFile(
+                SafeFileHandle file,
+                [Out] byte[] buffer,
+                int numberOfBytesToRead,
+                ref int numberOfBytesRead,
+                int overlapped);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -33,5 +33,10 @@ namespace GVFS.UnitTests.Mock.FileSystem
             normalizedPath = path;
             return true;
         }
+
+        public bool HydrateFile(string fileName, byte[] buffer)
+        {
+            throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
Fixes #243 

Implement a native macOS solution for 'gvfs prefetch --hydrate' and enable associated functional tests.

