### PR TITLE
Mac: Update build scripts to handle new Profiling configuration

### DIFF
--- a/MirrorProvider/Scripts/Mac/Build.sh
+++ b/MirrorProvider/Scripts/Mac/Build.sh
@@ -14,6 +14,11 @@ SLN=$SRCDIR/MirrorProvider/MirrorProvider.sln
 # Build the ProjFS kext and libraries
 $SRCDIR/ProjFS.Mac/Scripts/Build.sh $CONFIGURATION
 
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
 # Build the MirrorProvider
 dotnet restore $SLN /p:Configuration="$CONFIGURATION.Mac" --packages $ROOTDIR/packages
 dotnet build $SLN --configuration $CONFIGURATION.Mac

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -14,5 +14,10 @@ PROJFS=$SRCDIR/ProjFS.Mac
 
 xcodebuild -configuration $CONFIGURATION -workspace $PROJFS/PrjFS.xcworkspace build -scheme PrjFS -derivedDataPath $ROOTDIR/BuildOutput/ProjFS.Mac/Native || exit 1
 
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
 dotnet restore $PROJFS/PrjFSLib.Mac.Managed/PrjFSLib.Mac.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 --packages $PACKAGES || exit 1
 dotnet build $PROJFS/PrjFSLib.Mac.Managed/PrjFSLib.Mac.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 || exit 1

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -38,6 +38,11 @@ GITPATH="$(find $PACKAGES/gitformac.gvfs.installer/$GITVERSION -type f -name *.d
 # Now that we have a path containing the version number, generate GVFSConstants.GitVersion.cs
 $SCRIPTDIR/GenerateGitVersionConstants.sh "$GITPATH" $BUILDDIR || exit 1
 
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
 DOTNETCONFIGURATION=$CONFIGURATION.Mac
 dotnet restore $SRCDIR/GVFS.sln /p:Configuration=$DOTNETCONFIGURATION --packages $PACKAGES || exit 1
 dotnet build $SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $DOTNETCONFIGURATION /maxcpucount:1 || exit 1

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -43,10 +43,9 @@ if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
   CONFIGURATION=Release
 fi
 
-DOTNETCONFIGURATION=$CONFIGURATION.Mac
-dotnet restore $SRCDIR/GVFS.sln /p:Configuration=$DOTNETCONFIGURATION --packages $PACKAGES || exit 1
-dotnet build $SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $DOTNETCONFIGURATION /maxcpucount:1 || exit 1
-dotnet publish $SRCDIR/GVFS.sln /p:Configuration=$DOTNETCONFIGURATION /p:Platform=x64 --runtime osx-x64 --framework netcoreapp2.1 --self-contained --output $PUBLISHDIR /maxcpucount:1 || exit 1
+dotnet restore $SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Mac --packages $PACKAGES || exit 1
+dotnet build $SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $CONFIGURATION.Mac /maxcpucount:1 || exit 1
+dotnet publish $SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Mac /p:Platform=x64 --runtime osx-x64 --framework netcoreapp2.1 --self-contained --output $PUBLISHDIR /maxcpucount:1 || exit 1
 
 NATIVEDIR=$SRCDIR/GVFS/GVFS.Native.Mac
 xcodebuild -configuration $CONFIGURATION -workspace $NATIVEDIR/GVFS.Native.Mac.xcworkspace build -scheme GVFS.Native.Mac -derivedDataPath $ROOTDIR/BuildOutput/GVFS.Native.Mac || exit 1


### PR DESCRIPTION
Update build scripts to be able to handle the 'Profiling(Release)' configuration. Only pass that configuration value into xcodebuild as .NET requires 'Release.Mac' to be the configuration.