### PR TITLE
GVFS ConfigVerb - support for listing & CRUD

### DIFF
--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -106,6 +106,11 @@ namespace GVFS.Common
             }
         }
 
+        public void GetAllKeysAndValues(out Dictionary<TKey, TValue> keysAndValues)
+        {
+            keysAndValues = new Dictionary<TKey, TValue>(this.data);
+        }
+
         private void Flush()
         {
             this.WriteAndReplaceDataFile(this.GenerateDataLines);

--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -106,9 +106,9 @@ namespace GVFS.Common
             }
         }
 
-        public void GetAllKeysAndValues(out Dictionary<TKey, TValue> keysAndValues)
+        public Dictionary<TKey, TValue> GetAllKeysAndValues()
         {
-            keysAndValues = new Dictionary<TKey, TValue>(this.data);
+            return new Dictionary<TKey, TValue>(this.data);
         }
 
         private void Flush()

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -26,10 +26,7 @@ namespace GVFS.Common
         {
             Dictionary<string, string> configCopy = null;
             if (!this.TryPerformAction(
-                () =>
-                {
-                    configCopy = this.allSettings.GetAllKeysAndValues();
-                },
+                () => configCopy = this.allSettings.GetAllKeysAndValues(),
                 out error))
             {
                 allConfig = null;
@@ -48,10 +45,7 @@ namespace GVFS.Common
         {
             string valueFromDict = null;
             if (!this.TryPerformAction(
-                () =>
-                {
-                    this.allSettings.TryGetValue(name, out valueFromDict);
-                },
+                () => this.allSettings.TryGetValue(name, out valueFromDict),
                 out error))
             {
                 value = null;
@@ -69,10 +63,7 @@ namespace GVFS.Common
             out string error)
         {
             if (!this.TryPerformAction(
-                () => 
-                {
-                    this.allSettings.SetValueAndFlush(name, value);
-                }, 
+                () => this.allSettings.SetValueAndFlush(name, value), 
                 out error))
             {
                 error = $"Error writing config {name}={value}. {error}";
@@ -85,10 +76,7 @@ namespace GVFS.Common
         public bool TryRemoveConfig(string name, out string error)
         {
             if (!this.TryPerformAction(
-                () =>
-                {
-                    this.allSettings.RemoveAndFlush(name);
-                },
+                () => this.allSettings.RemoveAndFlush(name),
                 out error))
             {
                 error = $"Error deleting config {name}. {error}";

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -273,7 +273,7 @@ namespace GVFS.Common
             LocalGVFSConfig localConfig = new LocalGVFSConfig();
 
             string ringConfig = null;
-            if (localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error, this.tracer))
+            if (localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error))
             {
                 RingType ringType;
 

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
@@ -1,0 +1,105 @@
+﻿using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
+{
+    [TestFixture]
+    [NonParallelizable]
+    [Category(Categories.FullSuiteOnly)]
+    [Category(Categories.WindowsOnly)]
+    public class ConfigVerbTests : TestsWithMultiEnlistment
+    {
+        private const string ConfigFilePath = @"C:\ProgramData\GVFS\gvfs.config";
+
+        [OneTimeSetUp]
+        public void DeleteAllSettings()
+        {
+            if (File.Exists(ConfigFilePath))
+            {
+                File.Delete(ConfigFilePath);
+            }
+        }
+
+        [TestCase, Order(1)]
+        public void CreateValues()
+        {
+            this.RunConfigCommandAndCheckOutput("integerString 213", null);
+            this.RunConfigCommandAndCheckOutput("integerString", new string[] { "213" });
+
+            this.RunConfigCommandAndCheckOutput("floatString 213.15", null);
+            this.RunConfigCommandAndCheckOutput("floatString", new string[] { "213.15" });
+
+            this.RunConfigCommandAndCheckOutput("regularString foobar", null);
+            this.RunConfigCommandAndCheckOutput("regularString", new string[] { "foobar" });
+
+            this.RunConfigCommandAndCheckOutput("spacesString \"quick brown fox\"", null);
+            this.RunConfigCommandAndCheckOutput("spacesString", new string[] { "quick brown fox" });
+        }
+
+        [TestCase, Order(2)]
+        public void UpdateValues()
+        {
+            this.RunConfigCommandAndCheckOutput("integerString 314", null);
+            this.RunConfigCommandAndCheckOutput("integerString", new string[] { "314" });
+
+            this.RunConfigCommandAndCheckOutput("floatString 3.14159", null);
+            this.RunConfigCommandAndCheckOutput("floatString", new string[] { "3.14159" });
+
+            this.RunConfigCommandAndCheckOutput("regularString helloWorld!", null);
+            this.RunConfigCommandAndCheckOutput("regularString", new string[] { "helloWorld!" });
+
+            this.RunConfigCommandAndCheckOutput("spacesString \"jumped over lazy dog\"", null);
+            this.RunConfigCommandAndCheckOutput("spacesString", new string[] { "jumped over lazy dog" });
+        }
+
+        [TestCase, Order(3)]
+        public void ListValues()
+        {
+            string[] expectedSettings = new string[]
+            {
+                "integerString=314",
+                "floatString=3.1415",
+                "regularString=helloWorld!",
+                "spacesString=jumped over lazy dog"
+            };
+            this.RunConfigCommandAndCheckOutput("--list", expectedSettings);
+        }
+
+        [TestCase, Order(4)]
+        public void DeleteValues()
+        {
+            string[] expectedSettings = new string[]
+            {
+                "integerString",
+                "floatString",
+                "regularString",
+                "spacesString"
+            };
+            foreach (string keyValue in expectedSettings)
+            {
+                this.RunConfigCommandAndCheckOutput($"--delete {keyValue}", null);
+            }
+
+            this.RunConfigCommandAndCheckOutput($"--list", new string[] { string.Empty });
+        }
+
+        private void RunConfigCommandAndCheckOutput(string argument, string[] expectedOutput)
+        {
+            GVFSProcess gvfsProcess = new GVFSProcess(
+                GVFSTestConfig.PathToGVFS,
+                enlistmentRoot: null,
+                localCacheRoot: null);
+
+            string result = gvfsProcess.RunConfigVerb(argument);
+            if (expectedOutput != null)
+            {
+                foreach (string output in expectedOutput)
+                {
+                    result.ShouldContain(expectedOutput);
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
@@ -9,7 +9,6 @@ using System.IO;
 namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
 {
     [TestFixture]
-    [NonParallelizable]
     [Category(Categories.FullSuiteOnly)]
     [Category(Categories.MacTODO.M4)]
     public class ConfigVerbTests : TestsWithMultiEnlistment
@@ -38,6 +37,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase, Order(1)]
         public void CreateSettings()
         {
+            this.DeleteSettings();
             this.ApplySettings(this.initialSettings);
             this.ConfigShouldContainSettings(this.initialSettings);
         }

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -90,11 +90,6 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
-        public string RunConfigVerb(string argument)
-        {
-            return this.CallGVFS("config " + argument, failOnError: true);
-        }
-
         private string CallGVFS(string args, bool failOnError = false, string trace = null)
         {
             ProcessStartInfo processInfo = null;

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -90,6 +90,11 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
+        public string RunConfigVerb(string argument)
+        {
+            return this.CallGVFS("config " + argument, failOnError: true);
+        }
+
         private string CallGVFS(string args, bool failOnError = false, string trace = null)
         {
             ProcessStartInfo processInfo = null;

--- a/GVFS/GVFS/CommandLine/ConfigVerb.cs
+++ b/GVFS/GVFS/CommandLine/ConfigVerb.cs
@@ -22,7 +22,7 @@ namespace GVFS.CommandLine
             'd',
             "delete",
             Required = false,
-            HelpText = "Delete specified setting")]
+            HelpText = "Name of setting to delete")]
         public string KeyToDelete { get; set; }
 
         [Value(
@@ -72,21 +72,15 @@ namespace GVFS.CommandLine
                 {
                     Console.WriteLine(ConfigOutputFormat, setting.Key, setting.Value);
                 }
-
-                return;
             }
-
-            if (!string.IsNullOrEmpty(this.KeyToDelete))
+            else if (!string.IsNullOrEmpty(this.KeyToDelete))
             {
                 if (!this.localConfig.TryRemoveConfig(this.KeyToDelete, out error))
                 {
                     this.ReportErrorAndExit(error);
                 }
-
-                return;
             }
-
-            if (!string.IsNullOrEmpty(this.Key))
+            else if (!string.IsNullOrEmpty(this.Key))
             {
                 bool valueSpecified = !string.IsNullOrEmpty(this.Value);
                 if (valueSpecified)
@@ -95,8 +89,6 @@ namespace GVFS.CommandLine
                     {
                         this.ReportErrorAndExit(error);
                     }
-
-                    return;
                 }
                 else
                 {
@@ -109,9 +101,11 @@ namespace GVFS.CommandLine
                     {
                         Console.WriteLine(valueRead);
                     }
-                    
-                    return;
                 }
+            }
+            else
+            {
+                this.ReportErrorAndExit("You must specify an option. Run `gvfs config --help` for details.");
             }
         }
 

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -18,6 +18,7 @@ namespace GVFS
             {
                 typeof(CacheServerVerb),
                 typeof(CloneVerb),
+                typeof(ConfigVerb),
                 typeof(DehydrateVerb),
                 typeof(DiagnoseVerb),
                 typeof(LogVerb),
@@ -28,7 +29,6 @@ namespace GVFS
                 typeof(StatusVerb),
                 typeof(UnmountVerb),
                 typeof(UpgradeVerb),
-                typeof(ConfigVerb),
             };
 
             int consoleWidth = 80;


### PR DESCRIPTION
- Updated gvfs config verb to support CRUD and List operations on GVFS 
- Usage ```gvfs config [ --list | --delete ] <key> <value>```

<img width="478" alt="screen shot 2018-10-12 at 12 58 19 pm" src="https://user-images.githubusercontent.com/378580/46883047-aeb15c80-ce1e-11e8-94b2-b3b25c1e482e.png">
settings.