### PR TITLE
Include UTC offset in log timestamp.

### DIFF
--- a/GVFS/GVFS.Common/Tracing/InProcEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/InProcEventListener.cs
@@ -41,7 +41,7 @@ namespace GVFS.Common.Tracing
         {
             // Make a smarter guess (than 16 characters) about initial size to reduce allocations
             StringBuilder message = new StringBuilder(1024);
-            message.AppendFormat("[{0}] {1}", DateTime.Now, eventName);
+            message.AppendFormat("[{0:yyyy-MM-dd HH:mm:ss zzz}] {1}", DateTime.Now, eventName);
 
             if (opcode != 0)
             {


### PR DESCRIPTION
Change logging to include the date in consistent year-month-day format and include the machine's time zone offset.
This simplifies correlating user logs with server logs.

Previously
`[10/11/2018 3:16:00 PM] DownloadObjects`

Now
`[2018-10-11 15:16:00 -04:00] DownloadObjects`

