### PR TITLE
Mac: Update and delete placeholder functions should check if file is still a placeholder

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -496,7 +496,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
         // TODO(Mac): Figure out why git for Mac is not requesting a redownload of the truncated object
         [TestCase, Order(17)]
-        [Category(Categories.MacTODO.M3)]
+        [Category(Categories.MacTODO.M4)]
         public void TruncatedObjectRedownloaded()
         {
             GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "checkout " + this.Enlistment.Commitish);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -495,7 +495,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWithOpenHandleBlockingProjectionDeleteAndRepoMetdataUpdate()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -561,7 +560,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void CheckoutBranchWhileOutsideToolDoesNotAllowDeleteOfOpenRepoMetadata()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
@@ -610,8 +608,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             }
         }
 
+        // WindowsOnly because the test depends on Windows specific file sharing behavior
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
+        [Category(Categories.WindowsOnly)]
         public void CheckoutBranchWhileOutsideToolHasExclusiveReadHandleOnDatabasesFolder()
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -4,7 +4,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.MacTODO.M3)]
     public class CherryPickConflictTests : GitRepoTests
     {
         public CherryPickConflictTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -552,7 +552,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         // MacOnly because renames of partial folders are blocked on Windows
         [TestCase]
         [Category(Categories.MacOnly)]
-        [Category(Categories.MacTODO.M3)]
         public void MoveFolderCommitChangesSwitchBranchSwitchBackTest()
         {
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.MoveFolder);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -6,7 +6,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.MacTODO.M3)]
     public class MergeConflictTests : GitRepoTests
     {
         public MergeConflictTests() : base(enlistmentPerTest: true)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
@@ -4,7 +4,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 {
     [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.MacTODO.M3)]
     public class RebaseConflictTests : GitRepoTests
     {
         public RebaseConflictTests() : base(enlistmentPerTest: true)
@@ -12,6 +11,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RebaseConflict()
         {
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
@@ -30,6 +30,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RebaseConflict_ThenAbort()
         {
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
@@ -39,6 +40,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RebaseConflict_ThenSkip()
         {
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
@@ -48,6 +50,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RebaseConflict_RemoveDeletedTheirsFile()
         {
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
@@ -56,6 +59,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.M3)]
         public void RebaseConflict_AddThenContinue()
         {
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -126,7 +126,6 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void DeleteObjectsCacheAndCacheMappingBeforeMount()
         {
             GVFSFunctionalTestEnlistment enlistment1 = this.CloneAndMountEnlistment();
@@ -159,7 +158,6 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void DeleteCacheDuringHydrations()
         {
             GVFSFunctionalTestEnlistment enlistment1 = this.CloneAndMountEnlistment();

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -56,6 +56,9 @@ namespace GVFS.Platform.Mac
                 case Result.EDirectoryNotEmpty:
                     return FSResult.DirectoryNotEmpty;
 
+                case Result.EVirtualizationInvalidOperation:
+                    return FSResult.VirtualizationInvalidOperation;
+
                 default:
                     return FSResult.IOError;
             }

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
@@ -28,6 +28,7 @@ namespace GVFS.UnitTests.Platform.Mac
             { Result.EFileNotFound, FSResult.FileOrPathNotFound },
             { Result.EPathNotFound, FSResult.FileOrPathNotFound },
             { Result.EDirectoryNotEmpty, FSResult.DirectoryNotEmpty },
+            { Result.EVirtualizationInvalidOperation, FSResult.VirtualizationInvalidOperation },
         };
 
         [TestCase]

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Result.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Result.cs
@@ -23,6 +23,7 @@
         ENotAVirtualizationRoot             = 0x20000080,
         EVirtualizationRootAlreadyExists    = 0x20000100,
         EDirectoryNotEmpty                  = 0x20000200,
+        EVirtualizationInvalidOperation     = 0x20000400,
 
         ENotYetImplemented                  = 0xFFFFFFFF,
     }

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -542,7 +542,7 @@ PrjFS_Result PrjFS_DeleteFile(
     if (!(S_ISREG(path_stat.st_mode) || S_ISDIR(path_stat.st_mode)))
     {
         // Only files and directories can be deleted with PrjFS_DeleteFile
-        // Anything else should be treated as a full
+        // Anything else should be treated as a full file
         *failureCause = PrjFS_UpdateFailureCause_FullFile;
         return PrjFS_Result_EVirtualizationInvalidOperation;
     }
@@ -962,6 +962,8 @@ static PrjFS_Result HandleFileNotification(
     
     if (partialFile && PrjFS_NotificationType_FileModified == notificationType)
     {
+        // PrjFS_NotificationType_FileModified is a post-modified FileOp event (that cannot be stopped
+        // by the provider) and so there's no need to check the result of the call to NotifyOperation
         RemoveXAttr(fullPath, PrjFSFileXAttrName);
     }
     

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -34,6 +34,7 @@ typedef enum
     PrjFS_Result_ENotAVirtualizationRoot            = 0x20000080,
     PrjFS_Result_EVirtualizationRootAlreadyExists   = 0x20000100,
     PrjFS_Result_EDirectoryNotEmpty                 = 0x20000200,
+    PrjFS_Result_EVirtualizationInvalidOperation    = 0x20000400,
     
     PrjFS_Result_ENotYetImplemented                 = 0xFFFFFFFF,
     


### PR DESCRIPTION
Resolves #332

- Update `PrjFS_DeleteFile` so that it can only delete files and directories.  Additionally, `PrjFS_DeleteFile` will now only allow partial files to be deleted.
- Update `HandleFileNotification` to remove the `PrjFSFileXAttrName` attribute when a partial file is modified
- Enable functional tests that depended on this behavior