### PR TITLE
Managed interface for Linux projected filesystem

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/CallbackDelegates.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/CallbackDelegates.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace PrjFSLib.Linux
+{
+    // Callbacks
+    public delegate Result EnumerateDirectoryCallback(
+        ulong commandId,
+        string relativePath,
+        int triggeringProcessId,
+        string triggeringProcessName);
+
+    public delegate Result GetFileStreamCallback(
+        ulong commandId,
+        string relativePath,
+        [MarshalAs(UnmanagedType.LPArray, SizeConst = Interop.PrjFSLib.PlaceholderIdLength)]
+        byte[] providerId,
+        [MarshalAs(UnmanagedType.LPArray, SizeConst = Interop.PrjFSLib.PlaceholderIdLength)]
+        byte[] contentId,
+        int triggeringProcessId,
+        string triggeringProcessName,
+        IntPtr fileHandle);
+
+    public delegate Result NotifyOperationCallback(
+        ulong commandId,
+        string relativePath,
+        [MarshalAs(UnmanagedType.LPArray, SizeConst = Interop.PrjFSLib.PlaceholderIdLength)]
+        byte[] providerId,
+        [MarshalAs(UnmanagedType.LPArray, SizeConst = Interop.PrjFSLib.PlaceholderIdLength)]
+        byte[] contentId,
+        int triggeringProcessId,
+        string triggeringProcessName,
+        bool isDirectory,
+        NotificationType notificationType);
+
+    // Pre-event notifications
+    public delegate Result NotifyPreDeleteEvent(
+        string relativePath,
+        bool isDirectory);
+
+    public delegate Result NotifyFilePreConvertToFullEvent(
+        string relativePath);
+
+    public delegate Result NotifyPreModifyEvent(
+        string relativePath);
+
+    // Informational post-event notifications
+    public delegate void NotifyNewFileCreatedEvent(
+        string relativePath,
+        bool isDirectory);
+
+    public delegate void NotifyFileRenamedEvent(
+        string relativeDestinationPath,
+        bool isDirectory);
+
+    public delegate void NotifyHardLinkCreatedEvent(
+        string relativeNewLinkPath);
+
+    public delegate void NotifyFileModified(
+        string relativePath);
+
+    public delegate void NotifyFileDeleted(
+        string relativePath,
+        bool isDirectory);
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/Callbacks.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/Callbacks.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace PrjFSLib.Linux.Interop
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Callbacks
+    {
+        public EnumerateDirectoryCallback OnEnumerateDirectory;
+        public GetFileStreamCallback OnGetFileStream;
+        public NotifyOperationCallback OnNotifyOperation;
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace PrjFSLib.Linux.Interop
+{
+    internal static class PrjFSLib
+    {
+        // TODO(Linux): set value from that defined in Linux library header
+        public const int PlaceholderIdLength = 128;
+        private const string PrjFSLibPath = "libprojfs.so";
+
+        // TODO(Linux): revise library functions for Linux
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_StartVirtualizationInstance")]
+        public static extern Result StartVirtualizationInstance(
+            string virtualizationRootFullPath,
+            Callbacks callbacks,
+            uint poolThreadCount);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_ConvertDirectoryToVirtualizationRoot")]
+        public static extern Result ConvertDirectoryToVirtualizationRoot(
+            string virtualizationRootFullPath);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderDirectory")]
+        public static extern Result WritePlaceholderDirectory(
+            string relativePath);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderFile")]
+        public static extern Result WritePlaceholderFile(
+            string relativePath,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] providerId,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] contentId,
+            ulong fileSize,
+            ushort fileMode);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WriteSymLink")]
+        public static extern Result WriteSymLink(
+            string relativePath,
+            string symLinkTarget);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_UpdatePlaceholderFileIfNeeded")]
+        public static extern Result UpdatePlaceholderFileIfNeeded(
+            string relativePath,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] providerId,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] contentId,
+            ulong fileSize,
+            ushort fileMode,
+            UpdateType updateType,
+            ref UpdateFailureCause failureCause);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_ReplacePlaceholderFileWithSymLink")]
+        public static extern Result ReplacePlaceholderFileWithSymLink(
+            string relativePath,
+            string symLinkTarget,
+            UpdateType updateType,
+            ref UpdateFailureCause failureCause);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_DeleteFile")]
+        public static extern Result DeleteFile(
+            string relativePath,
+            UpdateType updateType,
+            ref UpdateFailureCause failureCause);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WriteFileContents")]
+        public static extern Result WriteFileContents(
+            IntPtr fileHandle,
+            IntPtr bytes,
+            uint byteCount);
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationMapping.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationMapping.cs
@@ -1,0 +1,8 @@
+﻿namespace PrjFSLib.Linux
+{
+    public class NotificationMapping
+    {
+        public NotificationType NotificationMask { get; set; }
+        public string NotificationRelativeRoot { get; set; }
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationType.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace PrjFSLib.Linux
+{
+    [Flags]
+    public enum NotificationType
+    {
+        Invalid             = 0x00000000,
+
+        None                = 0x00000001,
+        NewFileCreated      = 0x00000004,
+        PreDelete           = 0x00000010,
+        FileRenamed         = 0x00000080,
+        HardLinkCreated     = 0x00000100,
+        PreConvertToFull    = 0x00001000,
+
+        PreModify           = 0x10000001,
+        FileModified        = 0x10000002,
+        FileDeleted         = 0x10000004,
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <Platforms>x64</Platforms>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>..\..\..\BuildOutput\ProjFS.Linux\PrjFSLib.Linux.Managed\bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>..\..\..\BuildOutput\ProjFS.Linux\PrjFSLib.Linux.Managed\obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType></DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Error.MSBuild" Version="1.0.0" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="StyleCop.MSBuild" Version="5.0.0" Condition="'$(OS)' == 'Windows_NT'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Interop\" />
+  </ItemGroup>
+</Project>

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Result.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Result.cs
@@ -1,0 +1,29 @@
+﻿namespace PrjFSLib.Linux
+{
+    public enum Result : uint
+    {
+        Invalid                             = 0x00000000,
+
+        Success                             = 0x00000001,
+        Pending                             = 0x00000002,
+
+        // Bugs in the caller
+        EInvalidArgs                        = 0x10000001,
+        EInvalidOperation                   = 0x10000002,
+        ENotSupported                       = 0x10000004,
+
+        // Runtime errors
+        EDriverNotLoaded                    = 0x20000001,
+        EOutOfMemory                        = 0x20000002,
+        EFileNotFound                       = 0x20000004,
+        EPathNotFound                       = 0x20000008,
+        EAccessDenied                       = 0x20000010,
+        EInvalidHandle                      = 0x20000020,
+        EIOError                            = 0x20000040,
+        ENotAVirtualizationRoot             = 0x20000080,
+        EVirtualizationRootAlreadyExists    = 0x20000100,
+        EDirectoryNotEmpty                  = 0x20000200,
+
+        ENotYetImplemented                  = 0xFFFFFFFF,
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateFailureCause.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateFailureCause.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace PrjFSLib.Linux
+{
+    [Flags]
+    public enum UpdateFailureCause
+    {
+        NoFailure   = 0x00000000,
+        DirtyData   = 0x00000002,
+        ReadOnly    = 0x00000008,
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateType.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace PrjFSLib.Linux
+{
+    [Flags]
+    public enum UpdateType
+    {
+        Invalid         = 0x00000000,
+
+        AllowReadOnly   = 0x00000020,
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace PrjFSLib.Linux
+{
+    public class VirtualizationInstance
+    {
+        public const int PlaceholderIdLength = Interop.PrjFSLib.PlaceholderIdLength;
+
+        // We must hold a reference to the delegate to prevent garbage collection
+        private NotifyOperationCallback preventGCOnNotifyOperationDelegate;
+
+        // References held to these delegates via class properties
+        public virtual EnumerateDirectoryCallback OnEnumerateDirectory { get; set; }
+        public virtual GetFileStreamCallback OnGetFileStream { get; set; }
+
+        public virtual NotifyFileModified OnFileModified { get; set; }
+        public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
+        public virtual NotifyNewFileCreatedEvent OnNewFileCreated { get; set; }
+        public virtual NotifyFileRenamedEvent OnFileRenamed { get; set; }
+        public virtual NotifyHardLinkCreatedEvent OnHardLinkCreated { get; set; }
+
+        public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
+        {
+            return Interop.PrjFSLib.ConvertDirectoryToVirtualizationRoot(fullPath);
+        }
+
+        public virtual Result StartVirtualizationInstance(
+            string virtualizationRootFullPath,
+            uint poolThreadCount)
+        {
+            Interop.Callbacks callbacks = new Interop.Callbacks
+            {
+                OnEnumerateDirectory = this.OnEnumerateDirectory,
+                OnGetFileStream = this.OnGetFileStream,
+                OnNotifyOperation = this.preventGCOnNotifyOperationDelegate = new NotifyOperationCallback(this.OnNotifyOperation),
+            };
+
+            return Interop.PrjFSLib.StartVirtualizationInstance(
+                virtualizationRootFullPath,
+                callbacks,
+                poolThreadCount);
+        }
+
+        public virtual Result StopVirtualizationInstance()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Result WriteFileContents(
+            IntPtr fileHandle,
+            byte[] bytes,
+            uint byteCount)
+        {
+            GCHandle bytesHandle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                return Interop.PrjFSLib.WriteFileContents(
+                    fileHandle,
+                    bytesHandle.AddrOfPinnedObject(),
+                    byteCount);
+            }
+            finally
+            {
+                bytesHandle.Free();
+            }
+        }
+
+        public virtual Result DeleteFile(
+            string relativePath,
+            UpdateType updateFlags,
+            out UpdateFailureCause failureCause)
+        {
+            UpdateFailureCause deleteFailureCause = UpdateFailureCause.NoFailure;
+            Result result = Interop.PrjFSLib.DeleteFile(
+                relativePath,
+                updateFlags,
+                ref deleteFailureCause);
+
+            failureCause = deleteFailureCause;
+            return result;
+        }
+
+        public virtual Result WritePlaceholderDirectory(
+            string relativePath)
+        {
+            return Interop.PrjFSLib.WritePlaceholderDirectory(relativePath);
+        }
+
+        public virtual Result WritePlaceholderFile(
+            string relativePath,
+            byte[] providerId,
+            byte[] contentId,
+            ulong fileSize,
+            ushort fileMode)
+        {
+            if (providerId.Length != Interop.PrjFSLib.PlaceholderIdLength ||
+                contentId.Length != Interop.PrjFSLib.PlaceholderIdLength)
+            {
+                throw new ArgumentException();
+            }
+
+            return Interop.PrjFSLib.WritePlaceholderFile(
+                relativePath,
+                providerId,
+                contentId,
+                fileSize,
+                fileMode);
+        }
+
+        public virtual Result WriteSymLink(
+            string relativePath,
+            string symLinkTarget)
+        {
+            return Interop.PrjFSLib.WriteSymLink(relativePath, symLinkTarget);
+        }
+
+        public virtual Result UpdatePlaceholderIfNeeded(
+            string relativePath,
+            byte[] providerId,
+            byte[] contentId,
+            ulong fileSize,
+            ushort fileMode,
+            UpdateType updateFlags,
+            out UpdateFailureCause failureCause)
+        {
+            if (providerId.Length != Interop.PrjFSLib.PlaceholderIdLength ||
+                contentId.Length != Interop.PrjFSLib.PlaceholderIdLength)
+            {
+                throw new ArgumentException();
+            }
+
+            UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
+            Result result = Interop.PrjFSLib.UpdatePlaceholderFileIfNeeded(
+                relativePath,
+                providerId,
+                contentId,
+                fileSize,
+                fileMode,
+                updateFlags,
+                ref updateFailureCause);
+
+            failureCause = updateFailureCause;
+            return result;
+        }
+
+        public virtual Result ReplacePlaceholderFileWithSymLink(
+            string relativePath,
+            string symLinkTarget,
+            UpdateType updateFlags,
+            out UpdateFailureCause failureCause)
+        {
+            UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
+            Result result = Interop.PrjFSLib.ReplacePlaceholderFileWithSymLink(
+                relativePath,
+                symLinkTarget,
+                updateFlags,
+                ref updateFailureCause);
+
+            failureCause = updateFailureCause;
+            return result;
+        }
+
+        public virtual Result CompleteCommand(
+            ulong commandId,
+            Result result)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Result ConvertDirectoryToPlaceholder(
+            string relativeDirectoryPath)
+        {
+            throw new NotImplementedException();
+        }
+
+        private Result OnNotifyOperation(
+            ulong commandId,
+            string relativePath,
+            byte[] providerId,
+            byte[] contentId,
+            int triggeringProcessId,
+            string triggeringProcessName,
+            bool isDirectory,
+            NotificationType notificationType)
+        {
+            switch (notificationType)
+            {
+                case NotificationType.PreDelete:
+                    return this.OnPreDelete(relativePath, isDirectory);
+
+                case NotificationType.FileModified:
+                    this.OnFileModified(relativePath);
+                    return Result.Success;
+
+                case NotificationType.NewFileCreated:
+                    this.OnNewFileCreated(relativePath, isDirectory);
+                    return Result.Success;
+
+                case NotificationType.FileRenamed:
+                    this.OnFileRenamed(relativePath, isDirectory);
+                    return Result.Success;
+
+                case NotificationType.HardLinkCreated:
+                    this.OnHardLinkCreated(relativePath);
+                    return Result.Success;
+            }
+
+            return Result.ENotYetImplemented;
+        }
+    }
+}

--- a/ProjFS.Linux/Scripts/Build.sh
+++ b/ProjFS.Linux/Scripts/Build.sh
@@ -17,10 +17,5 @@ PROJFS=$SRCDIR/ProjFS.Linux
 #              into $ROOTDIR/BuildOutput/ProjFS.Linux/Native with
 #              given $CONFIGURATION
 
-# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
-if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
-  CONFIGURATION=Release
-fi
-
 dotnet restore $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 --packages $PACKAGES || exit 1
 dotnet build $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 || exit 1

--- a/ProjFS.Linux/Scripts/Build.sh
+++ b/ProjFS.Linux/Scripts/Build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
+SRCDIR=$SCRIPTDIR/../..
+ROOTDIR=$SRCDIR/..
+PACKAGES=$ROOTDIR/packages
+
+PROJFS=$SRCDIR/ProjFS.Linux
+
+# TODO(Linux): use pkg-config to look for installed libprojfs;
+#              if not found, retrieve latest stable from repo, build
+#              into $ROOTDIR/BuildOutput/ProjFS.Linux/Native with
+#              given $CONFIGURATION
+
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
+dotnet restore $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 --packages $PACKAGES || exit 1
+dotnet build $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 || exit 1


### PR DESCRIPTION
Add an initial Linux implementation of a VirtualizationInstance with the same types, callbacks, and functions as the Mac interface.

The underlying dynamic library used by the interoperability layer is not included here due to anticipated licensing requirements, but would be provided separately.

Note that it may be valuable to consider a future refactoring of identical classes between the Linux and Mac implementations (such as PrjFSLib.Linux.Result and PrjFSLib.Mac.Result).