### PR TITLE
Implement MirrorProvider support for Linux

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -1,0 +1,247 @@
+﻿using PrjFSLib.Linux;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MirrorProvider.Linux
+{
+    public class LinuxFileSystemVirtualizer : FileSystemVirtualizer
+    {
+        private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
+
+        public override bool TryConvertVirtualizationRoot(string directory, out string error)
+        {
+            Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(directory);
+
+            error = result.ToString();
+            return result == Result.Success;
+        }
+
+        public override bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)
+        {
+            this.virtualizationInstance.OnEnumerateDirectory = this.OnEnumerateDirectory;
+            this.virtualizationInstance.OnGetFileStream = this.OnGetFileStream;
+            this.virtualizationInstance.OnFileModified = this.OnFileModified;
+            this.virtualizationInstance.OnPreDelete = this.OnPreDelete;
+            this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
+            this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
+            this.virtualizationInstance.OnHardLinkCreated = this.OnHardLinkCreated;
+
+            Result result = this.virtualizationInstance.StartVirtualizationInstance(
+                enlistment.SrcRoot,
+                poolThreadCount: (uint)Environment.ProcessorCount * 2);
+
+            if (result == Result.Success)
+            {
+                return base.TryStartVirtualizationInstance(enlistment, out error);
+            }
+            else
+            {
+                error = result.ToString();
+                return false;
+            }
+        }
+
+        private Result OnEnumerateDirectory(
+            ulong commandId,
+            string relativePath,
+            int triggeringProcessId,
+            string triggeringProcessName)
+        {
+            Console.WriteLine($"OnEnumerateDirectory({commandId}, '{relativePath}', {triggeringProcessId}, {triggeringProcessName})");
+
+            try
+            {
+                if (!this.DirectoryExists(relativePath))
+                {
+                    return Result.EFileNotFound;
+                }
+
+                foreach (ProjectedFileInfo child in this.GetChildItems(relativePath))
+                {
+                    if (child.Type == ProjectedFileInfo.FileType.Directory)
+                    {
+                        Result result = this.virtualizationInstance.WritePlaceholderDirectory(
+                            Path.Combine(relativePath, child.Name));
+
+                        if (result != Result.Success)
+                        {
+                            Console.WriteLine($"WritePlaceholderDirectory failed: {result}");
+                            return result;
+                        }
+                    }
+                    else if (child.Type == ProjectedFileInfo.FileType.SymLink)
+                    {
+                        string childRelativePath = Path.Combine(relativePath, child.Name);
+
+                        string symLinkTarget;
+                        if (this.TryGetSymLinkTarget(childRelativePath, out symLinkTarget))
+                        {
+                            Result result = this.virtualizationInstance.WriteSymLink(
+                                childRelativePath,
+                                symLinkTarget);
+
+                            if (result != Result.Success)
+                            {
+                                Console.WriteLine($"WriteSymLink failed: {result}");
+                                return result;
+                            }
+                        }
+                        else
+                        {
+                            return Result.EIOError;
+                        }
+                    }
+                    else
+                    {
+                        // The MirrorProvider marks every file as executable (mode 755), but this is just a shortcut to avoid the pain of
+                        // having to p/invoke to determine if the original file is exectuable or not.
+                        // A real provider will have to get this information from its data source. For example, GVFS gets this info
+                        // out of the git index along with all the other info for projecting files.
+                        UInt16 fileMode = Convert.ToUInt16("755", 8);
+
+                        Result result = this.virtualizationInstance.WritePlaceholderFile(
+                            Path.Combine(relativePath, child.Name),
+                            providerId: ToVersionIdByteArray(1),
+                            contentId: ToVersionIdByteArray(0),
+                            fileSize: (ulong)child.Size,
+                            fileMode: fileMode);
+                        if (result != Result.Success)
+                        {
+                            Console.WriteLine($"WritePlaceholderFile failed: {result}");
+                            return result;
+                        }
+                    }
+                }
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"IOException in OnEnumerateDirectory: {e.Message}");
+                return Result.EIOError;
+            }
+
+            return Result.Success;
+        }
+
+        private Result OnGetFileStream(
+            ulong commandId,
+            string relativePath,
+            byte[] providerId,
+            byte[] contentId,
+            int triggeringProcessId,
+            string triggeringProcessName,
+            IntPtr fileHandle)
+        {
+            Console.WriteLine($"OnGetFileStream({commandId}, '{relativePath}', {contentId.Length}/{contentId[0]}:{contentId[1]}, {providerId.Length}/{providerId[0]}:{providerId[1]}, {triggeringProcessId}, {triggeringProcessName}, 0x{fileHandle.ToInt64():X})");
+
+            if (!this.FileExists(relativePath))
+            {
+                return Result.EFileNotFound;
+            }
+
+            try
+            {
+                const int bufferSize = 4096;
+                FileSystemResult hydrateFileResult = this.HydrateFile(
+                    relativePath,
+                    bufferSize,
+                    (buffer, bytesToCopy) =>
+                    {
+                        Result result = this.virtualizationInstance.WriteFileContents(
+                            fileHandle,
+                            buffer,
+                            (uint)bytesToCopy);
+                        if (result != Result.Success)
+                        {
+                        Console.WriteLine($"WriteFileContents failed: {result}");
+                            return false;
+                        }
+
+                        return true;
+                    });
+
+                if (hydrateFileResult != FileSystemResult.Success)
+                {
+                    return Result.EIOError;
+                }
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine($"IOException in OnGetFileStream: {e.Message}");
+                return Result.EIOError;
+            }
+
+            return Result.Success;
+        }
+
+        private void OnFileModified(string relativePath)
+        {
+            Console.WriteLine($"OnFileModified: {relativePath}");
+        }
+
+        private Result OnPreDelete(string relativePath, bool isDirectory)
+        {
+            Console.WriteLine($"OnPreDelete (isDirectory: {isDirectory}): {relativePath}");
+            return Result.Success;
+        }
+
+        private void OnNewFileCreated(string relativePath, bool isDirectory)
+        {
+            Console.WriteLine($"OnNewFileCreated (isDirectory: {isDirectory}): {relativePath}");
+        }
+
+        private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
+        {
+            Console.WriteLine($"OnFileRenamed (isDirectory: {isDirectory}) destination: {relativeDestinationPath}");
+        }
+
+        private void OnHardLinkCreated(string relativeNewLinkPath)
+        {
+            Console.WriteLine($"OnHardLinkCreated: {relativeNewLinkPath}");
+        }
+
+        private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
+        {
+            symLinkTarget = null;
+            string fullPathInMirror = this.GetFullPathInMirror(relativePath);
+
+            const ulong BufSize = 4096;
+            byte[] targetBuffer = new byte[BufSize];
+            long bytesRead = ReadLink(fullPathInMirror, targetBuffer, BufSize);
+            if (bytesRead < 0)
+            {
+                Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
+                return false;
+            }
+
+            targetBuffer[bytesRead] = 0;
+            symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
+
+            if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                // Link target is an absolute path inside the MirrorRoot.
+                // The target needs to be adjusted to point inside the src root
+                symLinkTarget = Path.Combine(
+                    this.Enlistment.SrcRoot.TrimEnd(Path.DirectorySeparatorChar),
+                    symLinkTarget.Substring(this.Enlistment.MirrorRoot.Length).TrimStart(Path.DirectorySeparatorChar));
+            }
+
+            return true;
+        }
+
+        private static byte[] ToVersionIdByteArray(byte version)
+        {
+            byte[] bytes = new byte[VirtualizationInstance.PlaceholderIdLength];
+            bytes[0] = version;
+
+            return bytes;
+        }
+
+        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+        private static extern long ReadLink(
+            string path,
+            byte[] buf,
+            ulong bufsize);
+    }
+}

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+    <Platforms>x64</Platforms>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildOutputDir>..\..\..\BuildOutput</BuildOutputDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IntermediateOutputPath>$(BuildOutputDir)\MirrorProvider.Linux\obj\$(Configuration)\$(Platform)</IntermediateOutputPath>
+    <OutputPath>$(BuildOutputDir)\MirrorProvider.Linux\bin\$(Configuration)\$(Platform)</OutputPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType></DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ProjFS.Linux\PrjFSLib.Linux.Managed\PrjFSLib.Linux.Managed.csproj" />
+    <ProjectReference Include="..\MirrorProvider\MirrorProvider.csproj" />
+  </ItemGroup>
+
+  <!-- TODO(Linux): enable copy when built locally and not already installed
+  <ItemGroup>
+    <None Include="$(BuildOutputDir)\ProjFS.Linux\Native\Build\Products\$(Configuration)\libprojfs.so" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  -->
+</Project>

--- a/MirrorProvider/MirrorProvider.Linux/Program.cs
+++ b/MirrorProvider/MirrorProvider.Linux/Program.cs
@@ -1,0 +1,10 @@
+﻿namespace MirrorProvider.Linux
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            MirrorProviderCLI.Run(args, new LinuxFileSystemVirtualizer());
+        }
+    }
+}

--- a/MirrorProvider/MirrorProvider.sln
+++ b/MirrorProvider/MirrorProvider.sln
@@ -2,9 +2,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27428.2011
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrjFSLib.Linux.Managed", "..\ProjFS.Linux\PrjFSLib.Linux.Managed\PrjFSLib.Linux.Managed.csproj", "{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrjFSLib.Mac.Managed", "..\ProjFS.Mac\PrjFSLib.Mac.Managed\PrjFSLib.Mac.Managed.csproj", "{064685CA-00F6-41AB-A2AB-3350AEC4419C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider.Windows", "MirrorProvider.Windows\MirrorProvider.Windows.csproj", "{1ED51604-045C-4914-8054-15AAED90FF45}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider.Linux", "MirrorProvider.Linux\MirrorProvider.Linux.csproj", "{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider.Mac", "MirrorProvider.Mac\MirrorProvider.Mac.csproj", "{4BD96573-BE04-421B-B8C4-207956970136}"
 EndProject
@@ -12,34 +16,62 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider", "MirrorPro
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug.Linux|x64 = Debug.Linux|x64
 		Debug.Mac|x64 = Debug.Mac|x64
 		Debug.Windows|x64 = Debug.Windows|x64
+		Release.Linux|x64 = Release.Linux|x64
 		Release.Mac|x64 = Release.Mac|x64
 		Release.Windows|x64 = Release.Windows|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Debug.Linux|x64.ActiveCfg = Debug|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Debug.Linux|x64.Build.0 = Debug|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Debug.Mac|x64.ActiveCfg = Debug|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Debug.Windows|x64.ActiveCfg = Debug|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Release.Linux|x64.ActiveCfg = Release|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Release.Linux|x64.Build.0 = Release|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Release.Mac|x64.ActiveCfg = Release|x64
+		{C1B30447-87BF-4AC3-AABC-95B8B30A4F13}.Release.Windows|x64.ActiveCfg = Release|x64
+		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Debug.Linux|x64.ActiveCfg = Debug|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Debug.Mac|x64.ActiveCfg = Debug|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Debug.Mac|x64.Build.0 = Debug|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Debug.Windows|x64.ActiveCfg = Debug|x64
+		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Release.Linux|x64.ActiveCfg = Release|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Release.Mac|x64.ActiveCfg = Release|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Release.Mac|x64.Build.0 = Release|x64
 		{064685CA-00F6-41AB-A2AB-3350AEC4419C}.Release.Windows|x64.ActiveCfg = Release|x64
+		{1ED51604-045C-4914-8054-15AAED90FF45}.Debug.Linux|x64.ActiveCfg = Debug|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Debug.Mac|x64.ActiveCfg = Debug|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Debug.Windows|x64.ActiveCfg = Debug|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Debug.Windows|x64.Build.0 = Debug|x64
+		{1ED51604-045C-4914-8054-15AAED90FF45}.Release.Linux|x64.ActiveCfg = Release|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Release.Mac|x64.ActiveCfg = Release|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Release.Windows|x64.ActiveCfg = Release|x64
 		{1ED51604-045C-4914-8054-15AAED90FF45}.Release.Windows|x64.Build.0 = Release|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Debug.Linux|x64.ActiveCfg = Debug|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Debug.Linux|x64.Build.0 = Debug|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Debug.Mac|x64.ActiveCfg = Debug|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Debug.Windows|x64.ActiveCfg = Debug|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Release.Linux|x64.ActiveCfg = Release|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Release.Linux|x64.Build.0 = Release|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Release.Mac|x64.ActiveCfg = Release|x64
+		{11C6ADF5-1BCA-4B0B-9CFA-B6B8D09B08DB}.Release.Windows|x64.ActiveCfg = Release|x64
+		{4BD96573-BE04-421B-B8C4-207956970136}.Debug.Linux|x64.ActiveCfg = Debug|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Debug.Mac|x64.ActiveCfg = Debug|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Debug.Mac|x64.Build.0 = Debug|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Debug.Windows|x64.ActiveCfg = Debug|x64
+		{4BD96573-BE04-421B-B8C4-207956970136}.Release.Linux|x64.ActiveCfg = Release|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Release.Mac|x64.ActiveCfg = Release|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Release.Mac|x64.Build.0 = Release|x64
 		{4BD96573-BE04-421B-B8C4-207956970136}.Release.Windows|x64.ActiveCfg = Release|x64
+		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Linux|x64.ActiveCfg = Debug|x64
+		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Linux|x64.Build.0 = Debug|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Mac|x64.ActiveCfg = Debug|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Mac|x64.Build.0 = Debug|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Windows|x64.ActiveCfg = Debug|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Debug.Windows|x64.Build.0 = Debug|x64
+		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Linux|x64.ActiveCfg = Release|x64
+		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Linux|x64.Build.0 = Release|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Mac|x64.ActiveCfg = Release|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Mac|x64.Build.0 = Release|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Windows|x64.ActiveCfg = Release|x64

--- a/MirrorProvider/Scripts/Linux/Build.sh
+++ b/MirrorProvider/Scripts/Linux/Build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
+
+SRCDIR=$SCRIPTDIR/../../..
+ROOTDIR=$SRCDIR/..
+SLN=$SRCDIR/MirrorProvider/MirrorProvider.sln
+
+# Build the ProjFS library interface
+$SRCDIR/ProjFS.Linux/Scripts/Build.sh $CONFIGURATION
+
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
+# Build the MirrorProvider
+dotnet restore $SLN /p:Configuration="$CONFIGURATION.Linux" --packages $ROOTDIR/packages
+dotnet build $SLN --configuration $CONFIGURATION.Linux

--- a/MirrorProvider/Scripts/Linux/Build.sh
+++ b/MirrorProvider/Scripts/Linux/Build.sh
@@ -14,11 +14,6 @@ SLN=$SRCDIR/MirrorProvider/MirrorProvider.sln
 # Build the ProjFS library interface
 $SRCDIR/ProjFS.Linux/Scripts/Build.sh $CONFIGURATION
 
-# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
-if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
-  CONFIGURATION=Release
-fi
-
 # Build the MirrorProvider
 dotnet restore $SLN /p:Configuration="$CONFIGURATION.Linux" --packages $ROOTDIR/packages
 dotnet build $SLN --configuration $CONFIGURATION.Linux

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
+BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
+
+dotnet $BUILDDIR/MirrorProvider.Linux.dll clone ~/PathToMirror ~/TestRoot

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
+BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
+
+dotnet $BUILDDIR/MirrorProvider.Linux.dll mount ~/TestRoot


### PR DESCRIPTION
Add initial MirrorProvider support for Linux based on the Mac implementation, including updates to the VisualStudio solution file to add Linux build targets.

Note that some small changes may be required in the future to accommodate the Linux ProjFS API as it evolves; in particular, a call to StopVirtualizationInstance may be needed in the generic MirrorProvider.  These will be submitted as separate PRs; for now, we just try to sync with the Mac implementation as a starting point.