### PR TITLE
Mount: Remove unnecessary tracing

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.Windows
 
         public string DriverLogFolderName { get; } = ProjFSFilter.ServiceName;
 
-        public static bool TryAttach(ITracer tracer, string enlistmentRoot, out string errorMessage)
+        public static bool TryAttach(string enlistmentRoot, out string errorMessage)
         {
             errorMessage = null;
             try
@@ -56,7 +56,6 @@ namespace GVFS.Platform.Windows
                 if (!NativeMethods.GetVolumePathName(enlistmentRoot, volumePathName, GVFSConstants.MaxPath))
                 {
                     errorMessage = "Could not get volume path name";
-                    tracer.RelatedError($"{nameof(TryAttach)}:{errorMessage}");
                     return false;
                 }
 
@@ -64,14 +63,12 @@ namespace GVFS.Platform.Windows
                 if (result != OkResult && result != NameCollisionErrorResult)
                 {
                     errorMessage = string.Format("Attaching the filter driver resulted in: {0}", result);
-                    tracer.RelatedError(errorMessage);
                     return false;
                 }
             }
             catch (Exception e)
             {
                 errorMessage = string.Format("Attaching the filter driver resulted in: {0}", e.Message);
-                tracer.RelatedError(errorMessage);
                 return false;
             }
 
@@ -373,7 +370,7 @@ namespace GVFS.Platform.Windows
             return
                 IsServiceRunning(tracer) &&
                 IsNativeLibInstalled(tracer, new PhysicalFileSystem()) &&
-                TryAttach(tracer, enlistmentRoot, out error);
+                TryAttach(enlistmentRoot, out error);
         }
 
         private static bool IsInboxAndEnabled()

--- a/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
@@ -130,7 +130,7 @@ namespace GVFS.Service.Handlers
 
             if (!string.IsNullOrEmpty(this.request.EnlistmentRoot))
             {
-                if (!ProjFSFilter.TryAttach(this.tracer, this.request.EnlistmentRoot, out errorMessage))
+                if (!ProjFSFilter.TryAttach(this.request.EnlistmentRoot, out errorMessage))
                 {
                     state = NamedPipeMessages.CompletionState.Failure;
                     this.tracer.RelatedError("Unable to attach filter to volume. Enlistment root: {0} \nError: {1} ", this.request.EnlistmentRoot, errorMessage);

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -117,7 +117,14 @@ namespace GVFS.CommandLine
 
                 if (!GVFSPlatform.Instance.KernelDriver.IsReady(tracer, enlistment.EnlistmentRoot, out errorMessage))
                 {
-                    tracer.RelatedInfo($"{nameof(MountVerb)}.{nameof(this.Execute)}: Enabling and attaching ProjFS through service");
+                    tracer.RelatedEvent(
+                        EventLevel.Informational,
+                            $"{nameof(MountVerb)}_{nameof(this.Execute)}_EnablingKernelDriverViaService",
+                            new EventMetadata
+                            {
+                                { "KernelDriver.IsReady_Error", errorMessage },
+                                { TracingConstants.MessageKey.InfoMessage, "Service will retry" }
+                            });
 
                     if (!this.ShowStatusWhileRunning(
                         () => { return this.TryEnableAndAttachPrjFltThroughService(enlistment.EnlistmentRoot, out errorMessage); },


### PR DESCRIPTION
We may fail to attach the filter from GVFS.exe due to the user not running as admin.  In this case we will retry the mount via GVFS.Service.exe.  We don't want GVFS.exe to log a failure telemetry event, since it may get successfully retried.  This change removes the tracing, since the if called via the service we will still log an error [here](https://github.com/Microsoft/VFSForGit/blob/3bd509d373734a9f9685d6a73ba73324f72931e3/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs#L143
) and send it back to GVFS.exe.

If we want to get more precise the error code I see on failing to attach the filter without permissions is (2147942405 or 0x80070005).  We could add specific handling for that code if we think that's more appropriate.