### PR TITLE
Fix repositoryPath to work on all platforms

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositoryPath" value="..\packages\" />
+    <add key="repositoryPath" value="../packages/" />
   </config>
   <packageSources>
     <clear />


### PR DESCRIPTION
If I recall correctly, the forward slash used to break nuget.exe on Windows, but I just tested it out and it builds fine. With this change, VS for Mac no longer drops packages in a folder named `..\\packages\\` inside the src folder.