### PR TITLE
PostFetchJob: Kill running Git process when unmounting

### DIFF
--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -150,27 +150,6 @@ namespace GVFS.Common.Git
             }
         }
 
-        public bool TryWriteMultiPackIndex(ITracer tracer, GVFSEnlistment enlistment, PhysicalFileSystem fileSystem)
-        {
-            using (ITracer activity = tracer.StartActivity(nameof(this.TryWriteMultiPackIndex), EventLevel.Informational, Keywords.Telemetry, metadata: null))
-            {
-                GitProcess process = new GitProcess(enlistment);
-                GitProcess.Result result = process.WriteMultiPackIndex(enlistment.GitObjectsRoot);
-
-                if (result.HasErrors)
-                {
-                    EventMetadata errorMetadata = new EventMetadata();
-                    errorMetadata.Add("Operation", nameof(this.TryWriteMultiPackIndex));
-                    errorMetadata.Add("objectDir", enlistment.GitObjectsRoot);
-                    errorMetadata.Add("Errors", result.Errors);
-                    errorMetadata.Add("Output", result.Output.Length > 1024 ? result.Output.Substring(1024) : result.Output);
-                    activity.RelatedError(errorMetadata, result.Errors, Keywords.Telemetry);
-                }
-
-                return !result.HasErrors;
-            }
-        }
-
         public virtual string WriteLooseObject(Stream responseStream, string sha, bool overwriteExistingObject, byte[] bufToCopyWith)
         {
             try


### PR DESCRIPTION
The post-fetch job runs up to two Git commands: 'git multi-pack-index write' and 'git commit-graph write'. These can each take up to 30s depending on the amount of work to do. When we unmount, we want to ensure these prcoesses terminate.

Before, we were aborting the post-fetch job thread. This is not cross-platform compliant.

The new approach is to store a `GitProcess` object and pass a Kill signal to that process during unmount. Watch that call for some possible exceptions. Also, add an additional `processLock` to `GitProcess` that holds around our state changes for the process (starting or killing the process) so we don't race by killing a process before it starts and have it start anyway.

As part of revealing this `GitProcess` to the necessary layer, I pulled the implementation of `TryWriteMultiPackIndex` out of the `GitObjects` class.

The test suite was previously exercising this code path during the functional tests, as the functional tests frequently ran faster than the background Git processes. That should give some good data on how this works.

Resolves #409