### PR TITLE
PostFetchJob: Delete stale .lock files

### DIFF
--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -585,6 +585,9 @@ namespace GVFS.Virtualization
 
                     using (ITracer activity = this.context.Tracer.StartActivity("TryWriteMultiPackIndex", EventLevel.Informational, Keywords.Telemetry, metadata: null))
                     {
+                        string midxLockFile = Path.Combine(this.context.Enlistment.GitPackRoot, "multi-pack-index.lock");
+                        this.context.FileSystem.TryDeleteFile(midxLockFile);
+
                         if (this.stopping)
                         {
                             this.context.Tracer.RelatedWarning(
@@ -614,6 +617,9 @@ namespace GVFS.Virtualization
 
                     using (ITracer activity = this.context.Tracer.StartActivity("TryWriteGitCommitGraph", EventLevel.Informational, Keywords.Telemetry, metadata: null))
                     {
+                        string graphLockFile = Path.Combine(this.context.Enlistment.GitObjectsRoot, "info", "commit-graph.lock");
+                        this.context.FileSystem.TryDeleteFile(graphLockFile);
+
                         if (this.stopping)
                         {
                             this.context.Tracer.RelatedWarning(

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -20,6 +20,8 @@ namespace GVFS.Virtualization
     {
         private const string EtwArea = nameof(FileSystemCallbacks);
         private const string PostFetchLock = "post-fetch.lock";
+        private const string CommitGraphLock = "commit-graph.lock";
+        private const string MultiPackIndexLock = "multi-pack-index.lock";
         private const string PostFetchTelemetryKey = "post-fetch";
 
         private static readonly GitCommandLineParser.Verbs LeavesProjectionUnchangedVerbs =
@@ -585,7 +587,7 @@ namespace GVFS.Virtualization
 
                     using (ITracer activity = this.context.Tracer.StartActivity("TryWriteMultiPackIndex", EventLevel.Informational, Keywords.Telemetry, metadata: null))
                     {
-                        string midxLockFile = Path.Combine(this.context.Enlistment.GitPackRoot, "multi-pack-index.lock");
+                        string midxLockFile = Path.Combine(this.context.Enlistment.GitPackRoot, MultiPackIndexLock);
                         this.context.FileSystem.TryDeleteFile(midxLockFile);
 
                         if (this.stopping)
@@ -617,7 +619,7 @@ namespace GVFS.Virtualization
 
                     using (ITracer activity = this.context.Tracer.StartActivity("TryWriteGitCommitGraph", EventLevel.Informational, Keywords.Telemetry, metadata: null))
                     {
-                        string graphLockFile = Path.Combine(this.context.Enlistment.GitObjectsRoot, "info", "commit-graph.lock");
+                        string graphLockFile = Path.Combine(this.context.Enlistment.GitObjectsRoot, "info", CommitGraphLock);
                         this.context.FileSystem.TryDeleteFile(graphLockFile);
 
                         if (this.stopping)


### PR DESCRIPTION
Before writing commit-graph or multi-pack-index, delete the .lock
file that prevents Git from writing to those files. This will
unblock users who have a stale .lock file from a previous early
termination (BSOD, process kill due to unmount, etc.). If the
Git commands are terminating due to legitimate problems, then their
logs will be filled with the correct error instead of a message
about a .lock file preventing the write.

Both of these commands are maintenance commands that users should
not be writing on their own, and we do them under our own file-
based lock.