### PR TITLE
GitProcess: return true when process is null

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -133,8 +133,9 @@ namespace GVFS.Common.Git
                     if (process != null)
                     {
                         process.Kill();
-                        return true;
                     }
+
+                    return true;
                 }
             }
             catch (Win32Exception)


### PR DESCRIPTION
In #420, we changed how we stopped the background process. However, there was a gap: if the `Process` was `null`, then we returned `false`, causing extra error messages. This fixes that problem and avoids the noise in the logs on unmount.