### PR TITLE
Modify PrepFunctionalTests.sh to work out of the output directories

### DIFF
--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -45,13 +45,8 @@ echo 'Copying native binaries to Publish directory...'
 cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.ReadObjectHook $VFS_PUBLISHDIR || exit 1
 cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.VirtualFileSystemHook $VFS_PUBLISHDIR || exit 1
 
-echo 'Copying Git installer to Publish directory...'
-GITPUBLISH=$VFS_PUBLISHDIR/Git
-if [[ -d $GITPUBLISH ]] ; then
-  rm -rf $GITPUBLISH
-fi
-mkdir $GITPUBLISH
-cp $GITPATH $GITPUBLISH
+echo 'Copying Git installer to the output directory...'
+$VFS_SCRIPTDIR/PublishGit.sh $GITPATH || exit 1
 
 echo 'Running VFS for Git unit tests...'
 $VFS_PUBLISHDIR/GVFS.UnitTests || exit 1

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -45,4 +45,13 @@ echo 'Copying native binaries to Publish directory...'
 cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.ReadObjectHook $VFS_PUBLISHDIR || exit 1
 cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.VirtualFileSystemHook $VFS_PUBLISHDIR || exit 1
 
+echo 'Copying Git installer to Publish directory...'
+GITPUBLISH=$VFS_PUBLISHDIR/Git
+if [[ -d $GITPUBLISH ]] ; then
+  rm -rf $GITPUBLISH
+fi
+mkdir $GITPUBLISH
+cp $GITPATH $GITPUBLISH
+
+echo 'Running VFS for Git unit tests...'
 $VFS_PUBLISHDIR/GVFS.UnitTests || exit 1

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -6,7 +6,7 @@
 $VFS_SRCDIR/ProjFS.Mac/Scripts/UnloadPrjFSKext.sh
 
 # Install GVFS-aware Git (that was published by the build script)
-GITPUBLISH=$VFS_PUBLISHDIR/Git
+GITPUBLISH=$VFS_OUTPUTDIR/Git
 if [[ ! -d $GITPUBLISH ]]; then
     echo "GVFS-aware Git package not found. Run BuildGVFSForMac.sh and try again"
     exit 1

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -5,14 +5,13 @@
 # Ensure the kext isn't loaded before installing Git
 $VFS_SRCDIR/ProjFS.Mac/Scripts/UnloadPrjFSKext.sh
 
-# Install GVFS-aware Git (that was downloaded by the build script)
-GITVERSION="$($SCRIPTDIR/GetGitVersionNumber.sh)"
-GITDIR=$VFS_PACKAGESDIR/gitformac.gvfs.installer/$GITVERSION/tools
-if [[ ! -d $GITDIR ]]; then
+# Install GVFS-aware Git (that was published by the build script)
+GITPUBLISH=$VFS_PUBLISHDIR/Git
+if [[ ! -d $GITPUBLISH ]]; then
     echo "GVFS-aware Git package not found. Run BuildGVFSForMac.sh and try again"
     exit 1
 fi
-hdiutil attach $GITDIR/*.dmg || exit 1
+hdiutil attach $GITPUBLISH/*.dmg || exit 1
 GITPKG="$(find /Volumes/Git* -type f -name *.pkg)" || exit 1
 sudo installer -pkg "$GITPKG" -target / || exit 1
 hdiutil detach /Volumes/Git*

--- a/Scripts/Mac/PublishGit.sh
+++ b/Scripts/Mac/PublishGit.sh
@@ -1,0 +1,15 @@
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+GITPATH=$1
+INSTALLER=$(basename $GITPATH)
+
+GITPUBLISH=$VFS_OUTPUTDIR/Git
+if [[ ! -d $GITPUBLISH ]] ; then
+  mkdir $GITPUBLISH
+fi
+
+find $GITPUBLISH -type f ! -name $INSTALLER -delete
+
+if [[ ! -e $GITPUBLISH/$INSTALLER ]] ; then
+  cp $GITPATH $GITPUBLISH
+fi

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -7,12 +7,6 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
-SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
-
-SRCDIR=$SCRIPTDIR/../..
-ROOTDIR=$SRCDIR/..
-PUBLISHDIR=$ROOTDIR/Publish
-
 sudo mkdir /GVFS.FT
 sudo chown $USER /GVFS.FT
 


### PR DESCRIPTION
Simplify PrepFunctionalTests by offloading determining exactly which version to install to the build script. PrepFunctionalTests will now assume the one-and-only dmg it finds in $VFS_PUBLISHDIR/Git is the version that needs to be installed to run the tests for $VFS_PUBLISHDIR

This refactoring will help support creating a minimal "functional test enlistment" for Mac.