### PR TITLE
Mac PrjFSLib: Use IOSharedDataQueue workaround library if available

### DIFF
--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -215,7 +215,7 @@ PrjFS_Result PrjFS_StartVirtualizationInstance(
         
         while (1)
         {
-            IODataQueueEntry* entry = IODataQueuePeek(dataQueue.queueMemory);
+            IODataQueueEntry* entry = DataQueue_Peek(dataQueue.queueMemory);
             if (nullptr == entry)
             {
                 // No more items in queue
@@ -226,13 +226,13 @@ PrjFS_Result PrjFS_StartVirtualizationInstance(
             if (messageSize < sizeof(Message))
             {
                 cerr << "Bad message size: got " << messageSize << " bytes, expected minimum of " << sizeof(Message) << ", skipping. Kernel/user version mismatch?\n";
-                IODataQueueDequeue(dataQueue.queueMemory, nullptr, nullptr);
+                DataQueue_Dequeue(dataQueue.queueMemory, nullptr, nullptr);
                 continue;
             }
             
             void* messageMemory = malloc(messageSize);
             uint32_t dequeuedSize = messageSize;
-            IOReturn result = IODataQueueDequeue(dataQueue.queueMemory, messageMemory, &dequeuedSize);
+            IOReturn result = DataQueue_Dequeue(dataQueue.queueMemory, messageMemory, &dequeuedSize);
             if (kIOReturnSuccess != result || dequeuedSize != messageSize)
             {
                 cerr << "Unexpected result dequeueing message - result 0x" << hex << result << " dequeued " << dequeuedSize << "/" << messageSize << " bytes\n";

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
@@ -23,3 +23,6 @@ bool PrjFSService_DataQueueInit(
     uint32_t clientPortType,
     uint32_t clientMemoryType,
     dispatch_queue_t eventHandlingQueue);
+
+IODataQueueEntry* DataQueue_Peek(IODataQueueMemory* dataQueue);
+IOReturn DataQueue_Dequeue(IODataQueueMemory* dataQueue, void* data, uint32_t* dataSize);

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char * argv[])
         
         while(true)
         {
-            IODataQueueEntry* entry = IODataQueuePeek(dataQueue.queueMemory);
+            IODataQueueEntry* entry = DataQueue_Peek(dataQueue.queueMemory);
             if(entry == nullptr)
             {
                 break;
@@ -65,7 +65,7 @@ int main(int argc, const char * argv[])
                 lineCount++;
             }
             
-            IODataQueueDequeue(dataQueue.queueMemory, nullptr, nullptr);
+            DataQueue_Dequeue(dataQueue.queueMemory, nullptr, nullptr);
         }
     });
     dispatch_resume(dataQueue.dispatchSource);


### PR DESCRIPTION
This allows the Mac PrjFSLib native library and prjfs-log tool to use fixed versions of the `IODataQueueDequeue()` and `IODataQueuePeek()` functions which suffer from severe regressions in macOS 10.13.6 and 10.14. (Darwin 17.7.0 and 18.0)

Assuming you have a [dynamic library containing alternate versions of the aforementioned functions](https://github.com/pmj/SharedDataQueue) and place it in the library search path as "libSharedDataQueue.dylib", this change will cause PrjFSLib and prjfs-log load that library and use the versions of the aforementioned functions it provides instead of the OS's IOKit.framework's.