### PR TITLE
Mac: Revisit DiffHelperTests parameterization to follow NUnit documentation.

### DIFF
--- a/GVFS/GVFS.Tests/DataSources.cs
+++ b/GVFS/GVFS.Tests/DataSources.cs
@@ -1,0 +1,18 @@
+﻿using System;
+namespace GVFS.Tests
+{
+    public class DataSources
+    {
+        public static object[] AllBools
+        {
+            get
+            {
+                return new object[]
+                {
+                     new object[] { true },
+                     new object[] { false },
+                };
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common.Git;
 using GVFS.Common.Prefetch.Git;
+using GVFS.Tests;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
@@ -11,29 +12,16 @@ using System.Reflection;
 
 namespace GVFS.UnitTests.Prefetch
 {
-    [TestFixtureSource(TestRunners)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     public class DiffHelperTests
     {
-        public const string TestRunners = "Runners";
-
-        private static readonly bool[] SymLinkSupport = new bool[]
-        {
-            true,
-            false,
-        };
-
         public DiffHelperTests(bool symLinkSupport)
         {
             this.IncludeSymLinks = symLinkSupport;
         }
 
-        public static bool[] Runners
-        {
-            get { return SymLinkSupport; }
-        }
-
         public bool IncludeSymLinks { get; set; }
-
+        
         // Make two commits. The first should look like this:
         // recursiveDelete
         // recursiveDelete/subfolder


### PR DESCRIPTION
In code reviewing #408, I discovered that my parameterization of DiffHelperTests doesn't follow the documented process for doing this:
https://github.com/nunit/docs/wiki/TestFixtureSource-Attribute
```
The single attribute argument in this form is a string representing the name of the source used to provide arguments for constructing the TestFixture. It has the following characteristics:

- It may be a field, property or method in the test class.
- It must be static.
- It must return an IEnumerable or a type that implements IEnumerable. For fields an array is generally used. For properties and methods, you may return an array or implement your own iterator.
- The individual items returned by the enumerator must either be object arrays or derive from the TestFixtureParameters class. Arguments must be consistent with the fixture constructor.

```


Change bool[] to object[].
Note that bool[] works fine today, but we've had issues with NUnit in the past that have gone away after making this change.