### PR TITLE
Mac: Consume libSharedDataQueue.dylib

### DIFF
--- a/Scripts/Mac/DownloadGVFSGit.sh
+++ b/Scripts/Mac/DownloadGVFSGit.sh
@@ -3,5 +3,5 @@
 BUILDDIR=$VFS_OUTPUTDIR/GVFS.Build
 GITVERSION="$($VFS_SCRIPTDIR/GetGitVersionNumber.sh)"
 cp $VFS_SRCDIR/nuget.config $BUILDDIR
-dotnet new classlib -n GVFS.Restore -o $BUILDDIR --force
-dotnet add $BUILDDIR/GVFS.Restore.csproj package --package-directory $VFS_PACKAGESDIR GitForMac.GVFS.Installer --version $GITVERSION
+dotnet new classlib -n Restore.GitInstaller -o $BUILDDIR --force
+dotnet add $BUILDDIR/Restore.GitInstaller.csproj package --package-directory $VFS_PACKAGESDIR GitForMac.GVFS.Installer --version $GITVERSION

--- a/Scripts/Mac/InstallSharedDataQueueDylib.sh
+++ b/Scripts/Mac/InstallSharedDataQueueDylib.sh
@@ -1,0 +1,9 @@
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+BUILDDIR=$VFS_OUTPUTDIR/GVFS.Build
+cp $VFS_SRCDIR/nuget.config $BUILDDIR
+dotnet new classlib -n GVFS.Restore -o $BUILDDIR --force
+dotnet add $BUILDDIR/GVFS.Restore.csproj package --package-directory $VFS_PACKAGESDIR SharedDataQueueDylib --version '1.0.0'
+
+# DYLD_LIBRARY_PATH contains /usr/local/lib by default, so we'll copy this library there.
+cp $VFS_PACKAGESDIR/shareddataqueuedylib/1.0.0/libSharedDataQueue.dylib /usr/local/lib

--- a/Scripts/Mac/InstallSharedDataQueueDylib.sh
+++ b/Scripts/Mac/InstallSharedDataQueueDylib.sh
@@ -1,9 +1,0 @@
-. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
-
-BUILDDIR=$VFS_OUTPUTDIR/GVFS.Build
-cp $VFS_SRCDIR/nuget.config $BUILDDIR
-dotnet new classlib -n GVFS.Restore -o $BUILDDIR --force
-dotnet add $BUILDDIR/GVFS.Restore.csproj package --package-directory $VFS_PACKAGESDIR SharedDataQueueDylib --version '1.0.0'
-
-# DYLD_LIBRARY_PATH contains /usr/local/lib by default, so we'll copy this library there.
-cp $VFS_PACKAGESDIR/shareddataqueuedylib/1.0.0/libSharedDataQueue.dylib /usr/local/lib

--- a/Scripts/Mac/InstallSharedDataQueueStallWorkaround.sh
+++ b/Scripts/Mac/InstallSharedDataQueueStallWorkaround.sh
@@ -1,0 +1,9 @@
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+BUILDDIR=$VFS_OUTPUTDIR/GVFS.Build
+cp $VFS_SRCDIR/nuget.config $BUILDDIR
+dotnet new classlib -n Restore.SharedDataQueueStallWorkaround -o $BUILDDIR --force
+dotnet add $BUILDDIR/Restore.SharedDataQueueStallWorkaround.csproj package --package-directory $VFS_PACKAGESDIR SharedDataQueueStallWorkaround --version '1.0.0'
+
+# DYLD_LIBRARY_PATH contains /usr/local/lib by default, so we'll copy this library there.
+cp $VFS_PACKAGESDIR/shareddataqueuestallworkaround/1.0.0/libSharedDataQueue.dylib /usr/local/lib

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -37,7 +37,7 @@ fi
 
 git-credential-manager install
 
-$VFS_SCRIPTDIR/InstallSharedDataQueueDylib.sh || exit 1
+$VFS_SCRIPTDIR/InstallSharedDataQueueStallWorkaround.sh || exit 1
 
 # If we're running on an agent where the PAT environment variable is set and a URL is passed into the script, add it to the keychain.
 PATURL=$1

--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -37,6 +37,8 @@ fi
 
 git-credential-manager install
 
+$VFS_SCRIPTDIR/InstallSharedDataQueueDylib.sh || exit 1
+
 # If we're running on an agent where the PAT environment variable is set and a URL is passed into the script, add it to the keychain.
 PATURL=$1
 PAT=$2


### PR DESCRIPTION
#429 updated our code to be able to consume both the system provided IOSharedDataQueue and libSharedDataQueue.dylib (which is needed to work around issues described in #161 that effect MacOS <10.14.1). 

This PR adds a script to consume that dylib via a NuGet package and puts it into DYLD_LIBRARY_PATH to be found by dlopen.

For now, we'll call this script as part of PrepFunctionalTests.sh to ensure everyone is on a healthy version of the library. When 10.14.1 is officially released and all of our machines are updated, we can consider removing this call. 