### PR TITLE
FastFetch: properly handle items with special tokens in path

### DIFF
--- a/GVFS/GVFS.Common/Prefetch/Git/GitIndexGenerator.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/GitIndexGenerator.cs
@@ -252,11 +252,10 @@ namespace GVFS.Common.Prefetch.Git
 
             public static LsTreeEntry ParseFromLsTreeLine(string line)
             {
-                int blobIndex = line.IndexOf(DiffTreeResult.BlobMarker);
-                if (blobIndex >= 0)
+                if (DiffTreeResult.IsLsTreeLineOfType(line, DiffTreeResult.BlobMarker))
                 {
                     LsTreeEntry blobEntry = new LsTreeEntry();
-                    blobEntry.Sha = line.Substring(blobIndex + DiffTreeResult.BlobMarker.Length, GVFSConstants.ShaStringLength);
+                    blobEntry.Sha = line.Substring(DiffTreeResult.TypeMarkerStartIndex + DiffTreeResult.BlobMarker.Length, GVFSConstants.ShaStringLength);
                     blobEntry.Filename = GitPathConverter.ConvertPathOctetsToUtf8(line.Substring(line.LastIndexOf("\t") + 1).Trim('"'));
 
                     return blobEntry;

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffTreeResultTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffTreeResultTests.cs
@@ -15,7 +15,9 @@ namespace GVFS.UnitTests.Prefetch
         private const string EmptySha1 = "0000000000000000000000000000000000000000";
 
         private const string TestTreePath1 = "Test/GVFS";
+        private const string TestTreePath2 = "Test/directory with blob and spaces";
         private const string TestBlobPath1 = "Test/file with spaces.txt";
+        private const string TestBlobPath2 = "Test/file with tree and spaces.txt";
         private static readonly string RepoRoot = Path.Combine("C:", "root");
 
         private static readonly string MissingColonLineFromDiffTree = $"040000 040000 {TestSha1} {Test2Sha1} M\t{TestTreePath1}";
@@ -31,7 +33,9 @@ namespace GVFS.UnitTests.Prefetch
         private static readonly string AddBlobLineFromDiffTree = $":000000 100644 {EmptySha1} {Test2Sha1} A\t{TestBlobPath1}";
 
         private static readonly string BlobLineFromLsTree = $"100644 blob {TestSha1}\t{TestTreePath1}";
+        private static readonly string BlobLineWithTreePathFromLsTree = $"100644 blob {TestSha1}\t{TestBlobPath2}";
         private static readonly string TreeLineFromLsTree = $"040000 tree {TestSha1}\t{TestTreePath1}";
+        private static readonly string TreeLineWithBlobPathFromLsTree = $"040000 tree {TestSha1}\t{TestTreePath2}";
         private static readonly string InvalidLineFromLsTree = $"040000 bad {TestSha1}\t{TestTreePath1}";
         private static readonly string SymLinkLineFromLsTree = $"120000 blob {TestSha1}\t{TestTreePath1}";
 
@@ -317,6 +321,52 @@ namespace GVFS.UnitTests.Prefetch
 
             DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(SymLinkLineFromLsTree, RepoRoot);
             this.ValidateDiffTreeResult(expected, result);
+        }
+
+        [TestCase]
+        public void ParseFromDiffTreeLine_TreeLineWithBlobPath()
+        {
+            DiffTreeResult expected = new DiffTreeResult()
+            {
+                Operation = DiffTreeResult.Operations.Add,
+                SourceIsDirectory = false,
+                TargetIsDirectory = true,
+                TargetPath = CreateTreePath(TestTreePath2),
+                SourceSha = null,
+                TargetSha = null
+            };
+
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(TreeLineWithBlobPathFromLsTree, RepoRoot);
+            this.ValidateDiffTreeResult(expected, result);
+        }
+
+        [TestCase]
+        public void ParseFromDiffTreeLine_BlobLineWithTreePath()
+        {
+            DiffTreeResult expected = new DiffTreeResult()
+            {
+                Operation = DiffTreeResult.Operations.Add,
+                SourceIsDirectory = false,
+                TargetIsDirectory = false,
+                TargetPath = Path.Combine(RepoRoot, TestBlobPath2.Replace('/', Path.DirectorySeparatorChar)),
+                SourceSha = null,
+                TargetSha = TestSha1
+            };
+
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineWithTreePathFromLsTree, RepoRoot);
+            this.ValidateDiffTreeResult(expected, result);
+        }
+
+        [TestCase("040000 tree 73b881d52b607b0f3e9e620d36f556d3d233a11d\tGVFS", DiffTreeResult.TreeMarker, true)]
+        [TestCase("040000 tree 73b881d52b607b0f3e9e620d36f556d3d233a11d\tGVFS", DiffTreeResult.BlobMarker, false)]
+        [TestCase("100644 blob 44c5f5cba4b29d31c2ad06eed51ea02af76c27c0\tReadme.md", DiffTreeResult.BlobMarker, true)]
+        [TestCase("100755 blob 196142fbb753c0a3c7c6690323db7aa0a11f41ec\tScripts / BuildGVFSForMac.sh", DiffTreeResult.BlobMarker, true)]
+        [TestCase("100755 blob 196142fbb753c0a3c7c6690323db7aa0a11f41ec\tScripts / BuildGVFSForMac.sh", DiffTreeResult.BlobMarker, true)]
+        [TestCase("100755 blob 196142fbb753c0a3c7c6690323db7aa0a11f41ec\tScripts / tree file.txt", DiffTreeResult.TreeMarker, false)]
+        [TestCase("100755 ", DiffTreeResult.TreeMarker, false)]
+        public void TestGetIndexOfTypeMarker(string line, string typeMarker, bool expectedResult)
+        {
+            DiffTreeResult.IsLsTreeLineOfType(line, typeMarker).ShouldEqual(expectedResult);
         }
 
         private static string CreateTreePath(string testPath)


### PR DESCRIPTION
This is a fix for an internally reported issue where FastFetch
created a directory for a file that contained the string " tree ".

FastFetch does not correctly handle paths with certain text. For
example, if a file includes the string " tree ", then FastFetch will
consider this a tree entry, and will create a directory for it.

This change it to only look at the type field from ls-tree when
determining the type of entry.