### PR TITLE
Mac: Run GitRepoTests with and without validating the working directory during setup

### DIFF
--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
@@ -28,7 +28,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             TruncateExisting = 5  // TRUNCATE_EXISTING
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void CaseOnlyRenameEmptyVirtualNTFSFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -50,7 +50,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             newFolderVirtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void CaseOnlyRenameToAllCapsEmptyVirtualNTFSFolder(FileSystemRunner fileSystem)
         {
             string testFolderName = Path.Combine("test_folder");
@@ -72,7 +72,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             newFolderVirtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void CaseOnlyRenameTopOfVirtualNTFSFolderTree(FileSystemRunner fileSystem)
         {
             string testFolderParent = "test_folder_parent";
@@ -117,7 +117,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             this.Enlistment.GetVirtualPathTo(relativeTestFilePath).ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void CaseOnlyRenameFullDotGitFolder(FileSystemRunner fileSystem)
         {
             string testFolderName = ".git\\test_folder";
@@ -139,7 +139,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             newFolderVirtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void CaseOnlyRenameTopOfDotGitFullFolderTree(FileSystemRunner fileSystem)
         {
             string testFolderParent = ".git\\test_folder_parent";
@@ -181,7 +181,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             this.Enlistment.GetVirtualPathTo(Path.Combine(".git", newFolderParentName)).ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void StreamAccessReadFromMemoryMappedVirtualNTFSFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -221,7 +221,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void RandomAccessReadFromMemoryMappedVirtualNTFSFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -267,7 +267,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void StreamAccessReadWriteFromMemoryMappedVirtualNTFSFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -335,7 +335,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void RandomAccessReadWriteFromMemoryMappedVirtualNTFSFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -405,7 +405,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void StreamAccessToExistingMemoryMappedFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -474,7 +474,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void RandomAccessToExistingMemoryMappedFile(string parentFolder)
         {
             // Use SystemIORunner as the text we are writing is too long to pass to the command line
@@ -543,7 +543,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void NativeReadAndWriteSeparateHandles(string parentFolder)
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -557,7 +557,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void NativeReadAndWriteSameHandle(string parentFolder)
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -575,7 +575,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void NativeReadAndWriteRepeatedly(string parentFolder)
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -593,7 +593,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void NativeRemoveReadOnlyAttribute(string parentFolder)
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
@@ -607,7 +607,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         public void NativeCannotWriteToReadOnlyFile(string parentFolder)
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -5,11 +5,6 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 {
     public abstract class FileSystemRunner
     {
-        /// <summary>
-        /// String that identifies which list to use when running tests
-        /// </summary>
-        public const string TestRunners = "Runners";
-
         private static FileSystemRunner defaultRunner = new SystemIORunner();
 
         public static object[] AllWindowsRunners { get; } = 

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -12,6 +12,8 @@ namespace GVFS.FunctionalTests
         
         public static object[] FileSystemRunners { get; set; }
 
+        public static object[] GitCommandTestWorkTreeValidation { get; set; }
+
         public static bool TestGVFSOnPath { get; set; }
 
         public static bool ReplaceInboxProjFS { get; set; }

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -12,6 +12,8 @@ namespace GVFS.FunctionalTests
         
         public static object[] FileSystemRunners { get; set; }
 
+        public static object[] GitRepoTestsValidateWorkTree { get; set; }
+
         public static bool TestGVFSOnPath { get; set; }
 
         public static bool ReplaceInboxProjFS { get; set; }

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -12,8 +12,6 @@ namespace GVFS.FunctionalTests
         
         public static object[] FileSystemRunners { get; set; }
 
-        public static object[] GitCommandTestWorkTreeValidation { get; set; }
-
         public static bool TestGVFSOnPath { get; set; }
 
         public static bool ReplaceInboxProjFS { get; set; }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.FunctionalTests.Tests;
 using GVFS.FunctionalTests.Tools;
+using GVFS.FunctionalTests.Tests.GitCommands;
 using GVFS.Tests;
 using System;
 using System.Collections.Generic;
@@ -43,6 +44,13 @@ namespace GVFS.FunctionalTests
             {
                 Console.WriteLine("Running the full suite of tests");
 
+                GVFSTestConfig.GitCommandTestWorkTreeValidation =
+                new object[]
+                {
+                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.ValidateWorkingTree },
+                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.DoNotValidateWorkingTree }
+                };
+
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllWindowsRunners;
@@ -51,11 +59,17 @@ namespace GVFS.FunctionalTests
                 {
                     GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllMacRunners;
                 }
+
             }
             else
             {
                 excludeCategories.Add(Categories.FullSuiteOnly);
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
+                GVFSTestConfig.GitCommandTestWorkTreeValidation = 
+                new object[] 
+                { 
+                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.ValidateWorkingTree } 
+                };
             }
 
             if (runner.HasCustomArg("--windows-only"))

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -1,5 +1,4 @@
 ﻿using GVFS.FunctionalTests.Tests;
-using GVFS.FunctionalTests.Tests.GitCommands;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests;
 using System;
@@ -44,13 +43,6 @@ namespace GVFS.FunctionalTests
             {
                 Console.WriteLine("Running the full suite of tests");
 
-                GVFSTestConfig.GitCommandTestWorkTreeValidation =
-                new object[]
-                {
-                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.ValidateWorkingTree },
-                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.DoNotValidateWorkingTree }
-                };
-
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllWindowsRunners;
@@ -64,11 +56,6 @@ namespace GVFS.FunctionalTests
             {
                 excludeCategories.Add(Categories.FullSuiteOnly);
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
-                GVFSTestConfig.GitCommandTestWorkTreeValidation = 
-                new object[] 
-                { 
-                    new object[] { GitRepoTests.ValidateWorkingTreeOptions.ValidateWorkingTree } 
-                };
             }
 
             if (runner.HasCustomArg("--windows-only"))

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -43,6 +43,8 @@ namespace GVFS.FunctionalTests
             {
                 Console.WriteLine("Running the full suite of tests");
 
+                GVFSTestConfig.GitRepoTestsValidateWorkTree = DataSources.AllBools;
+
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllWindowsRunners;
@@ -54,6 +56,12 @@ namespace GVFS.FunctionalTests
             }
             else
             {
+                GVFSTestConfig.GitRepoTestsValidateWorkTree = 
+                    new object[] 
+                    { 
+                        new object[] { true } 
+                    };
+            
                 excludeCategories.Add(Categories.FullSuiteOnly);
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -1,6 +1,6 @@
 ﻿using GVFS.FunctionalTests.Tests;
-using GVFS.FunctionalTests.Tools;
 using GVFS.FunctionalTests.Tests.GitCommands;
+using GVFS.FunctionalTests.Tools;
 using GVFS.Tests;
 using System;
 using System.Collections.Generic;
@@ -59,7 +59,6 @@ namespace GVFS.FunctionalTests
                 {
                     GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllMacRunners;
                 }
-
             }
             else
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -1,4 +1,4 @@
-using GVFS.FunctionalTests.FileSystemRunners;
+﻿using GVFS.FunctionalTests.FileSystemRunners;
 using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tests.EnlistmentPerFixture;
 using GVFS.FunctionalTests.Tools;
@@ -19,7 +19,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         private const int FileAttributeReparsePoint = 0x00000400;
         private const int FileAttributeRecallOnDataAccess = 0x00400000;
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void ShrinkFileContents(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "ShrinkFileContents");
@@ -35,7 +35,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void GrowFileContents(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "GrowFileContents");
@@ -51,7 +51,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void FilesAreBufferedAndCanBeFlushed(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "FilesAreBufferedAndCanBeFlushed");
@@ -78,7 +78,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             fileSystem.DeleteFile(filePath);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         [Category(Categories.WindowsOnly)]
         public void NewFileAttributesAreUpdated(string parentFolder)
         {
@@ -106,7 +106,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             virtualFile.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         [Category(Categories.WindowsOnly)]
         public void NewFolderAttributesAreUpdated(string parentFolder)
         {
@@ -201,7 +201,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
                 .WithInfo(testValue, testValue, testValue, FileAttributes.Hidden | FileAttributes.Directory, ignoreRecallAttributes: true);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void CannotWriteToReadOnlyFile(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "CannotWriteToReadOnlyFile");
@@ -228,7 +228,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void ReadonlyCanBeSetAndUnset(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "ReadonlyCanBeSetAndUnset");
@@ -252,7 +252,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, filename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void ChangeVirtualNTFSFileNameCase(FileSystemRunner fileSystem, string parentFolder)
         {
             string oldFilename = Path.Combine(parentFolder, "ChangePhysicalFileNameCase.txt");
@@ -273,7 +273,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, newFilename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void ChangeVirtualNTFSFileName(FileSystemRunner fileSystem, string parentFolder)
         {
             string oldFilename = Path.Combine(parentFolder, "ChangePhysicalFileName.txt");
@@ -294,7 +294,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, newFilename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFileToVirtualNTFSFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -324,7 +324,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, testFolderName, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void MoveWorkingDirectoryFileToDotGitFolder(FileSystemRunner fileSystem)
         {
             string testFolderName = ".git";
@@ -346,7 +346,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             newTestFileVirtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void MoveDotGitFileToWorkingDirectoryFolder(FileSystemRunner fileSystem)
         {
             string testFolderName = "test_folder";
@@ -375,7 +375,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             this.Enlistment.GetVirtualPathTo(testFolderName).ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFileToOverwriteVirtualNTFSFile(FileSystemRunner fileSystem, string parentFolder)
         {
             string targetFilename = Path.Combine(parentFolder, "TargetFile.txt");
@@ -401,7 +401,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, targetFilename, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFileToInvalidFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -425,7 +425,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, testFileName, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void DeletedFilesCanBeImmediatelyRecreated(FileSystemRunner fileSystem, string parentFolder)
         {
             string filename = Path.Combine(parentFolder, "DeletedFilesCanBeImmediatelyRecreated");
@@ -447,7 +447,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         // WindowsOnly due to differences between POSIX and Windows delete
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestCanDeleteFilesWhileTheyAreOpenRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.CanDeleteFilesWhileTheyAreOpenRunners))]
         [Category(Categories.WindowsOnly)]
         public void CanDeleteFilesWhileTheyAreOpen(FileSystemRunner fileSystem, string parentFolder)
         {
@@ -514,6 +514,8 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             virtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
+        // WindowsOnly because file timestamps on Mac are set to the time at which
+        // placeholders are written
         [TestCase]
         [Category(Categories.WindowsOnly)]
         public void ProjectedBlobFileTimesMatchHead()
@@ -562,7 +564,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             folderInfo.LastWriteTime.ShouldBeAtMost(DateTime.Now);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void NonExistentItemBehaviorIsCorrect(FileSystemRunner fileSystem, string parentFolder)
         {
             string nonExistentItem = Path.Combine(parentFolder, "BadFolderName");
@@ -584,7 +586,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             // fileSystem.ReplaceDirectoryShouldNotBeFound(nonExistentItem, true)
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void RenameEmptyVirtualNTFSFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -606,7 +608,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             newFolderVirtualPath.ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFolderIntoVirtualNTFSFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -642,7 +644,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, targetFolderName, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void RenameAndMoveVirtualNTFSFolderIntoVirtualNTFSFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderName = Path.Combine(parentFolder, "test_folder");
@@ -679,7 +681,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, targetFolderName, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void MoveVirtualNTFSFolderTreeIntoVirtualNTFSFolder(FileSystemRunner fileSystem)
         {
             string testFolderParent = "test_folder_parent";
@@ -743,7 +745,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             this.Enlistment.GetVirtualPathTo(relativeTestFilePath).ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void MoveDotGitFullFolderTreeToDotGitFullFolder(FileSystemRunner fileSystem)
         {
             string testFolderRoot = ".git";
@@ -808,7 +810,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             this.Enlistment.GetVirtualPathTo(relativeTestFilePath).ShouldNotExistOnDisk(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void DeleteIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));
@@ -817,7 +819,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             indexFilePath.ShouldBeAFile(fileSystem);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestRunners)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFolderIntoInvalidFolder(FileSystemRunner fileSystem, string parentFolder)
         {
             string testFolderParent = Path.Combine(parentFolder, "test_folder_parent");
@@ -865,7 +867,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileRunnersAndFolders.ShouldNotExistOnDisk(this.Enlistment, fileSystem, relativeTestFilePath, parentFolder);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         [Category(Categories.WindowsOnly)]
         public void CreateFileInheritsParentDirectoryAttributes(string parentFolder)
         {
@@ -882,7 +884,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileSystemRunner.DefaultRunner.DeleteDirectory(parentDirectoryPath);
         }
 
-        [TestCaseSource(typeof(FileRunnersAndFolders), FileRunnersAndFolders.TestFolders)]
+        [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Folders))]
         [Category(Categories.WindowsOnly)]
         public void CreateDirectoryInheritsParentDirectoryAttributes(string parentFolder)
         {
@@ -901,10 +903,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
 
         private class FileRunnersAndFolders
         {
-            public const string TestFolders = "Folders";
-            public const string TestRunners = "Runners";
-            public const string TestCanDeleteFilesWhileTheyAreOpenRunners = "CanDeleteFilesWhileTheyAreOpenRunners";
-            public const string DotGitFolder = ".git";
+            private const string DotGitFolder = ".git";
 
             private static object[] allFolders =
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class GitFilesTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     [Category(Categories.GitCommands)]
     public class GitMoveRenameTests : TestsWithEnlistmentPerFixture
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -64,7 +64,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.MountGVFS();
             string expectedHooksPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "hooks");
-            expectedHooksPath = expectedHooksPath.Replace("\\", "/");
+            expectedHooksPath = GitHelpers.ConvertPathToGitFormat(expectedHooksPath);
 
             GitProcess.Invoke(
                 this.Enlistment.RepoRoot, "config core.hookspath")

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
@@ -9,7 +9,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class MoveRenameFileTests : TestsWithEnlistmentPerFixture
     {
         public const string TestFileContents =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
@@ -7,7 +7,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     // TODO 452590 - Combine all of the MoveRenameTests into a single fixture, and have each use different
     // well known files
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class MoveRenameFileTests_2 : TestsWithEnlistmentPerFixture
     {
         private const string TestFileFolder = "Test_EPF_MoveRenameFileTests_2";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class MoveRenameFolderTests : TestsWithEnlistmentPerFixture
     {       
         private const string TestFileContents =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -1,4 +1,4 @@
-using GVFS.FunctionalTests.FileSystemRunners;
+﻿using GVFS.FunctionalTests.FileSystemRunners;
 using GVFS.FunctionalTests.Should;
 using GVFS.Tests.Should;
 using NUnit.Framework;
@@ -109,7 +109,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         [Order(3)]
         public void CanReadWriteAFileInParallel(FileSystemRunner fileSystem)
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixtureSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class WorkingDirectoryTests : TestsWithEnlistmentPerFixture
     {
         public const string TestFileContents =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -40,7 +40,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
                 $"A {FolderToDelete}/",
             };
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void DeletedTempFileIsRemovedFromModifiedFiles(FileSystemRunner fileSystem)
         {
             string tempFile = this.CreateFile(fileSystem, "temp.txt");
@@ -50,7 +50,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, fileSystem, "temp.txt");
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void DeletedTempFolderIsRemovedFromModifiedFiles(FileSystemRunner fileSystem)
         {
             string tempFolder = this.CreateDirectory(fileSystem, "Temp");
@@ -60,7 +60,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, fileSystem, "Temp/");
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void DeletedTempFolderDeletesFilesFromModifiedFiles(FileSystemRunner fileSystem)
         {
             string tempFolder = this.CreateDirectory(fileSystem, "Temp");
@@ -75,7 +75,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         }
 
         [Category(Categories.MacTODO.NeedsRenameOldPath)]
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void ModifiedPathsSavedAfterRemount(FileSystemRunner fileSystem)
         {
             string fileToAdd = this.Enlistment.GetVirtualPathTo(FileToAdd);
@@ -156,7 +156,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             }
         }
 
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void ModifiedPathsCorrectAfterHardLinking(FileSystemRunner fileSystem)
         {
             string[] expectedModifiedFilesContentsAfterHardlinks =

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
@@ -11,7 +11,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
     [Category(Categories.FullSuiteOnly)]
     public class PersistedWorkingDirectoryTests : TestsWithEnlistmentPerTestCase
     {
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void PersistedDirectoryLazyLoad(FileSystemRunner fileSystem)
         {
             string enumerateDirectoryName = Path.Combine("GVFS", "GVFS");
@@ -68,7 +68,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         /// test persistence, we want to save as much time in tests runs as possible by only
         /// remounting once.
         /// </summary>
-        [TestCaseSource(typeof(FileSystemRunner), FileSystemRunner.TestRunners)]
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void PersistedDirectoryTests(FileSystemRunner fileSystem)
         {
             // Delete File Setup

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -1,15 +1,16 @@
 ﻿using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class AddStageTests : GitRepoTests
     {
-        public AddStageTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public AddStageTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -5,11 +5,12 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class AddStageTests : GitRepoTests
     {
-        public AddStageTests() : base(enlistmentPerTest: false)
+        public AddStageTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -1,12 +1,11 @@
 ﻿using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class AddStageTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using NUnit.Framework;
@@ -11,11 +12,11 @@ using System.Threading.Tasks;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class CheckoutTests : GitRepoTests
     {
-        public CheckoutTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public CheckoutTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -11,11 +11,12 @@ using System.Threading.Tasks;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class CheckoutTests : GitRepoTests
     {
-        public CheckoutTests() : base(enlistmentPerTest: true)
+        public CheckoutTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -1,6 +1,5 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using NUnit.Framework;
@@ -12,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class CheckoutTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -2,11 +2,12 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class CherryPickConflictTests : GitRepoTests
     {
-        public CherryPickConflictTests() : base(enlistmentPerTest: true)
+        public CherryPickConflictTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class CherryPickConflictTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -1,12 +1,13 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class CherryPickConflictTests : GitRepoTests
     {
-        public CherryPickConflictTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public CherryPickConflictTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
@@ -7,13 +7,14 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class CreatePlaceholderTests : GitRepoTests
     {
         private static readonly string FileToRead = Path.Combine("GVFS", "GVFS", "Program.cs");
 
-        public CreatePlaceholderTests() : base(enlistmentPerTest: true)
+        public CreatePlaceholderTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -7,13 +8,13 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class CreatePlaceholderTests : GitRepoTests
     {
         private static readonly string FileToRead = Path.Combine("GVFS", "GVFS", "Program.cs");
 
-        public CreatePlaceholderTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public CreatePlaceholderTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
@@ -1,6 +1,5 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -8,7 +7,7 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class CreatePlaceholderTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
@@ -1,11 +1,10 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class DeleteEmptyFolderTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
@@ -4,11 +4,12 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class DeleteEmptyFolderTests : GitRepoTests
     {
-        public DeleteEmptyFolderTests() : base(enlistmentPerTest: true)
+        public DeleteEmptyFolderTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
@@ -1,14 +1,15 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class DeleteEmptyFolderTests : GitRepoTests
     {
-        public DeleteEmptyFolderTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public DeleteEmptyFolderTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
@@ -2,7 +2,7 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class EnumerationMergeTest : GitRepoTests
     {
@@ -10,7 +10,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         // enumeration when they don't fit in a user's buffer
         private const string EnumerationReproCommitish = "FunctionalTests/20170602";
 
-        public EnumerationMergeTest() : base(enlistmentPerTest: true)
+        public EnumerationMergeTest(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class EnumerationMergeTest : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
@@ -1,8 +1,9 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class EnumerationMergeTest : GitRepoTests
     {
@@ -10,7 +11,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         // enumeration when they don't fit in a user's buffer
         private const string EnumerationReproCommitish = "FunctionalTests/20170602";
 
-        public EnumerationMergeTest(ValidateWorkingTreeOptions validateWorkingTree) 
+        public EnumerationMergeTest(bool validateWorkingTree) 
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1,6 +1,5 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 using System;
@@ -9,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class GitCommandsTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class GitCommandsTests : GitRepoTests
     {
@@ -26,7 +26,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private static readonly string RenameFolderPathFrom = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacks");
         private static readonly string RenameFolderPathTo = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacksRenamed");
        
-        public GitCommandsTests() : base(enlistmentPerTest: false)
+        public GitCommandsTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 using System;
@@ -8,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class GitCommandsTests : GitRepoTests
     {
@@ -26,7 +27,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private static readonly string RenameFolderPathFrom = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacks");
         private static readonly string RenameFolderPathTo = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacksRenamed");
        
-        public GitCommandsTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public GitCommandsTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -13,6 +13,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [TestFixture]
     public abstract class GitRepoTests
     {
+        public const string ValidateWorkingTree = "WorkTreeValidation";
+
         protected const string ConflictSourceBranch = "FunctionalTests/20170206_Conflict_Source";
         protected const string ConflictTargetBranch = "FunctionalTests/20170206_Conflict_Target";
         protected const string NoConflictSourceBranch = "FunctionalTests/20170209_NoConflict_Source";
@@ -23,11 +25,25 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         protected const string DeepDirectoryWithOneDifferentFile = "FunctionalTests/20181010_DeepFolderOneDifferentFile";
 
         private bool enlistmentPerTest;
+        private bool validateWorkingTree;
 
-        public GitRepoTests(bool enlistmentPerTest)
+        public GitRepoTests(bool enlistmentPerTest, ValidateWorkingTreeOptions validateWorkingTree)
         {
             this.enlistmentPerTest = enlistmentPerTest;
+            this.validateWorkingTree = validateWorkingTree == ValidateWorkingTreeOptions.ValidateWorkingTree;
             this.FileSystem = new SystemIORunner();
+        }
+
+        public enum ValidateWorkingTreeOptions
+        {
+            Invalid = 0,
+            DoNotValidateWorkingTree,
+            ValidateWorkingTree,
+        }
+
+        public static object[] WorkTreeValidation
+        {
+            get { return GVFSTestConfig.GitCommandTestWorkTreeValidation; }
         }
 
         public ControlGitRepo ControlGitRepo
@@ -74,8 +90,13 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
 
             this.CheckHeadCommitTree();
-            this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
-                .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath);
+
+            if (this.validateWorkingTree)
+            {
+                this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
+                    .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath);
+            }
+
             this.ValidateGitCommand("status");
         }
 
@@ -90,16 +111,26 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             try
             {
                 this.CheckHeadCommitTree();
-                this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
-                    .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath, ignoreCase: ignoreCase);
+
+                if (this.validateWorkingTree)
+                {
+                    this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
+                        .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath, ignoreCase: ignoreCase);
+                }
 
                 this.RunGitCommand("reset --hard -q HEAD");
                 this.RunGitCommand("clean -d -f -x");
                 this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
 
                 this.CheckHeadCommitTree();
-                this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
-                    .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath, ignoreCase: ignoreCase);
+
+                // If enlistmentPerTest is true we can always validate the working tree because
+                // this is the last place we'll use it
+                if (this.validateWorkingTree || this.enlistmentPerTest)
+                {
+                    this.Enlistment.RepoRoot.ShouldBeADirectory(this.FileSystem)
+                        .WithDeepStructure(this.FileSystem, this.ControlGitRepo.RootPath, ignoreCase: ignoreCase);
+                }
             }
             finally
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -32,6 +32,14 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem = new SystemIORunner();
         }
 
+        public static object[] ValidateWorkingTree
+        {
+            get
+            {
+                return GVFSTestConfig.GitRepoTestsValidateWorkTree;
+            }
+        }
+
         public ControlGitRepo ControlGitRepo
         {
             get; private set;

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -13,8 +13,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [TestFixture]
     public abstract class GitRepoTests
     {
-        public const string ValidateWorkingTree = "WorkTreeValidation";
-
         protected const string ConflictSourceBranch = "FunctionalTests/20170206_Conflict_Source";
         protected const string ConflictTargetBranch = "FunctionalTests/20170206_Conflict_Target";
         protected const string NoConflictSourceBranch = "FunctionalTests/20170209_NoConflict_Source";
@@ -27,23 +25,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private bool enlistmentPerTest;
         private bool validateWorkingTree;
 
-        public GitRepoTests(bool enlistmentPerTest, ValidateWorkingTreeOptions validateWorkingTree)
+        public GitRepoTests(bool enlistmentPerTest, bool validateWorkingTree)
         {
             this.enlistmentPerTest = enlistmentPerTest;
-            this.validateWorkingTree = validateWorkingTree == ValidateWorkingTreeOptions.ValidateWorkingTree;
+            this.validateWorkingTree = validateWorkingTree;
             this.FileSystem = new SystemIORunner();
-        }
-
-        public enum ValidateWorkingTreeOptions
-        {
-            Invalid = 0,
-            DoNotValidateWorkingTree,
-            ValidateWorkingTree,
-        }
-
-        public static object[] WorkTreeValidation
-        {
-            get { return GVFSTestConfig.GitCommandTestWorkTreeValidation; }
         }
 
         public ControlGitRepo ControlGitRepo

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -4,12 +4,13 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     [Category(Categories.MacTODO.M3)]
     public class HashObjectTests : GitRepoTests
     {
-        public HashObjectTests() : base(enlistmentPerTest: false)
+        public HashObjectTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -1,16 +1,16 @@
 ﻿using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using NUnit.Framework;
+using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixture]
     [Category(Categories.GitCommands)]
-    [Category(Categories.MacTODO.M3)]
     public class HashObjectTests : GitRepoTests
     {
-        public HashObjectTests(ValidateWorkingTreeOptions validateWorkingTree) 
-            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
+        public HashObjectTests() 
+            : base(enlistmentPerTest: false, validateWorkingTree: ValidateWorkingTreeOptions.DoNotValidateWorkingTree)
         {
         }
 
@@ -19,8 +19,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ValidateGitCommand("status");
 
-            // Validate that Readme.md is not on disk at all
-            string fileName = "Readme.md";
+            // Validate that Scripts\RunUnitTests.bad is not on disk at all
+            string fileName = Path.Combine("Scripts", "RunUnitTests.bat");
 
             this.Enlistment.UnmountGVFS();
             this.Enlistment.GetVirtualPathTo(fileName).ShouldNotExistOnDisk(this.FileSystem);
@@ -29,7 +29,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // TODO 1087312: Fix 'git hash-oject' so that it works for files that aren't on disk yet
             GitHelpers.InvokeGitAgainstGVFSRepo(
                 this.Enlistment.RepoRoot,
-                "hash-object " + fileName);
+                "hash-object " + fileName.Replace("\\", "/"));
 
             this.FileContentsShouldMatch(fileName);
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -10,7 +10,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     public class HashObjectTests : GitRepoTests
     {
         public HashObjectTests() 
-            : base(enlistmentPerTest: false, validateWorkingTree: ValidateWorkingTreeOptions.DoNotValidateWorkingTree)
+            : base(enlistmentPerTest: false, validateWorkingTree: false)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -20,18 +20,18 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
 
             // Validate that Scripts\RunUnitTests.bad is not on disk at all
-            string fileName = Path.Combine("Scripts", "RunUnitTests.bat");
+            string filePath = Path.Combine("Scripts", "RunUnitTests.bat");
 
             this.Enlistment.UnmountGVFS();
-            this.Enlistment.GetVirtualPathTo(fileName).ShouldNotExistOnDisk(this.FileSystem);
+            this.Enlistment.GetVirtualPathTo(filePath).ShouldNotExistOnDisk(this.FileSystem);
             this.Enlistment.MountGVFS();
 
             // TODO 1087312: Fix 'git hash-oject' so that it works for files that aren't on disk yet
             GitHelpers.InvokeGitAgainstGVFSRepo(
                 this.Enlistment.RepoRoot,
-                "hash-object " + fileName.Replace("\\", "/"));
+                "hash-object " + GitHelpers.ConvertPathToGitFormat(filePath));
 
-            this.FileContentsShouldMatch(fileName);
+            this.FileContentsShouldMatch(filePath);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -1,11 +1,10 @@
 ﻿using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class MergeConflictTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -1,14 +1,15 @@
 ﻿using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class MergeConflictTests : GitRepoTests
     {
-        public MergeConflictTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public MergeConflictTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -4,11 +4,12 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class MergeConflictTests : GitRepoTests
     {
-        public MergeConflictTests() : base(enlistmentPerTest: true)
+        public MergeConflictTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
@@ -1,12 +1,13 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class RebaseConflictTests : GitRepoTests
     {
-        public RebaseConflictTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public RebaseConflictTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class RebaseConflictTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseConflictTests.cs
@@ -2,11 +2,12 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class RebaseConflictTests : GitRepoTests
     {
-        public RebaseConflictTests() : base(enlistmentPerTest: true)
+        public RebaseConflictTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class RebaseTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
@@ -1,12 +1,13 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class RebaseTests : GitRepoTests
     {
-        public RebaseTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public RebaseTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RebaseTests.cs
@@ -2,11 +2,12 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class RebaseTests : GitRepoTests
     {
-        public RebaseTests() : base(enlistmentPerTest: true)
+        public RebaseTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
@@ -1,10 +1,9 @@
 ﻿using GVFS.FunctionalTests.Should;
-using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class ResetHardTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
@@ -1,15 +1,16 @@
 ﻿using GVFS.FunctionalTests.Should;
+using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class ResetHardTests : GitRepoTests
     {
         private const string ResetHardCommand = "reset --hard";
 
-        public ResetHardTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public ResetHardTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
@@ -1,15 +1,16 @@
-using GVFS.FunctionalTests.Should;
+﻿using GVFS.FunctionalTests.Should;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class ResetHardTests : GitRepoTests
     {
         private const string ResetHardCommand = "reset --hard";
 
-        public ResetHardTests() : base(enlistmentPerTest: true)
+        public ResetHardTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -1,10 +1,9 @@
 ﻿using GVFS.FunctionalTests.Should;
-using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class ResetMixedTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -1,13 +1,14 @@
 ﻿using GVFS.FunctionalTests.Should;
+using GVFS.Tests;
 using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class ResetMixedTests : GitRepoTests
     {
-        public ResetMixedTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public ResetMixedTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -3,11 +3,12 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class ResetMixedTests : GitRepoTests
     {
-        public ResetMixedTests() : base(enlistmentPerTest: true)
+        public ResetMixedTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
@@ -1,12 +1,13 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class ResetSoftTests : GitRepoTests
     {
-        public ResetSoftTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public ResetSoftTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class ResetSoftTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetSoftTests.cs
@@ -2,11 +2,12 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class ResetSoftTests : GitRepoTests
     {
-        public ResetSoftTests() : base(enlistmentPerTest: true)
+        public ResetSoftTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.FunctionalTests.Should;
+using GVFS.FunctionalTests.Tools;
 using NUnit.Framework;
 using System.IO;
 
@@ -18,14 +19,14 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
 
             // Validate that Scripts\RunUnitTests.bad is not on disk at all
-            string fileName = Path.Combine("Scripts", "RunUnitTests.bat");
+            string filePath = Path.Combine("Scripts", "RunUnitTests.bat");
 
             this.Enlistment.UnmountGVFS();
-            this.Enlistment.GetVirtualPathTo(fileName).ShouldNotExistOnDisk(this.FileSystem);
+            this.Enlistment.GetVirtualPathTo(filePath).ShouldNotExistOnDisk(this.FileSystem);
             this.Enlistment.MountGVFS();
                     
-            this.ValidateGitCommand("rm --dry-run " + fileName.Replace("\\", "/"));
-            this.FileContentsShouldMatch(fileName);
+            this.ValidateGitCommand("rm --dry-run " + GitHelpers.ConvertPathToGitFormat(filePath));
+            this.FileContentsShouldMatch(filePath);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -3,10 +3,11 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     public class RmTests : GitRepoTests
     {
-        public RmTests() : base(enlistmentPerTest: false)
+        public RmTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -8,7 +8,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     public class RmTests : GitRepoTests
     {
         public RmTests()
-            : base(enlistmentPerTest: false, validateWorkingTree: ValidateWorkingTreeOptions.DoNotValidateWorkingTree)
+            : base(enlistmentPerTest: false, validateWorkingTree: false)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -1,32 +1,30 @@
 ﻿using GVFS.FunctionalTests.Should;
 using NUnit.Framework;
+using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixture]
     public class RmTests : GitRepoTests
     {
-        public RmTests(ValidateWorkingTreeOptions validateWorkingTree)
-            : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
+        public RmTests()
+            : base(enlistmentPerTest: false, validateWorkingTree: ValidateWorkingTreeOptions.DoNotValidateWorkingTree)
         {
         }
 
-        // Mac(TODO): Something is triggering Readme.md to get created on disk before this
-        // test validates that it's not present
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
         public void CanReadFileAfterGitRmDryRun()
         {
             this.ValidateGitCommand("status");
 
-            // Validate that Readme.md is not on disk at all
-            string fileName = "Readme.md";
+            // Validate that Scripts\RunUnitTests.bad is not on disk at all
+            string fileName = Path.Combine("Scripts", "RunUnitTests.bat");
 
             this.Enlistment.UnmountGVFS();
             this.Enlistment.GetVirtualPathTo(fileName).ShouldNotExistOnDisk(this.FileSystem);
             this.Enlistment.MountGVFS();
                     
-            this.ValidateGitCommand("rm --dry-run " + fileName);
+            this.ValidateGitCommand("rm --dry-run " + fileName.Replace("\\", "/"));
             this.FileContentsShouldMatch(fileName);
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -1,15 +1,16 @@
-﻿using GVFS.Tests.Should;
+﻿using GVFS.Tests;
+using GVFS.Tests.Should;
 using NUnit.Framework;
 using System.IO;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class StatusTests : GitRepoTests
     {
-        public StatusTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public StatusTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -5,11 +5,12 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class StatusTests : GitRepoTests
     {
-        public StatusTests() : base(enlistmentPerTest: true)
+        public StatusTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -1,12 +1,11 @@
-﻿using GVFS.Tests;
-using GVFS.Tests.Should;
+﻿using GVFS.Tests.Should;
 using NUnit.Framework;
 using System.IO;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class StatusTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
@@ -1,14 +1,15 @@
 ﻿using GVFS.FunctionalTests.Tools;
+using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class UpdateIndexTests : GitRepoTests
     {
-        public UpdateIndexTests(ValidateWorkingTreeOptions validateWorkingTree)
+        public UpdateIndexTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
@@ -1,11 +1,10 @@
 ﻿using GVFS.FunctionalTests.Tools;
-using GVFS.Tests;
 using NUnit.Framework;
 using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class UpdateIndexTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateIndexTests.cs
@@ -4,11 +4,12 @@ using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class UpdateIndexTests : GitRepoTests
     {
-        public UpdateIndexTests() : base(enlistmentPerTest: true)
+        public UpdateIndexTests(ValidateWorkingTreeOptions validateWorkingTree)
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -1,9 +1,8 @@
-﻿using GVFS.Tests;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
+    [TestFixtureSource(typeof(GitRepoTests), nameof(GitRepoTests.ValidateWorkingTree))]
     [Category(Categories.GitCommands)]
     public class UpdateRefTests : GitRepoTests
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -1,12 +1,13 @@
-﻿using NUnit.Framework;
+﻿using GVFS.Tests;
+using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
+    [TestFixtureSource(typeof(DataSources), nameof(DataSources.AllBools))]
     [Category(Categories.GitCommands)]
     public class UpdateRefTests : GitRepoTests
     {
-        public UpdateRefTests(ValidateWorkingTreeOptions validateWorkingTree) 
+        public UpdateRefTests(bool validateWorkingTree) 
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -2,11 +2,12 @@
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(GitRepoTests), GitRepoTests.ValidateWorkingTree)]
     [Category(Categories.GitCommands)]
     public class UpdateRefTests : GitRepoTests
     {
-        public UpdateRefTests() : base(enlistmentPerTest: true)
+        public UpdateRefTests(ValidateWorkingTreeOptions validateWorkingTree) 
+            : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
@@ -20,12 +20,20 @@ namespace GVFS.FunctionalTests.Tools
         private const string LockHolderCommandName = @"GVFS.FunctionalTests.LockHolder";
         private const string LockHolderCommand = @"GVFS.FunctionalTests.LockHolder.exe";
 
+        private const string WindowsPathSeparator = "\\";
+        private const string GitPathSeparator = "/";
+
         private static string LockHolderCommandPath
         {
             get
             {
                 return Path.Combine(Settings.Default.CurrentDirectory, LockHolderCommand);
             }
+        }
+
+        public static string ConvertPathToGitFormat(string relativePath)
+        {
+            return relativePath.Replace(WindowsPathSeparator, GitPathSeparator);
         }
 
         public static void CheckGitCommand(string virtualRepoRoot, string command, params string[] expectedLinesInResult)


### PR DESCRIPTION
Parameterize `GitRepoTests` so that the Mac functional tests are run with and without validation during test setup (so that the working tree is and is not expanded during setup).

Resolves #250 