### PR TITLE
Mac: Don't assert/panic when we fail to read attributes during a FileOp operation

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -500,8 +500,14 @@ static int HandleFileOpOperation(
             goto CleanupAndReturn;
         }
 
+        // We used to assert if we couldn't read the attributes of a file here.
+        // In practice, we always found that these panics were on accesses outside of a
+        // virtualization root, so we'll log as opposed to panicing.
         bool fileFlaggedInRoot;
-        assert(TryGetFileIsFlaggedAsInRoot(currentVnode, context, &fileFlaggedInRoot));
+        if (!TryGetFileIsFlaggedAsInRoot(currentVnode, context, &fileFlaggedInRoot))
+        {
+            KextLog_Info("Failed to read attributes when handling FileOp operation. Path is %s", path);
+        }
         
         if (fileFlaggedInRoot && KAUTH_FILEOP_CLOSE_MODIFIED != closeFlags)
         {


### PR DESCRIPTION
Historically, many of us have seen a panic on reading the attempting to read the attributes on some path outside of our virtualization root (Most reports of this have been when no virtualization root is attached). For now, let's avoid the panic here and log the path where the failure occurred.