### PR TITLE
Mac: Disable StatusTests.MoveFileIntoDotGitDirectory

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -26,6 +26,10 @@
 
             // Tests for GVFS features that are not required for correct git functionality
             public const string M4 = "M4_GVFSFeatures";
+
+            // Tests that have been flaky on build servers and need additional logging and\or
+            // investigation
+            public const string FlakyTest = "MacFlakyTest";
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -78,6 +78,7 @@ namespace GVFS.FunctionalTests
                 excludeCategories.Add(Categories.MacTODO.NeedsRenameOldPath);
                 excludeCategories.Add(Categories.MacTODO.M3);
                 excludeCategories.Add(Categories.MacTODO.M4);
+                excludeCategories.Add(Categories.MacTODO.FlakyTest);
                 excludeCategories.Add(Categories.WindowsOnly);
             }
             else

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -15,6 +15,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Category(Categories.MacTODO.FlakyTest)] 
         public void MoveFileIntoDotGitDirectory()
         {
             string srcPath = @"Readme.md";


### PR DESCRIPTION
See #312 for details on the test failure.

`StatusTests.MoveFileIntoDotGitDirectory` has been flaky on the build servers and should be disabled until we can track down more details on the failure (#312 has been re-purposed for re-enabling the test)