### PR TITLE
Mac: Handle setting the PAT in PrepFunctionalTests.sh correctly after a kernel panic

### DIFF
--- a/Scripts/Mac/PrepFunctionalTests.sh
+++ b/Scripts/Mac/PrepFunctionalTests.sh
@@ -43,5 +43,6 @@ $VFS_SCRIPTDIR/InstallSharedDataQueueStallWorkaround.sh || exit 1
 PATURL=$1
 PAT=$2
 if [[ ! -z $PAT && ! -z $PATURL ]] ; then
+    security delete-generic-password -s "gcm4ml:git:$PATURL"
     security add-generic-password -a "Personal Access Token" -s "gcm4ml:git:$PATURL" -D Credential -w $PAT || exit 1
 fi


### PR DESCRIPTION
In the case where a build agent panics as part of running tests, the next job will fail in PrepFunctionalTests.sh due to a stale PAT being on the keychain (see https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=7646091&view=logs).

Update PrepFunctionalTests.sh to remove the old PAT before trying to save the new one.