### PR TITLE
PrefetchVerbTests: Remove commit-graph check

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -140,9 +140,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             ProcessResult midxResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "multi-pack-index verify --object-dir=\"" + objectDir + "\"");
             midxResult.ExitCode.ShouldEqual(0);
 
-            ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph read --object-dir=\"" + objectDir + "\"");
-            graphResult.ExitCode.ShouldEqual(0);
-            graphResult.Output.ShouldContain("43475048"); // Header from commit-graph file.
+            // A commit graph is not always generated, but if it is, then we want to ensure it is in a good state
+            if (this.fileSystem.FileExists(Path.Combine(objectDir, "info", "commit-graph")))
+            {
+                ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph read --object-dir=\"" + objectDir + "\"");
+                graphResult.ExitCode.ShouldEqual(0);
+                graphResult.Output.ShouldContain("43475048"); // Header from commit-graph file.
+            }
         }
     }
 }


### PR DESCRIPTION
In the EnlistmentPerFixture.PrefetchVerbTests class, we have the same PostFetchJobShouldComplete() method as we do in the version without a shared cache, except that none of our tests in the class actually trigger a commit-graph write. The commit-graph write requires a prefetch that downloads a new prefetch packfile, while the multi-pack-index is rewritten on every prefetch (in case a non-prefetch packfile was added). We don't write the commit-graph on clone because we need a full enlistment to guarantee missing object downloads.

Somehow, these test succeed in the full test suite, but do not succeed when only the one class is run. This caused some pain for someone stepping through the tests in a debugger.

Instead of removing the commit-graph check, instead see if the commit-graph file exists before calling `git commit-graph read`. This allows us to still check that the commit-graph file exists and is in good condition (when it exists).