### PR TITLE
Mac: Support 'gvfs diagnose' verb

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -6,7 +6,7 @@ namespace GVFS.Common.FileSystem
     public interface IKernelDriver
     {
         bool EnumerationExpandsDirectories { get; }
-        string DriverLogFolderName { get; }
+        string KernelLogsFolderPath { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         string FlushDriverLogs();
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);

--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -6,9 +6,9 @@ namespace GVFS.Common.FileSystem
     public interface IKernelDriver
     {
         bool EnumerationExpandsDirectories { get; }
-        string KernelLogsFolderPath { get; }
+        string LogsFolderPath { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
-        string FlushDriverLogs();
+        string FlushLogs();
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
         bool IsGVFSUpgradeSupported();

--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -9,5 +9,8 @@
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);
         void ChangeMode(string path, int mode);
         bool HydrateFile(string fileName, byte[] buffer);
+
+        bool IsExecutable(string filePath);
+        bool IsSocket(string filePath);
     }
 }

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -23,6 +23,7 @@ namespace GVFS.Common
         public abstract IPlatformFileSystem FileSystem { get; }
         public virtual bool IsUnderConstruction { get; } = false;
         public virtual bool SupportsGVFSService { get; } = true;
+        public virtual bool SupportsGVFSUpgrade { get; } = true;
         public GVFSPlatformConstants Constants { get; }
 
         public static void Register(GVFSPlatform platform)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
@@ -9,7 +9,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [Category(Categories.FullSuiteOnly)]
-    [Category(Categories.MacTODO.M4)]
     public class DiagnoseTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -18,7 +19,7 @@ namespace GVFS.Platform.Mac
         {
             if (Rename(sourceFileName, destinationFilename) != 0)
             {
-                NativeMethods.ThrowLastWin32Exception($"Failed to renname {sourceFileName} to {destinationFilename}");
+                NativeMethods.ThrowLastWin32Exception($"Failed to rename {sourceFileName} to {destinationFilename}");
             }
         }
 
@@ -43,11 +44,100 @@ namespace GVFS.Platform.Mac
             return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
         }
 
+        public bool IsExecutable(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsExecutable(statBuffer.Mode);
+        }
+
+        public bool IsSocket(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsSock(statBuffer.Mode);
+        }
+
+        private NativeStat.StatBuffer StatFile(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = new NativeStat.StatBuffer();
+            if (NativeStat.Stat(fileName, out statBuffer) != 0)
+            {
+                NativeMethods.ThrowLastWin32Exception($"Failed to stat {fileName}");
+            }
+
+            return statBuffer;
+        }
+
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
         private static extern int Chmod(string pathname, int mode);
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
         private static extern int Rename(string oldPath, string newPath);
+
+        private static class NativeStat
+        {
+            // #define  S_IFMT      0170000     /* [XSI] type of file mask */
+            private static readonly ushort IFMT = Convert.ToUInt16("170000", 8);
+
+            // #define  S_IFSOCK    0140000     /* [XSI] socket */
+            private static readonly ushort IFSOCK = Convert.ToUInt16("0140000", 8);
+
+            // #define S_IXUSR     0000100     /* [XSI] X for owner */
+            private static readonly ushort IXUSR = Convert.ToUInt16("100", 8);
+
+            // #define S_IXGRP     0000010     /* [XSI] X for group */
+            private static readonly ushort IXGRP = Convert.ToUInt16("10", 8);
+
+            // #define S_IXOTH     0000001     /* [XSI] X for other */
+            private static readonly ushort IXOTH = Convert.ToUInt16("1", 8);
+
+            public static bool IsSock(ushort mode)
+            {
+                // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
+                return (mode & IFMT) == IFSOCK;
+            }
+
+            public static bool IsExecutable(ushort mode)
+            {
+                return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
+            }
+
+            [DllImport("libc", EntryPoint = "stat$INODE64", SetLastError = true)]
+            public static extern int Stat(string path, [Out] out StatBuffer statBuffer);
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct TimeSpec
+            {
+                public long Sec;
+                public long Nsec;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct StatBuffer
+            {
+                public int Dev;              /* ID of device containing file */
+                public ushort Mode;          /* Mode of file (see below) */
+                public ushort NLink;         /* Number of hard links */
+                public ulong Ino;            /* File serial number */
+                public uint UID;             /* User ID of the file */
+                public uint GID;             /* Group ID of the file */
+                public int RDev;             /* Device ID */
+
+                public TimeSpec ATimespec;     /* time of last access */
+                public TimeSpec MTimespec;     /* time of last data modification */
+                public TimeSpec CTimespec;     /* time of last status change */
+                public TimeSpec BirthTimespec; /* time of file creation(birth) */
+
+                public long Size;          /* file size, in bytes */
+                public long Blocks;        /* blocks allocated for file */
+                public int BlkSize;        /* optimal blocksize for I/O */
+                public uint Glags;         /* user defined flags for file */
+                public uint Gen;           /* file generation number */
+                public int LSpare;         /* RESERVED: DO NOT USE! */
+
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+                public long[] QSpare;     /* RESERVED: DO NOT USE! */
+            }
+        }
 
         private class NativeFileReader
         {

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -56,6 +56,12 @@ namespace GVFS.Platform.Mac
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
+        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int Chmod(string pathname, int mode);
+
+        [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
+        private static extern int Rename(string oldPath, string newPath);
+
         private NativeStat.StatBuffer StatFile(string fileName)
         {
             NativeStat.StatBuffer statBuffer = new NativeStat.StatBuffer();
@@ -66,12 +72,6 @@ namespace GVFS.Platform.Mac
 
             return statBuffer;
         }
-
-        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
-        private static extern int Chmod(string pathname, int mode);
-
-        [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
-        private static extern int Rename(string oldPath, string newPath);
 
         private static class NativeStat
         {

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -92,7 +92,8 @@ namespace GVFS.Platform.Mac
 
         public override string GetOSVersionInformation()
         {
-            throw new NotImplementedException();
+            ProcessResult result = ProcessHelper.Run("sw_vers", args: string.Empty, redirectOutput: true);
+            return string.IsNullOrWhiteSpace(result.Output) ? result.Errors : result.Output;
         }
 
         public override Dictionary<string, string> GetPhysicalDiskInfo(string path)

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -22,6 +22,7 @@ namespace GVFS.Platform.Mac
         public override IPlatformFileSystem FileSystem { get; } = new MacFileSystem();
         public override bool IsUnderConstruction { get; } = true;
         public override bool SupportsGVFSService { get; } = false;
+        public override bool SupportsGVFSUpgrade { get; } = false;
 
         public override void ConfigureVisualStudio(string gitBinPath, ITracer tracer)
         {

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -12,7 +12,7 @@ namespace GVFS.Platform.Mac
     {
         public bool EnumerationExpandsDirectories { get; } = true;
 
-        public string DriverLogFolderName => throw new NotImplementedException();
+        public string KernelLogsFolderPath => throw new NotImplementedException();
 
         public bool IsGVFSUpgradeSupported()
         {

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -12,7 +12,7 @@ namespace GVFS.Platform.Mac
     {
         public bool EnumerationExpandsDirectories { get; } = true;
 
-        public string KernelLogsFolderPath => throw new NotImplementedException();
+        public string LogsFolderPath => throw new NotImplementedException();
 
         public bool IsGVFSUpgradeSupported()
         {
@@ -41,7 +41,7 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public string FlushDriverLogs()
+        public string FlushLogs()
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.Windows
 
         public bool EnumerationExpandsDirectories { get; } = false;
 
-        public string KernelLogsFolderPath 
+        public string LogsFolderPath 
         { 
             get
             {

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -25,6 +25,8 @@ namespace GVFS.Platform.Windows
         private const string PrjFltAutoLoggerKey = "SYSTEM\\CurrentControlSet\\Control\\WMI\\Autologger\\Microsoft-Windows-ProjFS-Filter-Log";
         private const string PrjFltAutoLoggerStartValue = "Start";
 
+        private const string System32LogFilesRoot = @"%SystemRoot%\System32\LogFiles";
+
         // From "Autologger" section of prjflt.inf
         private const string FilterLoggerGuid = "ee4206ff-4a4d-452f-be56-6bd0ed272b44";
         private const string FilterLoggerSessionName = "Microsoft-Windows-ProjFS-Filter-Log";
@@ -45,7 +47,13 @@ namespace GVFS.Platform.Windows
 
         public bool EnumerationExpandsDirectories { get; } = false;
 
-        public string DriverLogFolderName { get; } = ProjFSFilter.ServiceName;
+        public string KernelLogsFolderPath 
+        { 
+            get
+            {
+                return Path.Combine(Environment.ExpandEnvironmentVariables(System32LogFilesRoot), ProjFSFilter.ServiceName);
+            }
+        }
 
         public static bool TryAttach(string enlistmentRoot, out string errorMessage)
         {

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -320,7 +320,7 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        public string FlushDriverLogs()
+        public string FlushLogs()
         {
             StringBuilder sb = new StringBuilder();
             try

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -42,6 +42,17 @@ namespace GVFS.Platform.Windows
             return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
         }
 
+        public bool IsExecutable(string fileName)
+        {
+            string fileExtension = Path.GetExtension(fileName);
+            return string.Equals(fileExtension, ".exe", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool IsSocket(string fileName)
+        {
+            return false;
+        }
+
         private class NativeFileReader
         {
             private const uint GenericRead = 0x80000000;

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
 using Microsoft.Win32.SafeHandles;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -38,5 +38,15 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
             throw new NotSupportedException();
         }
+
+        public bool IsExecutable(string fileName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool IsSocket(string fileName)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -16,8 +16,6 @@ namespace GVFS.CommandLine
     public class DiagnoseVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string DiagnoseVerbName = "diagnose";
-        private const string WindowsExecutableExtension = ".exe";
-        private const string MacNamedPipeSocketName = "GVFS_NetCorePipe";
 
         private TextWriter diagnosticLogFileWriter;
 
@@ -398,9 +396,9 @@ namespace GVFS.CommandLine
                 string fileName = Path.GetFileName(filePath);
                 try
                 {
-                    string fileExtension = Path.GetExtension(fileName);
-                    if (!string.Equals(fileExtension, WindowsExecutableExtension, StringComparison.OrdinalIgnoreCase) &&
-                        !string.Equals(fileName, MacNamedPipeSocketName, StringComparison.OrdinalIgnoreCase))
+                    string sourceFilePath = Path.Combine(sourcePath, fileName);
+                    if (!GVFSPlatform.Instance.FileSystem.IsSocket(sourceFilePath) &&
+                        !GVFSPlatform.Instance.FileSystem.IsExecutable(sourceFilePath))
                     {
                         File.Copy(
                             Path.Combine(sourcePath, fileName),

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -90,8 +90,8 @@ namespace GVFS.CommandLine
 
                         if (!GVFSPlatform.Instance.IsUnderConstruction)
                         {
-                            // filter
-                            this.FlushFilterLogBuffers();
+                            // driver
+                            this.FlushKernelDriverLogs();
                             string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
 
                             // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
@@ -473,7 +473,7 @@ namespace GVFS.CommandLine
             }
         }
 
-        private void FlushFilterLogBuffers()
+        private void FlushKernelDriverLogs()
         {
             string errors = GVFSPlatform.Instance.KernelDriver.FlushLogs();
             this.diagnosticLogFileWriter.WriteLine(errors);

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -4,7 +4,6 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Tracing;
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -17,7 +16,8 @@ namespace GVFS.CommandLine
     public class DiagnoseVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string DiagnoseVerbName = "diagnose";
-        private const string System32LogFilesRoot = @"%SystemRoot%\System32\LogFiles";
+        private const string WindowsExecutableExtension = ".exe";
+        private const string MacNamedPipeSocketName = "GVFS_NetCorePipe";
 
         private TextWriter diagnosticLogFileWriter;
 
@@ -90,13 +90,16 @@ namespace GVFS.CommandLine
                         // .gvfs
                         this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSConstants.DotGVFS.Root, copySubFolders: false);
 
-                        // filter
-                        this.FlushFilterLogBuffers();
-                        string system32LogFilesPath = Environment.ExpandEnvironmentVariables(System32LogFilesRoot);
+                        if (!GVFSPlatform.Instance.IsUnderConstruction)
+                        {
+                            // filter
+                            this.FlushFilterLogBuffers();
+                            string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.KernelLogsFolderPath;
 
-                        // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
-                        // for the user so we don't write the error message to stdout, just to our own log file.
-                        this.CopyAllFiles(system32LogFilesPath, archiveFolderPath, GVFSPlatform.Instance.KernelDriver.DriverLogFolderName, copySubFolders: false, hideErrorsFromStdout: true);
+                            // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
+                            // for the user so we don't write the error message to stdout, just to our own log file.
+                            this.CopyAllFiles(Path.GetDirectoryName(kernelLogsFolderPath), archiveFolderPath, Path.GetFileName(kernelLogsFolderPath), copySubFolders: false, hideErrorsFromStdout: true);
+                        }
 
                         // .git
                         this.CopyAllFiles(enlistment.WorkingDirectoryRoot, archiveFolderPath, GVFSConstants.DotGit.Root, copySubFolders: false);
@@ -117,25 +120,28 @@ namespace GVFS.CommandLine
                         // corrupt objects
                         this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGVFS.Root), GVFSConstants.DotGVFS.CorruptObjectsName, copySubFolders: false);
 
-                        // service
-                        this.CopyAllFiles(
-                            Paths.GetServiceDataRoot(string.Empty),
-                            archiveFolderPath,
-                            this.ServiceName,
-                            copySubFolders: true);
+                        if (!GVFSPlatform.Instance.IsUnderConstruction)
+                        {
+                            // service
+                            this.CopyAllFiles(
+                                Paths.GetServiceDataRoot(string.Empty),
+                                archiveFolderPath,
+                                this.ServiceName,
+                                copySubFolders: true);
 
-                        // upgrader
-                        this.CopyAllFiles(
-                            ProductUpgrader.GetUpgradesDirectoryPath(),
-                            archiveFolderPath,
-                            ProductUpgrader.LogDirectory,
-                            copySubFolders: true,
-                            targetFolderName: ProductUpgrader.UpgradeDirectoryName);
-                        this.LogDirectoryEnumeration(
-                            ProductUpgrader.GetUpgradesDirectoryPath(), 
-                            Path.Combine(archiveFolderPath, ProductUpgrader.UpgradeDirectoryName),
-                            ProductUpgrader.DownloadDirectory, 
-                            "downloaded-assets.txt");
+                            // upgrader
+                            this.CopyAllFiles(
+                                ProductUpgrader.GetUpgradesDirectoryPath(),
+                                archiveFolderPath,
+                                ProductUpgrader.LogDirectory,
+                                copySubFolders: true,
+                                targetFolderName: ProductUpgrader.UpgradeDirectoryName);
+                            this.LogDirectoryEnumeration(
+                                ProductUpgrader.GetUpgradesDirectoryPath(),
+                                Path.Combine(archiveFolderPath, ProductUpgrader.UpgradeDirectoryName),
+                                ProductUpgrader.DownloadDirectory,
+                                "downloaded-assets.txt");
+                        }
                      
                         return true;
                     },
@@ -390,7 +396,8 @@ namespace GVFS.CommandLine
                 try
                 {
                     string fileExtension = Path.GetExtension(fileName);
-                    if (!string.Equals(fileExtension, ".exe", StringComparison.OrdinalIgnoreCase))
+                    if (!string.Equals(fileExtension, WindowsExecutableExtension, StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(fileName, MacNamedPipeSocketName, StringComparison.OrdinalIgnoreCase))
                     {
                         File.Copy(
                             Path.Combine(sourcePath, fileName),

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -94,7 +94,7 @@ namespace GVFS.CommandLine
                         {
                             // filter
                             this.FlushFilterLogBuffers();
-                            string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.KernelLogsFolderPath;
+                            string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
 
                             // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
                             // for the user so we don't write the error message to stdout, just to our own log file.
@@ -120,7 +120,7 @@ namespace GVFS.CommandLine
                         // corrupt objects
                         this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGVFS.Root), GVFSConstants.DotGVFS.CorruptObjectsName, copySubFolders: false);
 
-                        if (!GVFSPlatform.Instance.IsUnderConstruction)
+                        if (GVFSPlatform.Instance.SupportsGVFSService)
                         {
                             // service
                             this.CopyAllFiles(
@@ -128,7 +128,10 @@ namespace GVFS.CommandLine
                                 archiveFolderPath,
                                 this.ServiceName,
                                 copySubFolders: true);
+                        }
 
+                        if (GVFSPlatform.Instance.SupportsGVFSUpgrade)
+                        {
                             // upgrader
                             this.CopyAllFiles(
                                 ProductUpgrader.GetUpgradesDirectoryPath(),
@@ -474,7 +477,7 @@ namespace GVFS.CommandLine
 
         private void FlushFilterLogBuffers()
         {
-            string errors = GVFSPlatform.Instance.KernelDriver.FlushDriverLogs();
+            string errors = GVFSPlatform.Instance.KernelDriver.FlushLogs();
             this.diagnosticLogFileWriter.WriteLine(errors);
         }
 

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -61,9 +61,7 @@ namespace GVFS.CommandLine
 
         private bool TryInitializeUpgrader()
         {
-            OperatingSystem os_info = Environment.OSVersion;
-
-            if (os_info.Platform == PlatformID.Win32NT)
+            if (GVFSPlatform.Instance.SupportsGVFSUpgrade)
             {
                 if (this.upgrader == null)
                 {
@@ -82,7 +80,7 @@ namespace GVFS.CommandLine
             }
             else
             {
-                this.ReportInfoToConsole($"ERROR: {GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} in only supported on Microsoft Windows Operating System.");
+                this.ReportInfoToConsole($"ERROR: {GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is not supported on this operating system.");
                 return false;
             }
         }


### PR DESCRIPTION
Resolves #459 

Minimum changes to get `gvfs diagnose` working on the Mac.  

Collecting logs from ProjFS will be covered in follow-up issues (#395 and #396).