### PR TITLE
TryPrefetchCommitsAndTrees downgraded to Warning

### DIFF
--- a/GVFS/GVFS.Common/Prefetch/BackgroundPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BackgroundPrefetcher.cs
@@ -109,7 +109,10 @@ namespace GVFS.Common.Prefetch
 
                     if (!CommitPrefetcher.TryPrefetchCommitsAndTrees(activity, this.enlistment, this.fileSystem, this.gitObjects, out error))
                     {
-                        activity.RelatedError($"{TelemetryKey}: {nameof(CommitPrefetcher.TryPrefetchCommitsAndTrees)} failed with error '{error}'");
+                        activity.RelatedWarning(
+                            metadata: null, 
+                            message: $"{TelemetryKey}: {nameof(CommitPrefetcher.TryPrefetchCommitsAndTrees)} failed with error '{error}'", 
+                            keywords: Keywords.Telemetry);
                     }
                 }
             }


### PR DESCRIPTION
This can worsen performance, but will not stop mount from working.  Hence this error has been downgraded to a warning.

resolves #464 