### PR TITLE
TryDeleteStatusCacheFile as Warning

### DIFF
--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -439,9 +439,10 @@ namespace GVFS.Common
                 metadata.Add("Area", EtwArea);
                 metadata.Add("Exception", ex.ToString());
 
-                this.context.Tracer.RelatedError(
+                this.context.Tracer.RelatedWarning(
                     metadata,
-                    string.Format("GitStatusCache encountered exception attempting to delete cache file at {0}.", this.serializedGitStatusFilePath));
+                    string.Format("GitStatusCache encountered exception attempting to delete cache file at {0}.", this.serializedGitStatusFilePath),
+                    Keywords.Telemetry);
 
                 return false;
             }


### PR DESCRIPTION
This is an expected condition that happens when status is being read to and removed at the same time.   This will self heal but we want to keep a warning to know how often it happens.