### PR TITLE
Atomic Placeholder Creation for MacOS

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -95,6 +95,7 @@ namespace GVFS.Common
         public static class DotGVFS
         {
             public const string Root = ".gvfs";
+            public const string TempRoot = ".staging";
             public const string CorruptObjectsName = "CorruptObjects";
 
             public static readonly string LogPath = Path.Combine(DotGVFS.Root, "logs");

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -30,6 +30,7 @@ namespace GVFS.Common
         {
             this.NamedPipeName = GVFSPlatform.Instance.GetNamedPipeName(this.EnlistmentRoot);
             this.DotGVFSRoot = Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGVFS.Root);
+            this.TempRoot = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.TempRoot);
             this.GitStatusCacheFolder = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.Name);
             this.GitStatusCachePath = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.CachePath);
             this.GVFSLogsRoot = Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGVFS.LogPath);
@@ -50,6 +51,8 @@ namespace GVFS.Common
         public string NamedPipeName { get; }
 
         public string DotGVFSRoot { get; }
+
+        public string TempRoot { get; }
 
         public string GVFSLogsRoot { get; }
 
@@ -209,6 +212,7 @@ namespace GVFS.Common
                 GVFSPlatform.Instance.InitializeEnlistmentACLs(this.EnlistmentRoot);
                 Directory.CreateDirectory(this.WorkingDirectoryRoot);
                 this.CreateHiddenDirectory(this.DotGVFSRoot);
+                this.CreateHiddenDirectory(this.TempRoot);
             }
             catch (IOException)
             {

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -223,6 +223,7 @@ namespace GVFS.Platform.Mac
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 this.Context.Enlistment.WorkingDirectoryRoot,
+                this.Context.Enlistment.TempRoot,
                 threadCount);
 
             if (result != Result.Success)

--- a/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
@@ -38,6 +38,7 @@ namespace GVFS.UnitTests.Mock.Mac
 
         public override Result StartVirtualizationInstance(
             string virtualizationRootFullPath,
+            string temporaryDirectoryFullPath,
             uint poolThreadCount)
         {
             poolThreadCount.ShouldBeAtLeast(1U, "poolThreadCount must be greater than 0");

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -30,6 +30,7 @@ namespace MirrorProvider.Mac
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
+                enlistment.TempRoot,
                 poolThreadCount: (uint)Environment.ProcessorCount * 2);
 
             if (result == Result.Success)

--- a/MirrorProvider/MirrorProvider/Enlistment.cs
+++ b/MirrorProvider/MirrorProvider/Enlistment.cs
@@ -8,6 +8,7 @@ namespace MirrorProvider
         {
             this.EnlistmentRoot = root;
             this.DotMirrorRoot = Path.Combine(root, ".mirror");
+            this.TempRoot = Path.Combine(this.DotMirrorRoot, ".staging");
             this.SrcRoot = Path.Combine(root, "src");
 
             this.ConfigFile = Path.Combine(this.DotMirrorRoot, "config");
@@ -17,7 +18,7 @@ namespace MirrorProvider
         public string EnlistmentRoot { get; private set; }
         public string DotMirrorRoot { get; private set; }
         public string SrcRoot { get; private set; }
-
+        public string TempRoot { get; private set; }
         public string ConfigFile { get; private set; }
 
         public string MirrorRoot { get; private set; }
@@ -31,6 +32,7 @@ namespace MirrorProvider
                 Directory.CreateDirectory(enlistment.EnlistmentRoot);
                 Directory.CreateDirectory(enlistment.DotMirrorRoot);
                 Directory.CreateDirectory(enlistment.SrcRoot);
+                Directory.CreateDirectory(enlistment.TempRoot);
 
                 File.WriteAllText(enlistment.ConfigFile, mirrorRoot);
                 return enlistment;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.hpp
@@ -35,7 +35,7 @@ struct VirtualizationRootResult
     errno_t error;
     VirtualizationRootHandle root;
 };
-VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProviderUserClient* _Nonnull userClient, pid_t clientPID, const char* _Nonnull virtualizationRootPath);
+VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProviderUserClient* _Nonnull userClient, pid_t clientPID, const char* _Nonnull virtualizationRootPath, const char* _Nonnull providerTemporaryDirectoryPath);
 void ActiveProvider_Disconnect(VirtualizationRootHandle rootHandle);
 
 struct Message;

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -11,6 +11,7 @@ namespace PrjFSLib.Mac.Interop
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_StartVirtualizationInstance")]
         public static extern Result StartVirtualizationInstance(
             string virtualizationRootFullPath,
+            string temporaryDirectoryFullPath,
             Callbacks callbacks,
             uint poolThreadCount);
 

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -27,6 +27,7 @@ namespace PrjFSLib.Mac
 
         public virtual Result StartVirtualizationInstance(
             string virtualizationRootFullPath,
+            string temporaryDirectoryFullPath,
             uint poolThreadCount)
         {
             Interop.Callbacks callbacks = new Interop.Callbacks
@@ -38,6 +39,7 @@ namespace PrjFSLib.Mac
 
             return Interop.PrjFSLib.StartVirtualizationInstance(
                 virtualizationRootFullPath,
+                temporaryDirectoryFullPath,
                 callbacks,
                 poolThreadCount);
         }

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -313,7 +313,7 @@ PrjFS_Result PrjFS_WritePlaceholderDirectory(
         goto CleanupAndFail;
     }
     
-    if (!InitializeEmptyPlaceholder(finalPath))
+    if (!InitializeEmptyPlaceholder(tempPath))
     {
         result = PrjFS_Result_EIOError;
         goto CleanupAndFail;

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -66,6 +66,7 @@ typedef struct
 
 extern "C" PrjFS_Result PrjFS_StartVirtualizationInstance(
     _In_    const char*                             virtualizationRootFullPath,
+    _In_    const char*                             temporaryDirectoryFullPath,
     _In_    PrjFS_Callbacks                         callbacks,
     _In_    unsigned int                            poolThreadCount);
 


### PR DESCRIPTION
This PR (previous discussion at #225) implements the design described at #234 to increase the reliability of VFSForGit by making the process in which we create placeholder files/directories 'atomic' (we create them outside of the virtualization root in a known temporary directory and move them into place once they're 'complete').

- [x] Functionality in the provider to create placeholders in the temp directory
- [x] Provider can now register a temp directory with the kext
- [x] Kext will no longer consider changes in a registered temp directory as one that should be considered
- [x] Rename .temp and put it under the provider folder
- [x] Use random names when creating placeholders in the temp directory
- [ ] Clear temp folder on provider mount
- [ ] Investigate if flushing is needed after setting file flags (and perf impact)
- [ ] Validate functionality on the large VFSForGit repo
- [ ] Performance analysis on the large VFSForGit repo
- [ ] Call UpdatePlaceholderIfNeeded when in a retry scenario where we could potentially be overwriting user data
- [ ] Use our kext to prevent the user from doing anything to our .staging folder