### PR TITLE
Easy fixes for 'git push' performance

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181018.1</GitPackageVersion>
+    <GitPackageVersion>2.20181107.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -100,6 +100,7 @@ namespace GVFS.CommandLine
                 { "index.version", "4" },
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
+                { "pack.useBitmaps", "false" },
                 { "receive.autogc", "false" },
                 { "status.deserializePath", gitStatusCachePath },
             };


### PR DESCRIPTION
This PR does two things that are super-easy fixes for improving 'git push' performance.

1. Set `pack.useBitmaps` to `false` on mount time.
2. Update Git to Git-2.19.1.gvfs.1.3.ge56ee8b, which includes a change to stop checking ambiguous refs during 'git pack-objects'. This reduces possibly thousands of file reads of the form:

```
.git/<oid>
.git/refs/<oid>
.git/refs/tags/<oid>
.git/refs/heads/<oid>
.git/refs/remotes/<oid>
.git/refs/remotes/<oid>/HEAD
```

By setting the config value, we don't perform these file checks for the object ids that are passed into stdin.

For (1), this PR sets `pack.useBitmaps` to false for VFS for Git enlistments. This config value defaults to true, and during `git pack-objects` we check for the existence of a `.bitmap` file for _every packfile_, even those covered by the multi-pack-index.

Each of these checks took 2-3 seconds on my small test. I hope to get better numbers before merging, but want to see our scale tests.