### PR TITLE
Ignore non-zero exit codes when calling `git config` and all lines on stderr are prefixed 'warning'

### DIFF
--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -111,7 +111,7 @@ namespace FastFetch
                         string remoteBranch = refs.GetBranchRefPairs().Single().Key;
                         GitProcess git = new GitProcess(this.Enlistment);
                         GitProcess.Result result = git.SetUpstream(branchOrCommit, remoteBranch);
-                        if (result.HasErrors)
+                        if (result.ExitCodeIsFailure)
                         {
                             activity.RelatedError("Could not set upstream for {0} to {1}: {2}", branchOrCommit, remoteBranch, result.Errors);
                             this.HasFailures = true;
@@ -204,7 +204,7 @@ namespace FastFetch
             uint valueCoreGvfs;
 
             // No errors getting the configuration and it is either "true" or numeric with the right bit set.
-            return !configCoreGvfs.HasErrors &&
+            return !configCoreGvfs.ExitCodeIsFailure &&
                 !string.IsNullOrEmpty(configCoreGvfs.Output) &&
                 (configCoreGvfs.Output.Equals("true", StringComparison.OrdinalIgnoreCase) ||
                 (uint.TryParse(configCoreGvfs.Output, out valueCoreGvfs) &&

--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -204,7 +204,7 @@ namespace FastFetch
             uint valueCoreGvfs;
 
             // No errors getting the configuration and it is either "true" or numeric with the right bit set.
-            return !configCoreGvfs.ExitCodeIsFailure &&
+            return configCoreGvfs.ExitCodeIsSuccess &&
                 !string.IsNullOrEmpty(configCoreGvfs.Output) &&
                 (configCoreGvfs.Output.Equals("true", StringComparison.OrdinalIgnoreCase) ||
                 (uint.TryParse(configCoreGvfs.Output, out valueCoreGvfs) &&

--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -200,14 +200,20 @@ namespace FastFetch
             const uint CoreGvfsUnsignedIndexFlag = 1;
 
             GitProcess git = new GitProcess(this.Enlistment);
-            GitProcess.Result configCoreGvfs = git.GetFromConfig("core.gvfs");
+            GitProcess.ConfigResult configCoreGvfs = git.GetFromConfig("core.gvfs");
+            string coreGvfs;
+            string error;
+            if (!configCoreGvfs.TryParseAsString(out coreGvfs, out error))
+            {
+                return false;
+            }
+
             uint valueCoreGvfs;
 
             // No errors getting the configuration and it is either "true" or numeric with the right bit set.
-            return configCoreGvfs.ExitCodeIsSuccess &&
-                !string.IsNullOrEmpty(configCoreGvfs.Output) &&
-                (configCoreGvfs.Output.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                (uint.TryParse(configCoreGvfs.Output, out valueCoreGvfs) &&
+            return !string.IsNullOrEmpty(coreGvfs) &&
+                (coreGvfs.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                (uint.TryParse(coreGvfs, out valueCoreGvfs) &&
                 ((valueCoreGvfs & CoreGvfsUnsignedIndexFlag) == CoreGvfsUnsignedIndexFlag)));
         }
     }

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -191,7 +191,7 @@ namespace FastFetch
             if (string.IsNullOrWhiteSpace(commitish))
             {
                 GitProcess.Result result = new GitProcess(enlistment).GetCurrentBranchName();
-                if (result.HasErrors || string.IsNullOrWhiteSpace(result.Output))
+                if (result.ExitCodeIsFailure || string.IsNullOrWhiteSpace(result.Output))
                 {
                     Console.WriteLine("Could not retrieve current branch name: " + result.Errors);
                     return ExitFailure;

--- a/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
@@ -181,7 +181,7 @@ namespace GVFS.DiskLayoutUpgrades
             foreach (string key in configSettings.Keys)
             {
                 GitProcess.Result result = git.SetInLocalConfig(key, configSettings[key]);
-                if (result.HasErrors)
+                if (result.ExitCodeIsFailure)
                 {
                     tracer.RelatedError("Could not set git config setting {0}. Error: {1}", key, result.Errors);
                     return false;

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -35,7 +35,7 @@ namespace GVFS.Common
             else
             {
                 GitProcess.Result originResult = gitProcess.GetOriginUrl();
-                if (originResult.HasErrors)
+                if (originResult.ExitCodeIsFailure)
                 {
                     if (originResult.Errors.Length == 0)
                     {

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -34,18 +34,18 @@ namespace GVFS.Common
             }
             else
             {
-                GitProcess.Result originResult = gitProcess.GetOriginUrl();
-                if (originResult.ExitCodeIsFailure)
+                GitProcess.ConfigResult originResult = gitProcess.GetOriginUrl();
+                if (!originResult.TryParseAsString(out string originUrl, out string error))
                 {
-                    if (originResult.Errors.Length == 0)
-                    {
-                        throw new InvalidRepoException("Could not get origin url. remote 'origin' is not configured for this repo.'");
-                    }
-
-                    throw new InvalidRepoException("Could not get origin url. git error: " + originResult.Errors);
+                    throw new InvalidRepoException("Could not get origin url. git error: " + error);
                 }
 
-                this.RepoUrl = originResult.Output.Trim();
+                if (originUrl == null)
+                {
+                    throw new InvalidRepoException("Could not get origin url. remote 'origin' is not configured for this repo.'");
+                }
+
+                this.RepoUrl = originUrl.Trim();
             }
             
             this.Authentication = authentication ?? new GitAuthentication(gitProcess, this.RepoUrl);

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -769,7 +769,7 @@ namespace GVFS.Common.Git
                 activity.RelatedWarning(errorMetadata, result.Errors, Keywords.Telemetry);
             }
 
-            return !result.ExitCodeIsFailure;
+            return result.ExitCodeIsSuccess;
         }
 
         private void CleanupTempFile(ITracer activity, string fullPath)

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -326,7 +326,7 @@ namespace GVFS.Common.Git
             try
             {
                 GitProcess.Result result = new GitProcess(this.Enlistment).IndexPack(packfilePath, tempIdxPath);
-                if (result.HasErrors)
+                if (result.ExitCodeIsFailure)
                 {
                     Exception exception;
                     if (!this.fileSystem.TryDeleteFile(tempIdxPath, exception: out exception))
@@ -750,7 +750,7 @@ namespace GVFS.Common.Git
         {
             result = this.IndexPackFile(packFullPath);
 
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 EventMetadata errorMetadata = CreateEventMetadata();
                 Exception exception;
@@ -769,7 +769,7 @@ namespace GVFS.Common.Git
                 activity.RelatedWarning(errorMetadata, result.Errors, Keywords.Telemetry);
             }
 
-            return !result.HasErrors;
+            return !result.ExitCodeIsFailure;
         }
 
         private void CleanupTempFile(ITracer activity, string fullPath)
@@ -884,7 +884,7 @@ namespace GVFS.Common.Git
             else
             {
                 GitProcess.Result result = this.TryAddPackFile(responseData.Stream, unpackObjects);
-                if (result.HasErrors)
+                if (result.ExitCodeIsFailure)
                 {
                     return new RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult(new InvalidOperationException("Could not add pack file: " + result.Errors), shouldRetry: false);
                 }

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -719,6 +719,18 @@ namespace GVFS.Common.Git
             {
                 get { return !this.ExitCodeIsSuccess; }
             }
+
+            public bool StderrContainsErrors()
+            {
+                if (!string.IsNullOrWhiteSpace(this.Errors))
+                {
+                    return !this.Errors
+                        .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                        .All(line => line.TrimStart().StartsWith("warning:", StringComparison.OrdinalIgnoreCase));
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -731,8 +731,8 @@ namespace GVFS.Common.Git
 
         public class ConfigResult
         {
-            private Result result;
-            private string configName;
+            private readonly Result result;
+            private readonly string configName;
 
             public ConfigResult(Result result, string configName)
             {

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -208,7 +208,7 @@ namespace GVFS.Common.Git
         public bool IsValidRepo()
         {
             Result result = this.InvokeGitAgainstDotGitFolder("rev-parse --show-toplevel");
-            return !result.ExitCodeIsFailure;
+            return result.ExitCodeIsSuccess;
         }
 
         public Result RevParse(string gitRef)
@@ -309,7 +309,7 @@ namespace GVFS.Common.Git
             try
             {
                 Result result = this.GetFromConfig(settingName, forceOutsideEnlistment, fileSystem);
-                if (!result.ExitCodeIsFailure)
+                if (result.ExitCodeIsSuccess)
                 {
                     value = result.Output;
                     return true;
@@ -445,7 +445,7 @@ namespace GVFS.Common.Git
             // If oldCommitResult doesn't fail, then the branch exists and update-ref will want the old sha
             Result oldCommitResult = this.RevParse(refToUpdate);
             string oldSha = string.Empty;
-            if (!oldCommitResult.ExitCodeIsFailure)
+            if (oldCommitResult.ExitCodeIsSuccess)
             {
                 oldSha = oldCommitResult.Output.TrimEnd('\n');
             }
@@ -710,9 +710,14 @@ namespace GVFS.Common.Git
             public string Errors { get; }
             public int ExitCode { get; }
 
+            public bool ExitCodeIsSuccess
+            {
+                get { return this.ExitCode == Result.SuccessCode; }
+            }
+
             public bool ExitCodeIsFailure
             {
-                get { return this.ExitCode != SuccessCode; }
+                get { return !this.ExitCodeIsSuccess; }
             }
         }
     }

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -740,9 +740,9 @@ namespace GVFS.Common.Git
                 this.configName = configName;
             }
 
-            public bool TryParseAsString(out string value, out string error)
+            public bool TryParseAsString(out string value, out string error, string defaultValue = null)
             {
-                value = null;
+                value = defaultValue;
                 error = string.Empty;
 
                 if (this.result.ExitCodeIsFailure && this.result.StderrContainsErrors())
@@ -753,7 +753,7 @@ namespace GVFS.Common.Git
 
                 if (this.result.ExitCodeIsSuccess)
                 {
-                    value = this.result.Output;
+                    value = this.result.Output?.TrimEnd('\n');
                 }
 
                 return true;

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -360,7 +360,7 @@ namespace GVFS.Common
             }
 
             bool rebuildSucceeded = false;
-            if (!statusResult.HasErrors)
+            if (!statusResult.ExitCodeIsFailure)
             {
                 lock (this.cacheFileLock)
                 {

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -360,7 +360,7 @@ namespace GVFS.Common
             }
 
             bool rebuildSucceeded = false;
-            if (!statusResult.ExitCodeIsFailure)
+            if (statusResult.ExitCodeIsSuccess)
             {
                 lock (this.cacheFileLock)
                 {

--- a/GVFS/GVFS.Common/GitStatusCacheConfig.cs
+++ b/GVFS/GVFS.Common/GitStatusCacheConfig.cs
@@ -86,16 +86,10 @@ namespace GVFS.Common
             error = string.Empty;
 
             GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.ExitCodeIsFailure)
+            if (result.ExitCodeIsFailure && result.StderrContainsErrors())
             {
-                if (result.Errors.Any())
-                {
-                    error = "Error while reading '" + configName + "' from config: " + result.Errors;
-                    return false;
-                }
-
-                // Git returns non-zero for non-existent settings and errors.
-                return true;
+                error = "Error while reading '" + configName + "' from config: " + result.Errors;
+                return false;
             }
 
             string valueString = result.Output.TrimEnd('\n');

--- a/GVFS/GVFS.Common/GitStatusCacheConfig.cs
+++ b/GVFS/GVFS.Common/GitStatusCacheConfig.cs
@@ -82,36 +82,8 @@ namespace GVFS.Common
 
         private static bool TryGetFromGitConfig(GitProcess git, string configName, int defaultValue, int minValue, out int value, out string error)
         {
-            value = defaultValue;
-            error = string.Empty;
-
-            GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.ExitCodeIsFailure && result.StderrContainsErrors())
-            {
-                error = "Error while reading '" + configName + "' from config: " + result.Errors;
-                return false;
-            }
-
-            string valueString = result.Output.TrimEnd('\n');
-            if (string.IsNullOrWhiteSpace(valueString))
-            {
-                // Use default value
-                return true;
-            }
-
-            if (!int.TryParse(valueString, out value))
-            {
-                error = string.Format("Misconfigured config setting {0}, could not parse value {1}", configName, valueString);
-                return false;
-            }
-
-            if (value < minValue)
-            {
-                error = string.Format("Invalid value {0} for setting {1}, value must be greater than or equal to {2}", value, configName, minValue);
-                return false;
-            }
-
-            return true;
+            GitProcess.ConfigResult result = git.GetFromConfig(configName);
+            return result.TryParseAsInt(defaultValue, minValue, out value, out error);
         }
     }
 }

--- a/GVFS/GVFS.Common/GitStatusCacheConfig.cs
+++ b/GVFS/GVFS.Common/GitStatusCacheConfig.cs
@@ -86,7 +86,7 @@ namespace GVFS.Common
             error = string.Empty;
 
             GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 if (result.Errors.Any())
                 {

--- a/GVFS/GVFS.Common/Http/CacheServerResolver.cs
+++ b/GVFS/GVFS.Common/Http/CacheServerResolver.cs
@@ -126,7 +126,7 @@ namespace GVFS.Common.Http
             GitProcess.Result result = git.SetInLocalConfig(GVFSConstants.GitConfig.CacheServer, cache.Url, replaceAll: true);
 
             error = result.Errors;
-            return !result.ExitCodeIsFailure;
+            return result.ExitCodeIsSuccess;
         }
 
         private static string GetValueFromConfig(GitProcess git, string configName, bool localOnly)
@@ -136,7 +136,7 @@ namespace GVFS.Common.Http
                 ? git.GetFromLocalConfig(configName)
                 : git.GetFromConfig(configName);
 
-            if (!result.ExitCodeIsFailure)
+            if (result.ExitCodeIsSuccess)
             {
                 return result.Output.TrimEnd('\n');
             }

--- a/GVFS/GVFS.Common/Http/CacheServerResolver.cs
+++ b/GVFS/GVFS.Common/Http/CacheServerResolver.cs
@@ -131,21 +131,17 @@ namespace GVFS.Common.Http
 
         private static string GetValueFromConfig(GitProcess git, string configName, bool localOnly)
         {
-            GitProcess.Result result =
+            GitProcess.ConfigResult result =
                 localOnly
                 ? git.GetFromLocalConfig(configName)
                 : git.GetFromConfig(configName);
 
-            if (result.ExitCodeIsSuccess)
+            if (!result.TryParseAsString(out string value, out string error))
             {
-                return result.Output.TrimEnd('\n');
-            }
-            else if (result.Errors.Any())
-            {
-                throw new InvalidRepoException("Error while reading '" + configName + "' from config: " + result.Errors);
+                throw new InvalidRepoException(error);
             }
 
-            return null;
+            return value;
         }
 
         private static string GetDeprecatedCacheConfigSettingName(Enlistment enlistment)

--- a/GVFS/GVFS.Common/Http/CacheServerResolver.cs
+++ b/GVFS/GVFS.Common/Http/CacheServerResolver.cs
@@ -126,7 +126,7 @@ namespace GVFS.Common.Http
             GitProcess.Result result = git.SetInLocalConfig(GVFSConstants.GitConfig.CacheServer, cache.Url, replaceAll: true);
 
             error = result.Errors;
-            return !result.HasErrors;
+            return !result.ExitCodeIsFailure;
         }
 
         private static string GetValueFromConfig(GitProcess git, string configName, bool localOnly)
@@ -136,7 +136,7 @@ namespace GVFS.Common.Http
                 ? git.GetFromLocalConfig(configName)
                 : git.GetFromConfig(configName);
 
-            if (!result.HasErrors)
+            if (!result.ExitCodeIsFailure)
             {
                 return result.Output.TrimEnd('\n');
             }

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -315,7 +315,7 @@ namespace GVFS.Common.Prefetch
                 // * ensures the default refspec (remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*) is removed which avoids some "git fetch/pull" failures
                 // * gives added "git fetch" performance since git will only fetch the branch provided in the refspec.
                 GitProcess.Result setResult = git.SetInLocalConfig(OriginRefMapSettingName, refSpec, replaceAll: true);
-                if (setResult.HasErrors)
+                if (setResult.ExitCodeIsFailure)
                 {
                     activity.RelatedError("Could not update ref spec to {0}: {1}", refSpec, setResult.Errors);
                     return false;
@@ -368,7 +368,7 @@ namespace GVFS.Common.Prefetch
                     result = gitProcess.UpdateBranchSha(refName, targetCommitish);
                 }
 
-                if (result.HasErrors)
+                if (result.ExitCodeIsFailure)
                 {
                     activity.RelatedError(result.Errors);
                     return false;

--- a/GVFS/GVFS.Common/Prefetch/CommitPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/CommitPrefetcher.cs
@@ -86,7 +86,7 @@ namespace GVFS.Common.Prefetch
                     metadata.Add("idxPath", idxPath);
                     metadata.Add("timestamp", timestamp);
                     GitProcess.Result indexResult = gitObjects.IndexPackFile(packPath);
-                    if (indexResult.HasErrors)
+                    if (indexResult.ExitCodeIsFailure)
                     {
                         firstBadPack = i;
 

--- a/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
@@ -109,7 +109,7 @@ namespace GVFS.Common.Prefetch.Git
                         recursive: true,
                         showAllTrees: true);
 
-                    if (result.HasErrors)
+                    if (result.ExitCodeIsFailure)
                     {
                         this.HasFailures = true;
                         metadata.Add("Errors", result.Errors);
@@ -126,7 +126,7 @@ namespace GVFS.Common.Prefetch.Git
                         targetTreeSha,
                         line => this.EnqueueOperationsFromDiffTreeLine(this.tracer, this.enlistment.WorkingDirectoryRoot, line));
                     
-                    if (result.HasErrors)
+                    if (result.ExitCodeIsFailure)
                     {
                         this.HasFailures = true;
                         metadata.Add("Errors", result.Errors);

--- a/GVFS/GVFS.Common/Prefetch/Git/GitIndexGenerator.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/GitIndexGenerator.cs
@@ -74,7 +74,7 @@ namespace GVFS.Common.Prefetch.Git
                     recursive: true,
                     showAllTrees: false);
 
-                if (result.HasErrors)
+                if (result.ExitCodeIsFailure)
                 {
                     this.tracer.RelatedError("LsTree failed during index generation: {0}", result.Errors);
                     this.HasFailures = true;

--- a/GVFS/GVFS.Common/Prefetch/Jobs/IndexPackJob.cs
+++ b/GVFS/GVFS.Common/Prefetch/Jobs/IndexPackJob.cs
@@ -44,7 +44,7 @@ namespace GVFS.Common.Prefetch.Jobs
                 using (ITracer activity = this.tracer.StartActivity(IndexPackAreaPath, EventLevel.Informational, Keywords.Telemetry, metadata))
                 {
                     GitProcess.Result result = this.gitObjects.IndexTempPackFile(request.TempPackFile);
-                    if (result.HasErrors)
+                    if (result.ExitCodeIsFailure)
                     {
                         EventMetadata errorMetadata = new EventMetadata();
                         errorMetadata.Add("RequestId", request.DownloadRequest.RequestId);

--- a/GVFS/GVFS.Common/RetryConfig.cs
+++ b/GVFS/GVFS.Common/RetryConfig.cs
@@ -135,7 +135,7 @@ namespace GVFS.Common
             error = string.Empty;
 
             GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 if (result.Errors.Any())
                 {

--- a/GVFS/GVFS.Common/RetryConfig.cs
+++ b/GVFS/GVFS.Common/RetryConfig.cs
@@ -135,16 +135,10 @@ namespace GVFS.Common
             error = string.Empty;
 
             GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.ExitCodeIsFailure)
+            if (result.ExitCodeIsFailure && result.StderrContainsErrors())
             {
-                if (result.Errors.Any())
-                {
-                    error = "Error while reading '" + configName + "' from config: " + result.Errors;
-                    return false;
-                }
-
-                // Git returns non-zero for non-existent settings and errors.
-                return true;
+                error = "Error while reading '" + configName + "' from config: " + result.Errors;
+                return false;
             }
 
             string valueString = result.Output.TrimEnd('\n');

--- a/GVFS/GVFS.Common/RetryConfig.cs
+++ b/GVFS/GVFS.Common/RetryConfig.cs
@@ -131,36 +131,8 @@ namespace GVFS.Common
 
         private static bool TryGetFromGitConfig(GitProcess git, string configName, int defaultValue, int minValue, out int value, out string error)
         {
-            value = defaultValue;
-            error = string.Empty;
-
-            GitProcess.Result result = git.GetFromConfig(configName);
-            if (result.ExitCodeIsFailure && result.StderrContainsErrors())
-            {
-                error = "Error while reading '" + configName + "' from config: " + result.Errors;
-                return false;
-            }
-
-            string valueString = result.Output.TrimEnd('\n');
-            if (string.IsNullOrWhiteSpace(valueString))
-            {
-                // Use default value
-                return true;
-            }
-
-            if (!int.TryParse(valueString, out value))
-            {
-                error = string.Format("Misconfigured config setting {0}, could not parse value {1}", configName, valueString);
-                return false;
-            }
-
-            if (value < minValue)
-            {
-                error = string.Format("Invalid value {0} for setting {1}, value must be greater than or equal to {2}", value, configName, minValue);
-                return false;
-            }
-
-            return true;
+            GitProcess.ConfigResult result = git.GetFromConfig(configName);
+            return result.TryParseAsInt(defaultValue, minValue, out value, out error);
         }
     }
 }

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -130,13 +130,13 @@ namespace GVFS.Mount
 
             GitProcess git = new GitProcess(enlistment);
             GitProcess.ConfigResult configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
-            if (configResult.TryParseAsString(out enlistmentId, out string _))
+            if (configResult.TryParseAsString(out enlistmentId, out string _, defaultValue: string.Empty))
             {
                 enlistmentId = enlistmentId.Trim();
             }
 
             configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
-            if (configResult.TryParseAsString(out mountId, out string _))
+            if (configResult.TryParseAsString(out mountId, out string _, defaultValue: string.Empty))
             {
                 mountId = mountId.Trim();
             }

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -130,13 +130,13 @@ namespace GVFS.Mount
 
             GitProcess git = new GitProcess(enlistment);
             GitProcess.Result configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
-            if (!configResult.ExitCodeIsFailure)
+            if (configResult.ExitCodeIsSuccess)
             {
                 enlistmentId = configResult.Output.Trim();
             }
 
             configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
-            if (!configResult.ExitCodeIsFailure)
+            if (configResult.ExitCodeIsSuccess)
             {
                 mountId = configResult.Output.Trim();
             }

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -130,13 +130,13 @@ namespace GVFS.Mount
 
             GitProcess git = new GitProcess(enlistment);
             GitProcess.Result configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
-            if (!configResult.HasErrors)
+            if (!configResult.ExitCodeIsFailure)
             {
                 enlistmentId = configResult.Output.Trim();
             }
 
             configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
-            if (!configResult.HasErrors)
+            if (!configResult.ExitCodeIsFailure)
             {
                 mountId = configResult.Output.Trim();
             }

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -129,16 +129,16 @@ namespace GVFS.Mount
             string mountId = null;
 
             GitProcess git = new GitProcess(enlistment);
-            GitProcess.Result configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
-            if (configResult.ExitCodeIsSuccess)
+            GitProcess.ConfigResult configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.EnlistmentId);
+            if (configResult.TryParseAsString(out enlistmentId, out string _))
             {
-                enlistmentId = configResult.Output.Trim();
+                enlistmentId = enlistmentId.Trim();
             }
 
             configResult = git.GetFromLocalConfig(GVFSConstants.GitConfig.MountId);
-            if (configResult.ExitCodeIsSuccess)
+            if (configResult.TryParseAsString(out mountId, out string _))
             {
-                mountId = configResult.Output.Trim();
+                mountId = mountId.Trim();
             }
 
             JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSMount", enlistmentId: enlistmentId, mountId: mountId);

--- a/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
+++ b/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
@@ -103,12 +103,12 @@ namespace GVFS.Platform.Windows
         private static string GetConfigValue(string gitBinRoot, string configKey)
         {
             GitProcess.Result result = GitProcess.GetFromSystemConfig(gitBinRoot, configKey);
-            if (result.HasErrors || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
+            if (result.ExitCodeIsFailure || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
             {
                 result = GitProcess.GetFromGlobalConfig(gitBinRoot, configKey);
             }
 
-            if (result.HasErrors || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
+            if (result.ExitCodeIsFailure || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
             {
                 return string.Empty;
             }

--- a/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
+++ b/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
@@ -102,18 +102,17 @@ namespace GVFS.Platform.Windows
 
         private static string GetConfigValue(string gitBinRoot, string configKey)
         {
-            GitProcess.Result result = GitProcess.GetFromSystemConfig(gitBinRoot, configKey);
-            if (result.ExitCodeIsFailure || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
+            string value = string.Empty;
+            string error;
+
+            GitProcess.ConfigResult result = GitProcess.GetFromSystemConfig(gitBinRoot, configKey);
+            if (!result.TryParseAsString(out value, out error, defaultValue: string.Empty) || string.IsNullOrWhiteSpace(value))
             {
                 result = GitProcess.GetFromGlobalConfig(gitBinRoot, configKey);
+                result.TryParseAsString(out value, out error, defaultValue: string.Empty);
             }
 
-            if (result.ExitCodeIsFailure || string.IsNullOrEmpty(result.Output.TrimEnd('\r', '\n')))
-            {
-                return string.Empty;
-            }
-
-            return result.Output.TrimEnd('\r', '\n');
+            return value.TrimEnd('\r', '\n');
         }
 
         private EventSourceOptions CreateOptions(EventLevel level, Keywords keywords, EventOpcode opcode)

--- a/GVFS/GVFS.Platform.Windows/WindowsGitHooksInstaller.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsGitHooksInstaller.cs
@@ -43,7 +43,7 @@ namespace GVFS.Platform.Windows
             string filename;
             string[] defaultHooksLines = { };
 
-            if (configProcess.TryGetFromConfig(configSettingName, forceOutsideEnlistment: true, value: out filename))
+            if (configProcess.TryGetFromConfig(configSettingName, forceOutsideEnlistment: true, value: out filename) && filename != null)
             {
                 filename = filename.Trim(' ', '\n');
                 defaultHooksLines = File.ReadAllLines(filename);

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -14,5 +14,121 @@ namespace GVFS.UnitTests.Git
             GitProcess process = new GitProcess(new MockGVFSEnlistment());
             process.TryKillRunningProcess().ShouldBeTrue();
         }
+
+        [TestCase]
+        public void ResultHasNoErrors()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                string.Empty,
+                0);
+
+            result.ExitCodeIsFailure.ShouldBeFalse();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ResultHasWarnings()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                "Warning: this is fine.\n",
+                0);
+
+            result.ExitCodeIsFailure.ShouldBeFalse();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_SingleLine_AllWarnings()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                "warning: this line should not be considered an error",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_Multiline_AllWarnings()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                @"warning: this line should not be considered an error
+WARNING: neither should this.",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_Multiline_EmptyLines()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                @"
+warning: this is fine
+
+warning: this is too
+
+",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_Singleline_AllErrors()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                "this is an error",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_Multiline_AllErrors()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                @"error1
+error2",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_Multiline_ErrorsAndWarnings()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                @"WARNING: this is fine
+this is an error",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void ResultHasNonWarningErrors_TrailingWhitespace_Warning()
+        {
+            GitProcess.Result result = new GitProcess.Result(
+                string.Empty,
+                "Warning: this is fine\n",
+                1);
+
+            result.ExitCodeIsFailure.ShouldBeTrue();
+            result.StderrContainsErrors().ShouldBeFalse();
+        }
     }
 }

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -130,5 +130,91 @@ this is an error",
             result.ExitCodeIsFailure.ShouldBeTrue();
             result.StderrContainsErrors().ShouldBeFalse();
         }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsString_NullWhenUnsetAndNoErrors()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, string.Empty, 1),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string _).ShouldBeTrue();
+            expectedValue.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsString_FailsWhenErrors()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, "errors", 1),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsString_NullWhenUnsetAndWarnings()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, "warning: ignored", 1),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string _).ShouldBeTrue();
+            expectedValue.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsString_PassesThroughErrors()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, "--local can only be used inside a git repository", 1),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string error).ShouldBeFalse();
+            error.Contains("--local").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsInt_FailsWithErrors()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, "errors", 1),
+                "settingName");
+
+            result.TryParseAsInt(0, -1, out int value, out string error).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsInt_DefaultWhenUnset()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, string.Empty, 1),
+                "settingName");
+
+            result.TryParseAsInt(1, -1, out int value, out string error).ShouldBeTrue();
+            value.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsInt_ParsesWhenNoError()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result("32", string.Empty, 0),
+                "settingName");
+
+            result.TryParseAsInt(1, -1, out int value, out string error).ShouldBeTrue();
+            value.ShouldEqual(32);
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsInt_ParsesWhenNoWarnings()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result("32", "warning: ignored", 0),
+                "settingName");
+
+            result.TryParseAsInt(1, -1, out int value, out string error).ShouldBeTrue();
+            value.ShouldEqual(32);
+        }
     }
 }

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -132,7 +132,7 @@ this is an error",
         }
 
         [TestCase]
-        public void ConfigResult_TryParseAsString_NullWhenUnsetAndNoErrors()
+        public void ConfigResult_TryParseAsString_DefaultIsNull()
         {
             GitProcess.ConfigResult result = new GitProcess.ConfigResult(
                 new GitProcess.Result(string.Empty, string.Empty, 1),
@@ -175,6 +175,28 @@ this is an error",
         }
 
         [TestCase]
+        public void ConfigResult_TryParseAsString_RespectsDefaultOnFailure()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result(string.Empty, string.Empty, 1),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string _, "default").ShouldBeTrue();
+            expectedValue.ShouldEqual("default");
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsString_OverridesDefaultOnSuccess()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result("expected", string.Empty, 0),
+                "settingName");
+
+            result.TryParseAsString(out string expectedValue, out string _, "default").ShouldBeTrue();
+            expectedValue.ShouldEqual("expected");
+        }
+
+        [TestCase]
         public void ConfigResult_TryParseAsInt_FailsWithErrors()
         {
             GitProcess.ConfigResult result = new GitProcess.ConfigResult(
@@ -207,10 +229,21 @@ this is an error",
         }
 
         [TestCase]
-        public void ConfigResult_TryParseAsInt_ParsesWhenNoWarnings()
+        public void ConfigResult_TryParseAsInt_ParsesWhenWarnings()
         {
             GitProcess.ConfigResult result = new GitProcess.ConfigResult(
                 new GitProcess.Result("32", "warning: ignored", 0),
+                "settingName");
+
+            result.TryParseAsInt(1, -1, out int value, out string error).ShouldBeTrue();
+            value.ShouldEqual(32);
+        }
+
+        [TestCase]
+        public void ConfigResult_TryParseAsInt_ParsesWhenOutputIncludesWhitespace()
+        {
+            GitProcess.ConfigResult result = new GitProcess.ConfigResult(
+                new GitProcess.Result("\n\t 32\t\r\n", "warning: ignored", 0),
                 "settingName");
 
             result.TryParseAsInt(1, -1, out int value, out string error).ShouldBeTrue();

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -605,7 +605,7 @@ namespace GVFS.Virtualization
 
                         GitProcess.Result result = this.postFetchGitProcess.WriteMultiPackIndex(this.context.Enlistment.GitObjectsRoot);
 
-                        if (!this.stopping && result.HasErrors)
+                        if (!this.stopping && result.ExitCodeIsFailure)
                         {
                             this.context.Tracer.RelatedWarning(
                                 metadata: null,
@@ -637,7 +637,7 @@ namespace GVFS.Virtualization
 
                         GitProcess.Result result = this.postFetchGitProcess.WriteCommitGraph(this.context.Enlistment.GitObjectsRoot, packIndexes);
 
-                        if (!this.stopping && result.HasErrors)
+                        if (!this.stopping && result.ExitCodeIsFailure)
                         {
                             this.context.Tracer.RelatedWarning(
                                 metadata: null,

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -541,7 +541,7 @@ namespace GVFS.CommandLine
             GitProcess git = new GitProcess(enlistment);
             string originBranchName = "origin/" + branch;
             GitProcess.Result createBranchResult = git.CreateBranchWithUpstream(branch, originBranchName);
-            if (createBranchResult.HasErrors)
+            if (createBranchResult.ExitCodeIsFailure)
             {
                 return new Result("Unable to create branch '" + originBranchName + "': " + createBranchResult.Errors + "\r\n" + createBranchResult.Output);
             }
@@ -565,7 +565,7 @@ namespace GVFS.CommandLine
             }
 
             GitProcess.Result forceCheckoutResult = git.ForceCheckout(branch);
-            if (forceCheckoutResult.HasErrors && forceCheckoutResult.Errors.IndexOf("unable to read tree") > 0)
+            if (forceCheckoutResult.ExitCodeIsFailure && forceCheckoutResult.Errors.IndexOf("unable to read tree") > 0)
             {
                 // It is possible to have the above TryDownloadCommit() fail because we
                 // already have the commit and root tree we intend to check out, but
@@ -589,7 +589,7 @@ namespace GVFS.CommandLine
                 forceCheckoutResult = git.ForceCheckout(branch);
             }
 
-            if (forceCheckoutResult.HasErrors)
+            if (forceCheckoutResult.ExitCodeIsFailure)
             {
                 string[] errorLines = forceCheckoutResult.Errors.Split('\n');
                 StringBuilder checkoutErrors = new StringBuilder();
@@ -677,7 +677,7 @@ git %*
         {
             string repoPath = enlistmentToInit.WorkingDirectoryRoot;
             GitProcess.Result initResult = GitProcess.Init(enlistmentToInit);
-            if (initResult.HasErrors)
+            if (initResult.ExitCodeIsFailure)
             {
                 string error = string.Format("Could not init repo at to {0}: {1}", repoPath, initResult.Errors);
                 tracer.RelatedError(error);
@@ -685,7 +685,7 @@ git %*
             }
 
             GitProcess.Result remoteAddResult = new GitProcess(enlistmentToInit).RemoteAdd("origin", enlistmentToInit.RepoUrl);
-            if (remoteAddResult.HasErrors)
+            if (remoteAddResult.ExitCodeIsFailure)
             {
                 string error = string.Format("Could not add remote to {0}: {1}", repoPath, remoteAddResult.Errors);
                 tracer.RelatedError(error);

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -158,7 +158,7 @@ of your enlistment's src folder.
 
                         GitProcess git = new GitProcess(enlistment);
                         statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false);
-                        if (statusResult.HasErrors)
+                        if (statusResult.ExitCodeIsFailure)
                         {
                             return false;
                         }
@@ -180,7 +180,7 @@ of your enlistment's src folder.
                         this.WriteMessage(tracer, "Failed to run git status because the repo is not mounted");
                         this.WriteMessage(tracer, "Either mount first, or run with --no-status");
                     }
-                    else if (statusResult.HasErrors)
+                    else if (statusResult.ExitCodeIsFailure)
                     {
                         this.WriteMessage(tracer, "Failed to run git status: " + statusResult.Errors);
                     }
@@ -361,7 +361,7 @@ of your enlistment's src folder.
                         GVFSGitObjects gitObjects = new GVFSGitObjects(new GVFSContext(tracer, fileSystem, gitRepo, enlistment), objectRequestor);
 
                         GitProcess.Result revParseResult = enlistment.CreateGitProcess().RevParse("HEAD");
-                        if (revParseResult.HasErrors)
+                        if (revParseResult.ExitCodeIsFailure)
                         {
                             errorMessage = "Unable to determine HEAD commit id: " + revParseResult.Errors;
                             return false;
@@ -402,7 +402,7 @@ of your enlistment's src folder.
                         GitProcess.Result checkoutResult = git.ForceCheckout("HEAD");
 
                         errorMessage = checkoutResult.Errors;
-                        return !checkoutResult.HasErrors;
+                        return !checkoutResult.ExitCodeIsFailure;
                     }
                 },
                 "Recreating git index",

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -402,7 +402,7 @@ of your enlistment's src folder.
                         GitProcess.Result checkoutResult = git.ForceCheckout("HEAD");
 
                         errorMessage = checkoutResult.Errors;
-                        return !checkoutResult.ExitCodeIsFailure;
+                        return checkoutResult.ExitCodeIsSuccess;
                     }
                 },
                 "Recreating git index",

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -468,7 +468,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 line => rootEntries.Add(DiffTreeResult.ParseFromLsTreeLine(line, repoRoot: string.Empty)),
                 recursive: false);
 
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 error = "Error returned from ls-tree to find " + GVFSConstants.SpecialGitFiles.GitAttributes + " file: " + result.Errors;
                 return false;
@@ -564,14 +564,14 @@ You can specify a URL, a name of a configured cache server, or the special names
             tracer.RelatedEvent(EventLevel.Informational, "EnlistmentInfo", metadata, Keywords.Telemetry);
 
             GitProcess.Result configResult = git.SetInLocalConfig(GVFSConstants.GitConfig.EnlistmentId, RepoMetadata.Instance.EnlistmentId, replaceAll: true);
-            if (configResult.HasErrors)
+            if (configResult.ExitCodeIsFailure)
             {
                 string error = "Could not update config with enlistment id, error: " + configResult.Errors;
                 tracer.RelatedWarning(error);
             }
 
             configResult = git.SetInLocalConfig(GVFSConstants.GitConfig.MountId, mountId, replaceAll: true);
-            if (configResult.HasErrors)
+            if (configResult.ExitCodeIsFailure)
             {
                 string error = "Could not update config with mount id, error: " + configResult.Errors;
                 tracer.RelatedWarning(error);
@@ -605,7 +605,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                         (isRequired && !existingSetting.HasValue(setting.Value)))
                     {
                         GitProcess.Result setConfigResult = git.SetInLocalConfig(setting.Key, setting.Value);
-                        if (setConfigResult.HasErrors)
+                        if (setConfigResult.ExitCodeIsFailure)
                         {
                             return false;
                         }

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -264,7 +264,7 @@ namespace GVFS.CommandLine
 
             GitProcess gitProcess = new GitProcess(enlistment);
             GitProcess.Result result = gitProcess.RevParse(GVFSConstants.DotGit.HeadName);
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 tracer.RelatedError(result.Errors);
                 this.Output.WriteLine(result.Errors);

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -23,7 +23,7 @@ namespace GVFS.RepairJobs
         {
             GitProcess git = new GitProcess(this.Enlistment);
             GitProcess.Result result = git.GetOriginUrl();
-            if (result.HasErrors)
+            if (result.ExitCodeIsFailure)
             {
                 if (result.Errors.Length == 0)
                 {

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -22,15 +22,12 @@ namespace GVFS.RepairJobs
         public override IssueType HasIssue(List<string> messages)
         {
             GitProcess git = new GitProcess(this.Enlistment);
-            GitProcess.Result result = git.GetOriginUrl();
-            if (result.ExitCodeIsFailure)
+            GitProcess.ConfigResult originResult = git.GetOriginUrl();
+            string error;
+            string originUrl;
+            if (!originResult.TryParseAsString(out originUrl, out error))
             {
-                if (result.Errors.Length == 0)
-                {
-                    messages.Add("Remote 'origin' is not configured for this repo. You can fix this by running 'git remote add origin <repourl>'");
-                    return IssueType.CantFix;
-                }
-                else if (result.Errors.Contains("--local"))
+                if (error.Contains("--local"))
                 {
                     // example error: '--local can only be used inside a git repository'
                     // Corrupting the git config does not cause git to not recognize the current folder as "not a git repository".
@@ -39,8 +36,14 @@ namespace GVFS.RepairJobs
                     return IssueType.CantFix;
                 }
 
-                messages.Add("Could not read origin url: " + result.Errors);
+                messages.Add("Could not read origin url: " + error);
                 return IssueType.Fixable;
+            }
+
+            if (originUrl == null)
+            {
+                messages.Add("Remote 'origin' is not configured for this repo. You can fix this by running 'git remote add origin <repourl>'");
+                return IssueType.CantFix;
             }
 
             // We've validated the repo URL, so now make sure we can authenticate
@@ -57,7 +60,7 @@ namespace GVFS.RepairJobs
                 {
                     messages.Add("Authentication failed. Run 'gvfs log' for more info.");
                     messages.Add(".git\\config is valid and remote 'origin' is set, but may have a typo:");
-                    messages.Add(result.Output.Trim());
+                    messages.Add(originUrl.Trim());
                     return IssueType.CantFix;
                 }
             }


### PR DESCRIPTION
This addresses #471 