### PR TITLE
Mac: Reset auth cache on provider disconnecting, improve VirtualizationRoot array correctness

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		4A08257B21E8F65A00E21AFD /* FileSystemMountPoints.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileSystemMountPoints.hpp; sourceTree = "<group>"; };
 		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
 		4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessaging.hpp; sourceTree = "<group>"; };
+		4A5A190C224E14FB009EC126 /* FileSystemMountPointsTestable.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileSystemMountPointsTestable.hpp; sourceTree = "<group>"; };
 		4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualizationRootsTests.mm; sourceTree = "<group>"; };
 		4A781DA6222094C300DB7733 /* VirtualizationRootsPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRootsPrivate.hpp; sourceTree = "<group>"; };
 		4A781DA82222C6EA00DB7733 /* PrjFSProviderUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSProviderUserClient.hpp; sourceTree = "<group>"; };
@@ -206,6 +207,7 @@
 		4A781DB122233A1E00DB7733 /* TestLocks.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestLocks.cpp; sourceTree = "<group>"; };
 		4A781DB322233A4500DB7733 /* TestMemory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestMemory.cpp; sourceTree = "<group>"; };
 		4A781DB722299C5300DB7733 /* VirtualizationRootsTestable.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRootsTestable.hpp; sourceTree = "<group>"; };
+		4A7A310B221190E0007B2AAF /* FileSystemMountPointsPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileSystemMountPointsPrivate.hpp; sourceTree = "<group>"; };
 		4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPrjFSKextTestable.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = PrjFSKextTests.exp; sourceTree = "<group>"; };
 		D9C087F122384670009C1110 /* MemoryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryTests.mm; sourceTree = "<group>"; };
@@ -344,6 +346,8 @@
 				4A781DA6222094C300DB7733 /* VirtualizationRootsPrivate.hpp */,
 				4A08257A21E8F65A00E21AFD /* FileSystemMountPoints.cpp */,
 				4A08257B21E8F65A00E21AFD /* FileSystemMountPoints.hpp */,
+				4A5A190C224E14FB009EC126 /* FileSystemMountPointsTestable.hpp */,
+				4A7A310B221190E0007B2AAF /* FileSystemMountPointsPrivate.hpp */,
 				4391F8A121E42AC50008103C /* VnodeUtilities.cpp */,
 				4391F8A221E42AC50008103C /* VnodeUtilities.hpp */,
 			);

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -64,10 +64,13 @@
 		4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
 		4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */; };
+		4A08257C21E8F65A00E21AFD /* FileSystemMountPoints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A08257A21E8F65A00E21AFD /* FileSystemMountPoints.cpp */; };
+		4A08257D21E8F65A00E21AFD /* FileSystemMountPoints.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A08257B21E8F65A00E21AFD /* FileSystemMountPoints.hpp */; };
 		4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
 		4A558DBB22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
 		4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
 		4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
+		4A5A190B224E0E89009EC126 /* FileSystemMountPoints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A08257A21E8F65A00E21AFD /* FileSystemMountPoints.cpp */; };
 		4A781DA52220946000DB7733 /* VirtualizationRootsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */; };
 		4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8A721E42AC50008103C /* VirtualizationRoots.cpp */; };
 		4A781DAB222330F700DB7733 /* KextMockUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DAA222330F700DB7733 /* KextMockUtilities.cpp */; };
@@ -188,6 +191,8 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A08257A21E8F65A00E21AFD /* FileSystemMountPoints.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystemMountPoints.cpp; sourceTree = "<group>"; };
+		4A08257B21E8F65A00E21AFD /* FileSystemMountPoints.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileSystemMountPoints.hpp; sourceTree = "<group>"; };
 		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
 		4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessaging.hpp; sourceTree = "<group>"; };
 		4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualizationRootsTests.mm; sourceTree = "<group>"; };
@@ -337,6 +342,8 @@
 				4391F89421E42AC40008103C /* VirtualizationRoots.hpp */,
 				4A781DB722299C5300DB7733 /* VirtualizationRootsTestable.hpp */,
 				4A781DA6222094C300DB7733 /* VirtualizationRootsPrivate.hpp */,
+				4A08257A21E8F65A00E21AFD /* FileSystemMountPoints.cpp */,
+				4A08257B21E8F65A00E21AFD /* FileSystemMountPoints.hpp */,
 				4391F8A121E42AC50008103C /* VnodeUtilities.cpp */,
 				4391F8A221E42AC50008103C /* VnodeUtilities.hpp */,
 			);
@@ -379,8 +386,6 @@
 			children = (
 				F5E39C7B21F1118D006D65C2 /* Info.plist */,
 				F5E39C7921F1118D006D65C2 /* KauthHandlerTests.mm */,
-				4A781DAF2223391A00DB7733 /* KextLogMock.cpp */,
-				F557623E22009F0E005DE35E /* KextLogMock.h */,
 				4A781DAA222330F700DB7733 /* KextMockUtilities.cpp */,
 				4A781DA92223305C00DB7733 /* KextMockUtilities.hpp */,
 				D9C087F122384670009C1110 /* MemoryTests.mm */,
@@ -388,7 +393,6 @@
 				265504CF224ADE11005FAD74 /* MockPerfTracing.hpp */,
 				4A781DAC2223374200DB7733 /* MockVnodeAndMount.cpp */,
 				4A781DAD2223374200DB7733 /* MockVnodeAndMount.hpp */,
-				4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */,
 				4A781DB122233A1E00DB7733 /* TestLocks.cpp */,
 				4A781DB322233A4500DB7733 /* TestMemory.cpp */,
 				4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */,
@@ -408,6 +412,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A08257D21E8F65A00E21AFD /* FileSystemMountPoints.hpp in Headers */,
 				4391F8A821E42AC50008103C /* Locks.hpp in Headers */,
 				4391F8B821E42AC50008103C /* PrjFSLogUserClient.hpp in Headers */,
 				4391F8B221E42AC50008103C /* Memory.hpp in Headers */,
@@ -651,6 +656,7 @@
 				4391F8C121E42AC50008103C /* VirtualizationRoots.cpp in Sources */,
 				4391F8C021E42AC50008103C /* Locks.cpp in Sources */,
 				4391F8AD21E42AC50008103C /* KauthHandler.cpp in Sources */,
+				4A08257C21E8F65A00E21AFD /* FileSystemMountPoints.cpp in Sources */,
 				4391F8AF21E42AC50008103C /* PrjFSProviderUserClient.cpp in Sources */,
 				4391F8BA21E42AC50008103C /* PrjFSLogUserClient.cpp in Sources */,
 				4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,
@@ -695,6 +701,7 @@
 				4A558DBB22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,
 				4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */,
 				4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */,
+				4A5A190B224E0E89009EC126 /* FileSystemMountPoints.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		4A781DB02223391A00DB7733 /* KextLogMock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DAF2223391A00DB7733 /* KextLogMock.cpp */; };
 		4A781DB222233A1E00DB7733 /* TestLocks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DB122233A1E00DB7733 /* TestLocks.cpp */; };
 		4A781DB422233A4500DB7733 /* TestMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DB322233A4500DB7733 /* TestMemory.cpp */; };
+		4A7A310D221211CC007B2AAF /* FileSystemMountPointTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A7A310C221211CC007B2AAF /* FileSystemMountPointTests.mm */; };
 		4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F89321E42AC40008103C /* KauthHandler.cpp */; };
 		4A8C13A621F2418400002878 /* libPrjFSKextTestable.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */; };
 		D9C087F222384670009C1110 /* MemoryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D9C087F122384670009C1110 /* MemoryTests.mm */; };
@@ -208,6 +209,7 @@
 		4A781DB322233A4500DB7733 /* TestMemory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestMemory.cpp; sourceTree = "<group>"; };
 		4A781DB722299C5300DB7733 /* VirtualizationRootsTestable.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRootsTestable.hpp; sourceTree = "<group>"; };
 		4A7A310B221190E0007B2AAF /* FileSystemMountPointsPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileSystemMountPointsPrivate.hpp; sourceTree = "<group>"; };
+		4A7A310C221211CC007B2AAF /* FileSystemMountPointTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileSystemMountPointTests.mm; sourceTree = "<group>"; };
 		4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPrjFSKextTestable.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = PrjFSKextTests.exp; sourceTree = "<group>"; };
 		D9C087F122384670009C1110 /* MemoryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryTests.mm; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 				4A781DB122233A1E00DB7733 /* TestLocks.cpp */,
 				4A781DB322233A4500DB7733 /* TestMemory.cpp */,
 				4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */,
+				4A7A310C221211CC007B2AAF /* FileSystemMountPointTests.mm */,
 				4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */,
 				F557623E22009F0E005DE35E /* KextLogMock.h */,
 				4A781DAF2223391A00DB7733 /* KextLogMock.cpp */,
@@ -721,6 +724,7 @@
 				4A781DB422233A4500DB7733 /* TestMemory.cpp in Sources */,
 				D9C087F222384670009C1110 /* MemoryTests.mm in Sources */,
 				F5E39C7A21F1118D006D65C2 /* KauthHandlerTests.mm in Sources */,
+				4A7A310D221211CC007B2AAF /* FileSystemMountPointTests.mm in Sources */,
 				4A781DB222233A1E00DB7733 /* TestLocks.cpp in Sources */,
 				4A781DB02223391A00DB7733 /* KextLogMock.cpp in Sources */,
 			);

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.cpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.cpp
@@ -1,11 +1,158 @@
+#include "FileSystemMountPointsPrivate.hpp"
 #include "FileSystemMountPoints.hpp"
 #include "kernel-header-wrappers/mount.h"
+#include "Locks.hpp"
+#include "KextLog.hpp"
+#include <kern/assert.h>
+
+#ifdef KEXT_UNIT_TESTING
+#include "FileSystemMountPointsTestable.hpp"
+#endif
+
+static Mutex s_mountPointsMutex;
+KEXT_STATIC MountPoint s_usedMountPoints[MaxUsedMountPoints];
+static bool s_reuseMountPointSlots;
+
+bool MountPoint_Init()
+{
+    s_reuseMountPointSlots = true;
+    s_mountPointsMutex = Mutex_Alloc();
+    if (!Mutex_IsValid(s_mountPointsMutex))
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+void MountPoint_Cleanup()
+{
+    if (Mutex_IsValid(s_mountPointsMutex))
+    {
+        Mutex_FreeMemory(&s_mountPointsMutex);
+    }
+    
+    for (size_t i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        // by the time this function is called, any provider user clients
+        // should have been terminated & deregistered
+        assert(s_usedMountPoints[i].authCacheDisableCount == 0);
+        assertf(
+            !s_reuseMountPointSlots || s_usedMountPoints[i].mountPoint == nullptr,
+            "If reusing slots is still allowed, they should all have been reset to the empty state by now; slot reuse allowed: %s, mount point registered in slot %lu: %p",
+            s_reuseMountPointSlots ? "yes" : "no",
+            i,
+            KextLog_Unslide(s_usedMountPoints[i].mountPoint));
+    }
+}
+
+KEXT_STATIC ssize_t FindMountPoint_Locked(mount_t mountPoint)
+{
+    for (size_t i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        if (s_usedMountPoints[i].mountPoint == mountPoint)
+        {
+            return i;
+        }
+    }
+    
+    return -1;
+}
+
+KEXT_STATIC_INLINE ssize_t FindEmptyMountPointSlot_Locked()
+{
+    return FindMountPoint_Locked(nullptr);
+}
+
+KEXT_STATIC ssize_t TryFindOrInsertMountPoint_Locked(mount_t mountPoint)
+{
+    ssize_t mountPointIndex = FindMountPoint_Locked(mountPoint);
+    if (mountPointIndex < 0)
+    {
+        mountPointIndex = FindEmptyMountPointSlot_Locked();
+        if (mountPointIndex >= 0)
+        {
+            s_usedMountPoints[mountPointIndex].mountPoint = mountPoint;
+            assert(s_usedMountPoints[mountPointIndex].authCacheDisableCount == 0);
+        }
+    }
+    
+    return mountPointIndex;
+}
 
 void MountPoint_DisableAuthCache(mount_t mountPoint)
 {
-    vfs_setauthcache_ttl(mountPoint, 0);
+    Mutex_Acquire(s_mountPointsMutex);
+    {
+        ssize_t mountPointIndex = TryFindOrInsertMountPoint_Locked(mountPoint);
+        if (mountPointIndex < 0)
+        {
+            // No space in array, just disable auth cache and don't save previous state
+            KextLog_Info("MountPoint_DisableAuthCache: No space to save auth cache state for mount point '%s', restoring will not be possible.", vfs_statfs(mountPoint)->f_mntonname);
+            vfs_setauthcache_ttl(mountPoint, 0);
+            // No longer allow reuse of slots once all are used; allowing it would
+            // open the possibility of miscounting "restore" operations, thus
+            // restoring the auth cache TTL despite mount points being in use.
+            s_reuseMountPointSlots = false;
+        }
+        else
+        {
+            MountPoint* usedMountPoint = &s_usedMountPoints[mountPointIndex];
+            if (usedMountPoint->authCacheDisableCount == 0)
+            {
+                // New entry, save state and disable cache
+                usedMountPoint->savedAuthCacheTTL = vfs_authcache_ttl(mountPoint);
+                usedMountPoint->authCacheDisableCount = 1;
+                vfs_setauthcache_ttl(mountPoint, 0);
+            }
+            else
+            {
+                ++usedMountPoint->authCacheDisableCount;
+            }
+        }
+        
+    }
+    Mutex_Release(s_mountPointsMutex);
 }
 
 void MountPoint_RestoreAuthCache(mount_t mountPoint)
 {
+    Mutex_Acquire(s_mountPointsMutex);
+    {
+        ssize_t mountPointIndex = FindMountPoint_Locked(mountPoint);
+        if (mountPointIndex < 0)
+        {
+            KextLog_Info("MountPoint_RestoreAuthCache: previous auth cache state for mount point '%s' not found, can't restore.", vfs_statfs(mountPoint)->f_mntonname);
+        }
+        else
+        {
+            MountPoint* usedMountPoint = &s_usedMountPoints[mountPointIndex];
+            usedMountPoint->authCacheDisableCount--;
+            if (0 == usedMountPoint->authCacheDisableCount)
+            {
+                int savedTTL = usedMountPoint->savedAuthCacheTTL;
+                // vfs_clearauthcache_ttl(mount) has a slightly different effect in the kernel than
+                // vfs_setauthcache_ttl(mount, CACHED_RIGHT_INFINITE_TTL) so make sure to call the
+                // appropriate one when resetting to the original state.
+                if (savedTTL == CACHED_RIGHT_INFINITE_TTL)
+                {
+                    KextLog_Info("DecrementAuthCacheDisableCount: resetting mount point '%s' to default auth cache behaviour",
+                        vfs_statfs(mountPoint)->f_mntonname);
+                    vfs_clearauthcache_ttl(mountPoint);
+                }
+                else
+                {
+                    KextLog_Info("DecrementAuthCacheDisableCount: resetting mount point '%s' TTL to %d",
+                        vfs_statfs(mountPoint)->f_mntonname, savedTTL);
+                    vfs_setauthcache_ttl(mountPoint, usedMountPoint->savedAuthCacheTTL);
+                }
+                
+                if (s_reuseMountPointSlots)
+                {
+                    usedMountPoint->mountPoint = nullptr;
+                }
+            }
+        }
+    }
+    Mutex_Release(s_mountPointsMutex);
 }

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.cpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.cpp
@@ -1,0 +1,11 @@
+#include "FileSystemMountPoints.hpp"
+#include "kernel-header-wrappers/mount.h"
+
+void MountPoint_DisableAuthCache(mount_t mountPoint)
+{
+    vfs_setauthcache_ttl(mountPoint, 0);
+}
+
+void MountPoint_RestoreAuthCache(mount_t mountPoint)
+{
+}

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.hpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.hpp
@@ -2,5 +2,8 @@
 
 struct mount;
 
+bool MountPoint_Init();
+void MountPoint_Cleanup();
+
 void MountPoint_DisableAuthCache(mount* mountPoint);
 void MountPoint_RestoreAuthCache(mount* mountPoint);

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.hpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPoints.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+struct mount;
+
+void MountPoint_DisableAuthCache(mount* mountPoint);
+void MountPoint_RestoreAuthCache(mount* mountPoint);

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPointsPrivate.hpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPointsPrivate.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <sys/kernel_types.h>
+
+struct MountPoint
+{
+    mount_t  mountPoint;
+    uint32_t authCacheDisableCount;
+    int      savedAuthCacheTTL;
+};
+
+static constexpr size_t MaxUsedMountPoints = 4;

--- a/ProjFS.Mac/PrjFSKext/FileSystemMountPointsTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/FileSystemMountPointsTestable.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifndef KEXT_UNIT_TESTING
+#error Don't #include this file in non-testing builds
+#endif
+
+#include "FileSystemMountPointsPrivate.hpp"
+#include "public/PrjFSCommon.h"
+
+KEXT_STATIC ssize_t FindMountPoint_Locked(mount_t mountPoint);
+KEXT_STATIC_INLINE ssize_t FindEmptyMountPointSlot_Locked();
+KEXT_STATIC ssize_t TryFindOrInsertMountPoint_Locked(mount_t mountPoint);
+
+#ifdef KEXT_UNIT_TESTING // otherwise this is a static
+extern MountPoint s_usedMountPoints[MaxUsedMountPoints];
+#endif

--- a/ProjFS.Mac/PrjFSKext/Memory.cpp
+++ b/ProjFS.Mac/PrjFSKext/Memory.cpp
@@ -41,6 +41,11 @@ void* Memory_Alloc(uint32_t size)
     return OSMalloc(size, s_mallocTag);
 }
 
+void* Memory_AllocNoBlock(uint32_t size)
+{
+    return OSMalloc_noblock(size, s_mallocTag);
+}
+
 void Memory_Free(void* buffer, uint32_t size)
 {
     OSFree(buffer, size, s_mallocTag);

--- a/ProjFS.Mac/PrjFSKext/Memory.hpp
+++ b/ProjFS.Mac/PrjFSKext/Memory.hpp
@@ -13,6 +13,7 @@ kern_return_t Memory_Init();
 kern_return_t Memory_Cleanup();
 
 void* Memory_Alloc(uint32_t size);
+void* Memory_AllocNoBlock(uint32_t size);
 void Memory_Free(void* buffer, uint32_t size);
 
 template <typename T>
@@ -27,6 +28,20 @@ T* Memory_AllocArray(uint32_t arrayLength)
 
     return static_cast<T*>(Memory_Alloc(allocBytes));
 }
+
+template <typename T>
+T* Memory_AllocArrayNoBlock(uint32_t arrayLength)
+{
+    uint32_t allocBytes;
+    if (__builtin_umul_overflow(arrayLength, sizeof(T), &allocBytes))
+    {
+        // Overflow occurred.
+        return nullptr;
+    }
+
+    return static_cast<T*>(Memory_AllocNoBlock(static_cast<uint32_t>(allocBytes)));
+}
+
 
 template <typename T>
 void Memory_FreeArray(T* array, uint32_t arrayLength)

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext.cpp
@@ -6,6 +6,7 @@
 #include "Locks.hpp"
 #include "Memory.hpp"
 #include "PerformanceTracing.hpp"
+#include "FileSystemMountPoints.hpp"
 
 extern "C" kern_return_t PrjFSKext_Start(kmod_info_t* ki, void* d);
 extern "C" kern_return_t PrjFSKext_Stop(kmod_info_t* ki, void* d);
@@ -25,6 +26,11 @@ kern_return_t PrjFSKext_Start(kmod_info_t* ki, void* d)
     }
     
     if (!KextLog_Init())
+    {
+        goto CleanupAndFail;
+    }
+    
+    if (!MountPoint_Init())
     {
         goto CleanupAndFail;
     }
@@ -52,6 +58,8 @@ kern_return_t PrjFSKext_Stop(kmod_info_t* ki, void* d)
     {
         result = KERN_FAILURE;
     }
+
+    MountPoint_Cleanup();
 
     if (Memory_Cleanup())
     {

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRootsPrivate.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRootsPrivate.hpp
@@ -18,3 +18,8 @@ struct VirtualizationRoot
     // TODO(Mac): this should eventually be entirely diagnostic and not used for decisions
     char                        path[PrjFSMaxPath];
 };
+
+#if defined(KEXT_UNIT_TESTING) && !defined(TESTABLE_KEXT_TARGET) // Building unit tests
+#include <type_traits>
+static_assert(std::is_trivially_copyable<VirtualizationRoot>::value, "The array of VirtualizationRoot objects is resized using memcpy");
+#endif

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
@@ -9,5 +9,5 @@
 extern uint16_t s_maxVirtualizationRoots;
 extern VirtualizationRoot* s_virtualizationRoots;
 
-KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
+KEXT_STATIC VirtualizationRootHandle FindOrInsertVirtualizationRoot_LockedMayUnlock(vnode_t virtualizationRootVNode, uint32_t rootVid, FsidInode persistentIds, const char* path);
 

--- a/ProjFS.Mac/PrjFSKextTests/FileSystemMountPointTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/FileSystemMountPointTests.mm
@@ -1,0 +1,212 @@
+#include "../PrjFSKext/FileSystemMountPoints.hpp"
+#include "../PrjFSKext/FileSystemMountPointsTestable.hpp"
+#include "MockVnodeAndMount.hpp"
+#include "KextMockUtilities.hpp"
+#import <XCTest/XCTest.h>
+#include <array>
+
+using std::shared_ptr;
+using std::array;
+using std::generate;
+
+
+@interface FileSystemMountPointTests : XCTestCase
+
+@end
+
+@implementation FileSystemMountPointTests
+{
+    array<shared_ptr<mount>, MaxUsedMountPoints> dummyMounts;
+}
+
+- (void) fillAllMountPointSlots
+{
+    for (unsigned i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        s_usedMountPoints[i].authCacheDisableCount = 1;
+        s_usedMountPoints[i].mountPoint = self->dummyMounts[i].get();
+    }
+}
+
+- (void) fillAllMountPointSlotsExcept:(unsigned)leaveEmptyIndex
+{
+    for (unsigned i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        if (i != leaveEmptyIndex)
+        {
+            s_usedMountPoints[i].authCacheDisableCount = 1;
+            s_usedMountPoints[i].mountPoint = self->dummyMounts[i].get();
+        }
+    }
+}
+
+
+- (void)setUp
+{
+    srand(0);
+    memset(s_usedMountPoints, 0, sizeof(s_usedMountPoints));
+    
+    // This is roughly what "real" fsids look like
+    fsid_t testMountFsid = { (1 << 24) | (rand() % 32), (rand() % 16) };
+    
+    for (shared_ptr<mount>& dummy : self->dummyMounts)
+    {
+        dummy = mount::Create("hfs", testMountFsid, rand() /* initial inode */);
+        testMountFsid.val[1]++;
+    }
+
+    MountPoint_Init();
+}
+
+- (void)tearDown
+{
+    MountPoint_Cleanup();
+    
+    for (shared_ptr<mount>& dummy : self->dummyMounts)
+    {
+        dummy.reset();
+    }
+    memset(s_usedMountPoints, 0, sizeof(s_usedMountPoints));
+}
+
+- (void)testFindEmptyMountPointSlot_AllFull
+{
+    [self fillAllMountPointSlots];
+    
+    ssize_t found = FindEmptyMountPointSlot_Locked();
+    XCTAssertLessThan(found, 0, "All slots taken, should return error (negative index)");
+}
+
+- (void)testFindEmptyMountPointSlot_AtIndex2
+{
+    constexpr unsigned emptyIndex = 2;
+    static_assert(emptyIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    [self fillAllMountPointSlotsExcept:emptyIndex];
+    
+    ssize_t found = FindEmptyMountPointSlot_Locked();
+    XCTAssertEqual(found, emptyIndex);
+}
+
+- (void)testFindMountPoint_AllFull
+{
+    [self fillAllMountPointSlots];
+    ssize_t found = FindMountPoint_Locked(self->dummyMounts[1].get());
+    XCTAssertEqual(found, 1);
+}
+
+- (void)testFindMountPoint_AfterEmpty
+{
+    constexpr unsigned emptyIndex = 1, lookingForIndex = 3;
+    static_assert(emptyIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    static_assert(lookingForIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    static_assert(emptyIndex < lookingForIndex, "");
+    
+    [self fillAllMountPointSlotsExcept:emptyIndex];
+
+    ssize_t found = FindMountPoint_Locked(self->dummyMounts[lookingForIndex].get());
+    XCTAssertEqual(found, lookingForIndex);
+}
+
+- (void)testFindMountPoint_NonExisting
+{
+    constexpr unsigned emptyIndex = 1;
+    static_assert(emptyIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    
+    [self fillAllMountPointSlotsExcept:emptyIndex];
+
+    shared_ptr<mount> mountNotPresent = mount::Create();
+    ssize_t found = FindMountPoint_Locked(mountNotPresent.get());
+    XCTAssertLessThan(found, 0);
+}
+
+- (void)testFindMountPoint_Empty
+{    
+    shared_ptr<mount> mountNotPresent = mount::Create();
+    ssize_t found = FindMountPoint_Locked(mountNotPresent.get());
+    XCTAssertLessThan(found, 0);
+}
+
+- (void)testFindOrInsert_InsertEmpty
+{
+    shared_ptr<mount> mountNotPresent = mount::Create();
+    ssize_t inserted = TryFindOrInsertMountPoint_Locked(mountNotPresent.get());
+    XCTAssertEqual(inserted, 0);
+}
+
+- (void)testFindOrInsert_InsertFull
+{
+    [self fillAllMountPointSlots];
+    shared_ptr<mount> mountNotPresent = mount::Create();
+    ssize_t inserted = TryFindOrInsertMountPoint_Locked(mountNotPresent.get());
+    XCTAssertLessThan(inserted, 0);
+}
+
+- (void)testFindOrInsert_Existing
+{
+    constexpr unsigned emptyIndex = 1, lookingForIndex = 2;
+    static_assert(emptyIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    static_assert(lookingForIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    static_assert(emptyIndex < lookingForIndex, "");
+    
+    [self fillAllMountPointSlotsExcept:emptyIndex];
+
+    ssize_t found = TryFindOrInsertMountPoint_Locked(self->dummyMounts[lookingForIndex].get());
+    XCTAssertEqual(found, lookingForIndex);
+}
+
+- (void)testFullSlotsDisableReuse
+{
+    constexpr unsigned tryReuseIndex = 2;
+    static_assert(tryReuseIndex < MaxUsedMountPoints, "If MaxUsedMountPoints changes, this might need updating");
+    
+    // First, *just* fill the array
+    for (unsigned i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        MountPoint_DisableAuthCache(self->dummyMounts[i].get());
+    }
+
+    // Sanity check that the mount we're going to remove is at the expected index
+    mount_t tryReuseMount = self->dummyMounts[tryReuseIndex].get();
+    ssize_t found = FindMountPoint_Locked(tryReuseMount);
+    XCTAssertEqual(found, tryReuseIndex);
+    
+    // Restoring the cache setting at this point should reuse the slot, as we haven't actually run out yet
+    MountPoint_RestoreAuthCache(tryReuseMount);
+    found = FindMountPoint_Locked(tryReuseMount);
+    XCTAssertLessThan(found, 0);
+    
+    // Fill all the slots again
+    MountPoint_DisableAuthCache(tryReuseMount);
+
+    // Now try disabling the cache on a mount point that won't fit
+    shared_ptr<mount> mountNotPresent = mount::Create();
+    MountPoint_DisableAuthCache(mountNotPresent.get());
+    //XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl, mountNotPresent.get(), 0));
+
+    // If we now restore one of the mounts that have a slot, the slot shouldn't be reused, but the cache on that mount should have been reset
+    MountPoint_RestoreAuthCache(tryReuseMount);
+    //XCTAssertTrue(MockCalls::DidCallFunction(vfs_clearauthcache_ttl, tryReuseMount));
+    found = FindMountPoint_Locked(tryReuseMount);
+    XCTAssertEqual(found, tryReuseIndex);
+    
+    // Disabling the cache again on the one that didn't fit should not cause that mount to get a slot
+    MountPoint_DisableAuthCache(mountNotPresent.get());
+    found = FindMountPoint_Locked(mountNotPresent.get());
+    XCTAssertLessThan(found, 0);
+    
+    // Restoring cache for a mount not in a slot should be a no-op
+    
+    MountPoint_RestoreAuthCache(mountNotPresent.get());
+    //XCTAssertFalse(MockCalls::DidCallFunction(vfs_clearauthcache_ttl, mountNotPresent.get()));
+
+    // clean up
+    for (unsigned i = 0; i < MaxUsedMountPoints; ++i)
+    {
+        if (i != tryReuseIndex)
+        {
+            MountPoint_RestoreAuthCache(self->dummyMounts[i].get());
+        }
+    }
+}
+
+@end

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -326,6 +326,16 @@ void vfs_setauthcache_ttl(mount_t mountPoint, int ttl)
     MockCalls::RecordFunctionCall(vfs_setauthcache_ttl, mountPoint, ttl);
 }
 
+int vfs_authcache_ttl(mount_t mountPoint)
+{
+    return CACHED_RIGHT_INFINITE_TTL;
+}
+
+void vfs_clearauthcache_ttl(mount_t mountPoint)
+{
+    MockCalls::RecordFunctionCall(vfs_clearauthcache_ttl, mountPoint);
+}
+
 void MockVnodes_CheckAndClear()
 {
     // All of the vnodes in s_allVnodes should have been destroyed by the time MockVnodes_CheckAndClear is called

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
@@ -32,6 +32,7 @@ private:
     std::weak_ptr<mount> weakSelfPointer;
     std::weak_ptr<vnode> rootVnode;
 
+    mount() = default;
 public:
     static std::shared_ptr<mount> Create(const char* fileSystemTypeName = "hfs", fsid_t fsid = fsid_t{}, uint64_t initialInode = 0);
 

--- a/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
@@ -1,6 +1,11 @@
 #include "../PrjFSKext/Locks.hpp"
+#include <cassert>
 
 struct __lck_rw_t__
+{
+};
+
+struct __lck_mtx_t__
 {
 };
 
@@ -38,4 +43,34 @@ void RWLock_FreeMemory(RWLock* rwLock)
 {
     delete rwLock->p;
     rwLock->p = nullptr;
+}
+
+
+Mutex Mutex_Alloc()
+{
+    return Mutex{ new __lck_mtx_t__{} };
+}
+
+void Mutex_FreeMemory(Mutex* mutex)
+{
+    delete mutex->p;
+    mutex->p = nullptr;
+}
+
+bool Mutex_IsValid(Mutex mutex)
+{
+    return mutex.p != nullptr;
+}
+
+void Mutex_Acquire(Mutex mutex)
+{
+}
+
+void Mutex_Release(Mutex mutex)
+{
+}
+
+void Mutex_Sleep(int seconds, void* channel, Mutex* mutex)
+{
+    assert(false);
 }

--- a/ProjFS.Mac/PrjFSKextTests/TestMemory.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/TestMemory.cpp
@@ -9,3 +9,8 @@ void* Memory_Alloc(uint32_t sizeBytes)
 {
     return malloc(sizeBytes);
 }
+
+void* Memory_AllocNoBlock(uint32_t size)
+{
+    return Memory_Alloc(size);
+}

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -314,7 +314,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
     shared_ptr<vnode> deepFileVnode = self->testMountPoint->CreateVnodeTree(deeplyNestedPath);
     
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
 
     VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
@@ -334,7 +334,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
     
     
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
     
     VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);


### PR DESCRIPTION
This fixes issue #284.

The actual fix is implemented in the final commit (5177369) and is quite simple: when a provider connects, check if the (VFS) mount point inside which its virtualisation root lives is already in use by another provider. If not, save the mount point's kauth TTL in an array of mount points and disable the kauth cache on the mount point. Either way, increment a counter.

When a provider disconnects, it looks up the saved mount point, decrementing the use counter. When the counter hits 0, the mount point's kauth cache TTL is reset to the saved, original value, and removes the mount point from the array.

The other 2 commits contain the messy logic of the resizeable associative array. My original approach to this fix had the array logic intermingled with the auth cache logic, and it wasn't especially nice, so I moved the array memory management, key search, insertion and removal to a reusable templated class instead. Some nice side effects of this, aside from keeping the business logic clean:

 * It's reusable within the kext and also unit testable, so I've also supplied 2 minimalistic test cases using the XCTest framework Apple provides with Xcode.
 * We can easily swap it out with a different data structure later (For example a hash table if the vnode cache goes ahead as I'm envisaging it.)

I'm not deeply invested in this approach, and it's certainly different from how we've previously done this sort of thing. For example, for the array of `VirtualizationRoot` structs, we directly manage the memory in `FindUnusedIndexOrGrow_Locked()`, although the way it's done there could technically be unsafe as we call `MemoryAlloc` without first dropping the lock. Anyway, as the kext increases in complexity, I thought it might be worth abstracting some if this sort of thing, so critique away! I can publish the non-abstracted version too if you like, but I'd need to update it with some bug fixes this version introduces, and I won't bother with that if nobody's interested anyway.

**Addendum:** I haven't added the tests to the overall VFSForGit test runner yet, as that'll require a bit of digging for me to figure out how to do it, and if we throw out the PR based on its general approach, I'll have wasted my time. So I'll do that if and when this gets positive feedback.