### PR TITLE
Mac kext: Abort events awaiting response when their provider disconnects

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -86,16 +86,16 @@ static bool ShouldHandleFileOpEvent(
     int* pid);
 
 // Structs
-typedef struct OutstandingMessage
+struct OutstandingMessage
 {
-    MessageHeader request;
-    MessageType response;
-    bool    receivedResponse;
-    VirtualizationRootHandle rootHandle;
+    MessageHeader                  request;
+    MessageType                    response;
+    bool                           receivedResponse;
+    VirtualizationRootHandle       rootHandle;
     
     LIST_ENTRY(OutstandingMessage) _list_privates;
     
-} OutstandingMessage;
+};
 
 // State
 static kauth_listener_t s_vnodeListener = nullptr;
@@ -850,7 +850,7 @@ static bool TrySendRequestAndWaitForResponse(
             result = true;
             goto CleanupUnlockAndReturn;
         }
-        else // failure reported by provider or aborted due disconnected provider
+        else
         {
             // Default error code is EACCES. See errno.h for more codes.
             *kauthError = EAGAIN;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.hpp
@@ -2,10 +2,12 @@
 #define KauthHandler_h
 
 #include "Message.h"
+#include "VirtualizationRoots.hpp"
 
 kern_return_t KauthHandler_Init();
 kern_return_t KauthHandler_Cleanup();
 
-void KauthHandler_HandleKernelMessageResponse(uint64_t messageId, MessageType responseType);
+void KauthHandler_HandleKernelMessageResponse(VirtualizationRootHandle providerVirtualizationRootHandle, uint64_t messageId, MessageType responseType);
+void KauthHandler_AbortOutstandingEventsForProvider(VirtualizationRootHandle providerVirtualizationRootHandle);
 
 #endif /* KauthHandler_h */

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.cpp
@@ -2,6 +2,7 @@
 #include <kern/locks.h>
 #include <kern/thread.h>
 #include <kern/assert.h>
+#include <kern/clock.h>
 #include <libkern/OSAtomic.h>
 
 #include "PrjFSCommon.h"
@@ -64,6 +65,14 @@ void Mutex_Acquire(Mutex mutex)
 void Mutex_Release(Mutex mutex)
 {
     lck_mtx_unlock(mutex.p);
+}
+
+void Mutex_Sleep(Mutex mutex, void* event, unsigned timeoutSeconds)
+{
+    uint64_t timeoutIntervalMachAbsolute, timeoutDeadline;
+    nanoseconds_to_absolutetime(NSEC_PER_SEC * timeoutSeconds, &timeoutIntervalMachAbsolute);
+    clock_absolutetime_interval_to_deadline(timeoutIntervalMachAbsolute, &timeoutDeadline);
+    lck_mtx_sleep_deadline(mutex.p, LCK_SLEEP_DEFAULT, event, THREAD_UNINT, timeoutDeadline);
 }
 
 // RWLock implementation functions

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.cpp
@@ -2,7 +2,6 @@
 #include <kern/locks.h>
 #include <kern/thread.h>
 #include <kern/assert.h>
-#include <kern/clock.h>
 #include <libkern/OSAtomic.h>
 
 #include "PrjFSCommon.h"
@@ -65,14 +64,6 @@ void Mutex_Acquire(Mutex mutex)
 void Mutex_Release(Mutex mutex)
 {
     lck_mtx_unlock(mutex.p);
-}
-
-void Mutex_Sleep(Mutex mutex, void* event, unsigned timeoutSeconds)
-{
-    uint64_t timeoutIntervalMachAbsolute, timeoutDeadline;
-    nanoseconds_to_absolutetime(NSEC_PER_SEC * timeoutSeconds, &timeoutIntervalMachAbsolute);
-    clock_absolutetime_interval_to_deadline(timeoutIntervalMachAbsolute, &timeoutDeadline);
-    lck_mtx_sleep_deadline(mutex.p, LCK_SLEEP_DEFAULT, event, THREAD_UNINT, timeoutDeadline);
 }
 
 // RWLock implementation functions

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
@@ -47,6 +47,7 @@ void RWLock_ReleaseShared(RWLock& rwLock);
 
 void RWLock_AcquireExclusive(RWLock& rwLock);
 void RWLock_ReleaseExclusive(RWLock& rwLock);
+void RWLock_DropExclusiveToShared(RWLock& rwLock);
 bool RWLock_AcquireSharedToExclusive(RWLock& rwLock);
 
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
@@ -22,6 +22,8 @@ bool Mutex_IsValid(Mutex mutex);
 void Mutex_Acquire(Mutex mutex);
 void Mutex_Release(Mutex mutex);
 
+void Mutex_Sleep(Mutex mutex, void* event, unsigned timeoutSeconds);
+
 typedef struct __lck_rw_t__ lck_rw_t;
 struct thread;
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Locks.hpp
@@ -22,8 +22,6 @@ bool Mutex_IsValid(Mutex mutex);
 void Mutex_Acquire(Mutex mutex);
 void Mutex_Release(Mutex mutex);
 
-void Mutex_Sleep(Mutex mutex, void* event, unsigned timeoutSeconds);
-
 typedef struct __lck_rw_t__ lck_rw_t;
 struct thread;
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -186,7 +186,7 @@ IOReturn PrjFSProviderUserClient::kernelMessageResponse(
 
 IOReturn PrjFSProviderUserClient::kernelMessageResponse(uint64_t messageId, MessageType responseType)
 {
-    KauthHandler_HandleKernelMessageResponse(messageId, responseType);
+    KauthHandler_HandleKernelMessageResponse(this->virtualizationRootHandle, messageId, responseType);
     return kIOReturnSuccess;
 }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -423,9 +423,9 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex)
         root->providerPid = 0;
         
         root->providerUserClient = nullptr;
-    }
-    RWLock_DropExclusiveToShared(s_virtualizationRootsLock);
-    {
+
+        RWLock_DropExclusiveToShared(s_virtualizationRootsLock);
+
         KauthHandler_AbortOutstandingEventsForProvider(rootIndex);
     }
     RWLock_ReleaseShared(s_virtualizationRootsLock);

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -9,6 +9,7 @@
 #include "Locks.hpp"
 #include "KextLog.hpp"
 #include "PrjFSProviderUserClient.hpp"
+#include "KauthHandler.hpp"
 #include "kernel-header-wrappers/mount.h"
 #include "VnodeUtilities.hpp"
 #include "PerformanceTracing.hpp"
@@ -423,7 +424,11 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex)
         
         root->providerUserClient = nullptr;
     }
-    RWLock_ReleaseExclusive(s_rwLock);
+    RWLock_DropExclusiveToShared(s_rwLock);
+    {
+        KauthHandler_AbortOutstandingEventsForProvider(rootIndex);
+    }
+    RWLock_ReleaseShared(s_rwLock);
 }
 
 errno_t ActiveProvider_SendMessage(VirtualizationRootHandle rootIndex, const Message message)

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -29,7 +29,9 @@ typedef enum
     // Responses
     MessageType_Response_Success,
     MessageType_Response_Fail,
-    MessageType_Response_Aborted,
+    
+    // Other message outcomes
+    MessageType_Result_Aborted,
     
 } MessageType;
 

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -29,6 +29,7 @@ typedef enum
     // Responses
     MessageType_Response_Success,
     MessageType_Response_Fail,
+    MessageType_Response_Aborted,
     
 } MessageType;
 

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -1160,7 +1160,7 @@ static inline PrjFS_NotificationType KUMessageTypeToNotificationType(MessageType
         case MessageType_KtoU_HydrateFile:
         case MessageType_Response_Success:
         case MessageType_Response_Fail:
-        case MessageType_Response_Aborted:
+        case MessageType_Result_Aborted:
             return PrjFS_NotificationType_Invalid;
     }
 }

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -1160,6 +1160,7 @@ static inline PrjFS_NotificationType KUMessageTypeToNotificationType(MessageType
         case MessageType_KtoU_HydrateFile:
         case MessageType_Response_Success:
         case MessageType_Response_Fail:
+        case MessageType_Response_Aborted:
             return PrjFS_NotificationType_Invalid;
     }
 }


### PR DESCRIPTION
This change ensures that any events awaiting a response from a provider get flushed out if their corresponding provider process disconnects/dies before responding. I think this should fix issue #499, but even if #499 has another cause, this is worth doing.

I was originally going to fix this by creating an outstanding message list for each provider rather than a single global one, but that would have taken some significantly larger code changes, and from an efficiency point of view, there's not much in it as the list tends to be fairly short.

The first commit in the series fixes a potential `nullptr` dereference KP, but more importantly syncs the event sleep on the outstanding message with the mutex. The second introduces a wrapper function for dropping a held exclusive lock to a shared lock without giving up the entire lock in between. The third commit then implements the fix by calling a new function which walks the list of messages and marks those matching the disconnecting provider as aborted, waking the corresponding threads.

I didn't run into any more deadlock problems when suddenly killing a provider in the middle of a build process. (And some debug output, which I inserted locally but have not included in these commits, indicated that pending events were indeed resumed/aborted.)