### PR TITLE
Check CanRead before constructing StreamReader

### DIFF
--- a/GVFS/GVFS.Common/Http/GitEndPointResponseData.cs
+++ b/GVFS/GVFS.Common/Http/GitEndPointResponseData.cs
@@ -59,6 +59,11 @@ namespace GVFS.Common.Http
                 throw new RetryableException("Stream is null (this could be a result of network flakiness), retrying.");
             }
 
+            if (!this.Stream.CanRead)
+            {
+                throw new RetryableException("Stream is not readable (this could be a result of network flakiness), retrying.");
+            }
+
             using (StreamReader contentStreamReader = new StreamReader(this.Stream))
             {
                 try


### PR DESCRIPTION
If Stream is not readable an exception will be thrown by the StreamReader constructor.

resolves #476 
