### PR TITLE
Git hooks to show no upgrade reminder when running un-attended

### DIFF
--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -69,7 +69,7 @@ namespace GVFS.Hooks
                             RunLockRequest(args, unattended, ReleaseGVFSLock);
                         }
 
-                        RunPostCommands(args);
+                        RunPostCommands(args, unattended);
                         break;
 
                     default:
@@ -95,9 +95,12 @@ namespace GVFS.Hooks
             }
         }
 
-        private static void RunPostCommands(string[] args)
+        private static void RunPostCommands(string[] args, bool unattended)
         {
-            RemindUpgradeAvailable();
+            if (!unattended)
+            {
+                RemindUpgradeAvailable();
+            }
         }
 
         private static void RemindUpgradeAvailable()


### PR DESCRIPTION
- Dont try to trigger reminder messaging when running in unattended mode.
- GVFS Hooks already check for un-attended mode. Re-using this to suppress upgrade reminder notification.

#### Issues
https://github.com/Microsoft/VFSForGit/issues/494

#### Testing suggestion
After updating the ```GVFS_UNATTENDED``` environment variable, relaunch ```Command Prompt``` before trying git commands. This is needed for the ```Command Prompt``` to reload the updated setting.