### PR TITLE
Add lower dir and handle to Linux VFS API

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -9,7 +9,6 @@ namespace MirrorProvider.Linux
     public class LinuxFileSystemVirtualizer : FileSystemVirtualizer
     {
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
-        private IntPtr mountHandle = IntPtr.Zero;
 
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
@@ -36,8 +35,7 @@ namespace MirrorProvider.Linux
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 storageRoot,
                 enlistment.SrcRoot,
-                poolThreadCount: (uint)Environment.ProcessorCount * 2,
-                mountHandle: out this.mountHandle);
+                poolThreadCount: (uint)Environment.ProcessorCount * 2);
 
             if (result == Result.Success)
             {
@@ -52,8 +50,7 @@ namespace MirrorProvider.Linux
 
         public override void Stop()
         {
-            this.virtualizationInstance.StopVirtualizationInstance(
-                this.mountHandle);
+            this.virtualizationInstance.StopVirtualizationInstance();
         }
 
         private Result OnEnumerateDirectory(

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -20,7 +20,7 @@ namespace MirrorProvider.Linux
 
         public override bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)
         {
-            string storageRoot = Path.Combine(enlistment.DotMirrorRoot, "src");
+            string storageRoot = Path.Combine(enlistment.DotMirrorRoot, "lower");
 
             Directory.CreateDirectory(storageRoot);
 

--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -17,6 +17,10 @@ namespace MirrorProvider
             return true;
         }
 
+        public virtual void Stop()
+        {
+        }
+
         protected string GetFullPathInMirror(string relativePath)
         {
             return Path.Combine(this.Enlistment.MirrorRoot, relativePath);

--- a/MirrorProvider/MirrorProvider/MountVerb.cs
+++ b/MirrorProvider/MirrorProvider/MountVerb.cs
@@ -37,7 +37,10 @@ namespace MirrorProvider
             else
             {
                 Console.WriteLine("Virtualization instance failed to start: " + error);
+                return;
             }
+
+            fileSystemVirtualizer.Stop();
         }
     }
 }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -16,7 +16,7 @@ namespace PrjFSLib.Linux.Interop
             string virtualizationRootFullPath,
             Callbacks callbacks,
             uint poolThreadCount,
-            ref IntPtr mountHandlePtr);
+            ref IntPtr mountHandle);
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_StopVirtualizationInstance")]
         public static extern void StopVirtualizationInstance(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -12,9 +12,15 @@ namespace PrjFSLib.Linux.Interop
         // TODO(Linux): revise library functions for Linux
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_StartVirtualizationInstance")]
         public static extern Result StartVirtualizationInstance(
+            string storageRootFullPath,
             string virtualizationRootFullPath,
             Callbacks callbacks,
-            uint poolThreadCount);
+            uint poolThreadCount,
+            ref IntPtr mountHandlePtr);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_StopVirtualizationInstance")]
+        public static extern void StopVirtualizationInstance(
+            IntPtr mountHandle);
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_ConvertDirectoryToVirtualizationRoot")]
         public static extern Result ConvertDirectoryToVirtualizationRoot(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -7,6 +7,8 @@ namespace PrjFSLib.Linux
     {
         public const int PlaceholderIdLength = Interop.PrjFSLib.PlaceholderIdLength;
 
+        private IntPtr mountHandle = IntPtr.Zero;
+
         // We must hold a reference to the delegate to prevent garbage collection
         private NotifyOperationCallback preventGCOnNotifyOperationDelegate;
 
@@ -28,8 +30,7 @@ namespace PrjFSLib.Linux
         public virtual Result StartVirtualizationInstance(
             string storageRootFullPath,
             string virtualizationRootFullPath,
-            uint poolThreadCount,
-            out IntPtr mountHandle)
+            uint poolThreadCount)
         {
             Interop.Callbacks callbacks = new Interop.Callbacks
             {
@@ -38,22 +39,19 @@ namespace PrjFSLib.Linux
                 OnNotifyOperation = this.preventGCOnNotifyOperationDelegate = new NotifyOperationCallback(this.OnNotifyOperation),
             };
 
-            mountHandle = IntPtr.Zero;
-
             Result result = Interop.PrjFSLib.StartVirtualizationInstance(
                 storageRootFullPath,
                 virtualizationRootFullPath,
                 callbacks,
                 poolThreadCount,
-                ref mountHandle);
+                ref this.mountHandle);
 
             return result;
         }
 
-        public virtual void StopVirtualizationInstance(
-            IntPtr mountHandle)
+        public virtual void StopVirtualizationInstance()
         {
-            Interop.PrjFSLib.StopVirtualizationInstance(mountHandle);
+            Interop.PrjFSLib.StopVirtualizationInstance(this.mountHandle);
         }
 
         public virtual Result WriteFileContents(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -44,14 +44,12 @@ namespace PrjFSLib.Linux
                 OnNotifyOperation = this.preventGCOnNotifyOperationDelegate = new NotifyOperationCallback(this.OnNotifyOperation),
             };
 
-            Result result = Interop.PrjFSLib.StartVirtualizationInstance(
+            return Interop.PrjFSLib.StartVirtualizationInstance(
                 storageRootFullPath,
                 virtualizationRootFullPath,
                 callbacks,
                 poolThreadCount,
                 ref this.mountHandle);
-
-            return result;
         }
 
         public virtual void StopVirtualizationInstance()

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -38,16 +38,15 @@ namespace PrjFSLib.Linux
                 OnNotifyOperation = this.preventGCOnNotifyOperationDelegate = new NotifyOperationCallback(this.OnNotifyOperation),
             };
 
-            IntPtr newMountHandle = IntPtr.Zero;
+            mountHandle = IntPtr.Zero;
 
             Result result = Interop.PrjFSLib.StartVirtualizationInstance(
                 storageRootFullPath,
                 virtualizationRootFullPath,
                 callbacks,
                 poolThreadCount,
-                ref newMountHandle);
+                ref mountHandle);
 
-            mountHandle = newMountHandle;
             return result;
         }
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -32,6 +32,11 @@ namespace PrjFSLib.Linux
             string virtualizationRootFullPath,
             uint poolThreadCount)
         {
+            if (mountHandle != IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
             Interop.Callbacks callbacks = new Interop.Callbacks
             {
                 OnEnumerateDirectory = this.OnEnumerateDirectory,

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -32,7 +32,7 @@ namespace PrjFSLib.Linux
             string virtualizationRootFullPath,
             uint poolThreadCount)
         {
-            if (mountHandle != IntPtr.Zero)
+            if (this.mountHandle != IntPtr.Zero)
             {
                 throw new InvalidOperationException();
             }
@@ -57,6 +57,7 @@ namespace PrjFSLib.Linux
         public virtual void StopVirtualizationInstance()
         {
             Interop.PrjFSLib.StopVirtualizationInstance(this.mountHandle);
+            this.mountHandle = IntPtr.Zero;
         }
 
         public virtual Result WriteFileContents(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -26,8 +26,10 @@ namespace PrjFSLib.Linux
         }
 
         public virtual Result StartVirtualizationInstance(
+            string storageRootFullPath,
             string virtualizationRootFullPath,
-            uint poolThreadCount)
+            uint poolThreadCount,
+            out IntPtr mountHandle)
         {
             Interop.Callbacks callbacks = new Interop.Callbacks
             {
@@ -36,15 +38,23 @@ namespace PrjFSLib.Linux
                 OnNotifyOperation = this.preventGCOnNotifyOperationDelegate = new NotifyOperationCallback(this.OnNotifyOperation),
             };
 
-            return Interop.PrjFSLib.StartVirtualizationInstance(
+            IntPtr newMountHandle = IntPtr.Zero;
+
+            Result result = Interop.PrjFSLib.StartVirtualizationInstance(
+                storageRootFullPath,
                 virtualizationRootFullPath,
                 callbacks,
-                poolThreadCount);
+                poolThreadCount,
+                ref newMountHandle);
+
+            mountHandle = newMountHandle;
+            return result;
         }
 
-        public virtual Result StopVirtualizationInstance()
+        public virtual void StopVirtualizationInstance(
+            IntPtr mountHandle)
         {
-            throw new NotImplementedException();
+            Interop.PrjFSLib.StopVirtualizationInstance(mountHandle);
         }
 
         public virtual Result WriteFileContents(


### PR DESCRIPTION
The VFSforGit API, as defined for Windows and MacOS, does not support the use of an opaque handle as required to allow the Linux libprojfs library to track its event loop thread (and thus allow it to start and, later, stop the thread).

Further, we need to pass the lower-level storageRoot directory path to libprojfs as it will be a stackable Linux filesystem which passes most or all operations through to the lower-level filesystem.

The GVFS.Virtualization.FileSystem.FileSystemVirtualizer class has a Stop() method which returns void, so we follow that lead for MirrorProvider as well.

And as we don't expect to return a value from the corresponding function in the Linux library either, we can also remove the return value from StopVirtualizationInstance() in the Linux PrjFSLib.