### PR TITLE
Upgrade reminder causing functional test failure

### DIFF
--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
@@ -159,7 +159,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
         private void GitCommandWaitsForLock(string gitWorkingDirectory)
         {
             ManualResetEventSlim resetEvent = GitHelpers.AcquireGVFSLock(this.Enlistment, out _, resetTimeout: 3000);
-            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(gitWorkingDirectory, "status", cleanErrors: false);
+            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(gitWorkingDirectory, "status", removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
             resetEvent.Set();
             this.Enlistment.WaitForBackgroundOperations();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -38,8 +38,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             for (int count = 0; count < 50; count++)
             {
                 ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
-                this.Enlistment.RepoRoot,
-                "status");
+                    this.Enlistment.RepoRoot,
+                    "status");
 
                 string.IsNullOrEmpty(result.Errors).ShouldBeTrue();
             }
@@ -54,8 +54,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             for (int count = 0; count < 50; count++)
             {
                 ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
-                this.Enlistment.RepoRoot,
-                "status");
+                    this.Enlistment.RepoRoot,
+                    "status",
+                    removeWaitingMessages: true,
+                    removeUpgradeMessages: false);
 
                 if (!string.IsNullOrEmpty(result.Errors))
                 {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -172,7 +172,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                     { "GIT_TRACE_PERFORMANCE", "1" },
                     { "git_trace", "1" },
                 },
-                cleanErrors: false);
+                removeWaitingMessages: false);
             result.Output.ShouldContain("* FunctionalTests");
             result.Errors.ShouldNotContain(ignoreCase: true, unexpectedSubstrings: "exception");
             result.Errors.ShouldContain("trace.c:", "git command:");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
@@ -54,7 +54,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             int pid;
             GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: 3000);
 
-            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", cleanErrors: false);
+            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
         }
 
@@ -67,7 +67,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             int pid;
             GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: 3000);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "config --local alias." + alias + " status");
-            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, alias, cleanErrors: false);
+            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, alias, removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
         }
 
@@ -83,7 +83,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(
                 Path.Combine(this.Enlistment.RepoRoot, "GVFS"),
                 alias + " origin/FunctionalTests/RebaseTestsSource_20170208",
-                cleanErrors: false);
+                removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "rebase --abort");
         }
@@ -100,7 +100,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             newFilePath.ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.WriteAllText(newFilePath, "New file contents");
 
-            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", cleanErrors: false);
+            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", removeWaitingMessages: false);
 
             // Validate that GVFS still reports that the git command is holding the lock
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
@@ -129,7 +129,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 }
             }
 
-            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", cleanErrors: false);
+            ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "status", removeWaitingMessages: false);
 
             // There should not be any errors - in particular, there should not be
             // an error about "Waiting for GVFS.FunctionalTests.LockHolder"


### PR DESCRIPTION
Previously downloaded upgrade installers were triggering reminder messaging from git hook. This in-turn cause FunctionalTests to fail. This PR deletes the downloaded installers before starting FunctionalTests. GVFS.Service is also updated to Not download upgrades when development version is installed. User can still run ```gvfs upgrade --confirm``` to manually upgrade gvfs.

Fixes #428