### PR TITLE
Fix 'Profiling(Release)' build configuration after GVFS.Installer.Mac inclusion

### DIFF
--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -29,8 +29,10 @@ echo "Downloaded Git $GITVERSION"
 $VFS_SCRIPTDIR/GenerateGitVersionConstants.sh "$GITPATH" $BUILDDIR || exit 1
 
 # If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+# Additionally, build a Release copy of the native code so we can successfully build a 'Release' configuration installer
 if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
   CONFIGURATION=Release
+  $VFS_SRCDIR/ProjFS.Mac/Scripts/Build.sh $CONFIGURATION || exit 1
 fi
 
 # /warnasmessage:MSB4011. Reference: https://bugzilla.xamarin.com/show_bug.cgi?id=58564


### PR DESCRIPTION
This configuration fails today as it can't find the native code in the right location. While we investigate the perf overhead of the Profiling configuration (this whole configuration could be rolled into the Release configuration if the overhead isn't large), unblock the build of this configuration by also building 'Release' flavored native code (The profiling test infrastructure will pick up the build output directly, not from the installer).