### PR TITLE
Allow multiple internal mount parameters

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -208,9 +208,11 @@ namespace GVFS.Common
 
         public static class VerbParameters
         {
+                public const string InternalUseOnly = "internal_use_only";
+
             public static class Mount
             {
-                public const string ServiceName = "internal_use_only_service_name";
+                public const string StartedByService = "StartedByService";
                 public const string Verbosity = "verbosity";
                 public const string Keywords = "keywords";
                 public const string DebugWindow = "debug-window";

--- a/GVFS/GVFS.Common/InternalVerbParameters.cs
+++ b/GVFS/GVFS.Common/InternalVerbParameters.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+namespace GVFS.Common
+{
+    public class InternalVerbParameters
+    {
+        public InternalVerbParameters(string serviceName, bool startedByService)
+        {
+            this.ServiceName = serviceName;
+            this.StartedByService = startedByService;
+        }
+
+        public string ServiceName { get; private set; }
+        public bool StartedByService { get; private set; }
+
+        public static InternalVerbParameters FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<InternalVerbParameters>(json);
+        }
+
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/JunctionAndSubstTests.cs
@@ -214,11 +214,11 @@ namespace GVFS.FunctionalTests.Windows.Tests
             string mountCommand;
             if (enlistmentPath != null)
             {
-                mountCommand = $"mount \"{enlistmentPath}\" --internal_use_only_service_name {GVFSServiceProcess.TestServiceName}";
+                mountCommand = $"mount \"{enlistmentPath}\" {TestConstants.InternalUseOnlyFlag} {GVFSHelpers.GetInternalParameter()}";
             }
             else
             {
-                mountCommand = $"mount --internal_use_only_service_name {GVFSServiceProcess.TestServiceName}";
+                mountCommand = $"mount {TestConstants.InternalUseOnlyFlag} {GVFSHelpers.GetInternalParameter()}";
             }
 
             ProcessStartInfo startInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -192,7 +192,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string enlistmentRoot = this.Enlistment.EnlistmentRoot;
 
             ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);
-            processInfo.Arguments = "dehydrate " + dehydrateFlags + " --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
+            processInfo.Arguments = "dehydrate " + dehydrateFlags + " " + TestConstants.InternalUseOnlyFlag + " " + GVFSHelpers.GetInternalParameter();
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.WorkingDirectory = enlistmentRoot;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -288,7 +288,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             // TODO: 865304 Use app.config instead of --internal* arguments
             ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);
-            processInfo.Arguments = "mount --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
+            processInfo.Arguments = "mount " + TestConstants.InternalUseOnlyFlag + " " + GVFSHelpers.GetInternalParameter();
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.WorkingDirectory = string.IsNullOrEmpty(mountWorkingDirectory) ? enlistmentRoot : mountWorkingDirectory;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
@@ -71,7 +71,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             // TODO: 865304 Use app.config instead of --internal* arguments
             ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);
-            processInfo.Arguments = "unmount " + extraParams + " --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
+            processInfo.Arguments = "unmount " + extraParams + " " + TestConstants.InternalUseOnlyFlag + " " + GVFSHelpers.GetInternalParameter();
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.WorkingDirectory = enlistmentRoot;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -133,6 +133,11 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
+        public static string GetInternalParameter()
+        {
+            return $"\"{{\\\"ServiceName\\\":\\\"{GVFSServiceProcess.TestServiceName}\\\",\\\"StartedByService\\\":false}}\"";
+        }
+
         private static string GetModifiedPathsContents(GVFSFunctionalTestEnlistment enlistment, FileSystemRunner fileSystem)
         {
             enlistment.WaitForBackgroundOperations();

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -94,7 +94,7 @@ namespace GVFS.FunctionalTests.Tools
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
-            processInfo.Arguments = args + " --internal_use_only_service_name " + GVFSServiceProcess.TestServiceName;
+            processInfo.Arguments = args + " " + TestConstants.InternalUseOnlyFlag + " " + GVFSHelpers.GetInternalParameter();
 
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tools/TestConstants.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/TestConstants.cs
@@ -7,6 +7,7 @@ namespace GVFS.FunctionalTests.Tools
         public const string AllZeroSha = "0000000000000000000000000000000000000000";
         public const string PartialFolderPlaceholderDatabaseValue = "                          PARTIAL FOLDER";
         public const char GitPathSeparator = '/';
+        public const string InternalUseOnlyFlag = "--internal_use_only";
 
         public static class DotGit
         {

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -47,6 +47,14 @@ namespace GVFS.Mount
             HelpText = "Show the debug window.  By default, all output is written to a log file and no debug window is shown.")]
         public bool ShowDebugWindow { get; set; }
 
+        [Option(
+            's',
+            GVFSConstants.VerbParameters.Mount.StartedByService,
+            Default = "false",
+            Required = false,
+            HelpText = "Service initiated mount.")]
+        public string StartedByService { get; set; }
+
         [Value(
                 0,
                 Required = true,
@@ -80,6 +88,7 @@ namespace GVFS.Mount
                 {
                     { "IsElevated", GVFSPlatform.Instance.IsElevated() },
                     { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
+                    { nameof(this.StartedByService), this.StartedByService },
                 });
 
             AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs e) =>

--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -58,7 +58,10 @@ namespace GVFS.Service
 
         private bool CallGVFSMount(string repoRoot)
         {
-            return this.CurrentUser.RunAs(Configuration.Instance.GVFSLocation, "mount " + repoRoot);
+            InternalVerbParameters mountInternal = new InternalVerbParameters(serviceName: null, startedByService: true);
+            return this.CurrentUser.RunAs(
+                Configuration.Instance.GVFSLocation,
+                $"mount {repoRoot} --{GVFSConstants.VerbParameters.InternalUseOnly} {mountInternal.ToJson()}");
         }
     }
 }

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -274,7 +274,9 @@ namespace GVFS.CommandLine
                     ParamPrefix + GVFSConstants.VerbParameters.Mount.Verbosity,
                     this.Verbosity,
                     ParamPrefix + GVFSConstants.VerbParameters.Mount.Keywords,
-                    this.KeywordsCsv
+                    this.KeywordsCsv,
+                    ParamPrefix + GVFSConstants.VerbParameters.Mount.StartedByService,
+                    this.StartedByService.ToString()
                 });
 
             if (GVFSPlatform.Instance.IsUnderConstruction)

--- a/GVFS/GVFS/GVFS.Windows.csproj
+++ b/GVFS/GVFS/GVFS.Windows.csproj
@@ -44,6 +44,11 @@
     <Reference Include="Microsoft.Data.Sqlite, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Data.Sqlite.Core.2.0.0\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\SQLitePCLRaw.bundle_green.1.1.7\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
     </Reference>

--- a/GVFS/GVFS/packages.config
+++ b/GVFS/GVFS/packages.config
@@ -4,6 +4,7 @@
   <package id="GVFS.VCRuntime" version="0.2.0-build" targetFramework="native" />
   <package id="Microsoft.Data.Sqlite" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.0.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.7" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.7" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.7" targetFramework="net461" />


### PR DESCRIPTION
We are seeing several errors come thru that say 'disk I/O error'

**The two flavors are:**
1. Failed to create src folder callback listener Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 10: 'disk I/O error'.
2. System.IO.IOException: The device is not ready.
The first is almost always on startup. The second is sometimes on startup.

This change logs whether the mount is started by the service.  This will help us determine how often mount is failing when launched via the service.

**There were 3 evaluated approaches**
1. Walk the process tree
This was decided against since it's not cross-plat and walking process trees is non-trivial
2. Use an env var
This was decided against since we start processes using native code and adding an env variable there adds new complexity.  It's also less than ideal since we don't pass any other arguments this way.
3. Use the existing internal-only property on MountVerb
I extended this option to allow you send a series of var=val;var=val; type arguments.  I originally considered using json but passing args via json has it's own set of complexities (double escaping) and can become quite verbose.  Since this is internal I'm voting to keep it simple.

The third approach here is what I went with.  It seems the most standard as well as giving an easy way to add internal parameters in the future.

resolves #479