### PR TITLE
Downloaded Installers of previous versions should not trigger upgrade reminders

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -301,6 +301,18 @@ namespace GVFS.Common
             return false;
         }
 
+        public void DeletePreviousDownloads()
+        {
+            try
+            {
+                this.fileSystem.DeleteDirectory(GetAssetDownloadsPath());
+            }
+            catch (Exception ex)
+            {
+                this.TraceException(ex, nameof(this.DeletePreviousDownloads), $"Could not remove directory: {GetAssetDownloadsPath()}");
+            }
+        }
+
         protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
             return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -79,6 +79,9 @@ namespace GVFS.Service
                 if (newerVersion == null)
                 {
                     // Already up-to-date
+                    // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
+                    // upgraded by manually downloading and running asset installers.
+                    productUpgrader.DeletePreviousDownloads();
                     errorMessage = null;
                     return true;
                 }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -115,6 +115,7 @@ namespace GVFS.CommandLine
                 this.tracer.RelatedInfo($"{nameof(this.TryRunProductUpgrade)}: {GVFSConstants.UpgradeVerbMessages.NoneRingConsoleAlert}");
                 this.ReportInfoToConsole(ring == ProductUpgrader.RingType.None ? GVFSConstants.UpgradeVerbMessages.NoneRingConsoleAlert : GVFSConstants.UpgradeVerbMessages.NoRingConfigConsoleAlert);
                 this.ReportInfoToConsole(GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand);
+                this.upgrader.DeletePreviousDownloads();
                 return true;
             }
                         
@@ -128,9 +129,13 @@ namespace GVFS.CommandLine
             if (newestVersion == null)
             {
                 this.ReportInfoToConsole($"Great news, you're all caught up on upgrades in the {this.upgrader.Ring} ring!");
+
+                // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
+                // upgraded by manually downloading and running asset installers.
+                this.upgrader.DeletePreviousDownloads();
                 return true;
             }
-            
+
             string upgradeAvailableMessage = $"New GVFS version {newestVersion.ToString()} available in ring {ring}";
             if (this.Confirmed)
             {


### PR DESCRIPTION
1. GVFS.Service does its periodic upgrade check. When it finds that the current version is up-to-date, it deletes the previously downloaded releases. In between the user may see reminder messaging while running git commands.
2. User manually runs `gvfs upgrade`. When gvfs cli finds that the current version is up-to-date it deletes the un-needed release downloads. User would no longer see reminders.

Fixes #502