### PR TITLE
gvfs config - error out while reading missing key

### DIFF
--- a/GVFS/GVFS/CommandLine/ConfigVerb.cs
+++ b/GVFS/GVFS/CommandLine/ConfigVerb.cs
@@ -93,11 +93,12 @@ namespace GVFS.CommandLine
                 else
                 {
                     string valueRead = null;
-                    if (!this.localConfig.TryGetConfig(this.Key, out valueRead, out error))
+                    if (!this.localConfig.TryGetConfig(this.Key, out valueRead, out error) ||
+                        string.IsNullOrEmpty(valueRead))
                     {
                         this.ReportErrorAndExit(error);
                     }
-                    else if (!string.IsNullOrEmpty(valueRead))
+                    else
                     {
                         Console.WriteLine(valueRead);
                     }


### PR DESCRIPTION
gvfs config now treats an attempt to read a unknown key as error and exits with GenericError code. No error message is printed.

Fixes #402

Comparing ```gvfs config``` behavior vs ```git config```.

<img width="455" alt="screen shot 2018-11-19 at 5 25 40 pm" src="https://user-images.githubusercontent.com/378580/48738875-4c6b2900-ec20-11e8-98b2-32d31fd468ea.png">
