### PR TITLE
Taking DEVELOPMENT_TEAM from environment variable, if set, allowing to easier build native mac binaries

### DIFF
--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -11,8 +11,14 @@ ROOTDIR=$SRCDIR/..
 PACKAGES=$ROOTDIR/packages
 
 PROJFS=$SRCDIR/ProjFS.Mac
-
-xcodebuild -configuration $CONFIGURATION -workspace $PROJFS/PrjFS.xcworkspace build -scheme PrjFS -derivedDataPath $ROOTDIR/BuildOutput/ProjFS.Mac/Native || exit 1
+if [ -z "$DEVELOPMENT_TEAM" ]
+then 
+    echo "DEVELOPMENT_TEAM environment variable not set, using DEVELOPMENT_TEAM from project..."
+    xcodebuild -configuration $CONFIGURATION -workspace $PROJFS/PrjFS.xcworkspace build -scheme PrjFS -derivedDataPath $ROOTDIR/BuildOutput/ProjFS.Mac/Native || exit 1
+else
+    echo "DEVELOPMENT_TEAM environment variable set to $DEVELOPMENT_TEAM, using it for build..."
+    xcodebuild -configuration $CONFIGURATION -workspace $PROJFS/PrjFS.xcworkspace build -scheme PrjFS -derivedDataPath $ROOTDIR/BuildOutput/ProjFS.Mac/Native DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM || exit 1
+fi
 
 # If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
 if [ "$CONFIGURATION" == "Profiling(Release)" ]; then

--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ Note that VFS for Git on Mac is under active development.
 
 * If you still do not have the `dotnet` cli `>= v2.1.300` installed [manually install it]. You can check what version you have with `dotnet --version`.(https://www.microsoft.com/net/download/dotnet-core/2.1)
 
-* If you're using `Xcode` for the first time, you may have to login to `Xcode` with your Apple ID to generate a codesigning certificate. You can do this by launching `Xcode.app`, opening the `PrjFS.xcworkspace` and trying to build. You can find the signing options in the General tab of the project's settings.
+* If you're using `Xcode` for the first time, you may have to login to `Xcode` with your Apple ID to generate a codesigning certificate. You can do this by launching `Xcode.app`, opening the `PrjFS.xcworkspace` and trying to build. You can find the signing options in the General tab of the project's settings. Instead of updating all the projects with your development team ID, you can set it via environment variable `DEVELOPMENT_TEAM`.
 
 * Create a `VFSForGit` directory and Clone VFSForGit into a directory called `src` inside it:
   ```

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -46,7 +46,14 @@ dotnet restore $VFS_SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Mac --packag
 dotnet build $VFS_SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $CONFIGURATION.Mac /maxcpucount:1 /warnasmessage:MSB4011 || exit 1
 
 NATIVEDIR=$VFS_SRCDIR/GVFS/GVFS.Native.Mac
-xcodebuild -configuration $CONFIGURATION -workspace $NATIVEDIR/GVFS.Native.Mac.xcworkspace build -scheme GVFS.Native.Mac -derivedDataPath $VFS_OUTPUTDIR/GVFS.Native.Mac || exit 1
+if [ -z "$DEVELOPMENT_TEAM" ]
+then
+    echo "DEVELOPMENT_TEAM environment variable not set, using from project..."
+    xcodebuild -configuration $CONFIGURATION -workspace $NATIVEDIR/GVFS.Native.Mac.xcworkspace build -scheme GVFS.Native.Mac -derivedDataPath $VFS_OUTPUTDIR/GVFS.Native.Mac || exit 1
+else
+    echo "DEVELOPMENT_TEAM environment variable is set to $DEVELOPMENT_TEAM, passing to xcodebuild..."
+    xcodebuild -configuration $CONFIGURATION -workspace $NATIVEDIR/GVFS.Native.Mac.xcworkspace build -scheme GVFS.Native.Mac -derivedDataPath $VFS_OUTPUTDIR/GVFS.Native.Mac DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM || exit 1
+fi
 
 if [ ! -d $VFS_PUBLISHDIR ]; then
   mkdir $VFS_PUBLISHDIR || exit 1


### PR DESCRIPTION
Not sure, if DEVELOPMENT_TEAM environment variable is supposed to be used by xcodebuild, but it wasn't on my machine with this xcodebuild version
```
Xcode 10.1
Build version 10B61
```
Modified build scripts to pass this environment variable to xcodebuild, if it is set, so that people, who do not have the developer certificate, that is defined in the project files, can build easier.