### PR TITLE
Add DiskInfo to HeartBeat

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -53,7 +53,7 @@ namespace GVFS.Common
 
         public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId);
 
-        public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path);
+        public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly);
 
         public abstract bool IsConsoleOutputRedirectedToFile();
         public abstract bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage);

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -97,7 +97,7 @@ namespace GVFS.Platform.Mac
             return string.IsNullOrWhiteSpace(result.Output) ? result.Errors : result.Output;
         }
 
-        public override Dictionary<string, string> GetPhysicalDiskInfo(string path)
+        public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly)
         {
             // TODO(Mac): Collect disk information
             Dictionary<string, string> result = new Dictionary<string, string>();

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -252,7 +252,7 @@ namespace GVFS.Platform.Windows
             return identity.User.Value;
         }
 
-        public override Dictionary<string, string> GetPhysicalDiskInfo(string path) => WindowsPhysicalDiskInfo.GetPhysicalDiskInfo(path);
+        public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly) => WindowsPhysicalDiskInfo.GetPhysicalDiskInfo(path, sizeStatsOnly);
 
         public override bool IsConsoleOutputRedirectedToFile()
         {

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -66,9 +66,9 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override Dictionary<string, string> GetPhysicalDiskInfo(string path)
+        public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly)
         {
-            throw new NotSupportedException();
+            return new Dictionary<string, string>();
         }
 
         public override void InitializeEnlistmentACLs(string enlistmentPath)

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -141,12 +141,13 @@ namespace GVFS.UnitTests.Virtualization
                 eventLevel.ShouldEqual(EventLevel.Informational);
 
                 // "ModifiedPathsCount" should be 1 because ".gitattributes" is always present
-                metadata.Count.ShouldEqual(5);
+                metadata.Count.ShouldEqual(6);
                 metadata.ShouldContain("ProcessName1", "GVFS.UnitTests.exe");
                 metadata.ShouldContain("ProcessCount1", 1);
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("PlaceholderCount", 1);
                 metadata.ShouldContain(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
+                metadata.ContainsKey("PhysicalDiskInfo").ShouldBeTrue();
 
                 // Create more placeholders
                 fileSystemCallbacks.OnPlaceholderFileCreated("test.txt", "2222233333444445555566666777778888899999", "GVFS.UnitTests.exe2");
@@ -156,7 +157,7 @@ namespace GVFS.UnitTests.Virtualization
                 metadata = fileSystemCallbacks.GetMetadataForHeartBeat(ref eventLevel);
                 eventLevel.ShouldEqual(EventLevel.Informational);
 
-                metadata.Count.ShouldEqual(5);
+                metadata.Count.ShouldEqual(6);
 
                 // Only processes that have created placeholders since the last heartbeat should be named
                 metadata.ShouldContain("ProcessName1", "GVFS.UnitTests.exe2");
@@ -164,6 +165,7 @@ namespace GVFS.UnitTests.Virtualization
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("PlaceholderCount", 3);
                 metadata.ShouldContain(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
+                metadata.ContainsKey("PhysicalDiskInfo").ShouldBeTrue();
             }
         }
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -344,6 +344,11 @@ namespace GVFS.Virtualization
             }
 
             metadata.Add(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
+            metadata.Add(
+                "PhysicalDiskInfo", 
+                GVFSPlatform.Instance.GetPhysicalDiskInfo(
+                    this.context.Enlistment.WorkingDirectoryRoot,
+                    sizeStatsOnly: true));
 
             return metadata;
         }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -560,7 +560,7 @@ You can specify a URL, a name of a configured cache server, or the special names
             metadata.Add(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
             metadata.Add(nameof(mountId), mountId);
             metadata.Add("Enlistment", enlistment);
-            metadata.Add("PhysicalDiskInfo", GVFSPlatform.Instance.GetPhysicalDiskInfo(enlistment.WorkingDirectoryRoot));
+            metadata.Add("PhysicalDiskInfo", GVFSPlatform.Instance.GetPhysicalDiskInfo(enlistment.WorkingDirectoryRoot, sizeStatsOnly: false));
             tracer.RelatedEvent(EventLevel.Informational, "EnlistmentInfo", metadata, Keywords.Telemetry);
 
             GitProcess.Result configResult = git.SetInLocalConfig(GVFSConstants.GitConfig.EnlistmentId, RepoMetadata.Instance.EnlistmentId, replaceAll: true);


### PR DESCRIPTION
This logs disk info on heat beat:

\"PhysicalDiskInfo\":{\"DriveLetter\":\"C\",\"VolumeDriveType\":\"Fixed\",\"VolumeFileSystem\":\"NTFS\",\"VolumeFileSystemLabel\":\"OSDisk\",\"VolumeSize\":\"510928089088\",\"VolumeSizeRemaining\":\"103830548480\",\"DiskNumber\":\"0\",\"DiskModel\":\"MTFDDAK512MBF1A\",\"DiskIsSystem\":\"True\",\"DiskIsBoot\":\"True\",\"DiskSerialNumber\":\"XXXXXX\",\"PhysicalMediaType\":\"SSD\",\"PhysicalBusType\":\"SATA\",\"PhysicalSpindleSpeed\":\"0\"}
This should come in very handy when investigating why users run out of disk space.

@sanoursa  I'm using the existing [GetPhysicalDiskInfo method](https://github.com/Microsoft/VFSForGit/blob/785ccb4a67281d0eb10f19cb53e6431b62b88555/GVFS/GVFS.Platform.Windows/WindowsPhysicalDiskInfo.cs#L57), which  brings back more info that we need.  Let me know if you think it's worth seperating queryVolumeString into it's own method and just calling that here.   I'll update the failing unit test once we make a decision there.