### PR TITLE
ReadMessage IOException should be a warning

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -223,9 +223,10 @@ namespace GVFS.Common.NamedPipes
                     EventMetadata metadata = new EventMetadata();
                     metadata.Add("ExceptionMessage", e.Message);
                     metadata.Add("StackTrace", e.StackTrace);
-                    this.tracer.RelatedError(
+                    this.tracer.RelatedWarning(
                         metadata: metadata,
-                        message: $"Error reading message from NamedPipe: {e.Message}");
+                        message: $"Error reading message from NamedPipe: {e.Message}",
+                        keywords: Keywords.Telemetry);
 
                     return null;
                 }


### PR DESCRIPTION
This can happen when user ctrl-c's on a command

I've added a feature request on our monitor project to alert when we get a large amount of warnings.