### PR TITLE
Mac kext review fixes

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -251,6 +251,7 @@ void KauthHandler_HandleKernelMessageResponse(VirtualizationRootHandle providerV
         case MessageType_KtoU_NotifyDirectoryRenamed:
         case MessageType_KtoU_NotifyFileHardLinkCreated:
         case MessageType_Result_Aborted:
+        default:
             KextLog_Error("KauthHandler_HandleKernelMessageResponse: Unexpected responseType: %d", responseType);
             break;
     }
@@ -1116,16 +1117,10 @@ static bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode)
         return false;
     case VSTR:
     case VCPLX:
-        {
-            char vnodePath[PrjFSMaxPath];
-            int vnodePathLength = PrjFSMaxPath;
-            vn_getpath(vnode, vnodePath, &vnodePathLength);
-            KextLog_Info("vnode with type %s encountered, path %s", vnodeType == VSTR ? "VSTR" : "VCPLX", vnodePath);
-            
-            return false;
-        }
+        KextLog_FileInfo(vnode, "vnode with type %s encountered", vnodeType == VSTR ? "VSTR" : "VCPLX");
+        return false;
     default:
-        KextLog_Info("vnode with unknown type %d encountered", vnodeType);
+        KextLog_FileInfo(vnode, "vnode with unknown type %d encountered", vnodeType);
         return false;
     }
 }

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -398,6 +398,11 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                             KextLog_Error("VirtualizationRoot_RegisterProviderForPath: failed to insert new root");
                         }
                     }
+                    
+                    if (0 == err)
+                    {
+                        userClient->setProperty(PrjFSProviderPathKey, virtualizationRootCanonicalPath);
+                    }
                 }
                 RWLock_ReleaseExclusive(s_virtualizationRootsLock);
             }

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -486,12 +486,23 @@ bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode_t vnode)
 
 static const char* GetRelativePath(const char* path, const char* root)
 {
-    assert(strlen(path) >= strlen(root));
+    size_t rootLength = strlen(root);
+    size_t pathLength = strlen(path);
+    if (pathLength < rootLength || 0 != memcmp(path, root, rootLength))
+    {
+        KextLog_Error("GetRelativePath: root path '%s' is not a prefix of path '%s'\n", root, path);
+        return nullptr;
+    }
     
-    const char* relativePath = path + strlen(root);
+    const char* relativePath = path + rootLength;
     if (relativePath[0] == '/')
     {
         relativePath++;
+    }
+    else if (rootLength > 0 && root[rootLength - 1] != '/' && pathLength > rootLength)
+    {
+        KextLog_Error("GetRelativePath: root path '%s' is not a parent directory of path '%s' (just a string prefix)\n", root, path);
+        return nullptr;
     }
     
     return relativePath;

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -330,6 +330,7 @@ static VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUse
 // ENOTDIR:  Selected virtualization root path does not resolve to a directory.
 // EBUSY:    Already a provider for this virtualization root.
 // ENOENT:   Error returned by vnode_lookup.
+// Any error returned by the call to vn_getpath()
 VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProviderUserClient* userClient, pid_t clientPID, const char* virtualizationRootPath)
 {
     assert(nullptr != virtualizationRootPath);
@@ -390,7 +391,7 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                         
                             virtualizationRootVNode = NULLVP; // prevent vnode_put later; active provider should hold vnode reference
                         
-                            KextLog_Note("VirtualizationRoot_RegisterProviderForPath: new root not found in offline roots, inserted as new root with index %d. path '%s'", rootIndex, virtualizationRootPath);
+                            KextLog_Note("VirtualizationRoot_RegisterProviderForPath: new root not found in offline roots, inserted as new root with index %d. path '%s'", rootIndex, virtualizationRootCanonicalPath);
                         }
                         else
                         {
@@ -398,13 +399,13 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                             KextLog_Error("VirtualizationRoot_RegisterProviderForPath: failed to insert new root");
                         }
                     }
-                    
-                    if (0 == err)
-                    {
-                        userClient->setProperty(PrjFSProviderPathKey, virtualizationRootCanonicalPath);
-                    }
                 }
                 RWLock_ReleaseExclusive(s_virtualizationRootsLock);
+                
+                if (0 == err)
+                {
+                    userClient->setProperty(PrjFSProviderPathKey, virtualizationRootCanonicalPath);
+                }
             }
         }
     }

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -15,6 +15,8 @@
 // Name of property on the main PrjFS IOService indicating the kext version, to be checked by user space
 #define PrjFSKextVersionKey "io.gvfs.PrjFSKext.Version"
 
+#define PrjFSProviderPathKey "io.gvfs.PrjFSKext.ProviderUserClient.Path"
+
 typedef enum
 {
     FileFlags_Invalid = 0,


### PR DESCRIPTION
While reviewing the kext code for potential security issues in preparation for #528, I found a few places in the code which aren't ideal, although they probably aren't exploitable.

1. The memory getter & notification port setter in the `IOUserClient` subclasses were not protected by the mutex. It's probably not a serious problem, but doesn't do any harm to fix this.
2. `GetRelativePath()` can be called with 2 unrelated paths. See issue #544. The immediate upshot is that you can easily KP the system by posing as a provider, creating a new root, and renaming it. We'll need to decide what to do about renaming virtualisation roots, but I've changed `GetRelativePath()` to behave more reasonably by returning `nullptr` if the arguments don't make sense, which appears to be safe at the sole call site.
3. I noticed some logging that could be improved by using the path-based logging macro.