### PR TITLE
Early exit a noop blob prefetch

### DIFF
--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -28,7 +28,16 @@ namespace FastFetch
             int indexThreadCount,
             int checkoutThreadCount,
             bool allowIndexMetadataUpdateFromWorkingTree,
-            bool forceCheckout) : base(tracer, enlistment, objectRequestor, chunkSize, searchThreadCount, downloadThreadCount, indexThreadCount)
+            bool forceCheckout) 
+                : base(
+                    tracer,
+                    enlistment,
+                    objectRequestor,
+                    null,
+                    chunkSize,
+                    searchThreadCount,
+                    downloadThreadCount,
+                    indexThreadCount)
         {
             this.checkoutThreadCount = checkoutThreadCount;
             this.allowIndexMetadataUpdateFromWorkingTree = allowIndexMetadataUpdateFromWorkingTree;

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -349,6 +349,7 @@ namespace FastFetch
                     tracer,
                     enlistment,
                     objectRequestor,
+                    null,
                     this.ChunkSize,
                     this.SearchThreadCount,
                     this.DownloadThreadCount,


### PR DESCRIPTION
I'm still looking into ways to just make the index parsing faster and not have to create this extra file, but in the meantime, here's a WIP PR to show what this approach will look like.

In this PR, we save a successful blob prefetch's parameters in a `FileBasedDictionary`. This allows a subsequent prefetch with the same exact parameters (including commit id) to early exit because it's nearly guaranteed to be a noop. This approach does have the potential to create false positives, e.g. the user could have deleted their cache between the last prefetch and the current one, but that will result in a perf hit in those situations, not a correctness issue.

It'll be nicer to avoid this extra fragility if we can, so I'm still investigating alternatives. Right now, the vast majority of the cost of a noop prefetch is in the `DiffHelper.PerformDiff` method, which is just calling `git ls-files -r -t` and then parsing the string output. That is about a constant 20s overhead on the Windows repo. We should be able to get this down to 3-5s, though that will be at a high complexity cost and probably still not fast enough for running in every build, so it may be unworkable in the end.