### PR TITLE
Update git version to 2.19.1.gvfs.1.7.g43ac102

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181107.1</GitPackageVersion>
+    <GitPackageVersion>2.20181127.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
This change updates git to not spawn the read-object process in send-pack after the pack-objects process has been spawned but instead read-object will be spawned by the pack-objects process.  This was needed because the stdin/stdout/stderr handles were changed when the read-object process was spawned after the pack-objects process started but send-pack still needed to use the handles of pack-objects.