### PR TITLE
Mac: Give an error message on CLI when the kext is not loaded

### DIFF
--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -10,6 +10,8 @@ namespace GVFS.Platform.Mac
 {
     public class ProjFSKext : IKernelDriver
     {
+        private const string DriverName = "io.gvfs.PrjFSKext";
+
         public bool EnumerationExpandsDirectories { get; } = true;
 
         public string LogsFolderPath => throw new NotImplementedException();
@@ -48,8 +50,15 @@ namespace GVFS.Platform.Mac
 
         public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)
         {
-            error = null;
-            return true;
+            ProcessResult loadedKexts = ProcessHelper.Run("kextstat", args: "-b " + DriverName, redirectOutput: true);
+            if (loadedKexts.Output.Contains(DriverName))
+            {
+                error = null;
+                return true;
+            }
+
+            error = DriverName + " is not loaded. Make sure the driver is loaded and try again.";
+            return false;
         }
 
         public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)


### PR DESCRIPTION
Currently if you try to mount without loading the kext first, the mount process detects it and shuts down, but the CLI just complains about a broken pipe.

Added a call to `kextstat` to ensure the kext is loaded before trying to mount, so the user gets a more meaningful error:

```
Saeeds-MacBook-Pro:GVFSTest sanoursa$ ~/Repos/VFSForGit/Publish/gvfs mount
io.gvfs.PrjFSKext is not loaded. Make sure the driver is loaded and try again.
```

The error message is currently not super actionable, but that's because the details of how the kext will ultimately be loaded are still in flight. For now, this is at least a more specific indication of why mount is failing.