### PR TITLE
Mac: Prjfs log reconnect

### DIFF
--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
@@ -11,6 +11,14 @@ struct DarwinVersion
     unsigned long major, minor, revision;
 };
 
+struct PrjFSService_WatchContext
+{
+    std::function<void(io_service_t, io_connect_t, PrjFSService_WatchContext*)> discoveryCallback;
+    io_iterator_t notificationIterator;
+    PrjFSServiceUserClientType clientType;
+};
+
+
 typedef decltype(IODataQueueDequeue)* ioDataQueueDequeueFunctionPtr;
 static ioDataQueueDequeueFunctionPtr ioDataQueueDequeueFunction = nullptr;
 typedef decltype(IODataQueuePeek)* ioDataQueuePeekFunctionPtr;
@@ -18,21 +26,8 @@ static ioDataQueuePeekFunctionPtr ioDataQueuePeekFunction = nullptr;
 
 static void InitDataQueueFunctions();
 
-
-io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType)
+bool PrjFSService_ValidateVersion(io_service_t prjfsService)
 {
-    CFDictionaryRef matchDict = IOServiceMatching(PrjFSServiceClass);
-    io_service_t prjfsService = IOServiceGetMatchingService(kIOMasterPortDefault, matchDict); // matchDict consumed
-
-    io_connect_t connection = IO_OBJECT_NULL;
-    
-    if (prjfsService == IO_OBJECT_NULL)
-    {
-        std::cerr << "Failed to find instance of service class " PrjFSServiceClass << std::endl;
-        return IO_OBJECT_NULL;
-    }
-    
-    // Check kernel's interface version matches ours or we're asking for trouble
     CFTypeRef kextVersionObj = IORegistryEntryCreateCFProperty(prjfsService, CFSTR(PrjFSKextVersionKey), kCFAllocatorDefault, 0);
     CFStringRef kextVersionString;
     if (nullptr == kextVersionObj || CFStringGetTypeID() != CFGetTypeID(kextVersionObj))
@@ -48,34 +43,100 @@ io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType client
         std::cerr << "PrjFS kernel service interface version mismatch. Kernel: " << kextVersion << ", this library expects: " << PrjFSKextVersion << std::endl;
         goto CleanupAndFail;
     }
-    else
-    {
-        CFRelease(kextVersionString);
-        
-        // Version matches, connect to kernel service
-        kern_return_t result = IOServiceOpen(prjfsService, mach_task_self(), clientType, &connection);
-        IOObjectRelease(prjfsService);
-        if (kIOReturnSuccess != result || IO_OBJECT_NULL == connection)
-        {
-            std::cerr << "Failed to open connection to kernel service: 0x" << std::hex << result << ", connection 0x" << std::hex << connection << std::endl;
-            connection = IO_OBJECT_NULL;
-        }
-    }
     
-    return connection;
+    CFRelease(kextVersionString);
+    
+    return true;
 
 CleanupAndFail:
-    if (IO_OBJECT_NULL != prjfsService)
-    {
-        IOObjectRelease(prjfsService);
-    }
-    
     if (nullptr != kextVersionObj)
     {
         CFRelease(kextVersionObj);
     }
     
-    return IO_OBJECT_NULL;
+    return false;
+}
+
+io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType)
+{
+    CFDictionaryRef matchDict = IOServiceMatching(PrjFSServiceClass);
+    io_service_t prjfsService = IOServiceGetMatchingService(kIOMasterPortDefault, matchDict); // matchDict consumed
+
+    io_connect_t connection = IO_OBJECT_NULL;
+    
+    if (prjfsService == IO_OBJECT_NULL)
+    {
+        std::cerr << "Failed to find instance of service class " PrjFSServiceClass << std::endl;
+        return IO_OBJECT_NULL;
+    }
+    
+    if (!PrjFSService_ValidateVersion(prjfsService))
+    {
+        IOObjectRelease(prjfsService);
+        return IO_OBJECT_NULL;
+    }
+
+    kern_return_t result = IOServiceOpen(prjfsService, mach_task_self(), clientType, &connection);
+    IOObjectRelease(prjfsService);
+    if (kIOReturnSuccess != result || IO_OBJECT_NULL == connection)
+    {
+        std::cerr << "Failed to open connection to kernel service: 0x" << std::hex << result << ", connection 0x" << std::hex << connection << std::endl;
+        connection = IO_OBJECT_NULL;
+    }
+
+    return connection;
+}
+
+static void ServiceMatched(
+    void* refcon,
+    io_iterator_t iterator)
+{
+    PrjFSService_WatchContext* context = static_cast<PrjFSService_WatchContext*>(refcon);
+    
+    while (io_service_t prjfsService = IOIteratorNext(context->notificationIterator))
+    {
+        io_connect_t connection = IO_OBJECT_NULL;
+        if (PrjFSService_ValidateVersion(prjfsService))
+        {
+            IOServiceOpen(prjfsService, mach_task_self(), context->clientType, &connection);
+        }
+        
+        context->discoveryCallback(prjfsService, connection, context);
+        
+        IOObjectRelease(prjfsService);
+    }
+}
+
+PrjFSService_WatchContext* PrjFSService_WatchForServiceAndConnect(
+    IONotificationPortRef notificationPort,
+    enum PrjFSServiceUserClientType clientType,
+    std::function<void(io_service_t, io_connect_t, PrjFSService_WatchContext*)> discoveryCallback)
+{
+    CFDictionaryRef matchDict = IOServiceMatching(PrjFSServiceClass);
+    PrjFSService_WatchContext* context = new PrjFSService_WatchContext { std::move(discoveryCallback), IO_OBJECT_NULL, clientType };
+    IOReturn result = IOServiceAddMatchingNotification(
+        notificationPort,
+        kIOMatchedNotification,
+        matchDict, // dictionary is consumed, no CFRelease needed
+        ServiceMatched,
+        context,
+        &context->notificationIterator);
+    if (kIOReturnSuccess == result)
+    {
+        ServiceMatched(context, context->notificationIterator);
+        return context;
+    }
+    else
+    {
+        delete context;
+        return nullptr;
+    }
+}
+
+void PrjFSService_StopWatching(PrjFSService_WatchContext* context)
+{
+    IOObjectRelease(context->notificationIterator);
+    delete context;
 }
 
 bool PrjFSService_DataQueueInit(
@@ -135,6 +196,27 @@ CleanupAndFail:
     memset(outQueue, 0, sizeof(*outQueue));
     return false;
 }
+
+void DataQueue_Dispose(DataQueueResources* queueResources, io_connect_t connection, uint32_t clientMemoryType)
+{
+    if (nullptr != queueResources->dispatchSource)
+    {
+        dispatch_cancel(queueResources->dispatchSource);
+        dispatch_release(queueResources->dispatchSource);
+        queueResources->dispatchSource = nullptr;
+    }
+
+    if (MACH_PORT_NULL != queueResources->notificationPort)
+    {
+        mach_port_deallocate(mach_task_self(), queueResources->notificationPort);
+    }
+
+    if (0 != queueResources->queueMemoryAddress)
+    {
+        IOConnectUnmapMemory64(connection, clientMemoryType, mach_task_self(), queueResources->queueMemoryAddress);
+    }
+}
+
 
 IOReturn DataQueue_Dequeue(IODataQueueMemory* dataQueue, void* data, uint32_t* dataSize)
 {

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
@@ -80,7 +80,7 @@ io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType client
     IOObjectRelease(prjfsService);
     if (kIOReturnSuccess != result || IO_OBJECT_NULL == connection)
     {
-        std::cerr << "Failed to open connection to kernel service: 0x" << std::hex << result << ", connection 0x" << std::hex << connection << std::endl;
+        std::cerr << "Failed to open connection to kernel service; error: 0x" << std::hex << result << ", connection 0x" << std::hex << connection << std::endl;
         connection = IO_OBJECT_NULL;
     }
 
@@ -98,7 +98,11 @@ static void ServiceMatched(
         io_connect_t connection = IO_OBJECT_NULL;
         if (PrjFSService_ValidateVersion(prjfsService))
         {
-            IOServiceOpen(prjfsService, mach_task_self(), context->clientType, &connection);
+            kern_return_t result = IOServiceOpen(prjfsService, mach_task_self(), context->clientType, &connection);
+            if (result != kIOReturnSuccess)
+            {
+                std::cerr << "Failed to open connection to kernel service; error: 0x" << std::hex << result << ", connection 0x" << std::hex << connection << std::endl;
+            }
         }
         
         context->discoveryCallback(prjfsService, connection, context);

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
@@ -5,6 +5,7 @@
 #include <IOKit/IODataQueueClient.h>
 #include <dispatch/dispatch.h>
 #include <IOKit/IOTypes.h>
+#include <functional>
 
 struct DataQueueResources
 {
@@ -17,12 +18,21 @@ struct DataQueueResources
 
 io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType);
 
+struct PrjFSService_WatchContext;
+PrjFSService_WatchContext* PrjFSService_WatchForServiceAndConnect(
+    struct IONotificationPort* notificationPort,
+    enum PrjFSServiceUserClientType clientType,
+    std::function<void(io_service_t, io_connect_t, PrjFSService_WatchContext*)> discoveryCallback);
+void PrjFSService_StopWatching(PrjFSService_WatchContext* context);
+bool PrjFSService_ValidateVersion(io_service_t prjfsService);
+
 bool PrjFSService_DataQueueInit(
     DataQueueResources* outQueue,
     io_connect_t connection,
     uint32_t clientPortType,
     uint32_t clientMemoryType,
     dispatch_queue_t eventHandlingQueue);
+void DataQueue_Dispose(DataQueueResources* queueResources, io_connect_t connection, uint32_t clientMemoryType);
 
 IODataQueueEntry* DataQueue_Peek(IODataQueueMemory* dataQueue);
 IOReturn DataQueue_Dequeue(IODataQueueMemory* dataQueue, void* data, uint32_t* dataSize);

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -106,6 +106,7 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
     uint64_t timeOffsetMS = NanosecondsFromAbsoluteTime(mach_absolute_time() - s_machStartTime) / NSEC_PER_MSEC;
     printf("(0x%x: %5d: %5llu.%03llu) START: Processing log messages from service with ID 0x%llx\n",
         connection, logState->lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, prjfsServiceEntryID);
+    fflush(stdout);
     ++logState->lineCount;
     
     dispatch_source_set_event_handler(logState->dataQueue.dispatchSource, ^{
@@ -140,6 +141,8 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
             
             DataQueue_Dequeue(logState->dataQueue.queueMemory, nullptr, nullptr);
         }
+        
+        fflush(stdout);
     });
     dispatch_resume(logState->dataQueue.dispatchSource);
 
@@ -156,6 +159,7 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
         {
             uint64_t timeOffsetMS = NanosecondsFromAbsoluteTime(mach_absolute_time() - s_machStartTime) / NSEC_PER_MSEC;
             printf("(0x%x: %5d: %5llu.%03llu) STOP: service with ID 0x%llx has terminated\n", connection, logState->lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, prjfsServiceEntryID);
+            fflush(stdout);
             logState->lineCount++;
 
             DataQueue_Dispose(&logState->dataQueue, connection, LogMemoryType_MessageQueue);

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -10,41 +10,114 @@
 static const char* KextLogLevelAsString(KextLog_Level level);
 static uint64_t NanosecondsFromAbsoluteTime(uint64_t machAbsoluteTime);
 static dispatch_source_t StartKextProfilingDataPolling(io_connect_t connection);
+static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t prjfsService);
 
 static mach_timebase_info_data_t s_machTimebase;
-
+static uint64_t s_machStartTime;
+static IONotificationPortRef s_notificationPort;
 
 int main(int argc, const char * argv[])
 {
     mach_timebase_info(&s_machTimebase);
-    const uint64_t machStartTime = mach_absolute_time();
+    s_machStartTime = mach_absolute_time();
 
-    io_connect_t connection = PrjFSService_ConnectToDriver(UserClientType_Log);
-    if (connection == IO_OBJECT_NULL)
+
+    s_notificationPort = IONotificationPortCreate(kIOMasterPortDefault);
+    IONotificationPortSetDispatchQueue(s_notificationPort, dispatch_get_main_queue());
+
+    PrjFSService_WatchContext* watchContext = PrjFSService_WatchForServiceAndConnect(
+        s_notificationPort, UserClientType_Log,
+        [](io_service_t service, io_connect_t connection, PrjFSService_WatchContext* context)
+        {
+            if (connection != IO_OBJECT_NULL)
+            {
+                ProcessLogMessagesOnConnection(connection, service);
+            }
+        });
+    if (nullptr == watchContext)
     {
-        std::cerr << "Failed to connect to kernel service.\n";
+        std::cerr << "Failed to register for IOService notifications.\n";
         return 1;
     }
     
-    DataQueueResources dataQueue = {};
-    if (!PrjFSService_DataQueueInit(&dataQueue, connection, LogPortType_MessageQueue, LogMemoryType_MessageQueue, dispatch_get_main_queue()))
+
+    CFRunLoopRun();
+    
+    PrjFSService_StopWatching(watchContext);
+
+    return 0;
+}
+
+struct TerminationNotificationContext
+{
+    std::function<void()> terminationCallback;
+    io_iterator_t terminatedServiceIterator;
+};
+
+static void ServiceTerminated(void* refcon, io_iterator_t iterator)
+{
+    TerminationNotificationContext* context = static_cast<TerminationNotificationContext*>(refcon);
+    
+    io_service_t terminatedService = IOIteratorNext(iterator);
+    if (terminatedService != IO_OBJECT_NULL)
     {
-        std::cerr << "Failed to set up shared data queue.\n";
-        return 1;
+        IOObjectRelease(terminatedService);
+        context->terminationCallback();
+        IOObjectRelease(iterator);
+        delete context;
+    }
+}
+
+static void WatchForServiceTermination(io_service_t service, IONotificationPortRef notificationPort, std::function<void()> terminationCallback)
+{
+    uint64_t serviceEntryID = 0;
+    IORegistryEntryGetRegistryEntryID(service, &serviceEntryID);
+    CFMutableDictionaryRef serviceMatching = IORegistryEntryIDMatching(serviceEntryID);
+    TerminationNotificationContext* context = new TerminationNotificationContext { std::move(terminationCallback), };
+    kern_return_t result = IOServiceAddMatchingNotification(notificationPort, kIOTerminatedNotification, serviceMatching, ServiceTerminated, context, &context->terminatedServiceIterator);
+    if (result != kIOReturnSuccess)
+    {
+        delete context;
+    }
+    else
+    {
+        ServiceTerminated(context, context->terminatedServiceIterator);
+    }
+}
+
+struct LogConnectionState
+{
+    DataQueueResources dataQueue;
+    unsigned lineCount;
+};
+
+static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t prjfsService)
+{
+    std::shared_ptr<LogConnectionState> logState(new LogConnectionState {{}, 0 });
+    if (!PrjFSService_DataQueueInit(&logState->dataQueue, connection, LogPortType_MessageQueue, LogMemoryType_MessageQueue, dispatch_get_main_queue()))
+    {
+        std::cerr << "Failed to set up shared data queue on connection 0x" << std::hex << connection << ".\n";
+        IOServiceClose(connection);
+        return;
     }
     
-    __block int lineCount = 0;
+    uint64_t prjfsServiceEntryID = 0;
+    IORegistryEntryGetRegistryEntryID(prjfsService, &prjfsServiceEntryID);
+    uint64_t timeOffsetMS = NanosecondsFromAbsoluteTime(mach_absolute_time() - s_machStartTime) / NSEC_PER_MSEC;
+    printf("(0x%x: %5d: %5llu.%03llu) START: Processing log messages from service with ID 0x%llx\n",
+        connection, logState->lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, prjfsServiceEntryID);
+    ++logState->lineCount;
     
-    dispatch_source_set_event_handler(dataQueue.dispatchSource, ^{
+    dispatch_source_set_event_handler(logState->dataQueue.dispatchSource, ^{
         struct {
-            mach_msg_header_t	msgHdr;
-            mach_msg_trailer_t	trailer;
+            mach_msg_header_t  msgHdr;
+            mach_msg_trailer_t trailer;
         } msg;
-        mach_msg(&msg.msgHdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(msg), dataQueue.notificationPort, 0, MACH_PORT_NULL);
+        mach_msg(&msg.msgHdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(msg), logState->dataQueue.notificationPort, 0, MACH_PORT_NULL);
         
         while(true)
         {
-            IODataQueueEntry* entry = DataQueue_Peek(dataQueue.queueMemory);
+            IODataQueueEntry* entry = DataQueue_Peek(logState->dataQueue.queueMemory);
             if(entry == nullptr)
             {
                 break;
@@ -58,17 +131,17 @@ int main(int argc, const char * argv[])
                 const char* messageType = KextLogLevelAsString(message.level);
                 int logStringLength = messageSize - sizeof(KextLog_MessageHeader) - 1;
                 
-                uint64_t timeOffsetNS = NanosecondsFromAbsoluteTime(message.machAbsoluteTimestamp - machStartTime);
+                uint64_t timeOffsetNS = NanosecondsFromAbsoluteTime(message.machAbsoluteTimestamp - s_machStartTime);
                 uint64_t timeOffsetMS = timeOffsetNS / NSEC_PER_MSEC;
                 
-                printf("(%d: %5llu.%03llu) %s: %.*s\n", lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, messageType, logStringLength, entry->data + sizeof(KextLog_MessageHeader));
-                lineCount++;
+                printf("(0x%x: %5d: %5llu.%03llu) %s: %.*s\n", connection, logState->lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, messageType, logStringLength, entry->data + sizeof(KextLog_MessageHeader));
+                logState->lineCount++;
             }
             
-            DataQueue_Dequeue(dataQueue.queueMemory, nullptr, nullptr);
+            DataQueue_Dequeue(logState->dataQueue.queueMemory, nullptr, nullptr);
         }
     });
-    dispatch_resume(dataQueue.dispatchSource);
+    dispatch_resume(logState->dataQueue.dispatchSource);
 
     dispatch_source_t timer = nullptr;
     if (PrjFSLog_FetchAndPrintKextProfilingData(connection))
@@ -76,15 +149,25 @@ int main(int argc, const char * argv[])
         timer = StartKextProfilingDataPolling(connection);
     }
 
-    CFRunLoopRun();
-    
-    if (nullptr != timer)
-    {
-        dispatch_cancel(timer);
-        dispatch_release(timer);
-    }
+    WatchForServiceTermination(
+        prjfsService,
+        s_notificationPort,
+        [timer, connection, logState, prjfsServiceEntryID]()
+        {
+            uint64_t timeOffsetMS = NanosecondsFromAbsoluteTime(mach_absolute_time() - s_machStartTime) / NSEC_PER_MSEC;
+            printf("(0x%x: %5d: %5llu.%03llu) STOP: service with ID 0x%llx has terminated\n", connection, logState->lineCount, timeOffsetMS / 1000u, timeOffsetMS % 1000u, prjfsServiceEntryID);
+            logState->lineCount++;
 
-    return 0;
+            DataQueue_Dispose(&logState->dataQueue, connection, LogMemoryType_MessageQueue);
+            
+            if (nullptr != timer)
+            {
+                dispatch_cancel(timer);
+                dispatch_release(timer);
+            }
+            
+            IOServiceClose(connection);
+        });
 }
 
 static const char* KextLogLevelAsString(KextLog_Level level)


### PR DESCRIPTION
This implements #564. 

Instead of searching for the PrjFS IOKit service once on startup, `prjfs-log` now registers for matching notifications. This means that if there is no PrjFS service running (the kext isn't loaded), it will sit and wait for it to turn up. Likewise, if the kext is unloaded, the logging infrastructure for that instance is cleanly torn down. The notification system continues to look out for new instances of the service, so when the kext is reloaded, logging immediately resumes.

I've also added new log entries for when prjfs starts and stops logging for a particular kext service instance.

Finally, I've added `fflush(stdout)` calls to avoid dropping buffered messages when prjfs-log output is redirected to a file.