### PR TITLE
Mac: Kill any git/gvfs processes when cleaning up after Functional Tests

### DIFF
--- a/Scripts/Mac/CleanupFunctionalTests.sh
+++ b/Scripts/Mac/CleanupFunctionalTests.sh
@@ -1,5 +1,10 @@
 . "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
 
+pkill -9 -l GVFS.FunctionalTests
+pkill -9 -l git
+pkill -9 -l gvfs
+pkill -9 -l prjfs-log
+
 $VFS_SRCDIR/ProjFS.Mac/Scripts/UnloadPrjFSKext.sh
 
 sudo rm -r /GVFS.FT


### PR DESCRIPTION
In some cases, a developer might make a change that causes the functional tests to hang or take an extremely long time. The job will time out after 120 minutes and we don't currently clean up any processes that could still be running. We should pkill any git/gvfs processes still running while we're cleaning up.

This is similar to what we're doing in UnInstallGVFS.bat on Windows.