### PR TITLE
Add Version to Heartbeat

### DIFF
--- a/GVFS/GVFS.Common/HeartbeatThread.cs
+++ b/GVFS/GVFS.Common/HeartbeatThread.cs
@@ -53,6 +53,7 @@ namespace GVFS.Common
                 EventLevel eventLevel = EventLevel.Verbose;
                 EventMetadata metadata = this.dataProvider.GetMetadataForHeartBeat(ref eventLevel) ?? new EventMetadata();
                 DateTime now = DateTime.Now;
+                metadata.Add("Version", ProcessHelper.GetCurrentProcessVersion());
                 metadata.Add("MinutesUptime", (long)(now - this.startTime).TotalMinutes);
                 metadata.Add("MinutesSinceLast", (int)(now - this.lastHeartBeatTime).TotalMinutes);
                 this.lastHeartBeatTime = now;

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -9,6 +9,8 @@ namespace GVFS.Common
 {
     public static class ProcessHelper
     {
+        private static string currentProcessVersion = null;
+
         public static ProcessResult Run(string programName, string args, bool redirectOutput = true)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(programName);
@@ -44,9 +46,14 @@ namespace GVFS.Common
 
         public static string GetCurrentProcessVersion()
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-            return fileVersionInfo.ProductVersion;
+            if (currentProcessVersion == null)
+            {
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+                currentProcessVersion = fileVersionInfo.ProductVersion;
+            }
+
+            return currentProcessVersion;
         }
         
         public static bool IsDevelopmentVersion()


### PR DESCRIPTION
This ties into telemetry for mount success.

We determine the number of running mounts (per day) by the MountId on the Heartbeat.  This will allow us to track running mounts by Version.  

While the initial mount also has Version, that could be many days old and no longer in telemetry.