### PR TITLE
Update git settings to enable optimizations in git 2.20

### DIFF
--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -103,6 +103,7 @@ namespace GVFS.CommandLine
             Dictionary<string, string> requiredSettings = new Dictionary<string, string>
             {
                 { "am.keepcr", "true" },
+                { "checkout.optimizenewbranch", "true" },
                 { "core.autocrlf", "false" },
                 { "core.commitGraph", "true" },
                 { "core.fscache", "true" },
@@ -123,11 +124,13 @@ namespace GVFS.CommandLine
                 { "diff.autoRefreshIndex", "false" },
                 { "gc.auto", "0" },
                 { "gui.gcwarning", "false" },
+                { "index.threads", "true" },
                 { "index.version", "4" },
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },
                 { "receive.autogc", "false" },
+                { "reset.quiet", "true" },
                 { "status.deserializePath", gitStatusCachePath },
             };
 


### PR DESCRIPTION
git 2.20 has some optimizations that will significantly help performance in VFS for Git repos.  Turn these options on by default in VFS for Git repros:

Set 'checkout.optimizeNewBranch=true' to enable optimized 'checkout -b'
Set 'index.threads=true' to enable multi-threaded index reads
Set 'reset.quiet=true' to speed up 'git reset <foo>"

The associated patches in git are:

commit fa655d8411cc2d7ffcf898e53a1493c737d7de68
Author: Ben Peart <Ben.Peart@microsoft.com>

    checkout: optimize "git checkout -b <new_branch>"

commit 2a9dedef2ef76916be4a314a7e739f253eaf05db
Author: Jonathan Nieder <jrnieder@gmail.com>

    index: make index.threads=true enable ieot and eoie

commit 4c3abd0551d8ff1c280de2bc53d6a7657b053d33
Author: Ben Peart <benpeart@microsoft.com>

    reset: add new reset.quiet config setting

Signed-off-by: Ben Peart <benpeart@microsoft.com>