### PR TITLE
Mac kext: Avoid working on file stream vnodes in fileop handler

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/KauthHandler.cpp
@@ -291,13 +291,12 @@ static void UseMainForkIfNamedStream(
         vnode_t mainFileFork = vnode_getparent(vnode);
         assert(NULLVP != mainFileFork);
         
-        if (putVnodeWhenDone)
-        {
-            vnode_put(vnode);
-        }
-        
         vnode = mainFileFork;
         putVnodeWhenDone = true;
+    }
+    else
+    {
+        putVnodeWhenDone = false;
     }
 }
 


### PR DESCRIPTION
 * Named file streams are not files themselves do not have file attributes, so attempting to do so on that type of vnode will fail.
 * In the vnode listener, we've already been checking for this edge case, but the fileop handler thus far has not checked for file forks, and we were getting errors in the KAUTH_FILEOP_CLOSE events.
 * This change moves the named stream check logic into a helper function which we can use from both vnode and fileop handlers. As this affects whether vnodes need to be released, I've unified the logic for this across the entire fileop handler.
 * Named forks can’t be renamed or hard linked, so we don’t expect to get those events for such vnodes, and we don’t need to defend against that case there.

This is one of the outcomes of my ongoing reliability/error logging efforts. (#555)