### PR TITLE
Fix bad test by fixing maintenance step lock string

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -377,7 +377,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void PostFetchJobShouldComplete()
         {
             string objectDir = this.Enlistment.GetObjectRoot(this.fileSystem);
-            string postFetchLock = Path.Combine(objectDir, "post-fetch.lock");
+            string postFetchLock = Path.Combine(objectDir, "git-maintenance-step.lock");
 
             while (this.fileSystem.FileExists(postFetchLock))
             {


### PR DESCRIPTION
The test `PrefetchVerbWithoutSharedCacheTests.PrefetchCommitsToEmptyCache()` only runs with the full test suite, not the PR test suite. This was not run during #493, and hence broke the CI build immediately after.

The fix is a simple constant string change.