### PR TITLE
GitMaintenanceQueue: fix null queue behavior

### DIFF
--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
@@ -95,7 +95,7 @@ namespace GVFS.UnitTests.Maintenance
 
             // Ensure we don't start a job after the Stop() call
             TestGitMaintenanceStep watchForStart = new TestGitMaintenanceStep(this.context, this.gitObjects);
-            queue.TryEnqueue(watchForStart).ShouldBeTrue();
+            queue.TryEnqueue(watchForStart).ShouldBeFalse();
 
             // This only ensures the event didn't happen within maxWaitTime
             Assert.IsFalse(watchForStart.EventTriggered.WaitOne(this.maxWaitTime));


### PR DESCRIPTION
I saw [a broken unit test build](https://gvfs.visualstudio.com/ci/_build/results?buildId=4499) in #581, but it wasn't due to a change there. It was due to an incorrect handling of a `null` member in `GitMaintenanceQueue` and how it returned `true` if the blocking collection was `null`. If the timing is just right, that value wasn't `null` and the output was `false`.

Fix this by doing the right thing: return `false` when the collection is `null`, and change the test to expect this.