### PR TITLE
Allow --files-list option for prefetch

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -145,6 +145,33 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             multiPackIndexLockFile.ShouldNotExistOnDisk(this.fileSystem);
         }
 
+        [TestCase, Order(12)]
+        public void PrefetchFilesFromFileListFile()
+        {
+            try
+            {
+                File.WriteAllLines("fileList",new []{
+                    Path.Combine("GVFS", "GVFS", "Program.cs"),
+                    Path.Combine("GVFS", "GVFS.FunctionalTests", "GVFS.FunctionalTests.csproj")
+                });
+                this.ExpectBlobCount(this.Enlistment.Prefetch("--files-list fileList"), 2);
+            }
+            finally
+            {
+                File.Delete("fileList");
+            }
+        }
+
+        [TestCase, Order(13)]
+        public void PrefetchFilesFromFileListStdIn()
+        {
+            var input = string.Join("\n",new []{
+                Path.Combine("GVFS", "GVFS", "packages.config"),
+                Path.Combine("GVFS", "GVFS.FunctionalTests", "App.config")
+            });
+            this.ExpectBlobCount(this.Enlistment.Prefetch("--files-list stdin", standardInput: input), 2);
+        }
+
         private void ExpectBlobCount(string output, int expectedCount)
         {
             output.ShouldContain("Matched blobs:    " + expectedCount);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -196,9 +196,9 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.TryMount(out output);
         }
 
-        public string Prefetch(string args, bool failOnError = true)
+        public string Prefetch(string args, bool failOnError = true, string standardInput = null)
         {
-            return this.gvfsProcess.Prefetch(args, failOnError);
+            return this.gvfsProcess.Prefetch(args, failOnError, standardInput);
         }
 
         public void Repair(bool confirm)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -42,9 +42,9 @@ namespace GVFS.FunctionalTests.Tools
             return this.IsEnlistmentMounted();
         }
 
-        public string Prefetch(string args, bool failOnError)
+        public string Prefetch(string args, bool failOnError, string standardInput = null)
         {
-            return this.CallGVFS("prefetch \"" + this.enlistmentRoot + "\" " + args, failOnError);
+            return this.CallGVFS("prefetch \"" + this.enlistmentRoot + "\" " + args, failOnError, standardInput: standardInput);
         }
 
         public void Repair(bool confirm)
@@ -90,7 +90,7 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
-        private string CallGVFS(string args, bool failOnError = false, string trace = null)
+        private string CallGVFS(string args, bool failOnError = false, string trace = null, string standardInput = null)
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
@@ -99,6 +99,10 @@ namespace GVFS.FunctionalTests.Tools
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
+            if(standardInput != null)
+            {
+                processInfo.RedirectStandardInput = true;
+            }
 
             if (trace != null)
             {
@@ -107,6 +111,11 @@ namespace GVFS.FunctionalTests.Tools
 
             using (Process process = Process.Start(processInfo))
             {
+                if(standardInput != null)
+                {
+                    process.StandardInput.Write(standardInput);
+                    process.StandardInput.Close();
+                }
                 string result = process.StandardOutput.ReadToEnd();
                 process.WaitForExit();
 

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -45,8 +45,15 @@ namespace GVFS.CommandLine
             "folders-list",
             Required = false,
             Default = "",
-            HelpText = "A file containing line-delimited list of folders to fetch. Wildcards are not supported.")]
+            HelpText = "A file containing line-delimited list of folders to fetch. Wildcards are not supported. Specify \"stdin\" for stdin")]
         public string FoldersListFile { get; set; }
+
+        [Option(
+            "files-list",
+            Required = false,
+            Default = "",
+            HelpText = "A file containing line-delimited list of files to fetch. Wildcards are supported. Specify \"stdin\" for stdin")]
+        public string FileListFile { get; set; }
 
         [Option(
             "hydrate",
@@ -105,6 +112,7 @@ namespace GVFS.CommandLine
                     metadata.Add("Commits", this.Commits);
                     metadata.Add("Files", this.Files);
                     metadata.Add("Folders", this.Folders);
+                    metadata.Add("FileListFile", this.FileListFile);
                     metadata.Add("FoldersListFile", this.FoldersListFile);
                     metadata.Add("HydrateFiles", this.HydrateFiles);
                     tracer.RelatedEvent(EventLevel.Informational, "PerformPrefetch", metadata);
@@ -288,7 +296,7 @@ namespace GVFS.CommandLine
             filesList = new List<string>();
             foldersList = new List<string>();
 
-            if (!BlobPrefetcher.TryLoadFileList(enlistment, this.Files, filesList, out error))
+            if (!BlobPrefetcher.TryLoadFileList(enlistment, this.Files, this.FileListFile, filesList, out error))
             {
                 this.ReportErrorAndExit(tracer, error);
             }


### PR DESCRIPTION
This PR addresses #580 and adds --files-list option to prefetch verb. It also adds a magic file name, to allow passing in both --files-list and --folders-list via stdin.