### PR TITLE
Fix issue building VFS for Git inside of Visual Studio

### DIFF
--- a/GVFS/GVFS.Build/GVFS.PreBuild.csproj
+++ b/GVFS/GVFS.Build/GVFS.PreBuild.csproj
@@ -162,7 +162,6 @@
   <ItemDefinitionGroup>
     <ApplicationNeedsManifest>
       <Visible>false</Visible>
-      <OutputFile>$(BuildOutputDir)\%(Identity).exe.manifest</OutputFile>
     </ApplicationNeedsManifest>
   </ItemDefinitionGroup>
 
@@ -203,6 +202,6 @@
           Inputs="$(RestoreTimestampPath);@(GeneratedPackageConfig);$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);$(MSBuildThisFileDirectory)GenerateVersionInfo.cs;$(MSBuildThisFileDirectory)GenerateApplicationManifests.cs"
           Outputs="$(AssemblyVersionPath);$(VersionHeaderPath);@(ApplicationNeedsManifest->'%(OutputFile)')">
     <GenerateVersionInfo Version="$(GVFSVersion)" AssemblyVersion="$(AssemblyVersionPath)" VersionHeader="$(VersionHeaderPath)" />
-    <GenerateApplicationManifests Version="$(GVFSVersion)" ApplicationName="@(ApplicationNeedsManifest)" ManifestPath="@(ApplicationNeedsManifest->'%(OutputFile)')" />  
+    <GenerateApplicationManifests Version="$(GVFSVersion)" ApplicationName="@(ApplicationNeedsManifest)" ManifestPath="$(BuildOutputDir)\@(ApplicationNeedsManifest).exe.manifest" />  
   </Target>
 </Project>


### PR DESCRIPTION
I am open to feedback / alternatives if there is a better way to fix this.

When building inside of Visual Studio, the application manifest for
GVFS.Service.exe.manifest is not created correctly in
GVFS.PreBuild.csproj. It appears the cause of this issue is that you
cannot use Item metadata from an ItemDefinitionGroup:

  Item metadata from an ItemGroup is not useful in an
  ItemDefinitionGroup metadata declaration because ItemDefinitionGroup
  elements are processed before ItemGroup elements.

https://docs.microsoft.com/en-us/visualstudio/msbuild/item-definitions?view=vs-2017