### PR TITLE
stop blocking unsupported git commands

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181211.5</GitPackageVersion>
+    <GitPackageVersion>2.20181213.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitBlockCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitBlockCommandsTests.cs
@@ -1,0 +1,106 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Should;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
+    [Category(Categories.GitCommands)]
+    public class GitBlockCommandsTests : TestsWithEnlistmentPerFixture
+    {
+        private FileSystemRunner fileSystem;
+        public GitBlockCommandsTests(FileSystemRunner fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        [TestCase, Order(1)]
+        public void GitFsck()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "fsck");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(2)]
+        public void GitGc()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "gc");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+            result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "gc --auto");
+            result.ExitCode.ShouldEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(3)]
+        public void GitPrune()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "prune");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(4)]
+        public void GitRepack()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "repack");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(5)]
+        public void GitSubmodule()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "submodule");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+            result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "submodule status");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(6)]
+        public void GitUpdateIndex()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "update-index --index-version 2");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+            result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "update-index --skip-worktree");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+            result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "update-index --no-skip-worktree");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+            result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "update-index --split-index");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+
+        [TestCase, Order(7)]
+        public void GitWorktree()
+        {
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "worktree list");
+            result.ExitCode.ShouldNotEqual(0, result.Errors);
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1036,10 +1036,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         public void UpdateIndexCannotModifySkipWorktreeBit()
         {
             ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "update-index --skip-worktree Readme.md");
-            result.Errors.ShouldContain("Modifying the skip worktree bit is not supported on a GVFS repo");
+            result.ExitCode.ShouldNotEqual(0);
 
             result = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "update-index --no-skip-worktree Readme.md");
-            result.Errors.ShouldContain("Modifying the skip worktree bit is not supported on a GVFS repo");
+            result.ExitCode.ShouldNotEqual(0);
         }
 
         [TestCase]

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -133,43 +133,8 @@ namespace GVFS.Hooks
             string command = GetGitCommand(args);
             switch (command)
             {
-                case "update-index":
-                    if (ContainsArg(args, "--split-index") ||
-                        ContainsArg(args, "--no-split-index"))
-                    {
-                        ExitWithError("Split index is not supported on a GVFS repo");
-                    }
-
-                    if (ContainsArg(args, "--index-version"))
-                    {
-                        ExitWithError("Changing the index version is not supported on a GVFS repo");
-                    }
-
-                    if (ContainsArg(args, "--skip-worktree") || 
-                        ContainsArg(args, "--no-skip-worktree"))
-                    {
-                        ExitWithError("Modifying the skip worktree bit is not supported on a GVFS repo");
-                    }
-
-                    break;
-
-                case "fsck":
-                case "gc":
-                case "prune":
-                case "repack":
-                    ExitWithError("'git " + command + "' is not supported on a GVFS repo");
-                    break;
-
-                case "submodule":
-                    ExitWithError("Submodule operations are not supported on a GVFS repo");
-                    break;
-
                 case "status":
                     VerifyRenameDetectionSettings(args);
-                    break;
-
-                case "worktree":
-                    ExitWithError("Worktree operations are not supported on a GVFS repo");
                     break;
 
                 case "gui":


### PR DESCRIPTION
Now that git has learned to block unsupported commands on VFS4G repos, we can remove that logic from the pre-command hook.

The corresponding changes to git can be found in https://github.com/Microsoft/git/pull/85/commits/cfe88be4e34695a4b6c1f3e76d5b8fc4349ba031

The version of git specified includes two fixes:

1. [block unsupported git commands](https://github.com/Microsoft/git/pull/91)
2. [reset.quiet and post-indextchanged hook](https://github.com/Microsoft/git/pull/93)

Signed-off-by: Ben Peart <benpeart@microsoft.com>