### PR TITLE
Update Git to v2.20.0.vfs.1.1

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181129.1</GitPackageVersion>
+    <GitPackageVersion>2.20181211.5</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
@@ -53,6 +53,7 @@ namespace GVFS.FunctionalTests.Tools
             GitProcess.Invoke(this.RootPath, "config merge.renames false");
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");
             GitProcess.Invoke(this.RootPath, "config core.abbrev 40");
+            GitProcess.Invoke(this.RootPath, "config rebase.useBuiltin false");
             GitProcess.Invoke(this.RootPath, "config status.aheadbehind false");
             GitProcess.Invoke(this.RootPath, "config user.name \"Functional Test User\"");
             GitProcess.Invoke(this.RootPath, "config user.email \"functional@test.com\"");

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -130,7 +130,6 @@ namespace GVFS.CommandLine
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },
                 { "receive.autogc", "false" },
-                { "reset.quiet", "true" },
                 { "status.deserializePath", gitStatusCachePath },
             };
 

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -129,6 +129,7 @@ namespace GVFS.CommandLine
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },
+                { "rebase.useBuiltin", "false" },
                 { "receive.autogc", "false" },
                 { "status.deserializePath", gitStatusCachePath },
             };


### PR DESCRIPTION
Includes v2.20.0.windows.1.

It also disables `reset.quiet` (correctness issue) and `rebase.useBuiltin` (performance issue).