### PR TITLE
Fix download cleanup issue caught by Functional test

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -301,7 +301,7 @@ namespace GVFS.Common
             return false;
         }
 
-        public void DeletePreviousDownloads()
+        public void CleanupDownloadDirectory()
         {
             try
             {
@@ -309,7 +309,7 @@ namespace GVFS.Common
             }
             catch (Exception ex)
             {
-                this.TraceException(ex, nameof(this.DeletePreviousDownloads), $"Could not remove directory: {GetAssetDownloadsPath()}");
+                this.TraceException(ex, nameof(this.CleanupDownloadDirectory), $"Could not remove directory: {GetAssetDownloadsPath()}");
             }
         }
 

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -115,7 +115,7 @@ namespace GVFS.CommandLine
                 this.tracer.RelatedInfo($"{nameof(this.TryRunProductUpgrade)}: {GVFSConstants.UpgradeVerbMessages.NoneRingConsoleAlert}");
                 this.ReportInfoToConsole(ring == ProductUpgrader.RingType.None ? GVFSConstants.UpgradeVerbMessages.NoneRingConsoleAlert : GVFSConstants.UpgradeVerbMessages.NoRingConfigConsoleAlert);
                 this.ReportInfoToConsole(GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand);
-                this.upgrader.DeletePreviousDownloads();
+                this.upgrader.CleanupDownloadDirectory();
                 return true;
             }
                         
@@ -132,7 +132,7 @@ namespace GVFS.CommandLine
 
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                this.upgrader.DeletePreviousDownloads();
+                this.upgrader.CleanupDownloadDirectory();
                 return true;
             }
 


### PR DESCRIPTION
When pre-checks fail, service was not cleaning up the upgrade downloads directory. This issue was caught by FT in CI build nodes, which don't have ProjFS inboxed causing pre-check to fail.

Updated service to do the cleanup even when pre-check or download tasks fail.