### PR TITLE
Loose Object Cleanup Step (Round 2)

### DIFF
--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -44,7 +44,7 @@ namespace GVFS.Common.Git
 
         public static bool IsLooseObjectsDirectory(string value)
         {
-            return value.Length == 2 && !value.Any(c => !Uri.IsHexDigit(c));
+            return value.Length == 2 && value.All(c => Uri.IsHexDigit(c));
         }
 
         public virtual bool TryDownloadCommit(string commitSha)

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -42,6 +42,11 @@ namespace GVFS.Common.Git
             Error
         }
 
+        public static bool IsLooseObjectsDirectory(string value)
+        {
+            return value.Length == 2 && !value.Any(c => !Uri.IsHexDigit(c));
+        }
+
         public virtual bool TryDownloadCommit(string commitSha)
         {
             const bool PreferLooseObjects = false;

--- a/GVFS/GVFS.Common/InternalVerbParameters.cs
+++ b/GVFS/GVFS.Common/InternalVerbParameters.cs
@@ -4,14 +4,16 @@ namespace GVFS.Common
 {
     public class InternalVerbParameters
     {
-        public InternalVerbParameters(string serviceName, bool startedByService)
+        public InternalVerbParameters(string serviceName, bool startedByService, string maintenanceJob)
         {
             this.ServiceName = serviceName;
             this.StartedByService = startedByService;
+            this.MaintenanceJob = maintenanceJob;
         }
 
         public string ServiceName { get; private set; }
         public bool StartedByService { get; private set; }
+        public string MaintenanceJob { get; private set; }
 
         public static InternalVerbParameters FromJson(string json)
         {

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceScheduler.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceScheduler.cs
@@ -7,6 +7,10 @@ namespace GVFS.Common.Maintenance
 {
     public class GitMaintenanceScheduler : IDisposable
     {
+        private readonly TimeSpan looseObjectsDueTime = TimeSpan.FromMinutes(5);
+        private readonly TimeSpan looseObjectsPeriod = TimeSpan.FromHours(6);
+        private readonly TimeSpan prefetchPeriod = TimeSpan.FromMinutes(15);
+
         private List<Timer> stepTimers;
         private GVFSContext context;
         private GitObjects gitObjects;
@@ -52,8 +56,14 @@ namespace GVFS.Common.Maintenance
                 this.stepTimers.Add(new Timer(
                     (state) => this.queue.TryEnqueue(new PrefetchStep(this.context, this.gitObjects, requireCacheLock: true)),
                     state: null,
-                    dueTime: prefetchPeriod,
-                    period: prefetchPeriod));
+                    dueTime: this.prefetchPeriod,
+                    period: this.prefetchPeriod));
+
+                this.stepTimers.Add(new Timer(
+                    (state) => this.queue.TryEnqueue(new LooseObjectsStep(this.context, requireCacheLock: true)),
+                    state: null,
+                    dueTime: this.looseObjectsDueTime,
+                    period: this.looseObjectsPeriod));
             }
         }
     }

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -60,7 +60,7 @@ namespace GVFS.Common.Maintenance
                         IEnumerable<int> processIds = this.RunningGitProcessIds();
                         if (processIds.Any())
                         {
-                            activity.RelatedWarning($"Skipping {nameof(LooseObjectsStep)} due to git pids {0}", string.Join(",", processIds), Keywords.Telemetry);
+                            activity.RelatedWarning($"Skipping {nameof(LooseObjectsStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);
                             return;
                         }
                     }

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -1,0 +1,87 @@
+﻿using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.Common.Maintenance
+{
+    // Remove loose objects that appear in packfiles
+    public class LooseObjectsStep : GitMaintenanceStep
+    {
+        public const string LooseObjectsLastRunFileName = "loose-objects.time";
+        private readonly bool forceRun;
+
+        public LooseObjectsStep(GVFSContext context, bool requireCacheLock, bool forceRun = false)
+            : base(context, gitObjects: null, requireObjectCacheLock: requireCacheLock)
+        {
+            this.forceRun = forceRun;
+        }
+
+        public override string Area => nameof(LooseObjectsStep);
+
+        protected override string LastRunTimeFilePath => Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", LooseObjectsLastRunFileName);
+        protected override TimeSpan TimeBetweenRuns => TimeSpan.FromDays(7);
+
+        public int CountLooseObjects()
+        {
+            int count = 0;
+            
+            foreach (string directoryPath in this.Context.FileSystem.EnumerateDirectories(this.Context.Enlistment.GitObjectsRoot))
+            {
+                string directoryName = directoryPath.TrimEnd(Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar).Last();
+
+                if (GitObjects.IsLooseObjectsDirectory(directoryName))
+                {                    
+                    count += this.Context.FileSystem.GetFiles(Path.Combine(this.Context.Enlistment.GitObjectsRoot, directoryPath), "*").Count();
+                }
+            }
+
+            return count;
+        }
+
+        protected override void PerformMaintenance()
+        {
+            using (ITracer activity = this.Context.Tracer.StartActivity(this.Area, EventLevel.Informational, Keywords.Telemetry, metadata: null))
+            {
+                try
+                {
+                    // forceRun is only currently true for functional tests
+                    if (!this.forceRun)
+                    {
+                        if (!this.EnoughTimeBetweenRuns())
+                        {
+                            activity.RelatedWarning($"Skipping {nameof(LooseObjectsStep)} due to not enough time between runs");
+                            return;
+                        }
+
+                        IEnumerable<int> processIds = this.RunningGitProcessIds();
+                        if (processIds.Any())
+                        {
+                            activity.RelatedWarning($"Skipping {nameof(LooseObjectsStep)} due to git pids {0}", string.Join(",", processIds), Keywords.Telemetry);
+                            return;
+                        }
+                    }
+
+                    int beforeCount = this.CountLooseObjects();
+                    GitProcess.Result result = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot));
+                    int afterCount = this.CountLooseObjects();
+
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add("StartingCount", beforeCount);
+                    metadata.Add("EndingCount", afterCount);
+                    metadata.Add("RemovedCount", beforeCount - afterCount);
+                    activity.RelatedEvent(EventLevel.Informational, this.Area, metadata, Keywords.Telemetry);
+
+                    this.SaveLastRunTimeToFile();
+                }
+                catch (Exception e)
+                {
+                    activity.RelatedWarning(this.CreateEventMetadata(e), "Failed to run LooseObjectsStep", Keywords.Telemetry);
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -70,6 +70,7 @@ namespace GVFS.Common.Maintenance
                     int afterCount = this.CountLooseObjects();
 
                     EventMetadata metadata = new EventMetadata();
+                    metadata.Add("GitObjectsRoot", this.Context.Enlistment.GitObjectsRoot);
                     metadata.Add("StartingCount", beforeCount);
                     metadata.Add("EndingCount", afterCount);
                     metadata.Add("RemovedCount", beforeCount - afterCount);

--- a/GVFS/GVFS.Common/SHA1Util.cs
+++ b/GVFS/GVFS.Common/SHA1Util.cs
@@ -9,7 +9,7 @@ namespace GVFS.Common
     {
         public static bool IsValidShaFormat(string sha)
         {
-            return sha.Length == 40 && !sha.Any(c => !Uri.IsHexDigit(c));
+            return sha.Length == 40 && sha.All(c => Uri.IsHexDigit(c));
         }
 
         public static string SHA1HashStringForUTF8String(string s)

--- a/GVFS/GVFS.Common/SHA1Util.cs
+++ b/GVFS/GVFS.Common/SHA1Util.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -8,7 +9,7 @@ namespace GVFS.Common
     {
         public static bool IsValidShaFormat(string sha)
         {
-            return sha.Length == 40 && !sha.Any(c => !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F'));
+            return sha.Length == 40 && !sha.Any(c => !Uri.IsHexDigit(c));
         }
 
         public static string SHA1HashStringForUTF8String(string s)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
@@ -1,0 +1,115 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Tools;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class LooseObjectStepTests : TestsWithEnlistmentPerFixture
+    {
+        private const string TempPackFolder = "tempPacks";
+        private FileSystemRunner fileSystem;
+
+        // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
+        // the cache 
+        public LooseObjectStepTests()
+            : base(forcePerRepoObjectCache: true)
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        private string GitObjectRoot => this.Enlistment.GetObjectRoot(this.fileSystem);
+        private string PackRoot => this.Enlistment.GetPackRoot(this.fileSystem);
+        private string TempPackRoot=> Path.Combine(this.PackRoot, TempPackFolder);
+
+        [TestCase]
+        public void RemoveLooseObjectsInPackFiles()
+        {
+            // Delete any starting loose objects and verify
+            this.DeleteFiles(this.GetLooseObjectFiles());
+            Assert.AreEqual(0, this.GetLooseObjectFiles().Count);
+
+            // Move packfiles to temp
+            this.MovePackFilesToTemp();
+
+            // Expand 1 pack file and Copy it back to packs
+            this.ExpandOneTempPackAndMoveBack();
+
+            // Verify we have some LooseObjects
+            // These objects will also appear in the pack file that was moved back
+            Assert.AreNotEqual(0, this.GetLooseObjectFiles().Count);
+
+            // Run Cleanup
+            this.Enlistment.LooseObjectStep();
+
+            // Verify loose objects appearing in the pack file are removed
+            Assert.AreEqual(0, this.GetLooseObjectFiles().Count);
+        }
+
+        private List<string> GetLooseObjectFiles()
+        {
+            List<string> looseObjectFiles = new List<string>();
+            foreach (string directory in Directory.GetDirectories(this.GitObjectRoot))
+            {
+                // Check if the directory is 2 letter HEX
+                if (Regex.IsMatch(directory, @"[/\\][0-9a-fA-F]{2}$"))
+                {
+                    string[] files = Directory.GetFiles(directory);
+                    looseObjectFiles.AddRange(files);
+                }
+            }
+
+            return looseObjectFiles;
+        }
+
+        private void DeleteFiles(List<string> filePaths)
+        {
+            foreach (string filePath in filePaths)
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        private void MovePackFilesToTemp()
+        {
+            string[] files = Directory.GetFiles(this.PackRoot);
+            foreach (string file in files)
+            {
+                string path2 = Path.Combine(this.TempPackRoot, Path.GetFileName(file));
+                File.Move(file, path2);
+            }
+        }
+
+        private void ExpandOneTempPackAndMoveBack()
+        {
+            // Find all pack files
+            string[] packFiles = Directory.GetFiles(this.TempPackRoot, "pack-*.pack");
+            Assert.Greater(packFiles.Length, 0);
+
+            // Pick the first one found
+            string packFile = packFiles[0];
+
+            // Send the contents of the packfile to unpack-objects to example the loose objects
+            // Note this won't work if the object exists in a pack file which is why we had to move them
+            using (FileStream packFileStream = File.OpenRead(packFile))
+            {
+                string output = GitProcess.InvokeProcess(
+                    this.Enlistment.RepoRoot, 
+                    "unpack-objects", 
+                    new Dictionary<string, string>() { { "GIT_OBJECT_DIRECTORY", this.GitObjectRoot } }, 
+                    inputStream: packFileStream).Output;
+            }
+
+            // Copy the pack file back to packs
+            string packFileName = Path.GetFileName(packFile);
+            File.Copy(packFile, Path.Combine(this.PackRoot, packFileName));
+
+            // Replace the '.pack' with '.idx' to copy the index file
+            string packFileIndexName = packFileName.Replace(".pack", ".idx");
+            File.Copy(Path.Combine(this.TempPackRoot, packFileIndexName), Path.Combine(this.PackRoot, packFileIndexName));
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -212,6 +212,11 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.Diagnose();
         }
 
+        public string LooseObjectStep()
+        {
+            return this.gvfsProcess.LooseObjectStep();
+        }
+
         public string Status(string trace = null)
         {
             return this.gvfsProcess.Status(trace);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -133,9 +133,9 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
-        public static string GetInternalParameter()
+        public static string GetInternalParameter(string maintenanceJob = "null")
         {
-            return $"\"{{\\\"ServiceName\\\":\\\"{GVFSServiceProcess.TestServiceName}\\\",\\\"StartedByService\\\":false}}\"";
+            return $"\"{{\\\"ServiceName\\\":\\\"{GVFSServiceProcess.TestServiceName}\\\",\\\"StartedByService\\\":false,\\\"MaintenanceJob\\\":{maintenanceJob}}}\"";
         }
 
         private static string GetModifiedPathsContents(GVFSFunctionalTestEnlistment enlistment, FileSystemRunner fileSystem)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -55,6 +55,14 @@ namespace GVFS.FunctionalTests.Tools
                 failOnError: true);
         }
 
+        public string LooseObjectStep()
+        {
+            return this.CallGVFS(
+                "dehydrate \"" + this.enlistmentRoot + "\"",
+                failOnError: false,
+                internalParameter: GVFSHelpers.GetInternalParameter("\\\"LooseObjects\\\""));
+        }
+
         public string Diagnose()
         {
             return this.CallGVFS("diagnose \"" + this.enlistmentRoot + "\"");
@@ -90,11 +98,17 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
-        private string CallGVFS(string args, bool failOnError = false, string trace = null, string standardInput = null)
+        private string CallGVFS(string args, bool failOnError = false, string trace = null, string standardInput = null, string internalParameter = null)
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
-            processInfo.Arguments = args + " " + TestConstants.InternalUseOnlyFlag + " " + GVFSHelpers.GetInternalParameter();
+
+            if (internalParameter == null)
+            {
+                internalParameter = GVFSHelpers.GetInternalParameter();
+            }
+
+            processInfo.Arguments = args + " " + TestConstants.InternalUseOnlyFlag + " " + internalParameter;
 
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;

--- a/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace GVFS.FunctionalTests.Tools
 {
@@ -10,7 +11,7 @@ namespace GVFS.FunctionalTests.Tools
             return InvokeProcess(executionWorkingDirectory, command).Output;
         }
 
-        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null)
+        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(Properties.Settings.Default.PathToGit);
             processInfo.WorkingDirectory = executionWorkingDirectory;
@@ -18,6 +19,11 @@ namespace GVFS.FunctionalTests.Tools
             processInfo.RedirectStandardOutput = true;
             processInfo.RedirectStandardError = true;
             processInfo.Arguments = command;
+
+            if (inputStream != null)
+            {
+                processInfo.RedirectStandardInput = true;
+            }
 
             processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
 
@@ -29,7 +35,7 @@ namespace GVFS.FunctionalTests.Tools
                 }
             }
 
-            return ProcessHelper.Run(processInfo);
+            return ProcessHelper.Run(processInfo, inputStream: inputStream);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tools/ProcessHelper.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ProcessHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO;
 
 namespace GVFS.FunctionalTests.Tools
 {
@@ -17,7 +18,7 @@ namespace GVFS.FunctionalTests.Tools
             return Run(startInfo);
         }
 
-        public static ProcessResult Run(ProcessStartInfo processInfo, string errorMsgDelimeter = "\r\n", object executionLock = null)
+        public static ProcessResult Run(ProcessStartInfo processInfo, string errorMsgDelimeter = "\r\n", object executionLock = null, Stream inputStream = null)
         {
             using (Process executingProcess = new Process())
             {
@@ -40,21 +41,26 @@ namespace GVFS.FunctionalTests.Tools
                 {
                     lock (executionLock)
                     {
-                        output = StartProcess(executingProcess);
+                        output = StartProcess(executingProcess, inputStream);
                     }
                 }
                 else
                 {
-                    output = StartProcess(executingProcess);
+                    output = StartProcess(executingProcess, inputStream);
                 }
 
                 return new ProcessResult(output.ToString(), errors.ToString(), executingProcess.ExitCode);
             }
         }
 
-        private static string StartProcess(Process executingProcess)
+        private static string StartProcess(Process executingProcess, Stream inputStream = null)
         {
             executingProcess.Start();
+
+            if (inputStream != null)
+            {
+                inputStream.CopyTo(executingProcess.StandardInput.BaseStream);
+            }
 
             if (executingProcess.StartInfo.RedirectStandardError)
             {

--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -58,7 +58,7 @@ namespace GVFS.Service
 
         private bool CallGVFSMount(string repoRoot)
         {
-            InternalVerbParameters mountInternal = new InternalVerbParameters(serviceName: null, startedByService: true);
+            InternalVerbParameters mountInternal = new InternalVerbParameters(serviceName: null, startedByService: true, maintenanceJob: null);
             return this.CurrentUser.RunAs(
                 Configuration.Instance.GVFSLocation,
                 $"mount {repoRoot} --{GVFSConstants.VerbParameters.InternalUseOnly} {mountInternal.ToJson()}");

--- a/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
@@ -8,12 +8,17 @@ namespace GVFS.UnitTests.Common
     public class GitObjectsTests
     {
         [TestCase]
-        public void IsLooseObjectsDirectory()
+        public void IsLooseObjectsDirectory_ValidDirectories()
         {
             GitObjects.IsLooseObjectsDirectory("BB").ShouldBeTrue();
             GitObjects.IsLooseObjectsDirectory("bb").ShouldBeTrue();
             GitObjects.IsLooseObjectsDirectory("A7").ShouldBeTrue();
             GitObjects.IsLooseObjectsDirectory("55").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void IsLooseObjectsDirectory_InvalidDirectories()
+        {
             GitObjects.IsLooseObjectsDirectory("K7").ShouldBeFalse();
             GitObjects.IsLooseObjectsDirectory("A-").ShouldBeFalse();
             GitObjects.IsLooseObjectsDirectory("?B").ShouldBeFalse();

--- a/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
@@ -10,15 +10,15 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void IsLooseObjectsDirectory()
         {
-            GitObjects.IsLooseObjectsDirectory("BB").ShouldEqual(true);
-            GitObjects.IsLooseObjectsDirectory("bb").ShouldEqual(true);
-            GitObjects.IsLooseObjectsDirectory("A7").ShouldEqual(true);
-            GitObjects.IsLooseObjectsDirectory("55").ShouldEqual(true);
-            GitObjects.IsLooseObjectsDirectory("K7").ShouldEqual(false);
-            GitObjects.IsLooseObjectsDirectory("A-").ShouldEqual(false);
-            GitObjects.IsLooseObjectsDirectory("?B").ShouldEqual(false);
-            GitObjects.IsLooseObjectsDirectory("BBB").ShouldEqual(false);
-            GitObjects.IsLooseObjectsDirectory("B-B").ShouldEqual(false);
+            GitObjects.IsLooseObjectsDirectory("BB").ShouldBeTrue();
+            GitObjects.IsLooseObjectsDirectory("bb").ShouldBeTrue();
+            GitObjects.IsLooseObjectsDirectory("A7").ShouldBeTrue();
+            GitObjects.IsLooseObjectsDirectory("55").ShouldBeTrue();
+            GitObjects.IsLooseObjectsDirectory("K7").ShouldBeFalse();
+            GitObjects.IsLooseObjectsDirectory("A-").ShouldBeFalse();
+            GitObjects.IsLooseObjectsDirectory("?B").ShouldBeFalse();
+            GitObjects.IsLooseObjectsDirectory("BBB").ShouldBeFalse();
+            GitObjects.IsLooseObjectsDirectory("B-B").ShouldBeFalse();
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitObjectsTests.cs
@@ -1,0 +1,24 @@
+﻿using GVFS.Common.Git;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class GitObjectsTests
+    {
+        [TestCase]
+        public void IsLooseObjectsDirectory()
+        {
+            GitObjects.IsLooseObjectsDirectory("BB").ShouldEqual(true);
+            GitObjects.IsLooseObjectsDirectory("bb").ShouldEqual(true);
+            GitObjects.IsLooseObjectsDirectory("A7").ShouldEqual(true);
+            GitObjects.IsLooseObjectsDirectory("55").ShouldEqual(true);
+            GitObjects.IsLooseObjectsDirectory("K7").ShouldEqual(false);
+            GitObjects.IsLooseObjectsDirectory("A-").ShouldEqual(false);
+            GitObjects.IsLooseObjectsDirectory("?B").ShouldEqual(false);
+            GitObjects.IsLooseObjectsDirectory("BBB").ShouldEqual(false);
+            GitObjects.IsLooseObjectsDirectory("B-B").ShouldEqual(false);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
@@ -111,10 +111,10 @@ namespace GVFS.UnitTests.Maintenance
                 new List<MockFile>()
                 {
                      new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "test1"), string.Empty),
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F2", "test2"), string.Empty)
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "test2"), string.Empty)
                 });
 
-            // Create NonHex Folder 2 with 2 Files
+            // Create NonHex Folder with 4 Files
             MockDirectory nonhex = new MockDirectory(
                 Path.Combine(enlistment.GitObjectsRoot, "ZZ"), 
                 null, 

--- a/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
@@ -1,0 +1,141 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Maintenance;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using GVFS.UnitTests.Mock.Git;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GVFS.UnitTests.Maintenance
+{
+    [TestFixture]
+    public class LooseObjectStepTests
+    {
+        private const string PrunePackedCommand = "prune-packed -q";
+        private MockTracer tracer;
+        private MockGitProcess gitProcess;
+        private GVFSContext context;
+
+        [TestCase]
+        public void LooseObjectsIgnoreTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: true);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(1);
+            commands[0].ShouldEqual(PrunePackedCommand);
+        }
+
+        [TestCase]
+        public void LooseObjectsFailTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(1);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void LooseObjectsPassTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow.AddDays(-7));
+
+            LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(1);
+            commands[0].ShouldEqual(PrunePackedCommand);
+        }
+
+        [TestCase]
+        public void LooseObjectsCount()
+        {
+            this.TestSetup(DateTime.Now.AddDays(-7));
+
+            LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: false);
+            int count = step.CountLooseObjects();
+
+            count.ShouldEqual(3);
+        }
+
+        private void TestSetup(DateTime lastRun)
+        {
+            string lastRunTime = EpochConverter.ToUnixEpochSeconds(lastRun).ToString();
+
+            // Create GitProcess
+            this.gitProcess = new MockGitProcess();
+            this.gitProcess.SetExpectedCommandResult(
+                PrunePackedCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+
+            // Create enlistment using git process
+            GVFSEnlistment enlistment = new MockGVFSEnlistment(this.gitProcess);
+
+            // Create a last run time file
+            MockFile timeFile = new MockFile(Path.Combine(enlistment.GitObjectsRoot, "info", LooseObjectsStep.LooseObjectsLastRunFileName), lastRunTime);
+
+            // Create info directory to hold last run time file
+            MockDirectory infoRoot = new MockDirectory(Path.Combine(enlistment.GitObjectsRoot, "info"), null, new List<MockFile>() { timeFile });
+
+            // Create Hex Folder 1 with 1 File
+            MockDirectory hex1 = new MockDirectory(
+                Path.Combine(enlistment.GitObjectsRoot, "AA"), 
+                null, 
+                new List<MockFile>()
+                {
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "AA", "test"), string.Empty)
+                });
+
+            // Create Hex Folder 2 with 2 Files
+            MockDirectory hex2 = new MockDirectory(
+                Path.Combine(enlistment.GitObjectsRoot, "F1"), 
+                null, 
+                new List<MockFile>()
+                {
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "test1"), string.Empty),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F2", "test2"), string.Empty)
+                });
+
+            // Create NonHex Folder 2 with 2 Files
+            MockDirectory nonhex = new MockDirectory(
+                Path.Combine(enlistment.GitObjectsRoot, "ZZ"), 
+                null, 
+                new List<MockFile>()
+                {
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "test1"), string.Empty),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "test2"), string.Empty),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "test3"), string.Empty),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "test4"), string.Empty)
+                });
+
+            // Create git objects directory
+            MockDirectory gitObjectsRoot = new MockDirectory(enlistment.GitObjectsRoot, new List<MockDirectory>() { infoRoot, hex1, hex2, nonhex }, null);
+
+            // Add object directory to file System
+            List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, directories, null));
+
+            // Create and return Context
+            this.tracer = new MockTracer();
+            this.context = new GVFSContext(this.tracer, fileSystem, repository: null, enlistment: enlistment);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -18,6 +18,7 @@ namespace GVFS.UnitTests.Mock.Common
             this.RelatedErrorEvents = new List<string>();
         }
 
+        public MockTracer StartActivityTracer { get; private set; }
         public string WaitRelatedEventName { get; set; }
 
         public List<string> RelatedInfoEvents { get; }
@@ -97,17 +98,18 @@ namespace GVFS.UnitTests.Mock.Common
 
         public ITracer StartActivity(string activityName, EventLevel level)
         {
-            return new MockTracer();
+            return this.StartActivity(activityName, level, metadata: null);
         }
 
         public ITracer StartActivity(string activityName, EventLevel level, EventMetadata metadata)
         {
-            return new MockTracer();
+            return this.StartActivity(activityName, level, Keywords.None, metadata);
         }
 
         public ITracer StartActivity(string activityName, EventLevel level, Keywords startStopKeywords, EventMetadata metadata)
         {
-            return new MockTracer();
+            this.StartActivityTracer = new MockTracer();
+            return this.StartActivityTracer;
         }
 
         public TimeSpan Stop(EventMetadata metadata)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -165,27 +165,38 @@ namespace GVFS.UnitTests.Mock.FileSystem
             MockDirectory directory = this.RootDirectory.FindDirectory(path);
             directory.ShouldNotBeNull();
 
+            foreach (MockDirectory subDirectory in directory.Directories.Values)
+            {
+                yield return new DirectoryItemInfo()
+                {
+                    Name = subDirectory.Name,
+                    FullName = subDirectory.FullName,
+                    IsDirectory = true
+                };
+            }
+
+            foreach (MockFile file in directory.Files.Values)
+            {
+                yield return new DirectoryItemInfo()
+                {
+                    FullName = file.FullName,
+                    Name = file.Name,
+                    IsDirectory = false,
+                    Length = file.FileProperties.Length
+                };
+            }
+        }
+
+        public override IEnumerable<string> EnumerateDirectories(string path)
+        {
+            MockDirectory directory = this.RootDirectory.FindDirectory(path);
+            directory.ShouldNotBeNull();
+
             if (directory != null)
             {
                 foreach (MockDirectory subDirectory in directory.Directories.Values)
                 {
-                    yield return new DirectoryItemInfo()
-                    {
-                        Name = subDirectory.Name,
-                        FullName = subDirectory.FullName,
-                        IsDirectory = true
-                    };
-                }
-
-                foreach (MockFile file in directory.Files.Values)
-                {
-                    yield return new DirectoryItemInfo()
-                    {
-                        FullName = file.FullName,
-                        Name = file.Name,
-                        IsDirectory = false,
-                        Length = file.FileProperties.Length
-                    };
+                    yield return subDirectory.Name;
                 }
             }
         }
@@ -226,7 +237,21 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
         public override string[] GetFiles(string directoryPath, string mask)
         {
-            throw new NotImplementedException();
+            if (!mask.Equals("*"))
+            {
+                throw new NotImplementedException();
+            }
+
+            MockDirectory directory = this.RootDirectory.FindDirectory(directoryPath);
+            directory.ShouldNotBeNull();
+
+            List<string> files = new List<string>();
+            foreach (MockFile file in directory.Files.Values)
+            {
+                files.Add(file.FullName);
+            }
+
+            return files.ToArray();
         }
 
         private Stream CreateAndOpenFileStream(string path)

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -16,8 +16,10 @@ namespace GVFS.UnitTests.Mock.Git
         public MockGitProcess()
             : base(new MockGVFSEnlistment())
         {
+            this.CommandsRun = new List<string>();
         }
 
+        public List<string> CommandsRun { get; }
         public bool ShouldFail { get; set; }
 
         public void SetExpectedCommandResult(string command, Func<Result> result, bool matchPrefix = false)
@@ -26,8 +28,18 @@ namespace GVFS.UnitTests.Mock.Git
             this.expectedCommandInfos.Add(commandInfo);
         }
 
-        protected override Result InvokeGitImpl(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, Action<StreamWriter> writeStdIn, Action<string> parseStdOutLine, int timeoutMs)
+        protected override Result InvokeGitImpl(
+            string command,
+            string workingDirectory,
+            string dotGitDirectory,
+            bool useReadObjectHook,
+            Action<StreamWriter> writeStdIn,
+            Action<string> parseStdOutLine,
+            int timeoutMs,
+            string gitObjectsDirectory = null)
         {
+            this.CommandsRun.Add(command);
+
             if (this.ShouldFail)
             {
                 return new Result(string.Empty, string.Empty, Result.GenericFailureCode);

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -359,7 +359,7 @@ namespace GVFS.CommandLine
 
                     foreach (DirectoryInfo directory in objectDirectory.EnumerateDirectories())
                     {
-                        if (directory.Name.Length == 2)
+                        if (GitObjects.IsLooseObjectsDirectory(directory.Name))
                         {
                             countFolders++;
                             int numObjects = directory.EnumerateFiles().Count();

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -52,6 +52,11 @@ namespace GVFS.CommandLine
                             this.ServiceName = mountInternal.ServiceName;
                         }
 
+                        if (!string.IsNullOrEmpty(mountInternal.MaintenanceJob))
+                        {
+                            this.MaintenanceJob = mountInternal.MaintenanceJob;
+                        }
+
                         this.StartedByService = mountInternal.StartedByService;
                     }
                     catch (JsonReaderException e)
@@ -63,6 +68,8 @@ namespace GVFS.CommandLine
         }
 
         public string ServiceName { get; set; }
+
+        public string MaintenanceJob { get; set; }
 
         public bool StartedByService { get; set; }
 


### PR DESCRIPTION
**LooseObjectsStep**
- We call prune-packed to remove loose objects that are already in pack-files
- This is scheduled to run every 6 hours, but only runs if it's been 7 days since last run or ignoreTimeRestriction=true
- There will be part 2 of this Step that packs loose objects into a packfile. That will come in a later iteration

**Testing**
- Unit tests have been added for coverage
- Dehydrate will call the step via the internal only flag.  
- Functional Tests are still WIP