### PR TITLE
[WIP] Upgrade extensibility - adding scaffolding for Nuget

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -135,7 +135,7 @@ namespace GVFS.Common.Git
             this.isInitialized = true;
             return true;
         }
-        
+
         public bool TryInitializeAndRequireAuth(ITracer tracer, out string errorMessage)
         {
             if (this.isInitialized)

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -1,0 +1,626 @@
+﻿using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Security.Cryptography.X509Certificates;
+
+namespace GVFS.Common
+{
+    public class GitHubUpgrader : ProductUpgrader
+    {
+        private const string GitHubReleaseURL = @"https://api.github.com/repos/microsoft/vfsforgit/releases";
+        private const string JSONMediaType = @"application/vnd.github.v3+json";
+        private const string UserAgent = @"GVFS_Auto_Upgrader";
+        private const string GitAssetId = "Git";
+        private const string GVFSAssetId = "GVFS";
+        private const string GitInstallerFileNamePrefix = "Git-";
+        private const string PreAndPostInstallerError = "Pre & post installers are not supported in GVFS releases from Github.";
+
+        private Release newestRelease;
+        private InstallerCertificateVerifier installerVerifier;
+
+        public GitHubUpgrader(
+            string currentVersion,
+            ITracer tracer, 
+            GitHubUpgraderConfig upgraderConfig, 
+            InstallerCertificateVerifier verifier)
+            : base(currentVersion, tracer)
+        {
+            this.Config = upgraderConfig;
+            this.installerVerifier = verifier;
+        }
+
+        public GitHubUpgraderConfig Config { get; private set; }
+
+        public static bool TryCreateGitHubUpgrader(
+            ITracer tracer,
+            out bool isEnabled,
+            out bool isConfigured,
+            out ProductUpgrader upgrader,
+            out string error)
+        {
+            LocalGVFSConfig localConfig = new LocalGVFSConfig();
+            GitHubUpgraderConfig gitHubUpgraderConfig = new GitHubUpgraderConfig(tracer, localConfig);
+
+            if (gitHubUpgraderConfig.TryLoad(out isEnabled, out isConfigured, out error))
+            {
+                upgrader = new GitHubUpgrader(
+                    ProcessHelper.GetCurrentProcessVersion(), 
+                    tracer, 
+                    gitHubUpgraderConfig,
+                    new InstallerCertificateVerifier());
+                return true;
+            }
+
+            upgrader = null;
+            return false;
+        }
+
+        public Version QueryLatestVersion()
+        {
+            Version version;
+            string consoleMessage;
+            string error;
+            this.TryGetNewerVersion(out version, out consoleMessage, out error);
+            return version;
+        }
+
+        public void DownloadLatestVersion()
+        {
+            string error;
+            this.TryDownloadNewestVersion(out error);
+        }
+
+        public void InstallLatestVersion()
+        {
+            string error;
+            this.TryDownloadNewestVersion(out error);
+        }
+
+        public override bool Initialize(out string errorMessage)
+        {
+            errorMessage = null;
+            return true;
+        }
+
+        public override bool CanRunUsingCurrentConfig(
+            out bool isConfigError, 
+            out string consoleMessage,
+            out string errorMessage)
+        {
+            if (this.Config.UpgradeRing == GitHubUpgraderConfig.RingType.None)
+            {
+                isConfigError = false;
+                consoleMessage = GVFSConstants.UpgradeVerbMessages.NoneRingConsoleAlert + Environment.NewLine + GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
+                errorMessage = null;
+                return false;
+            }
+
+            if (this.Config.UpgradeRing == GitHubUpgraderConfig.RingType.NoConfig)
+            {
+                isConfigError = false;
+                consoleMessage = GVFSConstants.UpgradeVerbMessages.NoRingConfigConsoleAlert + Environment.NewLine + GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
+                errorMessage = null;
+                return false;
+            }
+
+            if (this.Config.UpgradeRing == GitHubUpgraderConfig.RingType.Invalid)
+            {
+                string ring;
+                string error;
+                if (!this.Config.LocalConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ring, out error))
+                {
+                    ring = "invalid";
+                }
+
+                consoleMessage = null;
+                errorMessage = $"Invalid upgrade ring `{ring}` specified in gvfs config." + Environment.NewLine + GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
+                isConfigError = true;
+                return false;
+            }
+
+            isConfigError = false;
+            consoleMessage = null;
+            errorMessage = null;
+            return true;
+        }
+
+        public override bool TryGetNewerVersion(
+            out Version newVersion,
+            out string consoleMessage,
+            out string errorMessage)
+        {
+            List<Release> releases;
+
+            newVersion = null;
+            consoleMessage = null;
+            bool isConfigError;
+            if (!this.CanRunUsingCurrentConfig(out isConfigError, out consoleMessage, out errorMessage))
+            {
+                return !isConfigError;
+            }
+
+            if (this.TryFetchReleases(out releases, out errorMessage))
+            {
+                foreach (Release nextRelease in releases)
+                {
+                    Version releaseVersion = null;
+
+                    if (nextRelease.Ring <= this.Config.UpgradeRing &&
+                        nextRelease.TryParseVersion(out releaseVersion) &&
+                        releaseVersion > this.InstalledVersion)
+                    {
+                        newVersion = releaseVersion;
+                        this.newestRelease = nextRelease;
+                        consoleMessage = $"New GVFS version {newVersion.ToString()} available in ring {this.Config.UpgradeRing}.";
+                        break;
+                    }
+                }
+                
+                if (newVersion == null)
+                {
+                    consoleMessage = $"Great news, you're all caught up on upgrades in the {this.Config.UpgradeRing} ring!";
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public override bool TryGetGitVersion(out GitVersion gitVersion, out string error)
+        {
+            error = null;
+
+            foreach (Asset asset in this.newestRelease.Assets)
+            {
+                if (asset.Name.StartsWith(GitInstallerFileNamePrefix) &&
+                    GitVersion.TryParseInstallerName(asset.Name, ProductUpgrader.InstallerExtension, out gitVersion))
+                {
+                    return true;
+                }
+            }
+
+            error = "Could not find Git version info in newest release";
+            gitVersion = null;
+            return false;
+        }
+
+        public override bool TryDownloadNewestVersion(out string errorMessage)
+        {
+            bool downloadedGit = false;
+            bool downloadedGVFS = false;
+            foreach (Asset asset in this.newestRelease.Assets)
+            {
+                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), ProductUpgrader.InstallerExtension, StringComparison.OrdinalIgnoreCase);
+                bool isGitAsset = this.IsGitAsset(asset);
+                bool isGVFSAsset = isGitAsset ? false : this.IsGVFSAsset(asset);
+                if (!targetOSMatch || (!isGVFSAsset && !isGitAsset))
+                {
+                    continue;
+                }
+
+                if (!this.TryDownloadAsset(asset, out errorMessage))
+                {
+                    errorMessage = $"Could not download {(isGVFSAsset ? GVFSAssetId : GitAssetId)} installer. {errorMessage}";
+                    return false;
+                }
+                else
+                {
+                    downloadedGit = isGitAsset ? true : downloadedGit;
+                    downloadedGVFS = isGVFSAsset ? true : downloadedGVFS;
+                }
+            }
+
+            if (!downloadedGit || !downloadedGVFS)
+            {
+                errorMessage = $"Could not find {(!downloadedGit ? GitAssetId : GVFSAssetId)} installer in the latest release.";
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
+        public override bool TryRunGitInstaller(out bool installationSucceeded, out string error)
+        {
+            error = null;
+            installationSucceeded = false;
+
+            int exitCode = 0;
+            bool launched = this.TryRunInstallerForAsset(GitAssetId, out exitCode, out error);
+            installationSucceeded = exitCode == 0;
+
+            return launched;
+        }
+
+        public override bool TryRunGVFSInstaller(out bool installationSucceeded, out string error)
+        {
+            error = null;
+            installationSucceeded = false;
+
+            int exitCode = 0;
+            bool launched = this.TryRunInstallerForAsset(GVFSAssetId, out exitCode, out error);
+            installationSucceeded = exitCode == 0 || exitCode == ProductUpgrader.RepoMountFailureExitCode;
+
+            return launched;
+        }
+
+        public override bool TryCleanup(out string error)
+        {
+            error = string.Empty;
+            if (this.newestRelease == null)
+            {
+                return true;
+            }
+
+            foreach (Asset asset in this.newestRelease.Assets)
+            {
+                Exception exception;
+                if (!this.TryDeleteDownloadedAsset(asset, out exception))
+                {
+                    error += $"Could not delete {asset.LocalPath}. {exception.ToString()}." + Environment.NewLine;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                error.TrimEnd(Environment.NewLine.ToCharArray());
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
+        {
+            return this.FileSystem.TryDeleteFile(asset.LocalPath, out exception);
+        }
+
+        protected virtual bool TryDownloadAsset(Asset asset, out string errorMessage)
+        {
+            errorMessage = null;
+
+            string downloadPath = GetAssetDownloadsPath();
+            Exception exception;
+            if (!GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
+            {
+                errorMessage = exception.Message;
+                this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
+                return false;
+            }
+
+            string localPath = Path.Combine(downloadPath, asset.Name);
+            WebClient webClient = new WebClient();
+
+            try
+            {
+                webClient.DownloadFile(asset.DownloadURL, localPath);
+                asset.LocalPath = localPath;
+            }
+            catch (WebException webException)
+            {
+                errorMessage = "Download error: " + exception.Message;
+                this.TraceException(webException, nameof(this.TryDownloadAsset), $"Error downloading asset {asset.Name}.");
+                return false;
+            }
+
+            return true;
+        }
+
+        protected virtual bool TryFetchReleases(out List<Release> releases, out string errorMessage)
+        {
+            HttpClient client = new HttpClient();
+
+            client.DefaultRequestHeaders.Accept.Clear();
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(JSONMediaType));
+            client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+
+            releases = null;
+            errorMessage = null;
+
+            try
+            {
+                Stream result = client.GetStreamAsync(GitHubReleaseURL).GetAwaiter().GetResult();
+
+                DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(List<Release>));
+                releases = serializer.ReadObject(result) as List<Release>;
+                return true;
+            }
+            catch (HttpRequestException exception)
+            {
+                errorMessage = string.Format("Network error: could not connect to GitHub({0}). {1}", GitHubReleaseURL, exception.Message);
+                this.TraceException(exception, nameof(this.TryFetchReleases), $"Error fetching release info.");
+            }
+            catch (SerializationException exception)
+            {
+                errorMessage = string.Format("Parse error: could not parse releases info from GitHub({0}). {1}", GitHubReleaseURL, exception.Message);
+                this.TraceException(exception, nameof(this.TryFetchReleases), $"Error parsing release info.");
+            }
+
+            return false;
+        }
+
+        private bool TryRunInstallerForAsset(string assetId, out int installerExitCode, out string error)
+        {
+            error = null;
+            installerExitCode = 0;
+
+            bool installerIsRun = false;
+            string path;
+            string installerArgs;
+            string gitSigner = "CN=Johannes Schindelin, O=Johannes Schindelin";
+            string gvfsSigner = "CN=Microsoft Corporation, O=Microsoft Corporation";
+            string expectedPublisher = assetId == GitAssetId ? gitSigner : assetId == GVFSAssetId ? gvfsSigner : null;
+
+            if (this.TryGetLocalInstallerPath(assetId, out path, out installerArgs))
+            {
+                FileStream installerHandle = null;
+                bool isValidated = true;
+                if (this.installerVerifier != null)
+                {
+                    isValidated = this.installerVerifier.TryGetValidatedFileStream(expectedPublisher, path, out installerHandle, out error);
+                }
+                
+                if (isValidated)
+                {
+                    string logFilePath = GVFSEnlistment.GetNewLogFileName(GetLogDirectoryPath(), Path.GetFileNameWithoutExtension(path));
+                    string args = installerArgs + " /Log=" + logFilePath;
+                    this.RunInstaller(path, args, out installerExitCode, out error);
+
+                    if (installerExitCode != 0 && string.IsNullOrEmpty(error))
+                    {
+                        error = assetId + " installer failed. Error log: " + logFilePath;
+                    }
+
+                    installerIsRun = true;
+                }
+                else
+                {
+                    installerIsRun = false;
+                }
+
+                if (installerHandle != null)
+                {
+                    installerHandle.Close();
+                }
+            }
+            else
+            {
+                error = "Could not find downloaded installer for " + assetId;
+            }
+
+            return installerIsRun;
+        }
+
+        private bool TryGetLocalInstallerPath(string assetId, out string path, out string args)
+        {
+            foreach (Asset asset in this.newestRelease.Assets)
+            {
+                if (string.Equals(Path.GetExtension(asset.Name), ProductUpgrader.InstallerExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    path = asset.LocalPath;
+                    if (assetId == GitAssetId && this.IsGitAsset(asset))
+                    {
+                        args = ProductUpgrader.GitInstallerArgs;
+                        return true;
+                    }
+
+                    if (assetId == GVFSAssetId && this.IsGVFSAsset(asset))
+                    {
+                        args = ProductUpgrader.GVFSInstallerArgs;
+                        return true;
+                    }
+                }
+            }
+
+            path = null;
+            args = null;
+            return false;
+        }
+
+        private bool IsGVFSAsset(Asset asset)
+        {
+            return this.AssetInstallerNameCompare(asset, ProductUpgrader.GVFSInstallerFileNamePrefix, ProductUpgrader.VFSForGitInstallerFileNamePrefix);
+        }
+
+        private bool IsGitAsset(Asset asset)
+        {
+            return this.AssetInstallerNameCompare(asset, GitInstallerFileNamePrefix);
+        }
+
+        private bool AssetInstallerNameCompare(Asset asset, params string[] expectedFileNamePrefixes)
+        {
+            foreach (string fileNamePrefix in expectedFileNamePrefixes)
+            {
+                if (asset.Name.StartsWith(fileNamePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public class InstallerCertificateVerifier
+        {
+            public bool TryGetValidatedFileStream(
+                string expectedPublisher, 
+                string path, 
+                out FileStream validatedStream, 
+                out string error)
+            {
+                try
+                {
+                    validatedStream = null;
+                    FileStream fileStream = File.OpenRead(path);
+                    X509Certificate signer = X509Certificate.CreateFromSignedFile(path);
+                    X509Certificate2 certificate = new X509Certificate2(signer);
+                    var certificateChain = new X509Chain
+                    {
+                        ChainPolicy =
+                        {
+                            RevocationFlag = X509RevocationFlag.EntireChain,
+                            RevocationMode = X509RevocationMode.Online,
+                            UrlRetrievalTimeout = new TimeSpan(0, 1, 0),
+                            VerificationFlags = X509VerificationFlags.NoFlag
+                        }
+                    };
+
+                    bool chainIsValid = certificateChain.Build(certificate);
+                    if (!chainIsValid)
+                    {
+                        error = $"Verification of {path} failed. Invalid certificate chain.";
+                        fileStream.Close();
+                        return false;
+                    }
+
+                    if (!certificate.SubjectName.Name.StartsWith(expectedPublisher, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        error = $"Verification of {path} failed. Invalid certificate.";
+                        fileStream.Close();
+                        return false;
+                    }
+
+                    error = null;
+                    validatedStream = fileStream;
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    error = $"Verification of {path} failed. {ex.ToString()}.";
+                    validatedStream = null;
+                    return false;
+                }
+            }
+        }
+
+        public class GitHubUpgraderConfig
+        {
+            public GitHubUpgraderConfig(ITracer tracer, LocalGVFSConfig localGVFSConfig)
+            {
+                this.Tracer = tracer;
+                this.LocalConfig = localGVFSConfig;
+            }
+
+            public enum RingType
+            {
+                // The values here should be ascending.
+                // Invalid - User has set an incorrect ring
+                // NoConfig - User has Not set any ring yet
+                // None - User has set a valid "None" ring
+                // (Fast should be greater than Slow, 
+                //  Slow should be greater than None, None greater than Invalid.)
+                // This is required for the correct implementation of Ring based 
+                // upgrade logic.
+                Invalid = 0,
+                NoConfig = None - 1,
+                None = 10,
+                Slow = None + 1,
+                Fast = Slow + 1,
+            }
+
+            public RingType UpgradeRing { get; private set; }
+            public LocalGVFSConfig LocalConfig { get; private set; }
+            private ITracer Tracer { get; set; }            
+
+            public bool TryLoad(out bool isEnabled, out bool isConfigured, out string error)
+            {
+                isEnabled = false;
+                isConfigured = false;
+
+                string ringConfig = null;
+                if (this.LocalConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error))
+                {
+                    RingType ringType;
+                    if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) &&
+                        Enum.IsDefined(typeof(RingType), ringType) &&
+                        ringType != RingType.Invalid)
+                    {
+                        this.UpgradeRing = ringType;
+                        isEnabled = true;
+                        isConfigured = true;
+                    }
+                    else
+                    {
+                        if (!string.IsNullOrEmpty(ringConfig))
+                        {
+                            isEnabled = true;
+                            this.UpgradeRing = RingType.Invalid;
+                        }
+                        else
+                        {
+                            this.UpgradeRing = RingType.NoConfig;
+                        }
+                    }
+
+                    return true;
+                }
+
+                error = "Could not read GVFS Config." + Environment.NewLine;
+                error += GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
+                return false;
+            }
+        }
+
+        [DataContract(Name = "asset")]
+        protected class Asset
+        {
+            [DataMember(Name = "name")]
+            public string Name { get; set; }
+
+            [DataMember(Name = "size")]
+            public long Size { get; set; }
+
+            [DataMember(Name = "browser_download_url")]
+            public Uri DownloadURL { get; set; }
+
+            [IgnoreDataMember]
+            public string LocalPath { get; set; }
+        }
+
+        [DataContract(Name = "release")]
+        protected class Release
+        {
+            [DataMember(Name = "name")]
+            public string Name { get; set; }
+
+            [DataMember(Name = "tag_name")]
+            public string Tag { get; set; }
+
+            [DataMember(Name = "prerelease")]
+            public bool PreRelease { get; set; }
+
+            [DataMember(Name = "assets")]
+            public List<Asset> Assets { get; set; }
+
+            [IgnoreDataMember]
+            public GitHubUpgraderConfig.RingType Ring
+            {
+                get
+                {
+                    return this.PreRelease == true ? GitHubUpgraderConfig.RingType.Fast : GitHubUpgraderConfig.RingType.Slow;
+                }
+            }
+
+            public bool TryParseVersion(out Version version)
+            {
+                version = null;
+
+                if (this.Tag.StartsWith("v", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return Version.TryParse(this.Tag.Substring(1), out version);
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -79,7 +79,8 @@ namespace GVFS.Common
             {
                 upgrader = new GitHubUpgrader(
                     ProcessHelper.GetCurrentProcessVersion(),
-                    tracer);
+                    tracer,
+                    gitHubUpgraderConfig);
             }
 
             return upgrader;
@@ -269,6 +270,8 @@ namespace GVFS.Common
                 error = localError;
                 return false;
             }
+
+            this.LogVersionInfo(this.newestVersion, newGitVersion, "Newly Installed Version");
 
             error = null;
             return true;
@@ -614,6 +617,18 @@ namespace GVFS.Common
             }
 
             return false;
+        }
+
+        private void LogVersionInfo(
+            Version gvfsVersion,
+            GitVersion gitVersion,
+            string message)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add(nameof(gvfsVersion), gvfsVersion.ToString());
+            metadata.Add(nameof(gitVersion), gitVersion.ToString());
+
+            this.tracer.RelatedEvent(EventLevel.Informational, message, metadata);
         }
 
         public class GitHubUpgraderConfig

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -13,16 +13,17 @@ namespace GVFS.Common
         private readonly PhysicalFileSystem fileSystem;
         private FileBasedDictionary<string, string> allSettings;
         
-        public LocalGVFSConfig()
+        public LocalGVFSConfig(FileBasedDictionary<string, string> settings = null)
         {
             string servicePath = Paths.GetServiceDataRoot(GVFSConstants.Service.ServiceName);
             string gvfsDirectory = Path.GetDirectoryName(servicePath);
 
             this.configFile = Path.Combine(gvfsDirectory, FileName);
             this.fileSystem = new PhysicalFileSystem();
+            this.allSettings = settings;
         }
 
-        public bool TryGetAllConfig(out Dictionary<string, string> allConfig, out string error)
+        public virtual bool TryGetAllConfig(out Dictionary<string, string> allConfig, out string error)
         {
             Dictionary<string, string> configCopy = null;
             if (!this.TryPerformAction(
@@ -38,7 +39,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public bool TryGetConfig(
+        public virtual bool TryGetConfig(
             string name, 
             out string value, 
             out string error)
@@ -57,7 +58,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public bool TrySetConfig(
+        public virtual bool TrySetConfig(
             string name, 
             string value, 
             out string error)
@@ -73,7 +74,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public bool TryRemoveConfig(string name, out string error)
+        public virtual bool TryRemoveConfig(string name, out string error)
         {
             if (!this.TryPerformAction(
                 () => this.allSettings.RemoveAndFlush(name),
@@ -90,7 +91,7 @@ namespace GVFS.Common
         {
             if (!this.TryLoadSettings(out error))
             {
-                error = $"Error loading config settings.";
+                error = $"Error loading config settings. {error}";
                 return false;
             }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
@@ -10,9 +10,9 @@ namespace GVFS.Common
         public const string LogDirectory = "Logs";
         public const string DownloadDirectory = "Downloads";
 
-        private const string RootDirectory = UpgradeDirectoryName;
-        private const string GVFSInstallerFileNamePrefix = "SetupGVFS";
-        private const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
+        protected const string RootDirectory = UpgradeDirectoryName;
+        protected const string GVFSInstallerFileNamePrefix = "SetupGVFS";
+        protected const string VFSForGitInstallerFileNamePrefix = "VFSForGit";
 
         public static bool IsLocalUpgradeAvailable(string installerExtension)
         {
@@ -51,7 +51,7 @@ namespace GVFS.Common
             return Path.Combine(Paths.GetServiceDataRoot(RootDirectory), LogDirectory);
         }
 
-        private static string GetAssetDownloadsPath()
+        public static string GetAssetDownloadsPath()
         {
             return Path.Combine(
                 Paths.GetServiceDataRoot(RootDirectory),

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -1,193 +1,105 @@
-using GVFS.Common.FileSystem;
+﻿using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 
 namespace GVFS.Common
 {
-    public partial class ProductUpgrader
+    public abstract partial class ProductUpgrader
     {
-        private const string GitHubReleaseURL = @"https://api.github.com/repos/microsoft/vfsforgit/releases";
-        private const string JSONMediaType = @"application/vnd.github.v3+json";
-        private const string UserAgent = @"GVFS_Auto_Upgrader";
-        private const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
-        private const string GVFSInstallerArgs = CommonInstallerArgs + " /MOUNTREPOS=false";
-        private const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
-        private const string GitAssetId = "Git";
-        private const string GVFSAssetId = "GVFS";
-        private const string GitInstallerFileNamePrefix = "Git-";
-        private const int RepoMountFailureExitCode = 17;
-        private const string ToolsDirectory = "Tools";
-        private static readonly string UpgraderToolName = GVFSPlatform.Instance.Constants.GVFSUpgraderExecutableName;
-        private static readonly string UpgraderToolConfigFile = UpgraderToolName + ".config";
-        private static readonly string[] UpgraderToolAndLibs =
-            {
-                UpgraderToolName,
-                UpgraderToolConfigFile,
-                "GVFS.Common.dll",
-                "GVFS.Platform.Windows.dll",
-                "Microsoft.Diagnostics.Tracing.EventSource.dll",
-                "netstandard.dll",
-                "System.Net.Http.dll",
-                "Newtonsoft.Json.dll"
-            };
-        
-        private Version installedVersion;
-        private Release newestRelease;
-        private PhysicalFileSystem fileSystem;
-        private ITracer tracer;
+        protected const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
+        protected const string GVFSInstallerArgs = CommonInstallerArgs + " /MOUNTREPOS=false";
+        protected const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
+        protected const int RepoMountFailureExitCode = 17;
+        protected const string ToolsDirectory = "Tools";
 
-        public ProductUpgrader(
-            string currentVersion,
-            ITracer tracer)
+        protected static readonly string GitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+        protected static readonly string UpgraderToolName = GVFSPlatform.Instance.Constants.GVFSUpgraderExecutableName;
+        protected static readonly string InstallerExtension = GVFSPlatform.Instance.Constants.InstallerExtension;
+        protected static readonly string UpgraderToolConfigFile = UpgraderToolName + ".config";
+        protected static readonly string[] UpgraderToolAndLibs =
         {
-            this.installedVersion = new Version(currentVersion);
-            this.fileSystem = new PhysicalFileSystem();
-            this.Ring = RingType.Invalid;
-            this.tracer = tracer;
+            UpgraderToolName,
+            UpgraderToolConfigFile,
+            "GVFS.Common.dll",
+            "GVFS.Platform.Windows.dll",
+            "Microsoft.Diagnostics.Tracing.EventSource.dll",
+            "netstandard.dll",
+            "System.Net.Http.dll",
+            "Newtonsoft.Json.dll"
+        };
+
+        protected ProductUpgrader(string currentVersion, ITracer tracer)
+        {
+            this.InstalledVersion = new Version(currentVersion);
+            this.Tracer = tracer;
+            this.FileSystem = new PhysicalFileSystem();
 
             string upgradesDirectoryPath = GetUpgradesDirectoryPath();
-            this.fileSystem.CreateDirectory(upgradesDirectoryPath);
+            this.FileSystem.CreateDirectory(upgradesDirectoryPath);
         }
 
-        public enum RingType
+        protected Version InstalledVersion { get; set; }
+        protected PhysicalFileSystem FileSystem { get; set; }
+        protected ITracer Tracer { get; set; }
+
+        public static ProductUpgrader CreateUpgrader(ITracer tracer, out string error)
         {
-            // The values here should be ascending.
-            // Invalid - User has set an incorrect ring
-            // NoConfig - User has Not set any ring yet
-            // None - User has set a valid "None" ring
-            // (Fast should be greater than Slow, 
-            //  Slow should be greater than None, None greater than Invalid.)
-            // This is required for the correct implementation of Ring based 
-            // upgrade logic.
-            Invalid = 0,
-            NoConfig = None - 1,
-            None = 10,
-            Slow = None + 1,
-            Fast = Slow + 1,
-        }
-
-        public RingType Ring { get; protected set; }
-        
-        public bool TryGetNewerVersion(
-            out Version newVersion,
-            out string errorMessage)
-        {
-            List<Release> releases;
-
-            newVersion = null;
-            if (this.Ring == RingType.Invalid && !this.TryLoadRingConfig(out errorMessage))
+            ProductUpgrader upgrader;
+            bool isEnabled;
+            bool isConfigured;
+            if (GitHubUpgrader.TryCreateGitHubUpgrader(tracer, out isEnabled, out isConfigured, out upgrader, out error))
             {
-                return false;
-            }
-            
-            if (this.TryFetchReleases(out releases, out errorMessage))
-            {
-                foreach (Release nextRelease in releases)
-                {
-                    Version releaseVersion;
-
-                    if (nextRelease.Ring <= this.Ring &&
-                        nextRelease.TryParseVersion(out releaseVersion) &&
-                        releaseVersion > this.installedVersion)
-                    {
-                        newVersion = releaseVersion;
-                        this.newestRelease = nextRelease;
-                        break;
-                    }
-                }
-
-                return true;
+                return upgrader;
             }
 
-            return false;
-        }
-
-        public bool TryGetGitVersion(out GitVersion gitVersion, out string error)
-        {
-            gitVersion = null;
-            error = null;
-            
-            foreach (Asset asset in this.newestRelease.Assets)
+            if (isEnabled && !isConfigured)
             {
-                if (asset.Name.StartsWith(GitInstallerFileNamePrefix) &&
-                    GitVersion.TryParseInstallerName(asset.Name, GVFSPlatform.Instance.Constants.InstallerExtension, out gitVersion))
-                {
-                    return true;
-                }
+                // Configuration error
+                return null;
             }
 
-            error = "Could not find Git version info in newest release";
-
-            return false;
-        }
-
-        public bool TryDownloadNewestVersion(out string errorMessage)
-        {
-            bool downloadedGit = false;
-            bool downloadedGVFS = false;
-            foreach (Asset asset in this.newestRelease.Assets)
+            if (tracer != null)
             {
-                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase);
-                bool isGitAsset = this.IsGitAsset(asset);
-                bool isGVFSAsset = isGitAsset ? false : this.IsGVFSAsset(asset);
-                if (!targetOSMatch || (!isGVFSAsset && !isGitAsset))
-                {
-                    continue;
-                }
-                                
-                if (!this.TryDownloadAsset(asset, out errorMessage))
-                {
-                    errorMessage = $"Could not download {(isGVFSAsset ? GVFSAssetId : GitAssetId)} installer. {errorMessage}";
-                    return false;
-                }
-                else
-                {
-                    downloadedGit = isGitAsset ? true : downloadedGit;
-                    downloadedGVFS = isGVFSAsset ? true : downloadedGVFS;
-                }
+                tracer.RelatedError($"{nameof(CreateUpgrader)}: Could not create upgrader. {error}");
             }
 
-            if (!downloadedGit || !downloadedGVFS)
+            error = GVFSConstants.UpgradeVerbMessages.InvalidRingConsoleAlert + Environment.NewLine + Environment.NewLine + "Error: " + error;
+            return null;
+        }
+
+        public static void CleanupDownloadDirectory(ITracer tracer)
+        {
+            try
             {
-                errorMessage = $"Could not find {(!downloadedGit ? GitAssetId : GVFSAssetId)} installer in the latest release.";
-                return false;
+                PhysicalFileSystem fileSystem = new PhysicalFileSystem();
+                fileSystem.DeleteDirectory(GetAssetDownloadsPath());
             }
-
-            errorMessage = null;
-            return true;
+            catch (Exception ex)
+            {
+                if (tracer != null)
+                {
+                    tracer.RelatedError($"Could not cleanup upgrade downloads directory: {GetAssetDownloadsPath()}. {ex.ToString()}");
+                }
+            }
         }
 
-        public bool TryRunGitInstaller(out bool installationSucceeded, out string error)
-        {
-            error = null;
-            installationSucceeded = false;
+        public abstract bool Initialize(out string errorMessage);
 
-            int exitCode = 0;
-            bool launched = this.TryRunInstallerForAsset(GitAssetId, out exitCode, out error);
-            installationSucceeded = exitCode == 0;
+        public abstract bool CanRunUsingCurrentConfig(out bool isConfigError, out string consoleMessage, out string errorMessage);
 
-            return launched;
-        }
+        public abstract bool TryGetNewerVersion(out Version newVersion, out string consoleMessage, out string errorMessage);
 
-        public bool TryRunGVFSInstaller(out bool installationSucceeded, out string error)
-        {
-            error = null;
-            installationSucceeded = false;
+        public abstract bool TryGetGitVersion(out GitVersion gitVersion, out string error);
 
-            int exitCode = 0;
-            bool launched = this.TryRunInstallerForAsset(GVFSAssetId, out exitCode, out error);
-            installationSucceeded = exitCode == 0 || exitCode == RepoMountFailureExitCode;
+        public abstract bool TryDownloadNewestVersion(out string errorMessage);
 
-            return launched;
-        }
+        public abstract bool TryRunGitInstaller(out bool installationSucceeded, out string error);
+
+        public abstract bool TryRunGVFSInstaller(out bool installationSucceeded, out string error);
+
+        public abstract bool TryCleanup(out string error);
 
         // TrySetupToolsDirectory -
         // Copies GVFS Upgrader tool and its dependencies to a temporary location in ProgramData.
@@ -216,8 +128,8 @@ namespace GVFS.Common
                     catch (UnauthorizedAccessException e)
                     {
                         error = string.Join(
-                            Environment.NewLine, 
-                            "File copy error - " + e.Message, 
+                            Environment.NewLine,
+                            "File copy error - " + e.Message,
                             $"Make sure you have write permissions to directory {rootDirectoryPath} and run {GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm} again.");
                         this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
                         break;
@@ -240,157 +152,14 @@ namespace GVFS.Common
             return false;
         }
 
-        public bool TryCleanup(out string error)
+        protected static string GetTempPath()
         {
-            error = string.Empty;
-            if (this.newestRelease == null)
-            {
-                return true;
-            }
-
-            foreach (Asset asset in this.newestRelease.Assets)
-            {
-                Exception exception;
-                if (!this.TryDeleteDownloadedAsset(asset, out exception))
-                {
-                    error += $"Could not delete {asset.LocalPath}. {exception.ToString()}." + Environment.NewLine;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(error))
-            {
-                error.TrimEnd(Environment.NewLine.ToCharArray());
-                return false;
-            }
-
-            error = null;
-            return true;
-        }
-        
-        public virtual bool TryLoadRingConfig(out string error)
-        {
-            string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            LocalGVFSConfig localConfig = new LocalGVFSConfig();
-
-            string ringConfig = null;
-            if (localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error))
-            {
-                RingType ringType;
-
-                if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) &&
-                    Enum.IsDefined(typeof(RingType), ringType) &&
-                    ringType != RingType.Invalid)
-                {
-                    this.Ring = ringType;
-                    error = null;
-                    return true;
-                }
-
-                if (string.IsNullOrEmpty(ringConfig))
-                {
-                    this.Ring = RingType.NoConfig;
-                    error = null;
-                    return true;
-                }
-
-                error = "Invalid upgrade ring `" + ringConfig + "` specified in gvfs config." + Environment.NewLine;
-            }
-            
-            error += GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
-            this.Ring = RingType.Invalid;
-            return false;
+            return Path.Combine(
+                Paths.GetServiceDataRoot(RootDirectory),
+                "InstallerTemp");
         }
 
-        public void CleanupDownloadDirectory()
-        {
-            try
-            {
-                this.fileSystem.DeleteDirectory(GetAssetDownloadsPath());
-            }
-            catch (Exception ex)
-            {
-                this.TraceException(ex, nameof(this.CleanupDownloadDirectory), $"Could not remove directory: {GetAssetDownloadsPath()}");
-            }
-        }
-
-        protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
-        {
-            return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);
-        }
-
-        protected virtual bool TryDownloadAsset(Asset asset, out string errorMessage)
-        {
-            errorMessage = null;
-
-            string downloadPath = GetAssetDownloadsPath();
-            Exception exception;
-            if (!ProductUpgrader.TryCreateDirectory(downloadPath, out exception))
-            {
-                errorMessage = exception.Message;
-                this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
-                return false;
-            }
-
-            string localPath = Path.Combine(downloadPath, asset.Name);
-            WebClient webClient = new WebClient();
-
-            try
-            {
-                webClient.DownloadFile(asset.DownloadURL, localPath);
-                asset.LocalPath = localPath;
-            }
-            catch (WebException webException)
-            {
-                errorMessage = "Download error: " + exception.Message;
-                this.TraceException(webException, nameof(this.TryDownloadAsset), $"Error downloading asset {asset.Name}.");
-                return false;
-            }
-
-            return true;
-        }
-
-        protected virtual bool TryFetchReleases(out List<Release> releases, out string errorMessage)
-        {
-            HttpClient client = new HttpClient();
-
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(JSONMediaType));
-            client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
-
-            releases = null;
-            errorMessage = null;
-
-            try
-            {
-                Stream result = client.GetStreamAsync(GitHubReleaseURL).GetAwaiter().GetResult();
-
-                DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(List<Release>));
-                releases = serializer.ReadObject(result) as List<Release>;
-                return true;
-            }
-            catch (HttpRequestException exception)
-            {
-                errorMessage = string.Format("Network error: could not connect to GitHub({0}). {1}", GitHubReleaseURL, exception.Message);
-                this.TraceException(exception, nameof(this.TryFetchReleases), $"Error fetching release info.");
-            }
-            catch (SerializationException exception)
-            {
-                errorMessage = string.Format("Parse error: could not parse releases info from GitHub({0}). {1}", GitHubReleaseURL, exception.Message);
-                this.TraceException(exception, nameof(this.TryFetchReleases), $"Error parsing release info.");
-            }
-
-            return false;
-        }
-
-        protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)
-        {
-            ProcessResult processResult = ProcessHelper.Run(path, args);
-
-            exitCode = processResult.ExitCode;
-            error = processResult.Errors;
-        }
-
-        private static bool TryCreateDirectory(string path, out Exception exception)
+        protected static bool TryCreateDirectory(string path, out Exception exception)
         {
             try
             {
@@ -411,143 +180,41 @@ namespace GVFS.Common
             return true;
         }
 
-        private bool TryRunInstallerForAsset(string assetId, out int installerExitCode, out string error)
-        {
-            error = null;
-            installerExitCode = 0;
-
-            bool installerIsRun = false;
-            string path;
-            string installerArgs;
-            if (this.TryGetLocalInstallerPath(assetId, out path, out installerArgs))
-            {
-                string logFilePath = GVFSEnlistment.GetNewLogFileName(GetLogDirectoryPath(), Path.GetFileNameWithoutExtension(path));
-                string args = installerArgs + " /Log=" + logFilePath;
-                this.RunInstaller(path, args, out installerExitCode, out error);
-
-                if (installerExitCode != 0 && string.IsNullOrEmpty(error))
-                {
-                    error = assetId + " installer failed. Error log: " + logFilePath;
-                }
-
-                installerIsRun = true;
-            }
-            else
-            {
-                error = "Could not find downloaded installer for " + assetId;
-            }
-
-            return installerIsRun;
-        }
-
-        private void TraceException(Exception exception, string method, string message)
+        protected void TraceException(Exception exception, string method, string message)
         {
             EventMetadata metadata = new EventMetadata();
             metadata.Add("Method", method);
             metadata.Add("Exception", exception.ToString());
-            this.tracer.RelatedError(metadata, message, Keywords.Telemetry);
+            this.Tracer.RelatedError(metadata, message, Keywords.Telemetry);
         }
 
-        private bool TryGetLocalInstallerPath(string assetId, out string path, out string args)
+        protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)
         {
-            foreach (Asset asset in this.newestRelease.Assets)
-            {
-                if (string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    path = asset.LocalPath;
-                    if (assetId == GitAssetId && this.IsGitAsset(asset))
-                    {
-                        args = GitInstallerArgs;
-                        return true;
-                    }
+            ProcessResult processResult = ProcessHelper.Run(path, args);
 
-                    if (assetId == GVFSAssetId && this.IsGVFSAsset(asset))
-                    {
-                        args = GVFSInstallerArgs;
-                        return true;
-                    }
-                }
+            exitCode = processResult.ExitCode;
+            error = processResult.Errors;
+        }
+
+        protected bool TryDeleteDirectory(string path, out Exception exception)
+        {
+            try
+            {
+                this.FileSystem.DeleteDirectory(path);
             }
-
-            path = null;
-            args = null;
-            return false;
-        }
-
-        private bool IsGVFSAsset(Asset asset)
-        {
-            return this.AssetInstallerNameCompare(asset, GVFSInstallerFileNamePrefix, VFSForGitInstallerFileNamePrefix);
-        }
-
-        private bool IsGitAsset(Asset asset)
-        {
-            return this.AssetInstallerNameCompare(asset, GitInstallerFileNamePrefix);
-        }
-
-        private bool AssetInstallerNameCompare(Asset asset, params string[] expectedFileNamePrefixes)
-        {
-            foreach (string fileNamePrefix in expectedFileNamePrefixes)
+            catch (IOException e)
             {
-                if (asset.Name.StartsWith(fileNamePrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        [DataContract(Name = "asset")]
-        protected class Asset
-        {
-            [DataMember(Name = "name")]
-            public string Name { get; set; }
-
-            [DataMember(Name = "size")]
-            public long Size { get; set; }
-
-            [DataMember(Name = "browser_download_url")]
-            public Uri DownloadURL { get; set; }
-
-            [IgnoreDataMember]
-            public string LocalPath { get; set; }
-        }
-
-        [DataContract(Name = "release")]
-        protected class Release
-        {
-            [DataMember(Name = "name")]
-            public string Name { get; set; }
-
-            [DataMember(Name = "tag_name")]
-            public string Tag { get; set; }
-
-            [DataMember(Name = "prerelease")]
-            public bool PreRelease { get; set; }
-
-            [DataMember(Name = "assets")]
-            public List<Asset> Assets { get; set; }
-
-            [IgnoreDataMember]
-            public RingType Ring
-            {
-                get
-                {
-                    return this.PreRelease == true ? RingType.Fast : RingType.Slow;
-                }
-            }
-
-            public bool TryParseVersion(out Version version)
-            {
-                version = null;
-
-                if (this.Tag.StartsWith("v", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    return Version.TryParse(this.Tag.Substring(1), out version);
-                }
-
+                exception = e;
                 return false;
             }
+            catch (UnauthorizedAccessException e)
+            {
+                exception = e;
+                return false;
+            }
+
+            exception = null;
+            return true;
         }
     }
 }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
@@ -55,15 +56,18 @@ namespace GVFS.Service
         private void TimerCallback(object unusedState)
         {
             string errorMessage = null;
-
             InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);
-            ProductUpgrader productUpgrader = new ProductUpgrader(ProcessHelper.GetCurrentProcessVersion(), this.tracer);
-            if (prerunChecker.TryRunPreUpgradeChecks(out string _) && this.TryDownloadUpgrade(productUpgrader, out errorMessage))
-            {
-                return;
-            }
+            ProductUpgrader productUpgrader = ProductUpgrader.CreateUpgrader(this.tracer, out errorMessage);
 
-            productUpgrader.CleanupDownloadDirectory();
+            if (productUpgrader != null)
+            {
+                if (prerunChecker.TryRunPreUpgradeChecks(out string _) && this.TryDownloadUpgrade(productUpgrader, out errorMessage))
+                {
+                    return;
+                }
+
+                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+            }
 
             if (errorMessage != null)
             {
@@ -77,7 +81,7 @@ namespace GVFS.Service
             {
                 Version newerVersion = null;
                 string detailedError = null;
-                if (!productUpgrader.TryGetNewerVersion(out newerVersion, out detailedError))
+                if (!productUpgrader.TryGetNewerVersion(out newerVersion, out string _, out detailedError))
                 {
                     errorMessage = "Could not fetch new version info. " + detailedError;
                     return false;
@@ -88,7 +92,7 @@ namespace GVFS.Service
                     // Already up-to-date
                     // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                     // upgraded by manually downloading and running asset installers.
-                    productUpgrader.CleanupDownloadDirectory();
+                    ProductUpgrader.CleanupDownloadDirectory(this.tracer);
                     errorMessage = null;
                     return true;
                 }
@@ -103,6 +107,25 @@ namespace GVFS.Service
                     errorMessage = "Could not download product upgrade. " + detailedError;
                     return false;
                 }
+            }
+        }
+
+        private void CleanupDownloadsDirectory(ProductUpgrader productUpgrader)
+        {
+            if (productUpgrader != null)
+            {
+                ProductUpgrader.CleanupDownloadDirectory(this.tracer);
+                return;
+            }
+
+            try
+            {
+                PhysicalFileSystem fileSystem = new PhysicalFileSystem();
+                fileSystem.DeleteDirectory(ProductUpgrader.GetAssetDownloadsPath());
+            }
+            catch (Exception ex)
+            {
+                this.tracer.RelatedError($"Unable to delete upgrade downloads directory {ProductUpgrader.GetAssetDownloadsPath()}. {ex.ToString()}");
             }
         }
     }

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Windows\Mock\MockInstallerPreRunChecker.cs" />
+    <Compile Include="Windows\Mock\MockLocalGVFSConfig.cs" />
     <Compile Include="Windows\Mock\MockProcessLauncher.cs" />
     <Compile Include="Windows\Mock\MockProductUpgrader.cs" />
     <Compile Include="Windows\Mock\MockTextWriter.cs" />

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockLocalGVFSConfig.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockLocalGVFSConfig.cs
@@ -1,0 +1,52 @@
+﻿using GVFS.Common;
+using System.Collections.Generic;
+
+namespace GVFS.UnitTests.Windows.Mock.Upgrader
+{
+    public class MockLocalGVFSConfig : LocalGVFSConfig
+    {
+        public MockLocalGVFSConfig()
+        {
+            this.MockSettings = new Dictionary<string, string>();
+        }
+
+        private Dictionary<string, string> MockSettings { get; set; }
+
+        public override bool TryGetAllConfig(out Dictionary<string, string> allConfig, out string error)
+        {
+            allConfig = new Dictionary<string, string>(this.MockSettings);
+            error = null;
+
+            return true;
+        }
+
+        public override bool TryGetConfig(
+            string name,
+            out string value,
+            out string error)
+        {
+            error = null;
+
+            return this.MockSettings.TryGetValue(name, out value);
+        }
+
+        public override bool TrySetConfig(
+            string name,
+            string value,
+            out string error)
+        {
+            error = null;
+            this.MockSettings[name] = value;
+
+            return true;
+        }
+
+        public override bool TryRemoveConfig(string name, out string error)
+        {
+            error = null;
+            this.MockSettings.Remove(name);
+
+            return true;
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace GVFS.UnitTests.Windows.Mock.Upgrader
 {
-    public class MockProductUpgrader : ProductUpgrader
+    public class MockProductUpgrader : GitHubUpgrader
     {
         private string expectedGVFSAssetName;
         private string expectedGitAssetName;
@@ -15,7 +15,8 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
         public MockProductUpgrader(
             string currentVersion,
-            ITracer tracer) : base(currentVersion, tracer)
+            ITracer tracer,
+            GitHubUpgraderConfig config) : base(currentVersion, tracer, config, verifier: null)
         {
             this.DownloadedFiles = new List<string>();
             this.InstallerArgs = new Dictionary<string, Dictionary<string, string>>();
@@ -35,7 +36,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             GitCleanup = 0x80,
         }
 
-        public RingType LocalRingConfig { get; set; }
         public List<string> DownloadedFiles { get; private set; }
         public Dictionary<string, Dictionary<string, string>> InstallerArgs { get; private set; }
 
@@ -56,14 +56,14 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             this.failActionTypes = ActionType.Invalid;
         }
 
-        public void PretendNewReleaseAvailableAtRemote(string upgradeVersion, RingType remoteRing)
+        public void PretendNewReleaseAvailableAtRemote(string upgradeVersion, GitHubUpgraderConfig.RingType remoteRing)
         {
             string assetDownloadURLPrefix = "https://github.com/Microsoft/VFSForGit/releases/download/v" + upgradeVersion;
             Release release = new Release();
 
             release.Name = "GVFS " + upgradeVersion;
             release.Tag = "v" + upgradeVersion;
-            release.PreRelease = remoteRing == RingType.Fast;
+            release.PreRelease = remoteRing == GitHubUpgraderConfig.RingType.Fast;
             release.Assets = new List<Asset>();
 
             Random random = new Random();
@@ -96,20 +96,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             }
 
             upgraderToolPath = @"C:\ProgramData\GVFS\GVFS.Upgrade\Tools\GVFS.Upgrader.exe";
-            error = null;
-            return true;
-        }
-
-        public override bool TryLoadRingConfig(out string error)
-        {
-            this.Ring = this.LocalRingConfig;
-
-            if (this.LocalRingConfig == RingType.Invalid)
-            {
-                error = "Invalid upgrade ring `Invalid` specified in gvfs config.";
-                return false;
-            }
-
             error = null;
             return true;
         }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
@@ -18,9 +18,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnFastWhileOnLocalNoneRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Fast,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing: ProductUpgrader.RingType.None,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.None,
                 expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
@@ -29,9 +29,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnSlowWhileOnLocalNoneRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Slow,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing: ProductUpgrader.RingType.None,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.None,
                 expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
@@ -40,9 +40,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnFastWhileOnLocalSlowRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Fast,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing: ProductUpgrader.RingType.Slow,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow,
                 expectedReturn: true,
                 expectedUpgradeVersion: null);
         }
@@ -51,9 +51,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnSlowWhileOnLocalSlowRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Slow,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing: ProductUpgrader.RingType.Slow,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow,
                 expectedReturn: true,
                 expectedUpgradeVersion: UpgradeTests.NewerThanLocalVersion);
         }
@@ -62,9 +62,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnFastWhileOnLocalFastRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Fast,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing: ProductUpgrader.RingType.Fast,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast,
                 expectedReturn: true,
                 expectedUpgradeVersion: UpgradeTests.NewerThanLocalVersion);
         }
@@ -73,9 +73,9 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public void UpgradeAvailableOnSlowWhileOnLocalFastRing()
         {
             this.SimulateUpgradeAvailable(
-                remoteRing: ProductUpgrader.RingType.Slow,
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow,
                 remoteVersion: UpgradeTests.NewerThanLocalVersion,
-                localRing:ProductUpgrader.RingType.Fast,
+                localRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast,
                 expectedReturn: true,
                 expectedUpgradeVersion:UpgradeTests.NewerThanLocalVersion);
         }
@@ -101,20 +101,21 @@ namespace GVFS.UnitTests.Windows.Upgrader
         }
 
         private void SimulateUpgradeAvailable(
-            ProductUpgrader.RingType remoteRing,
+            GitHubUpgrader.GitHubUpgraderConfig.RingType remoteRing,
             string remoteVersion,
-            ProductUpgrader.RingType localRing,
+            GitHubUpgrader.GitHubUpgraderConfig.RingType localRing,
             bool expectedReturn,
             string expectedUpgradeVersion)
         {
-            this.Upgrader.LocalRingConfig = localRing;
+            this.SetUpgradeRing(localRing.ToString());
             this.Upgrader.PretendNewReleaseAvailableAtRemote(
                 remoteVersion,
                 remoteRing);
 
             Version newVersion;
             string errorMessage;
-            this.Upgrader.TryGetNewerVersion(out newVersion, out errorMessage).ShouldEqual(expectedReturn);
+            string consoleMessage;
+            this.Upgrader.TryGetNewerVersion(out newVersion, out consoleMessage, out errorMessage).ShouldEqual(expectedReturn);
 
             if (string.IsNullOrEmpty(expectedUpgradeVersion))
             {

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -19,19 +19,25 @@ namespace GVFS.UnitTests.Windows.Upgrader
         protected MockTextWriter Output { get; private set; }
         protected MockInstallerPrerunChecker PrerunChecker { get; private set; }
         protected MockProductUpgrader Upgrader { get; private set; }
+        protected MockLocalGVFSConfig LocalConfig { get; private set; }
 
         public virtual void Setup()
         {
             this.Tracer = new MockTracer();
             this.Output = new MockTextWriter();
             this.PrerunChecker = new MockInstallerPrerunChecker(this.Tracer);
-            this.Upgrader = new MockProductUpgrader(LocalGVFSVersion, this.Tracer);
+            this.LocalConfig = new MockLocalGVFSConfig();
+
+            this.Upgrader = new MockProductUpgrader(
+                LocalGVFSVersion, 
+                this.Tracer, 
+                new GitHubUpgrader.GitHubUpgraderConfig(this.Tracer, this.LocalConfig));
      
             this.PrerunChecker.Reset();
             this.Upgrader.PretendNewReleaseAvailableAtRemote(
                 upgradeVersion: NewerThanLocalVersion,
-                remoteRing: ProductUpgrader.RingType.Slow);
-            this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.Slow;
+                remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow);
+            this.SetUpgradeRing("Slow");
         }
 
         [TestCase]
@@ -41,7 +47,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
-                    this.Upgrader.LocalRingConfig = ProductUpgrader.RingType.None;
+                    this.SetUpgradeRing("None");
                 },
                 expectedReturn: ReturnCode.Success,
                 expectedOutput: new List<string>
@@ -60,7 +66,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
-                    this.Upgrader.LocalRingConfig = GVFS.Common.ProductUpgrader.RingType.Invalid;
+                    this.SetUpgradeRing("Invalid");
                 },
                 expectedReturn: ReturnCode.GenericError,
                 expectedOutput: new List<string>
@@ -81,6 +87,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
+                    this.SetUpgradeRing("Fast");
                     this.Upgrader.SetFailOnAction(MockProductUpgrader.ActionType.FetchReleaseInfo);
                 },
                 expectedReturn: ReturnCode.GenericError,
@@ -119,6 +126,48 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     expectedErrors,
                     (error, expectedError) => { return error.Contains(expectedError); });
             }
+        }
+
+        protected void SetUpgradeRing(string ringName)
+        {
+            GitHubUpgrader.GitHubUpgraderConfig.RingType ring;
+            if (!Enum.TryParse<GitHubUpgrader.GitHubUpgraderConfig.RingType>(ringName, ignoreCase: true, result: out ring))
+            {
+                ring = GitHubUpgrader.GitHubUpgraderConfig.RingType.Invalid;
+            }
+
+            string error;
+            if (ring == GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow ||
+                ring == GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast ||
+                ring == GitHubUpgrader.GitHubUpgraderConfig.RingType.None)
+            {
+                this.LocalConfig.TrySetConfig("upgrade.ring", ringName, out error);
+                this.VerifyConfig(ring, isEnabled: true, isConfigured: true);
+                return;
+            }
+
+            if (ring == GitHubUpgrader.GitHubUpgraderConfig.RingType.Invalid)
+            {
+                this.LocalConfig.TrySetConfig("upgrade.ring", ringName, out error);
+                this.VerifyConfig(ring, isEnabled: true, isConfigured: false);
+                return;
+            }
+        }
+
+        protected void VerifyConfig(
+            GVFS.Common.GitHubUpgrader.GitHubUpgraderConfig.RingType ring,
+            bool isEnabled,
+            bool isConfigured)
+        {
+            bool enabled;
+            bool configured;
+            string error;
+            this.Upgrader.Config.TryLoad(out enabled, out configured, out error);
+
+            Assert.AreEqual(ring, this.Upgrader.Config.UpgradeRing);
+            enabled.ShouldEqual(isEnabled);
+            configured.ShouldEqual(isConfigured);
+            error.ShouldBeNull();
         }
     }
 }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -36,9 +36,10 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
+                    this.SetUpgradeRing("Slow");
                     this.Upgrader.PretendNewReleaseAvailableAtRemote(
                         upgradeVersion: NewerThanLocalVersion,
-                        remoteRing: ProductUpgrader.RingType.Slow);
+                        remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow);
                 },
                 expectedReturn: ReturnCode.Success,
                 expectedOutput: new List<string>
@@ -55,9 +56,10 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
+                    this.SetUpgradeRing("Slow");
                     this.Upgrader.PretendNewReleaseAvailableAtRemote(
                         upgradeVersion: OlderThanLocalVersion,
-                        remoteRing: ProductUpgrader.RingType.Slow);
+                        remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow);
                 },
                 expectedReturn: ReturnCode.Success,
                 expectedOutput: new List<string>
@@ -74,6 +76,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
+                    this.SetUpgradeRing("Slow");
                     this.upgradeVerb.Confirmed = true;
                     this.PrerunChecker.SetCommandToRerun("`gvfs upgrade --confirm`");
                 },
@@ -109,6 +112,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
+                    this.SetUpgradeRing("Slow");
                     this.Upgrader.SetFailOnAction(MockProductUpgrader.ActionType.CopyTools);
                     this.upgradeVerb.Confirmed = true;
                     this.PrerunChecker.SetCommandToRerun("`gvfs upgrade --confirm`");

--- a/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
+++ b/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
@@ -57,7 +57,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -128,7 +128,6 @@ namespace GVFS.Upgrader
             newVersion = null;
 
             Version newGVFSVersion = null;
-            GitVersion newGitVersion = null;
             string error = null;
             string consoleMessage;
             bool isError;
@@ -199,8 +198,6 @@ namespace GVFS.Upgrader
             {
                 return false;
             }
-
-            this.LogVersionInfo(newGVFSVersion, newGitVersion, "Newly Installed Version");
 
             newVersion = newGVFSVersion;
             consoleError = null;
@@ -313,18 +310,6 @@ namespace GVFS.Upgrader
             }
 
             return true;
-        }
-
-        private void LogVersionInfo(
-            Version gvfsVersion,
-            GitVersion gitVersion,
-            string message)
-        {
-            EventMetadata metadata = new EventMetadata();
-            metadata.Add(nameof(gvfsVersion), gvfsVersion.ToString());
-            metadata.Add(nameof(gitVersion), gitVersion.ToString());
-
-            this.tracer.RelatedEvent(EventLevel.Informational, message, metadata);
         }
 
         private void LogInstalledVersionInfo()


### PR DESCRIPTION
Restructuring upgrader code to incorporate upcoming nuget upgrader

* Changed ProductUpgrader to be an abstract class. 
* GitHubUpgrader now inherits from ProductUpgrader base. 
* In an upcoming PR NugetUpgrader would be created. That would also inherit from ProductUpgrader.
* ProductUpgrader implements a Factory method that creates GithubUpgrader (or NugetUpgrader in an upcoming PR) based on Local GVFS Configuration.
* `gvfs upgrade` using existing Github/release upgrade works. UT also work.

TODO: Create a new interface class IProductUpgrader that both GithubUpgrader (and NugetUpgrader in an upcoming PR) can implement.