### PR TITLE
Enable reset.quiet optimization in VFSForGit repos

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181211.5</GitPackageVersion>
+    <GitPackageVersion>2.20181213.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
@@ -44,6 +44,9 @@ namespace GVFS.FunctionalTests.Tools
                 commitish == null ? Properties.Settings.Default.Commitish : commitish);
         }
 
+        //
+        // IMPORTANT! These must parallel the settings in GVFSVerb:TrySetRequiredGitConfigSettings
+        //
         public void Initialize()
         {
             Directory.CreateDirectory(this.RootPath);
@@ -54,6 +57,7 @@ namespace GVFS.FunctionalTests.Tools
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");
             GitProcess.Invoke(this.RootPath, "config core.abbrev 40");
             GitProcess.Invoke(this.RootPath, "config rebase.useBuiltin false");
+            GitProcess.Invoke(this.RootPath, "config reset.quiet true");
             GitProcess.Invoke(this.RootPath, "config status.aheadbehind false");
             GitProcess.Invoke(this.RootPath, "config user.name \"Functional Test User\"");
             GitProcess.Invoke(this.RootPath, "config user.email \"functional@test.com\"");

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -100,6 +100,9 @@ namespace GVFS.CommandLine
 
             // These settings are required for normal GVFS functionality.
             // They will override any existing local configuration values.
+            //
+            // IMPORTANT! These must parallel the settings in ControlGitRepo:Initialize
+            //
             Dictionary<string, string> requiredSettings = new Dictionary<string, string>
             {
                 { "am.keepcr", "true" },
@@ -131,6 +134,7 @@ namespace GVFS.CommandLine
                 { "pack.useBitmaps", "false" },
                 { "rebase.useBuiltin", "false" },
                 { "receive.autogc", "false" },
+                { "reset.quiet", "true" },
                 { "status.deserializePath", gitStatusCachePath },
             };
 


### PR DESCRIPTION
Update VFSForGit to use git build v2.20.0.vfs.1.1 that contains fixes for bad interactions between reset.quiet and the post-indexchanged hook.

Set the reset.quiet setting in GVFSVerb:TrySetRequiredGitConfigSettings and to take advantage of the performance improvements to 'git reset' in 2.20.0.

Signed-off-by: Ben Peart <benpeart@microsoft.com>