### PR TITLE
Update gitignore for new TestResult.xml filenames 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ bld/
 
 # NUNIT
 *.VisualState.xml
-TestResult.xml
+TestResult*.xml
 
 # Build Results of an ATL Project
 [Dd]ebugPS/


### PR DESCRIPTION
The TestResult.xml filenames were changed as part of the work to move to YAML pipelines, but the gitignore wasn't updated. 