### PR TITLE
Improve dev inner loop by enabling .NET SDK projects to build with dotnet CLI

### DIFF
--- a/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
+++ b/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
@@ -30,8 +30,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT' And '$(CopyPrjFS)' == 'true'">
     <None Include="$(BuildOutputDir)\ProjFS.Mac\Native\Build\Products\$(Configuration)\libPrjFSLib.dylib" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-
 </Project>

--- a/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
+++ b/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
@@ -3,14 +3,18 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Version>$(GVFSVersion)</Version>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Version>$(GVFSVersion)</Version>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Version)' == ''">
+    <Version>$(GVFSVersion)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj
+++ b/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Platforms>x64</Platforms>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -34,6 +35,8 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.SDK" Version="15.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="NUnitLite" Version="3.10.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -46,7 +46,7 @@ $VFS_SCRIPTDIR/GenerateCommonAssemblyVersion.sh || exit 1
 # by this switch.
 echo 'Restoring packages...'
 dotnet restore $VFS_SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Mac --packages $VFS_PACKAGESDIR /warnasmessage:MSB4011 || exit 1
-dotnet build $VFS_SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $CONFIGURATION.Mac /maxcpucount:1 /warnasmessage:MSB4011 || exit 1
+dotnet build $VFS_SRCDIR/GVFS.sln --runtime osx-x64 --framework netcoreapp2.1 --configuration $CONFIGURATION.Mac -p:CopyPrjFS=true /maxcpucount:1 /warnasmessage:MSB4011 || exit 1
 
 NATIVEDIR=$VFS_SRCDIR/GVFS/GVFS.Native.Mac
 xcodebuild -configuration $CONFIGURATION -workspace $NATIVEDIR/GVFS.Native.Mac.xcworkspace build -scheme GVFS.Native.Mac -derivedDataPath $VFS_OUTPUTDIR/GVFS.Native.Mac || exit 1


### PR DESCRIPTION
Update build environment to allow better integration with .NET tooling. The goal is to improve the dev inner loop by allowing developers to build and test specific projects with the `dotnet` command line.

This change enables that goal with one caveat - it does not automagically generate `CommonAssemblyVersion.cs` and copy it to the expected build location. As a workaround, this file can be generated by running the build script `/Scripts/Mac/BuildGVFSForMac.sh` and copying the generated `CommonAssemblyVersion.cs` from the BuildOutput folder to the BuildOutput folder for the local dotnet command. After copying this file over, dotnet build and dotnet test can be run for that project.

## Non Goals
It is not a goal to replace the existing `BuildGVFSForMac.sh` script for official buils.

## Motivation
Enable the following scenarios:

1) build the GVFS.Platform.Mac project by running `dotnet build`
`GVFS/GVFS.Platform.Mac> dotnet build`

2) Run unit tests by running `dotnet test` in the `GVFS/GVFS.UnitTests` directory.
`GVFS/GVFS.UnitTests> dotnet test`

This PR included changes to enable these scenarios.

## Tasks
- [x] `GVFS.Platform.Mac` always attempts to copy the native library libPrjFSLib, even though it doesn't directly build it. We teach the csproj file the `copyPrjFS` property, which controls whether it copies libPrjFSLib. By default, this file is not copied, but the BuildGVFSForMac script will specify this property.

- [x] Ensure changes are compatible with VS for Mac.