### PR TITLE
Update Git to include builtin rebase perf fix

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181213.2</GitPackageVersion>
+    <GitPackageVersion>2.20181213.4</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
@@ -56,7 +56,6 @@ namespace GVFS.FunctionalTests.Tools
             GitProcess.Invoke(this.RootPath, "config merge.renames false");
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");
             GitProcess.Invoke(this.RootPath, "config core.abbrev 40");
-            GitProcess.Invoke(this.RootPath, "config rebase.useBuiltin false");
             GitProcess.Invoke(this.RootPath, "config reset.quiet true");
             GitProcess.Invoke(this.RootPath, "config status.aheadbehind false");
             GitProcess.Invoke(this.RootPath, "config user.name \"Functional Test User\"");

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -132,7 +132,6 @@ namespace GVFS.CommandLine
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },
-                { "rebase.useBuiltin", "false" },
                 { "receive.autogc", "false" },
                 { "reset.quiet", "true" },
                 { "status.deserializePath", gitStatusCachePath },


### PR DESCRIPTION
Includes changes from [microsoft/git PR 94](https://github.com/Microsoft/git/pull/94) to fix a perf regression in builtin rebase. Re-enables builtin rebase by default.