### PR TITLE
Remove trailing whitespace and enforce StyleCop rule SA1028

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+trim_trailing_whitespace = true

--- a/GVFS.sln
+++ b/GVFS.sln
@@ -4,6 +4,7 @@ VisualStudioVersion = 15.0.27428.2015
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DCE11095-DA5F-4878-B58D-2702765560F5}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		AuthoringTests.md = AuthoringTests.md

--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -28,7 +28,7 @@ namespace FastFetch
             int indexThreadCount,
             int checkoutThreadCount,
             bool allowIndexMetadataUpdateFromWorkingTree,
-            bool forceCheckout) 
+            bool forceCheckout)
                 : base(
                     tracer,
                     enlistment,
@@ -142,9 +142,9 @@ namespace FastFetch
                     if (!indexGen.HasFailures)
                     {
                         Index newIndex = new Index(
-                            this.Enlistment.EnlistmentRoot, 
+                            this.Enlistment.EnlistmentRoot,
                             this.Tracer,
-                            Path.Combine(this.Enlistment.DotGitRoot, GVFSConstants.DotGit.IndexName), 
+                            Path.Combine(this.Enlistment.DotGitRoot, GVFSConstants.DotGit.IndexName),
                             readOnly: false);
 
                         // Update from disk only if the caller says it is ok via command line
@@ -155,7 +155,7 @@ namespace FastFetch
                 }
             }
         }
-        
+
         /// <summary>
         /// * Updates local branch (N/A for checkout to detached HEAD)
         /// * Updates HEAD
@@ -179,7 +179,7 @@ namespace FastFetch
 
             base.UpdateRefs(branchOrCommit, isBranch, refs);
         }
-        
+
         private Index GetSourceIndex()
         {
             string indexPath = Path.Combine(this.Enlistment.DotGitRoot, GVFSConstants.DotGit.IndexName);
@@ -193,7 +193,7 @@ namespace FastFetch
                 this.Tracer.RelatedEvent(EventLevel.Informational, "CreateBackup", new EventMetadata() { { "BackupIndexName", backupIndexPath } });
                 File.Delete(backupIndexPath);
                 File.Move(indexPath, backupIndexPath);
-                
+
                 Index output = new Index(this.Enlistment.EnlistmentRoot, this.Tracer, backupIndexPath, readOnly: true);
                 output.Parse();
                 return output;

--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -17,7 +17,7 @@ namespace FastFetch
     {
         private const string AreaPath = nameof(CheckoutStage);
         private const int NumOperationsPerStatus = 10000;
-        
+
         private ITracer tracer;
         private Enlistment enlistment;
         private string targetCommitSha;
@@ -54,7 +54,7 @@ namespace FastFetch
         {
             get { return this.diff.RequiredBlobs; }
         }
-        
+
         public BlockingCollection<string> AvailableBlobShas { get; }
 
         public bool UpdatedWholeTree
@@ -124,7 +124,7 @@ namespace FastFetch
 
         protected override void DoAfterWork()
         {
-            // If for some reason a blob doesn't become available, 
+            // If for some reason a blob doesn't become available,
             // checkout might complete with file writes still left undone.
             if (this.diff.FileAddOperations.Count > 0)
             {
@@ -162,7 +162,7 @@ namespace FastFetch
                 {
                     return;
                 }
-                
+
                 switch (treeOp.Operation)
                 {
                     case DiffTreeResult.Operations.Modify:
@@ -259,7 +259,7 @@ namespace FastFetch
                     {
                         return;
                     }
-                    
+
                     Interlocked.Increment(ref this.shasReceived);
 
                     HashSet<PathWithMode> paths;

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -11,8 +11,8 @@ namespace FastFetch
     [Verb("fastfetch", HelpText = "Fast-fetch a branch")]
     public class FastFetchVerb
     {
-        // Testing has shown that more than 16 download threads does not improve 
-        // performance even with 56 core machines with 40G NICs. More threads does 
+        // Testing has shown that more than 16 download threads does not improve
+        // performance even with 56 core machines with 40G NICs. More threads does
         // create more load on the servers as they have to handle extra connections.
         private const int MaxDefaultDownloadThreads = 16;
 

--- a/GVFS/FastFetch/GitEnlistment.cs
+++ b/GVFS/FastFetch/GitEnlistment.cs
@@ -31,7 +31,7 @@ namespace FastFetch
         {
             get { return Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGit.Root, ".fastfetch"); }
         }
-                       
+
         public static GitEnlistment CreateFromCurrentDirectory(string gitBinPath)
         {
             string root = Paths.GetGitEnlistmentRoot(Environment.CurrentDirectory);

--- a/GVFS/FastFetch/Index.cs
+++ b/GVFS/FastFetch/Index.cs
@@ -36,13 +36,13 @@ namespace FastFetch
 
         // Location of the version marker file
         private readonly string versionMarkerFile;
-        
+
         private readonly bool readOnly;
 
         // Index paths
         private readonly string indexPath;
         private readonly string updatedIndexPath;
-        
+
         private readonly ITracer tracer;
         private readonly string repoRoot;
 
@@ -83,9 +83,9 @@ namespace FastFetch
         ///     1) If there was an index in place when this object was constructed, then:
         ///      a) Copy all valid entries (below) from the previous index to the new index
         ///      b) Conditionally (below) get times/sizes from the working tree for files not updated from the previous index
-        ///     
+        ///
         ///     2) If there was no index in place, conditionally populate all entries from disk
-        ///     
+        ///
         /// Conditions:
         /// - Working tree is only searched if allowUpdateFromWorkingTree is specified
         /// - A valid entry is an entry that exist and has a non-zero creation time (ctime)
@@ -107,7 +107,7 @@ namespace FastFetch
                 this.Parse();
 
                 bool anyEntriesUpdated = false;
-                
+
                 using (MemoryMappedFile mmf = this.GetMemoryMappedFile())
                 using (MemoryMappedViewAccessor indexView = mmf.CreateViewAccessor())
                 {
@@ -149,7 +149,7 @@ namespace FastFetch
                 }
             }
         }
-        
+
         public void Parse()
         {
             using (ITracer activity = this.tracer.StartActivity("ParseIndex", EventLevel.Informational, Keywords.Telemetry, new EventMetadata() { { "Index", this.updatedIndexPath } }))
@@ -232,7 +232,7 @@ namespace FastFetch
             this.tracer.RelatedEvent(EventLevel.Informational, "UpdateIndexFileInformation", new EventMetadata() { { "UpdatedFromDisk", updatedEntriesFromDisk } }, Keywords.Telemetry);
             return updatedEntriesFromDisk > 0;
         }
-        
+
         private bool UpdateFileInformationForAllEntries(MemoryMappedViewAccessor indexView, Index otherIndex, bool shouldAlsoTryPopulateFromDisk)
         {
             long updatedEntriesFromOtherIndex = 0;
@@ -424,7 +424,7 @@ namespace FastFetch
                 {
                     // Examine only the things we're not skipping...
                     // Potential Future Perf Optimization: Perform this work on multiple threads.  If we take the first byte and % by number of threads,
-                    // we can ensure that all entries for a given folder end up in the same dictionary              
+                    // we can ensure that all entries for a given folder end up in the same dictionary
                     string path = Encoding.UTF8.GetString(pathBuffer, 0, pathLength);
                     this.indexEntryOffsets[path] = entryOffset;
                 }
@@ -680,7 +680,7 @@ namespace FastFetch
                     return (this.Flags & Index.ExtendedBit) == Index.ExtendedBit;
                 }
             }
-            
+
             public static bool HasInitializedCTimeEntry(MemoryMappedViewAccessor indexView, long offset)
             {
                 return EndianHelper.Swap(indexView.ReadUInt32(offset + (long)EntryOffsets.ctimeSeconds)) != 0;

--- a/GVFS/FastFetch/NativeUnixMethods.cs
+++ b/GVFS/FastFetch/NativeUnixMethods.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace FastFetch
 {
-    public class NativeUnixMethods 
+    public class NativeUnixMethods
     {
         public const int ReadOnly = 0x0000;
         public const int WriteOnly = 0x0001;

--- a/GVFS/FastFetch/Properties/AssemblyInfo.cs
+++ b/GVFS/FastFetch/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("FastFetch")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Build/GVFS.ruleset
+++ b/GVFS/GVFS.Build/GVFS.ruleset
@@ -4,7 +4,6 @@
     <Rule Id="SA1003" Action="None" />
     <Rule Id="SA1024" Action="None" />
     <Rule Id="SA1025" Action="None" />
-    <Rule Id="SA1028" Action="None" />
     <Rule Id="SA1100" Action="None" />
     <Rule Id="SA1107" Action="None" />
     <Rule Id="SA1115" Action="None" />

--- a/GVFS/GVFS.Build/GenerateVersionInfo.cs
+++ b/GVFS/GVFS.Build/GenerateVersionInfo.cs
@@ -26,7 +26,7 @@ namespace GVFS.PreBuild
             File.WriteAllText(
                 this.AssemblyVersion,
                 string.Format(
-@"using System.Reflection; 
+@"using System.Reflection;
 
 [assembly: AssemblyVersion(""{0}"")]
 [assembly: AssemblyFileVersion(""{0}"")]

--- a/GVFS/GVFS.Common/ConcurrentHashSet.cs
+++ b/GVFS/GVFS.Common/ConcurrentHashSet.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common
         {
             this.dictionary = new ConcurrentDictionary<T, bool>();
         }
-        
+
         public ConcurrentHashSet(IEqualityComparer<T> comparer)
         {
             this.dictionary = new ConcurrentDictionary<T, bool>(comparer);

--- a/GVFS/GVFS.Common/ConsoleHelper.cs
+++ b/GVFS/GVFS.Common/ConsoleHelper.cs
@@ -29,22 +29,22 @@ namespace GVFS.Common
                 };
 
             ActionResult result = ShowStatusWhileRunning(
-                actionResultAction, 
-                message, 
-                output, 
-                showSpinner, 
-                gvfsLogEnlistmentRoot, 
+                actionResultAction,
+                message,
+                output,
+                showSpinner,
+                gvfsLogEnlistmentRoot,
                 initialDelayMs: initialDelayMs);
 
             return result == ActionResult.Success;
         }
 
         public static ActionResult ShowStatusWhileRunning(
-            Func<ActionResult> action, 
-            string message, 
-            TextWriter output, 
-            bool showSpinner, 
-            string gvfsLogEnlistmentRoot, 
+            Func<ActionResult> action,
+            string message,
+            TextWriter output,
+            bool showSpinner,
+            string gvfsLogEnlistmentRoot,
             int initialDelayMs)
         {
             ActionResult result = ActionResult.Failure;

--- a/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
@@ -25,7 +25,7 @@ namespace GVFS.DiskLayoutUpgrades
             {
                 RegisterUpgrade(upgrade);
             }
-            
+
             using (JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "DiskLayoutUpgrade"))
             {
                 try

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace GVFS.Common
 {
     public abstract class Enlistment
-    {       
+    {
         protected Enlistment(
             string enlistmentRoot,
             string workingDirectoryRoot,
@@ -47,7 +47,7 @@ namespace GVFS.Common
 
                 this.RepoUrl = originUrl.Trim();
             }
-            
+
             this.Authentication = authentication ?? new GitAuthentication(gitProcess, this.RepoUrl);
         }
 

--- a/GVFS/GVFS.Common/FileBasedCollection.cs
+++ b/GVFS/GVFS.Common/FileBasedCollection.cs
@@ -16,7 +16,7 @@ namespace GVFS.Common
         private const string AddEntryPrefix = "A ";
         private const string RemoveEntryPrefix = "D ";
 
-        // Use the same newline separator regardless of platform 
+        // Use the same newline separator regardless of platform
         private const string NewLine = "\r\n";
         private const int IoFailureRetryDelayMS = 50;
         private const int IoFailureLoggingThreshold = 500;
@@ -44,7 +44,7 @@ namespace GVFS.Common
             this.dataDirectoryPath = Path.GetDirectoryName(this.DataFilePath);
             this.collectionAppendsDirectlyToFile = collectionAppendsDirectlyToFile;
         }
-        
+
         protected delegate bool TryParseAdd<TKey, TValue>(string line, out TKey key, out TValue value, out string error);
         protected delegate bool TryParseRemove<TKey>(string line, out TKey key, out string error);
 
@@ -82,7 +82,7 @@ namespace GVFS.Common
 
                     bool tmpFileCreated = false;
                     int tmpFileCreateAttempts = 0;
-                    
+
                     bool tmpFileMoved = false;
                     int tmpFileMoveAttempts = 0;
 
@@ -96,7 +96,7 @@ namespace GVFS.Common
                             if (!tmpFileCreated)
                             {
                                 if (this.Tracer != null && tmpFileCreateAttempts % IoFailureLoggingThreshold == 0)
-                                {                                    
+                                {
                                     EventMetadata metadata = CreateEventMetadata(lastException);
                                     metadata.Add("tmpFileCreateAttempts", tmpFileCreateAttempts);
                                     this.Tracer.RelatedWarning(metadata, nameof(this.WriteAndReplaceDataFile) + ": Failed to create tmp file ... retrying");
@@ -131,7 +131,7 @@ namespace GVFS.Common
                             catch (Win32Exception e)
                             {
                                 if (this.Tracer != null && tmpFileMoveAttempts % IoFailureLoggingThreshold == 0)
-                                {                                    
+                                {
                                     EventMetadata metadata = CreateEventMetadata(e);
                                     metadata.Add("tmpFileMoveAttempts", tmpFileMoveAttempts);
                                     this.Tracer.RelatedWarning(metadata, nameof(this.WriteAndReplaceDataFile) + ": Failed to overwrite data file ... retrying");
@@ -154,7 +154,7 @@ namespace GVFS.Common
                 }
             }
         }
-        
+
         protected string FormatAddLine(string line)
         {
             return AddEntryPrefix + line;
@@ -213,7 +213,7 @@ namespace GVFS.Common
 
         /// <param name="synchronizedAction">An optional callback to be run as soon as the fileLock is taken</param>
         protected bool TryLoadFromDisk<TKey, TValue>(
-            TryParseAdd<TKey, TValue> tryParseAdd, 
+            TryParseAdd<TKey, TValue> tryParseAdd,
             TryParseRemove<TKey> tryParseRemove,
             Action<TKey, TValue> add,
             out string error,
@@ -345,9 +345,9 @@ namespace GVFS.Common
                     if (this.dataFileHandle == null)
                     {
                         this.dataFileHandle = this.fileSystem.OpenFileStream(
-                            this.DataFilePath, 
-                            FileMode.OpenOrCreate, 
-                            this.collectionAppendsDirectlyToFile ? FileAccess.ReadWrite : FileAccess.Read, 
+                            this.DataFilePath,
+                            FileMode.OpenOrCreate,
+                            this.collectionAppendsDirectlyToFile ? FileAccess.ReadWrite : FileAccess.Read,
                             FileShare.Read,
                             callFlushFileBuffers: false);
                     }

--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -13,26 +13,26 @@ namespace GVFS.Common
 
         private FileBasedDictionary(
             ITracer tracer,
-            PhysicalFileSystem fileSystem, 
-            string dataFilePath, 
-            IEqualityComparer<TKey> keyComparer) 
+            PhysicalFileSystem fileSystem,
+            string dataFilePath,
+            IEqualityComparer<TKey> keyComparer)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: false)
         {
             this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer);
         }
 
         public static bool TryCreate(
-            ITracer tracer, 
-            string dictionaryPath, 
+            ITracer tracer,
+            string dictionaryPath,
             PhysicalFileSystem fileSystem,
-            out FileBasedDictionary<TKey, TValue> output, 
+            out FileBasedDictionary<TKey, TValue> output,
             out string error,
             IEqualityComparer<TKey> keyComparer = null)
         {
             output = new FileBasedDictionary<TKey, TValue>(
-                tracer, 
-                fileSystem, 
-                dictionaryPath, 
+                tracer,
+                fileSystem,
+                dictionaryPath,
                 keyComparer ?? EqualityComparer<TKey>.Default);
 
             if (!output.TryLoadFromDisk<TKey, TValue>(

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -33,7 +33,7 @@ namespace GVFS.Common
             public const string HooksPrefix = GitConfig.GVFSPrefix + "clone.default-";
             public const string GVFSTelemetryId = GitConfig.GVFSPrefix + "telemetry-id";
             public const string IKey = GitConfig.GVFSPrefix + "ikey";
-            public const string HooksExtension = ".hooks";            
+            public const string HooksExtension = ".hooks";
         }
 
         public static class LocalGVFSConfig
@@ -76,7 +76,7 @@ namespace GVFS.Common
         }
 
         public static class LogFileTypes
-        {            
+        {
             public const string MountPrefix = "mount";
             public const string UpgradePrefix = "productupgrade";
 
@@ -89,7 +89,7 @@ namespace GVFS.Common
             public const string Repair = "repair";
             public const string Service = "service";
             public const string UpgradeVerb = UpgradePrefix + "_verb";
-            public const string UpgradeProcess = UpgradePrefix + "_process";            
+            public const string UpgradeProcess = UpgradePrefix + "_process";
         }
 
         public static class DotGVFS
@@ -177,7 +177,7 @@ namespace GVFS.Common
             public static class Objects
             {
                 public static readonly string Root = Path.Combine(DotGit.Root, "objects");
-                
+
                 public static class Info
                 {
                     public static readonly string Root = Path.Combine(Objects.Root, "info");

--- a/GVFS/GVFS.Common/GVFSContext.cs
+++ b/GVFS/GVFS.Common/GVFSContext.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common
     public class GVFSContext : IDisposable
     {
         private bool disposedValue = false;
-        
+
         public GVFSContext(ITracer tracer, PhysicalFileSystem fileSystem, GitRepo repository, GVFSEnlistment enlistment)
         {
             this.Tracer = tracer;

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -116,7 +116,7 @@ namespace GVFS.Common
         public static string GetNewGVFSLogFileName(string logsRoot, string logFileType)
         {
             return Enlistment.GetNewLogFileName(
-                logsRoot, 
+                logsRoot,
                 "gvfs_" + logFileType);
         }
 
@@ -188,7 +188,7 @@ namespace GVFS.Common
         public void InitializeCachePathsFromKey(string localCacheRoot, string localCacheKey)
         {
             this.InitializeCachePaths(
-                localCacheRoot, 
+                localCacheRoot,
                 Path.Combine(localCacheRoot, localCacheKey, GitObjectCacheName),
                 Path.Combine(localCacheRoot, localCacheKey, BlobSizesCacheName));
         }

--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -337,10 +337,10 @@ namespace GVFS.Common
         /// the lock can be held by us or by an external process, and because the external process that holds the lock
         /// can terminate without releasing the lock. If that happens, we implicitly release the lock the next time we
         /// check to see who is holding it.
-        /// 
+        ///
         /// The goal of this class is to make it impossible for the rest of GVFSLock to read the external holder without being
         /// aware of the fact that it could have terminated.
-        /// 
+        ///
         /// This class assumes that the caller is handling all synchronization.
         /// </summary>
         private class LockHolder

--- a/GVFS/GVFS.Common/Git/DiffTreeResult.cs
+++ b/GVFS/GVFS.Common/Git/DiffTreeResult.cs
@@ -47,7 +47,7 @@ namespace GVFS.Common.Git
 
             /*
              * The lines passed to this method should be the result of a call to git diff-tree -r -t (sourceTreeish) (targetTreeish)
-             * 
+             *
              * Example output lines from git diff-tree
              * :000000 040000 0000000000000000000000000000000000000000 cee82f9d431bf610404f67bcdda3fee76f0c1dd5 A\tGVFS/FastFetch/Git
              * :000000 100644 0000000000000000000000000000000000000000 cdc036f9d561f14d908e0a0c337105b53c778e5e A\tGVFS/FastFetch/Git/FastFetchGitObjects.cs
@@ -58,7 +58,7 @@ namespace GVFS.Common.Git
              *  ^-[0]  ^-[1]  ^-[2]                                    ^-[3]                                    ^-[4]
              *                                                                                                   ^-tab
              *                                                                                                     ^-[5]
-             * 
+             *
              * This output will only happen if -C or -M is passed to the diff-tree command
              * Since we are not passing those options we shouldn't have to handle this format.
              * :100644 100644 3ac7d60a25bb772af1d5843c76e8a070c062dc5d c31a95125b8a6efd401488839a7ed1288ce01634 R094\tGVFS/GVFS.CLI/CommandLine/CloneVerb.cs\tGVFS/GVFS/CommandLine/CloneVerb.cs
@@ -71,7 +71,7 @@ namespace GVFS.Common.Git
 
             // Skip the colon at the front
             line = line.Substring(1);
-            
+
             // Filenames may contain spaces, but always follow a \t. Other fields are space delimited.
             // Splitting on \t will give us the mode, sha, operation in parts[0] and that path in parts[1] and optionally in paths[2]
             string[] parts = line.Split(new[] { '\t' }, count: 2);
@@ -136,7 +136,7 @@ namespace GVFS.Common.Git
 
             /*
              * Example output lines from ls-tree
-             * 
+             *
              * 040000 tree 73b881d52b607b0f3e9e620d36f556d3d233a11d\tGVFS
              * 100644 blob 44c5f5cba4b29d31c2ad06eed51ea02af76c27c0\tReadme.md
              * 100755 blob 196142fbb753c0a3c7c6690323db7aa0a11f41ec\tScripts/BuildGVFSForMac.sh

--- a/GVFS/GVFS.Common/Git/EndianHelper.cs
+++ b/GVFS/GVFS.Common/Git/EndianHelper.cs
@@ -25,23 +25,23 @@
 
         public static uint Swap(uint source)
         {
-            return 
-                ((source & 0x000000FF) << 24) | 
-                ((source & 0x0000FF00) << 8)  | 
-                ((source & 0x00FF0000) >> 8)  | 
+            return
+                ((source & 0x000000FF) << 24) |
+                ((source & 0x0000FF00) << 8)  |
+                ((source & 0x00FF0000) >> 8)  |
                 ((source & 0xFF000000) >> 24);
         }
 
         public static ulong Swap(ulong source)
         {
             return
-                ((source & 0x00000000000000FF) << 56) | 
-                ((source & 0x000000000000FF00) << 40) | 
-                ((source & 0x0000000000FF0000) << 24) | 
-                ((source & 0x00000000FF000000) << 8)  | 
-                ((source & 0x000000FF00000000) >> 8)  | 
-                ((source & 0x0000FF0000000000) >> 24) | 
-                ((source & 0x00FF000000000000) >> 40) | 
+                ((source & 0x00000000000000FF) << 56) |
+                ((source & 0x000000000000FF00) << 40) |
+                ((source & 0x0000000000FF0000) << 24) |
+                ((source & 0x00000000FF000000) << 8)  |
+                ((source & 0x000000FF00000000) >> 8)  |
+                ((source & 0x0000FF0000000000) >> 24) |
+                ((source & 0x00FF000000000000) >> 40) |
                 ((source & 0xFF00000000000000) >> 56);
         }
     }

--- a/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common.Git
         private static readonly TimeSpan NegativeCacheTTL = TimeSpan.FromSeconds(30);
 
         private ConcurrentDictionary<string, DateTime> objectNegativeCache;
-        
+
         public GVFSGitObjects(GVFSContext context, GitObjectsHttpRequestor objectRequestor)
             : base(context.Tracer, context.Enlistment, objectRequestor, context.FileSystem)
         {
@@ -34,13 +34,13 @@ namespace GVFS.Common.Git
         protected GVFSContext Context { get; private set; }
 
         public virtual bool TryCopyBlobContentStream(
-            string sha, 
+            string sha,
             CancellationToken cancellationToken,
             RequestSource requestSource,
             Action<Stream, long> writeAction)
         {
             RetryWrapper<bool> retrier = new RetryWrapper<bool>(this.GitObjectRequestor.RetryConfig.MaxAttempts, cancellationToken);
-            retrier.OnFailure += 
+            retrier.OnFailure +=
                 errorArgs =>
                 {
                     EventMetadata metadata = new EventMetadata();
@@ -63,7 +63,7 @@ namespace GVFS.Common.Git
                         this.Tracer.RelatedError(metadata, message);
                     }
                 };
-            
+
             RetryWrapper<bool>.InvocationResult invokeResult = retrier.Invoke(
                 tryCount =>
                 {
@@ -106,9 +106,9 @@ namespace GVFS.Common.Git
         }
 
         private DownloadAndSaveObjectResult TryDownloadAndSaveObject(
-            string objectId, 
-            CancellationToken cancellationToken, 
-            RequestSource requestSource, 
+            string objectId,
+            CancellationToken cancellationToken,
+            RequestSource requestSource,
             bool retryOnFailure)
         {
             if (objectId == GVFSConstants.AllZeroSha)

--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -135,7 +135,7 @@ namespace GVFS.Common.Git
             this.isInitialized = true;
             return true;
         }
-        
+
         public bool TryInitializeAndRequireAuth(ITracer tracer, out string errorMessage)
         {
             if (this.isInitialized)

--- a/GVFS/GVFS.Common/Git/GitIndexGenerator.cs
+++ b/GVFS/GVFS.Common/Git/GitIndexGenerator.cs
@@ -23,7 +23,7 @@ namespace GVFS.Common.Git
         };
 
         // We can't accurated fill times and length in realtime, so we block write the zeroes and probably save time.
-        private static readonly byte[] EntryHeader = new byte[] 
+        private static readonly byte[] EntryHeader = new byte[]
         {
             0, 0, 0, 0,
             0, 0, 0, 0, // ctime
@@ -46,13 +46,13 @@ namespace GVFS.Common.Git
         private uint entryCount = 0;
 
         private BlockingCollection<LsTreeEntry> entryQueue = new BlockingCollection<LsTreeEntry>();
-        
+
         public GitIndexGenerator(ITracer tracer, Enlistment enlistment, bool shouldHashIndex)
         {
             this.tracer = tracer;
             this.enlistment = enlistment;
             this.shouldHashIndex = shouldHashIndex;
-            
+
             this.indexLockPath = Path.Combine(enlistment.DotGitRoot, GVFSConstants.DotGit.IndexName + GVFSConstants.DotGit.LockExtension);
         }
 
@@ -142,9 +142,9 @@ namespace GVFS.Common.Git
             long startPosition = writer.BaseStream.Position;
 
             this.entryCount++;
-            
+
             writer.Write(EntryHeader, 0, EntryHeader.Length);
-            
+
             writer.Write(SHA1Util.BytesFromHexString(sha));
 
             byte[] filenameBytes = Encoding.UTF8.GetBytes(filename);
@@ -162,7 +162,7 @@ namespace GVFS.Common.Git
 
             writer.Flush();
             long endPosition = writer.BaseStream.Position;
-            
+
             // Version 4 requires a nul-terminated string.
             int numPaddingBytes = 1;
             if (version < 4)
@@ -258,7 +258,7 @@ namespace GVFS.Common.Git
 
                     return blobEntry;
                 }
-                
+
                 return null;
             }
         }

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -97,7 +97,7 @@ namespace GVFS.Common.Git
                 this.Tracer.RelatedEvent(EventLevel.Informational, nameof(this.DeleteStaleTempPrefetchPackAndIdxs), metadata);
             }
         }
-        
+
         public virtual void DeleteTemporaryFiles()
         {
             string[] temporaryFiles = this.fileSystem.GetFiles(this.Enlistment.GitPackRoot, "tmp_*");
@@ -885,7 +885,7 @@ namespace GVFS.Common.Git
         }
 
         private RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult TrySavePackOrLooseObject(
-                                                                                                IEnumerable<string> objectShas, 
+                                                                                                IEnumerable<string> objectShas,
                                                                                                 bool unpackObjects,
                                                                                                 GitEndPointResponseData responseData,
                                                                                                 GitProcess gitProcess)

--- a/GVFS/GVFS.Common/Git/GitOid.cs
+++ b/GVFS/GVFS.Common/Git/GitOid.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.Git
         // OIDs are 20 bytes long
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
         public byte[] Id;
-        
+
         public override string ToString()
         {
             return SHA1Util.HexStringFromBytes(this.Id);

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -419,7 +419,7 @@ namespace GVFS.Common.Git
 
         /// <summary>
         /// Write a new multi-pack-index (MIDX) in the specified pack directory.
-        /// 
+        ///
         /// If no new packfiles are found, then this is a no-op.
         /// </summary>
         public Result WriteMultiPackIndex(string objectDir)

--- a/GVFS/GVFS.Common/Git/GitRefs.cs
+++ b/GVFS/GVFS.Common/Git/GitRefs.cs
@@ -18,7 +18,7 @@ namespace GVFS.Common.Git
 
         public GitRefs(IEnumerable<string> infoRefsResponse, string branch)
         {
-            // First 4 characters of a given line are the length of the line and not part of the commit id so 
+            // First 4 characters of a given line are the length of the line and not part of the commit id so
             //  skip them (https://git-scm.com/book/en/v2/Git-Internals-Transfer-Protocols)
             this.commitsPerRef =
                 infoRefsResponse
@@ -65,7 +65,7 @@ namespace GVFS.Common.Git
 
             if (headRefMatches.Count() == 0 || headRefMatches.Count(reference => reference.Key == (OriginRemoteRefPrefix + Master)) > 0)
             {
-                // Default to master if no HEAD or if the commit ID or the dafult branch matches master (this is 
+                // Default to master if no HEAD or if the commit ID or the dafult branch matches master (this is
                 //  the same behavior as git.exe)
                 return Master;
             }
@@ -80,7 +80,7 @@ namespace GVFS.Common.Git
 
             return defaultBranch.Substring(OriginRemoteRefPrefix.Length);
         }
-        
+
         /// <summary>
         /// Checks if the specified branch exists (case sensitive)
         /// </summary>

--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common.Git
 
             this.RepoHandle = repoHandle;
         }
-        
+
         protected LibGit2Repo()
         {
         }
@@ -141,7 +141,7 @@ namespace GVFS.Common.Git
 
             return false;
         }
-        
+
         public virtual bool TryCopyBlob(string sha, Action<Stream, long> writeAction)
         {
             IntPtr objHandle;
@@ -159,12 +159,12 @@ namespace GVFS.Common.Git
                         case Native.ObjectTypes.Blob:
                             byte* originalData = Native.Blob.GetRawContent(objHandle);
                             long originalSize = Native.Blob.GetRawSize(objHandle);
-                            
+
                             // TODO 938696: UnmanagedMemoryStream marshals content even for CopyTo
                             // If GetRawContent changed to return IntPtr and ProjFS changed WriteBuffer to expose an IntPtr,
                             // We could probably pinvoke memcpy and avoid marshalling.
                             using (Stream mem = new UnmanagedMemoryStream(originalData, originalSize))
-                            { 
+                            {
                                 writeAction(mem, originalSize);
                             }
 

--- a/GVFS/GVFS.Common/Git/RefLogEntry.cs
+++ b/GVFS/GVFS.Common/Git/RefLogEntry.cs
@@ -12,7 +12,7 @@
         public string SourceSha { get; }
         public string TargetSha { get; }
         public string Reason { get; }
-        
+
         public static bool TryParse(string line, out RefLogEntry entry)
         {
             entry = null;
@@ -25,7 +25,7 @@
             {
                 return false;
             }
-            
+
             string sourceSha = line.Substring(0, GVFSConstants.ShaStringLength);
             string targetSha = line.Substring(GVFSConstants.ShaStringLength + 1, GVFSConstants.ShaStringLength);
 

--- a/GVFS/GVFS.Common/Git/Sha1Id.cs
+++ b/GVFS/GVFS.Common/Git/Sha1Id.cs
@@ -63,9 +63,9 @@ namespace GVFS.Common.Git
         }
 
         public static void ShaBufferToParts(
-            byte[] shaBuffer, 
-            out ulong shaBytes1Through8, 
-            out ulong shaBytes9Through16, 
+            byte[] shaBuffer,
+            out ulong shaBytes1Through8,
+            out ulong shaBytes9Through16,
             out uint shaBytes17Through20)
         {
             if (shaBuffer == null)

--- a/GVFS/GVFS.Common/GitCommandLineParser.cs
+++ b/GVFS/GVFS.Common/GitCommandLineParser.cs
@@ -90,7 +90,7 @@ namespace GVFS.Common
                     return true;
                 }
 
-                // We also special case one usage with HEAD, as long as there are no other arguments with - or -- that might 
+                // We also special case one usage with HEAD, as long as there are no other arguments with - or -- that might
                 // result in behavior we haven't tested.
                 // e.g. git checkout HEAD fileName
                 if (numArguments >= 2 &&

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common
     /// Responsible for orchestrating the Git Status Cache interactions. This is a cache of the results of running
     /// the "git status" command.
     ///
-    /// Consumers are responsible for invalidating the cache and directing it to rebuild. 
+    /// Consumers are responsible for invalidating the cache and directing it to rebuild.
     /// </summary>
     public class GitStatusCache : IDisposable
     {
@@ -348,8 +348,8 @@ namespace GVFS.Common
 
             // Do not modify this block unless you completely understand the comments and code within
             {
-                // We MUST set the state to Rebuilding _immediately before_ we call the `git status` command. That allows us to 
-                // check afterwards if anything happened during the status command that should invalidate the cache, and we 
+                // We MUST set the state to Rebuilding _immediately before_ we call the `git status` command. That allows us to
+                // check afterwards if anything happened during the status command that should invalidate the cache, and we
                 // can discard its results if that happens.
                 this.cacheState = CacheState.Rebuilding;
 

--- a/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
@@ -10,8 +10,8 @@ namespace GVFS.Common.Http
     public class ConfigHttpRequestor : HttpRequestor
     {
         private readonly string repoUrl;
-        
-        public ConfigHttpRequestor(ITracer tracer, Enlistment enlistment, RetryConfig retryConfig) 
+
+        public ConfigHttpRequestor(ITracer tracer, Enlistment enlistment, RetryConfig retryConfig)
             : base(tracer, retryConfig, enlistment.Authentication)
         {
             this.repoUrl = enlistment.RepoUrl;

--- a/GVFS/GVFS.Common/Http/GitEndPointResponseData.cs
+++ b/GVFS/GVFS.Common/Http/GitEndPointResponseData.cs
@@ -143,7 +143,7 @@ namespace GVFS.Common.Http
         }
 
         /// <summary>
-        /// Convert from a string-based Content-Type to <see cref="GitObjectsHttpRequestor.ContentType"/> 
+        /// Convert from a string-based Content-Type to <see cref="GitObjectsHttpRequestor.ContentType"/>
         /// </summary>
         private static GitObjectContentType MapContentType(string contentType)
         {

--- a/GVFS/GVFS.Common/Http/GitObjectsHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/GitObjectsHttpRequestor.cs
@@ -15,7 +15,7 @@ namespace GVFS.Common.Http
     {
         private static readonly MediaTypeWithQualityHeaderValue CustomLooseObjectsHeader
             = new MediaTypeWithQualityHeaderValue(GVFSConstants.MediaTypes.CustomLooseObjectsMediaType);
-        
+
         private Enlistment enlistment;
 
         private DateTime nextCacheServerAttemptTime = DateTime.Now;
@@ -26,7 +26,7 @@ namespace GVFS.Common.Http
             this.enlistment = enlistment;
             this.CacheServer = cacheServer;
         }
-        
+
         public CacheServerInfo CacheServer { get; private set; }
 
         public virtual List<GitObjectSize> QueryForFileSizes(IEnumerable<string> objectIds, CancellationToken cancellationToken)
@@ -88,7 +88,7 @@ namespace GVFS.Common.Http
 
             return requestTask.Result ?? new List<GitObjectSize>(0);
         }
-        
+
         public virtual GitRefs QueryInfoRefs(string branch)
         {
             long requestId = HttpRequestor.GetNewRequestId();
@@ -128,7 +128,7 @@ namespace GVFS.Common.Http
 
             return output.Result;
         }
-        
+
         public virtual RetryWrapper<GitObjectTaskResult>.InvocationResult TryDownloadLooseObject(
             string objectId,
             bool retryOnFailure,
@@ -228,7 +228,7 @@ namespace GVFS.Common.Http
                 method,
                 endPoint,
                 cancellationToken,
-                () => requestBody,                
+                () => requestBody,
                 acceptType,
                 retryOnFailure);
         }
@@ -240,7 +240,7 @@ namespace GVFS.Common.Http
             HttpMethod method,
             Uri endPoint,
             CancellationToken cancellationToken,
-            Func<string> requestBodyGenerator,            
+            Func<string> requestBodyGenerator,
             MediaTypeWithQualityHeaderValue acceptType = null,
             bool retryOnFailure = true)
         {
@@ -268,7 +268,7 @@ namespace GVFS.Common.Http
             bool retryOnFailure = true)
         {
             RetryWrapper<GitObjectTaskResult> retrier = new RetryWrapper<GitObjectTaskResult>(
-                retryOnFailure ? this.RetryConfig.MaxAttempts : 1, 
+                retryOnFailure ? this.RetryConfig.MaxAttempts : 1,
                 cancellationToken);
             if (onFailure != null)
             {

--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -46,7 +46,7 @@ namespace GVFS.Common.Http
         public RetryConfig RetryConfig { get; }
 
         protected ITracer Tracer { get; }
-        
+
         public static long GetNewRequestId()
         {
             return Interlocked.Increment(ref requestCount);
@@ -61,7 +61,7 @@ namespace GVFS.Common.Http
             }
         }
 
-        protected GitEndPointResponseData SendRequest(            
+        protected GitEndPointResponseData SendRequest(
             long requestId,
             Uri requestUri,
             HttpMethod httpMethod,
@@ -77,7 +77,7 @@ namespace GVFS.Common.Http
                 return new GitEndPointResponseData(
                     HttpStatusCode.Unauthorized,
                     new GitObjectsHttpException(HttpStatusCode.Unauthorized, errorMessage),
-                    shouldRetry: true, 
+                    shouldRetry: true,
                     message: null,
                     onResponseDisposed: null);
             }
@@ -118,7 +118,7 @@ namespace GVFS.Common.Http
             HttpResponseMessage response = null;
 
             try
-            {               
+            {
                 requestStopwatch.Restart();
 
                 try
@@ -142,8 +142,8 @@ namespace GVFS.Common.Http
                     Stream responseStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 
                     gitEndPointResponseData = new GitEndPointResponseData(
-                        response.StatusCode, 
-                        contentType, 
+                        response.StatusCode,
+                        contentType,
                         responseStream,
                         message: response,
                         onResponseDisposed: () => availableConnections.Release());
@@ -193,8 +193,8 @@ namespace GVFS.Common.Http
                 errorMessage = string.Format("Request to {0} timed out", requestUri);
 
                 gitEndPointResponseData = new GitEndPointResponseData(
-                    HttpStatusCode.RequestTimeout, 
-                    new GitObjectsHttpException(HttpStatusCode.RequestTimeout, errorMessage), 
+                    HttpStatusCode.RequestTimeout,
+                    new GitObjectsHttpException(HttpStatusCode.RequestTimeout, errorMessage),
                     shouldRetry: true,
                     message: response,
                     onResponseDisposed: () => availableConnections.Release());
@@ -202,8 +202,8 @@ namespace GVFS.Common.Http
             catch (WebException ex)
             {
                 gitEndPointResponseData = new GitEndPointResponseData(
-                    HttpStatusCode.InternalServerError, 
-                    ex, 
+                    HttpStatusCode.InternalServerError,
+                    ex,
                     shouldRetry: true,
                     message: response,
                     onResponseDisposed: () => availableConnections.Release());
@@ -214,7 +214,7 @@ namespace GVFS.Common.Http
                 responseMetadata.Add("responseWaitTimeMS", $"{responseWaitTime.TotalMilliseconds:F4}");
 
                 this.Tracer.RelatedEvent(EventLevel.Informational, "NetworkResponse", responseMetadata);
-                
+
                 if (gitEndPointResponseData == null)
                 {
                     // If gitEndPointResponseData is null there was an unhandled exception
@@ -229,7 +229,7 @@ namespace GVFS.Common.Http
 
             return gitEndPointResponseData;
         }
-        
+
         private static bool ShouldRetry(HttpStatusCode statusCode)
         {
             // Retry timeout, Unauthorized, and 5xx errors
@@ -249,7 +249,7 @@ namespace GVFS.Common.Http
             IEnumerable<string> values;
             if (headers.TryGetValues(headerName, out values))
             {
-                return values.First();                
+                return values.First();
             }
 
             return string.Empty;

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -34,7 +34,7 @@ namespace GVFS.Upgrader
                     this.tracer.RelatedError($"{nameof(this.TryRunPreUpgradeChecks)}: {consoleError}");
                     return false;
                 }
-                
+
                 if (!this.IsGVFSUpgradeAllowed(out consoleError))
                 {
                     this.tracer.RelatedError($"{nameof(this.TryRunPreUpgradeChecks)}: {consoleError}");
@@ -42,7 +42,7 @@ namespace GVFS.Upgrader
                 }
 
                 activity.RelatedInfo($"Successfully finished pre upgrade checks. Okay to run {GVFSConstants.UpgradeVerbMessages.GVFSUpgrade}.");
-            }                
+            }
 
             consoleError = null;
             return true;
@@ -69,9 +69,9 @@ namespace GVFS.Upgrader
                     return false;
                 }
 
-                // While checking for blocking processes like GVFS.Mount immediately after un-mounting, 
-                // then sometimes GVFS.Mount shows up as running. But if the check is done after waiting 
-                // for some time, then eventually GVFS.Mount goes away. The retry loop below is to help 
+                // While checking for blocking processes like GVFS.Mount immediately after un-mounting,
+                // then sometimes GVFS.Mount shows up as running. But if the check is done after waiting
+                // for some time, then eventually GVFS.Mount goes away. The retry loop below is to help
                 // account for this delay between the time un-mount call returns and when GVFS.Mount
                 // actually quits.
                 this.tracer.RelatedInfo("Checking if GVFS or dependent processes are running.");
@@ -125,7 +125,7 @@ namespace GVFS.Upgrader
         {
             return GVFSEnlistment.IsUnattended(this.tracer);
         }
-        
+
         protected virtual bool IsBlockingProcessRunning(out HashSet<string> processes)
         {
             int currentProcessId = Process.GetCurrentProcess().Id;

--- a/GVFS/GVFS.Common/LibGit2RepoPool.cs
+++ b/GVFS/GVFS.Common/LibGit2RepoPool.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
     {
         private const int TryAddTimeoutMilliseconds = 10;
         private const int TryTakeTimeoutMilliseconds = Timeout.Infinite;
-        
+
         private readonly BlockingCollection<LibGit2Repo> pool;
         private readonly ITracer tracer;
 
@@ -34,7 +34,7 @@ namespace GVFS.Common
             this.pool.CompleteAdding();
             this.CleanUpPool();
         }
-        
+
         public bool TryInvoke<TResult>(Func<LibGit2Repo, TResult> function, out TResult result)
         {
             LibGit2Repo repo = null;

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common
     {
         public const string DefaultGVFSCacheFolderName = ".gvfsCache";
 
-        private const string EtwArea = nameof(LocalCacheResolver);        
+        private const string EtwArea = nameof(LocalCacheResolver);
         private const string MappingFile = "mapping.dat";
         private const string MappingVersionKey = "GVFS_LocalCache_MappingVersion";
         private const string CurrentMappingDataVersion = "1";
@@ -43,11 +43,11 @@ namespace GVFS.Common
         }
 
         public bool TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers(
-            ITracer tracer, 
+            ITracer tracer,
             ServerGVFSConfig serverGVFSConfig,
-            CacheServerInfo currentCacheServer, 
+            CacheServerInfo currentCacheServer,
             string localCacheRoot,
-            out string localCacheKey, 
+            out string localCacheKey,
             out string errorMessage)
         {
             if (serverGVFSConfig == null)
@@ -65,8 +65,8 @@ namespace GVFS.Common
                 this.fileSystem.CreateDirectory(localCacheRoot);
 
                 using (FileBasedLock mappingLock = GVFSPlatform.Instance.CreateFileBasedLock(
-                    this.fileSystem, 
-                    tracer, 
+                    this.fileSystem,
+                    tracer,
                     lockPath))
                 {
                     if (!this.TryAcquireLockWithRetries(tracer, mappingLock))
@@ -193,8 +193,8 @@ namespace GVFS.Common
         private bool TryGetLocalCacheKeyFromRemoteCacheServers(
             ITracer tracer,
             ServerGVFSConfig serverGVFSConfig,
-            CacheServerInfo currentCacheServer, 
-            FileBasedDictionary<string, string> mappingFile, 
+            CacheServerInfo currentCacheServer,
+            FileBasedDictionary<string, string> mappingFile,
             out string localCacheKey,
             out string error)
         {
@@ -202,7 +202,7 @@ namespace GVFS.Common
             localCacheKey = null;
 
             try
-            { 
+            {
                 if (this.TryFindExistingLocalCacheKey(mappingFile, serverGVFSConfig.CacheServers, out localCacheKey))
                 {
                     EventMetadata metadata = CreateEventMetadata();
@@ -294,7 +294,7 @@ namespace GVFS.Common
 
             return false;
         }
-        
+
         private string ToMappingKey(string url)
         {
             return url.ToLowerInvariant();

--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common
         private readonly string configFile;
         private readonly PhysicalFileSystem fileSystem;
         private FileBasedDictionary<string, string> allSettings;
-        
+
         public LocalGVFSConfig()
         {
             string servicePath = Paths.GetServiceDataRoot(GVFSConstants.Service.ServiceName);
@@ -39,8 +39,8 @@ namespace GVFS.Common
         }
 
         public bool TryGetConfig(
-            string name, 
-            out string value, 
+            string name,
+            out string value,
             out string error)
         {
             string valueFromDict = null;
@@ -58,12 +58,12 @@ namespace GVFS.Common
         }
 
         public bool TrySetConfig(
-            string name, 
-            string value, 
+            string name,
+            string value,
             out string error)
         {
             if (!this.TryPerformAction(
-                () => this.allSettings.SetValueAndFlush(name, value), 
+                () => this.allSettings.SetValueAndFlush(name, value),
                 out error))
             {
                 error = $"Error writing config {name}={value}. {error}";

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -23,7 +23,7 @@ namespace GVFS.Common.Maintenance
         }
 
         public override string Area => nameof(LooseObjectsStep);
-        
+
         // 50,000 was found to be the optimal time taking ~5 minutes
         public int MaxLooseObjectsInPack { get; set; } = 50000;
 

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -15,7 +15,7 @@ namespace GVFS.Common
     {
         private ConcurrentHashSet<string> modifiedPaths;
 
-        protected ModifiedPathsDatabase(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath) 
+        protected ModifiedPathsDatabase(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: true)
         {
             this.modifiedPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -29,7 +29,7 @@ namespace GVFS.Common
         public static bool TryLoadOrCreate(ITracer tracer, string dataDirectory, PhysicalFileSystem fileSystem, out ModifiedPathsDatabase output, out string error)
         {
             ModifiedPathsDatabase temp = new ModifiedPathsDatabase(tracer, fileSystem, dataDirectory);
-            
+
             if (!temp.TryLoadFromDisk<string, string>(
                 temp.TryParseAddLine,
                 temp.TryParseRemoveLine,

--- a/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
@@ -113,7 +113,7 @@ namespace GVFS.Common.NamedPipes
                 // Message Format
                 //     FailedUpdateCount<FailedDeleteCount<FailedUpdateList<FailedDeleteList
                 //
-                //     - If the sum of FailedUpdateCount and FailedDeleteCount exceeds MaxReportedFileNames then 
+                //     - If the sum of FailedUpdateCount and FailedDeleteCount exceeds MaxReportedFileNames then
                 //       FailedUpdateList and FailedDeleteList will be empty
                 //
                 //     - Format of each list is Path1|Path2|Path3|...|PathN
@@ -123,7 +123,7 @@ namespace GVFS.Common.NamedPipes
 
                 public ReleaseLockData(List<string> failedToUpdateFileList, List<string> failedToDeleteFileList)
                     : this(
-                          failedToUpdateFileList.Count, 
+                          failedToUpdateFileList.Count,
                           failedToDeleteFileList.Count,
                           (failedToUpdateFileList.Count + failedToDeleteFileList.Count <= MaxReportedFileNames) ? failedToUpdateFileList : new List<string>(),
                           (failedToUpdateFileList.Count + failedToDeleteFileList.Count <= MaxReportedFileNames) ? failedToDeleteFileList : new List<string>())
@@ -131,9 +131,9 @@ namespace GVFS.Common.NamedPipes
                 }
 
                 private ReleaseLockData(
-                    int failedToUpdateCount, 
-                    int failedToDeleteCount, 
-                    List<string> failedToUpdateFileList, 
+                    int failedToUpdateCount,
+                    int failedToDeleteCount,
+                    List<string> failedToUpdateFileList,
                     List<string> failedToDeleteFileList)
                 {
                     this.FailedToUpdateCount = failedToUpdateCount;
@@ -216,13 +216,13 @@ namespace GVFS.Common.NamedPipes
 
                 internal string ToMessage()
                 {
-                    return 
+                    return
                         this.FailedToUpdateCount.ToString() +
                         SectionSeparator +
                         this.FailedToDeleteCount.ToString() +
                         SectionSeparator +
-                        string.Join(MessageSeparator.ToString(), this.FailedToUpdateFileList) + 
-                        SectionSeparator + 
+                        string.Join(MessageSeparator.ToString(), this.FailedToUpdateFileList) +
+                        SectionSeparator +
                         string.Join(MessageSeparator.ToString(), this.FailedToDeleteFileList);
                 }
             }

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.NamedPipes
     /// Define messages used to communicate via the named-pipe in GVFS.
     /// </summary>
     /// <remarks>
-    /// This class is defined as partial so that GVFS.Hooks 
+    /// This class is defined as partial so that GVFS.Hooks
     /// can compile the portions of it that it cares about (see LockedNamedPipeMessages).
     /// </remarks>
     public static partial class NamedPipeMessages

--- a/GVFS/GVFS.Common/NativeMethods.cs
+++ b/GVFS/GVFS.Common/NativeMethods.cs
@@ -20,11 +20,11 @@ namespace GVFS.Common
         public enum MoveFileFlags : uint
         {
             MoveFileReplaceExisting = 0x00000001,    // MOVEFILE_REPLACE_EXISTING
-            MoveFileCopyAllowed = 0x00000002,        // MOVEFILE_COPY_ALLOWED           
-            MoveFileDelayUntilReboot = 0x00000004,   // MOVEFILE_DELAY_UNTIL_REBOOT     
-            MoveFileWriteThrough = 0x00000008,       // MOVEFILE_WRITE_THROUGH          
-            MoveFileCreateHardlink = 0x00000010,     // MOVEFILE_CREATE_HARDLINK        
-            MoveFileFailIfNotTrackable = 0x00000020, // MOVEFILE_FAIL_IF_NOT_TRACKABLE  
+            MoveFileCopyAllowed = 0x00000002,        // MOVEFILE_COPY_ALLOWED
+            MoveFileDelayUntilReboot = 0x00000004,   // MOVEFILE_DELAY_UNTIL_REBOOT
+            MoveFileWriteThrough = 0x00000008,       // MOVEFILE_WRITE_THROUGH
+            MoveFileCreateHardlink = 0x00000010,     // MOVEFILE_CREATE_HARDLINK
+            MoveFileFailIfNotTrackable = 0x00000020, // MOVEFILE_FAIL_IF_NOT_TRACKABLE
         }
 
         [Flags]

--- a/GVFS/GVFS.Common/NetworkStreams/BatchedLooseObjectDeserializer.cs
+++ b/GVFS/GVFS.Common/NetworkStreams/BatchedLooseObjectDeserializer.cs
@@ -93,7 +93,7 @@ namespace GVFS.Common.NetworkStreams
             }
             else if (totalBytes == NumObjectIdBytes)
             {
-                // We may have finished reading all the objects 
+                // We may have finished reading all the objects
                 for (int i = 0; i < NumObjectIdBytes; i++)
                 {
                     if (curObjectHeader[i] != 0)

--- a/GVFS/GVFS.Common/NetworkStreams/PrefetchPacksDeserializer.cs
+++ b/GVFS/GVFS.Common/NetworkStreams/PrefetchPacksDeserializer.cs
@@ -13,7 +13,7 @@ namespace GVFS.Common.NetworkStreams
     {
         private const int NumPackHeaderBytes = 3 * sizeof(long);
 
-        private static readonly byte[] PrefetchPackExpectedHeader = 
+        private static readonly byte[] PrefetchPackExpectedHeader =
             new byte[]
             {
                 (byte)'G', (byte)'P', (byte)'R', (byte)'E', (byte)' ', // Magic

--- a/GVFS/GVFS.Common/NetworkStreams/RestrictedStream.cs
+++ b/GVFS/GVFS.Common/NetworkStreams/RestrictedStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 namespace GVFS.Common.NetworkStreams
 {
     /// <summary>
-    /// Stream wrapper for a length-limited subview of another stream. 
+    /// Stream wrapper for a length-limited subview of another stream.
     /// </summary>
     internal class RestrictedStream : Stream
     {

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -16,7 +16,7 @@ namespace GVFS.Common
 
         private const char PathTerminator = '\0';
 
-        // This list holds placeholder entries that are created between calls to 
+        // This list holds placeholder entries that are created between calls to
         // GetAllEntriesAndPrepToWriteAllEntries and WriteAllEntriesAndFlush.
         //
         //    Example:
@@ -25,20 +25,20 @@ namespace GVFS.Common
         //       2) VFS4G starts the work to update placeholders
         //       3) VFS4G calls GetAllEntriesAndPrepToWriteAllEntries
         //       4) VFS4G starts updating placeholders
-        //       5) Some application reads a pure-virtual file (creating a new placeholder) while VFS4G is updating existing placeholders. 
+        //       5) Some application reads a pure-virtual file (creating a new placeholder) while VFS4G is updating existing placeholders.
         //          That new placeholder is added to placeholderChangesWhileRebuildingList.
-        //       6) VFS4G completes updating the placeholders and calls WriteAllEntriesAndFlush. 
+        //       6) VFS4G completes updating the placeholders and calls WriteAllEntriesAndFlush.
         //          Note: this list does *not* include the placeholders created in step 5, as the were not included in GetAllEntries.
         //       7) WriteAllEntriesAndFlush writes *both* the entires in placeholderDataEntries and those that were passed in as the parameter.
         //
         // This scenario is covered in the unit test PlaceholderDatabaseTests.HandlesRaceBetweenAddAndWriteAllEntries
         //
         // Because of this list, callers must always call WriteAllEntries after calling GetAllEntriesAndPrepToWriteAllEntries.
-        // 
+        //
         // This list must always be accessed from inside one of FileBasedCollection's synchronizedAction callbacks because
         // there is race potential between creating the queue, adding to the queue, and writing to the data file.
         private List<PlaceholderDataEntry> placeholderChangesWhileRebuildingList;
-        
+
         private PlaceholderListDatabase(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: true)
         {
@@ -208,7 +208,7 @@ namespace GVFS.Common
         {
             try
             {
-                Dictionary<string, PlaceholderListDatabase.PlaceholderData> filePlaceholdersFromDiskByPath = 
+                Dictionary<string, PlaceholderListDatabase.PlaceholderData> filePlaceholdersFromDiskByPath =
                     new Dictionary<string, PlaceholderListDatabase.PlaceholderData>(Math.Max(1, this.EstimatedCount), StringComparer.Ordinal);
 
                 string error;
@@ -358,7 +358,7 @@ namespace GVFS.Common
 
             public bool IsFolder
             {
-                get 
+                get
                 {
                     return this.Sha == PartialFolderValue || this.IsExpandedFolder;
                 }

--- a/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
@@ -124,7 +124,7 @@ namespace GVFS.Common.Prefetch.Git
                         sourceTreeSha,
                         targetTreeSha,
                         line => this.EnqueueOperationsFromDiffTreeLine(this.tracer, this.enlistment.WorkingDirectoryRoot, line));
-                    
+
                     if (result.ExitCodeIsFailure)
                     {
                         this.HasFailures = true;

--- a/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
@@ -16,7 +16,7 @@ namespace GVFS.Common.Prefetch.Git
         public override bool Equals(object obj)
         {
             PathWithMode x = obj as PathWithMode;
-            
+
             if (x == null)
             {
                 return false;

--- a/GVFS/GVFS.Common/Prefetch/Pipeline/BatchObjectDownloadStage.cs
+++ b/GVFS/GVFS.Common/Prefetch/Pipeline/BatchObjectDownloadStage.cs
@@ -19,7 +19,7 @@ namespace GVFS.Common.Prefetch.Pipeline
     {
         private const string AreaPath = nameof(BatchObjectDownloadStage);
         private const string DownloadAreaPath = "Download";
-        
+
         private static readonly TimeSpan HeartBeatPeriod = TimeSpan.FromSeconds(20);
 
         private readonly DownloadRequestAggregator downloadRequests;
@@ -46,7 +46,7 @@ namespace GVFS.Common.Prefetch.Pipeline
             : base(maxParallel)
         {
             this.tracer = tracer.StartActivity(AreaPath, EventLevel.Informational, Keywords.Telemetry, metadata: null);
-            
+
             this.downloadRequests = new DownloadRequestAggregator(missingBlobs, chunkSize);
 
             this.enlistment = enlistment;
@@ -61,7 +61,7 @@ namespace GVFS.Common.Prefetch.Pipeline
         public BlockingCollection<IndexPackRequest> AvailablePacks { get; }
 
         public BlockingCollection<string> AvailableObjects { get; }
-        
+
         protected override void DoBeforeWork()
         {
             this.heartbeat = new Timer(this.EmitHeartbeat, null, TimeSpan.Zero, HeartBeatPeriod);
@@ -138,7 +138,7 @@ namespace GVFS.Common.Prefetch.Pipeline
                     fileName = this.gitObjects.WriteLooseObject(
                         response.Stream,
                         sha,
-                        overwriteExistingObject: false, 
+                        overwriteExistingObject: false,
                         bufToCopyWith: bufToCopyWith);
                     this.AvailableObjects.Add(sha);
                     break;

--- a/GVFS/GVFS.Common/Prefetch/Pipeline/PrefetchPipelineStage.cs
+++ b/GVFS/GVFS.Common/Prefetch/Pipeline/PrefetchPipelineStage.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common.Prefetch.Pipeline
         {
             this.maxParallel = maxParallel;
         }
-        
+
         public bool HasFailures { get; protected set; }
 
         public void Start()
@@ -21,7 +21,7 @@ namespace GVFS.Common.Prefetch.Pipeline
             {
                 throw new InvalidOperationException("Cannot call start twice");
             }
-            
+
             this.DoBeforeWork();
 
             this.workers = new Thread[this.maxParallel];

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -35,7 +35,7 @@ namespace GVFS.Common
             Assembly assembly = Assembly.GetEntryAssembly();
             if (assembly == null)
             {
-                // The PR build tests doesn't produce an entry assembly because it is run from unmanaged code, 
+                // The PR build tests doesn't produce an entry assembly because it is run from unmanaged code,
                 // so we'll fall back on using this assembly. This should never ever happen for a normal exe invocation.
                 assembly = Assembly.GetExecutingAssembly();
             }
@@ -54,7 +54,7 @@ namespace GVFS.Common
 
             return currentProcessVersion;
         }
-        
+
         public static bool IsDevelopmentVersion()
         {
             Version currentVersion = new Version(ProcessHelper.GetCurrentProcessVersion());
@@ -70,7 +70,7 @@ namespace GVFS.Common
                 return null;
             }
 
-            string firstPath = 
+            string firstPath =
                 string.IsNullOrWhiteSpace(result.Output)
                 ? null
                 : result.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();

--- a/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.Shared.cs
@@ -29,8 +29,8 @@ namespace GVFS.Common
                 {
                     string[] components = Path.GetFileName(file).Split('.');
                     int length = components.Length;
-                    if (length >= 2 && 
-                        installerNames.Contains(components[0]) && 
+                    if (length >= 2 &&
+                        installerNames.Contains(components[0]) &&
                         installerExtension.Equals(components[length - 1], StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
@@ -45,7 +45,7 @@ namespace GVFS.Common
         {
             return Paths.GetServiceDataRoot(RootDirectory);
         }
-        
+
         public static string GetLogDirectoryPath()
         {
             return Path.Combine(Paths.GetServiceDataRoot(RootDirectory), LogDirectory);

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -38,7 +38,7 @@ namespace GVFS.Common
                 "System.Net.Http.dll",
                 "Newtonsoft.Json.dll"
             };
-        
+
         private Version installedVersion;
         private Release newestRelease;
         private PhysicalFileSystem fileSystem;
@@ -63,9 +63,9 @@ namespace GVFS.Common
             // Invalid - User has set an incorrect ring
             // NoConfig - User has Not set any ring yet
             // None - User has set a valid "None" ring
-            // (Fast should be greater than Slow, 
+            // (Fast should be greater than Slow,
             //  Slow should be greater than None, None greater than Invalid.)
-            // This is required for the correct implementation of Ring based 
+            // This is required for the correct implementation of Ring based
             // upgrade logic.
             Invalid = 0,
             NoConfig = None - 1,
@@ -75,7 +75,7 @@ namespace GVFS.Common
         }
 
         public RingType Ring { get; protected set; }
-        
+
         public bool TryGetNewerVersion(
             out Version newVersion,
             out string errorMessage)
@@ -87,7 +87,7 @@ namespace GVFS.Common
             {
                 return false;
             }
-            
+
             if (this.TryFetchReleases(out releases, out errorMessage))
             {
                 foreach (Release nextRelease in releases)
@@ -114,7 +114,7 @@ namespace GVFS.Common
         {
             gitVersion = null;
             error = null;
-            
+
             foreach (Asset asset in this.newestRelease.Assets)
             {
                 if (asset.Name.StartsWith(GitInstallerFileNamePrefix) &&
@@ -142,7 +142,7 @@ namespace GVFS.Common
                 {
                     continue;
                 }
-                                
+
                 if (!this.TryDownloadAsset(asset, out errorMessage))
                 {
                     errorMessage = $"Could not download {(isGVFSAsset ? GVFSAssetId : GitAssetId)} installer. {errorMessage}";
@@ -194,7 +194,7 @@ namespace GVFS.Common
         // Reason why this is needed - When GVFS.Upgrader.exe is run from C:\ProgramFiles\GVFS folder
         // upgrade installer that is downloaded and run will fail. This is because it cannot overwrite
         // C:\ProgramFiles\GVFS\GVFS.Upgrader.exe that is running. Moving GVFS.Upgrader.exe along with
-        // its dependencies to a temporary location inside ProgramData and running GVFS.Upgrader.exe 
+        // its dependencies to a temporary location inside ProgramData and running GVFS.Upgrader.exe
         // from this temporary location helps avoid this problem.
         public virtual bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
         {
@@ -216,8 +216,8 @@ namespace GVFS.Common
                     catch (UnauthorizedAccessException e)
                     {
                         error = string.Join(
-                            Environment.NewLine, 
-                            "File copy error - " + e.Message, 
+                            Environment.NewLine,
+                            "File copy error - " + e.Message,
                             $"Make sure you have write permissions to directory {rootDirectoryPath} and run {GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm} again.");
                         this.TraceException(e, nameof(this.TrySetupToolsDirectory), $"Error copying {toolPath} to {destinationPath}.");
                         break;
@@ -266,7 +266,7 @@ namespace GVFS.Common
             error = null;
             return true;
         }
-        
+
         public virtual bool TryLoadRingConfig(out string error)
         {
             string gitPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
@@ -295,7 +295,7 @@ namespace GVFS.Common
 
                 error = "Invalid upgrade ring `" + ringConfig + "` specified in gvfs config." + Environment.NewLine;
             }
-            
+
             error += GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
             this.Ring = RingType.Invalid;
             return false;

--- a/GVFS/GVFS.Common/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.Common/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.Common")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Common/RepoMetadata.cs
+++ b/GVFS/GVFS.Common/RepoMetadata.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
     {
         private FileBasedDictionary<string, string> repoMetadata;
         private ITracer tracer;
-        
+
         private RepoMetadata(ITracer tracer)
         {
             this.tracer = tracer;
@@ -60,7 +60,7 @@ namespace GVFS.Common
             else
             {
                 Instance = new RepoMetadata(tracer);
-                if (!FileBasedDictionary<string, string>.TryCreate(   
+                if (!FileBasedDictionary<string, string>.TryCreate(
                     tracer,
                     dictionaryPath,
                     fileSystem,
@@ -70,7 +70,7 @@ namespace GVFS.Common
                     return false;
                 }
             }
-            
+
             error = null;
             return true;
         }
@@ -96,7 +96,7 @@ namespace GVFS.Common
                 DiskLayoutVersion.CurrentMajorVersion,
                 DiskLayoutVersion.CurrentMinorVersion);
         }
-        
+
         public bool TryGetOnDiskLayoutVersion(out int majorVersion, out int minorVersion, out string error)
         {
             majorVersion = 0;
@@ -169,7 +169,7 @@ namespace GVFS.Common
         {
             return this.HasEntry(Keys.PlaceholdersNeedUpdate);
         }
-        
+
         public void SetProjectionInvalidAndPlaceholdersNeedUpdate()
         {
             this.repoMetadata.SetValuesAndFlush(
@@ -297,7 +297,7 @@ namespace GVFS.Common
 
             return false;
         }
-        
+
         public static class Keys
         {
             public const string ProjectionInvalid = "ProjectionInvalid";

--- a/GVFS/GVFS.Common/RetryConfig.cs
+++ b/GVFS/GVFS.Common/RetryConfig.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common
         private const string EtwArea = nameof(RetryConfig);
 
         private const int MinRetries = 0;
-        
+
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(DefaultTimeoutSeconds);
 
         public RetryConfig(int maxRetries = DefaultMaxRetries)
@@ -115,11 +115,11 @@ namespace GVFS.Common
             timeout = TimeSpan.FromSeconds(0);
             int timeoutSeconds;
             if (!TryGetFromGitConfig(
-                git, 
-                GVFSConstants.GitConfig.TimeoutSecondsConfig, 
-                DefaultTimeoutSeconds, 
-                0, 
-                out timeoutSeconds, 
+                git,
+                GVFSConstants.GitConfig.TimeoutSecondsConfig,
+                DefaultTimeoutSeconds,
+                0,
+                out timeoutSeconds,
                 out error))
             {
                 return false;

--- a/GVFS/GVFS.Common/RetryWrapper.cs
+++ b/GVFS/GVFS.Common/RetryWrapper.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 namespace GVFS.Common
 {
     public class RetryWrapper<T>
-    {        
+    {
         private const float MaxBackoffInSeconds = 300; // 5 minutes
-        private readonly int maxAttempts;        
+        private readonly int maxAttempts;
         private readonly double exponentialBackoffBase;
         private readonly CancellationToken cancellationToken;
 
@@ -56,7 +56,7 @@ namespace GVFS.Common
                     tracer.RelatedError(metadata, message, Keywords.Network);
                 }
             };
-        }        
+        }
 
         public InvocationResult Invoke(Func<int, CallbackResult> toInvoke)
         {

--- a/GVFS/GVFS.Common/ReturnCode.cs
+++ b/GVFS/GVFS.Common/ReturnCode.cs
@@ -2,7 +2,7 @@
 {
     public enum ReturnCode
     {
-        Success = 0,       
+        Success = 0,
         ParsingError = 1,
         RebootRequired = 2,
         GenericError = 3,

--- a/GVFS/GVFS.Common/SHA1Util.cs
+++ b/GVFS/GVFS.Common/SHA1Util.cs
@@ -28,7 +28,7 @@ namespace GVFS.Common
         }
 
         /// <summary>
-        /// Returns a string representation of a byte array from the first 
+        /// Returns a string representation of a byte array from the first
         /// <param name="numBytes"/> bytes of the buffer.
         /// </summary>
         public static string HexStringFromBytes(byte[] buf, int numBytes = -1)
@@ -56,7 +56,7 @@ namespace GVFS.Common
                 }
             }
         }
-        
+
         public static byte[] BytesFromHexString(string sha)
         {
             byte[] arr = new byte[sha.Length / 2];

--- a/GVFS/GVFS.Common/StreamUtil.cs
+++ b/GVFS/GVFS.Common/StreamUtil.cs
@@ -9,10 +9,10 @@ namespace GVFS.Common
         /// .NET default buffer size <see cref="Stream.CopyTo"/> uses as of 8/30/16
         /// </summary>
         public const int DefaultCopyBufferSize = 81920;
-                
+
         /// <summary>
         /// Copies all bytes from the source stream to the destination stream.  This is an exact copy
-        /// of Stream.CopyTo(), but can uses the supplied buffer instead of allocating a new one. 
+        /// of Stream.CopyTo(), but can uses the supplied buffer instead of allocating a new one.
         /// </summary>
         /// <remarks>
         /// As of .NET 4.6, each call to Stream.CopyTo() allocates a new 80K byte[] buffer, which
@@ -49,7 +49,7 @@ namespace GVFS.Common
         }
 
         /// <summary>
-        /// Call <see cref="Stream.Read"/> until either <paramref name="count"/> bytes are read or 
+        /// Call <see cref="Stream.Read"/> until either <paramref name="count"/> bytes are read or
         /// the end of <paramref name="stream"/> is reached.
         /// </summary>
         /// <param name="buf">Buffer to read bytes into.</param>

--- a/GVFS/GVFS.Common/Tracing/ITracer.cs
+++ b/GVFS/GVFS.Common/Tracing/ITracer.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common.Tracing
         void RelatedEvent(EventLevel level, string eventName, EventMetadata metadata, Keywords keywords);
 
         void RelatedInfo(string format, params object[] args);
-                
+
         void RelatedWarning(EventMetadata metadata, string message);
 
         void RelatedWarning(EventMetadata metadata, string message, Keywords keywords);
@@ -22,7 +22,7 @@ namespace GVFS.Common.Tracing
         void RelatedWarning(string message);
 
         void RelatedWarning(string format, params object[] args);
-        
+
         void RelatedError(EventMetadata metadata, string message);
 
         void RelatedError(EventMetadata metadata, string message, Keywords keywords);

--- a/GVFS/GVFS.Common/Tracing/InProcEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/InProcEventListener.cs
@@ -17,14 +17,14 @@ namespace GVFS.Common.Tracing
         public virtual void Dispose()
         {
         }
-        
+
         public void RecordMessage(string eventName, Guid activityId, Guid parentActivityId, EventLevel level, Keywords keywords, EventOpcode opcode, string jsonPayload)
         {
             if (!this.IsEnabled(level, keywords))
             {
                 return;
             }
-            
+
             this.RecordMessageInternal(eventName, activityId, parentActivityId, level, keywords, opcode, jsonPayload);
         }
 
@@ -52,7 +52,7 @@ namespace GVFS.Common.Tracing
             {
                 message.Append(" " + jsonPayload);
             }
-            
+
             return message.ToString();
         }
 

--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -124,7 +124,7 @@ namespace GVFS.Common.Tracing
             metadata.Add(TracingConstants.MessageKey.InfoMessage, string.Format(format, args));
             this.RelatedEvent(EventLevel.Informational, "Information", metadata);
         }
-        
+
         public virtual void RelatedWarning(EventMetadata metadata, string message)
         {
             this.RelatedWarning(metadata, message, Keywords.None);
@@ -139,7 +139,7 @@ namespace GVFS.Common.Tracing
 
         public virtual void RelatedWarning(string message)
         {
-            EventMetadata metadata = new EventMetadata();            
+            EventMetadata metadata = new EventMetadata();
             this.RelatedWarning(metadata, message);
         }
 

--- a/GVFS/GVFS.Common/Tracing/LogFileEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/LogFileEventListener.cs
@@ -13,7 +13,7 @@ namespace GVFS.Common.Tracing
         {
             this.SetLogFilePath(logFilePath);
         }
-        
+
         public override void Dispose()
         {
             if (this.writer != null)

--- a/GVFS/GVFS.FunctionalTests.Windows/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.FunctionalTests")]
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/DiskLayoutUpgradeTests.cs
@@ -174,7 +174,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
 
             // Placeholder database file should only have file placeholders
             this.fileSystem.WriteAllText(
-                placeholderDatabasePath, 
+                placeholderDatabasePath,
                 string.Join(Environment.NewLine, lines.Where(x => !x.EndsWith(TestConstants.PartialFolderPlaceholderDatabaseValue))) + Environment.NewLine);
 
             GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, "12", "1");
@@ -201,9 +201,9 @@ namespace GVFS.FunctionalTests.Windows.Tests
 
             // Update the placeholder file so that folders have an all zero SHA
             this.fileSystem.WriteAllText(
-                placeholderDatabasePath, 
+                placeholderDatabasePath,
                 string.Join(
-                    Environment.NewLine, 
+                    Environment.NewLine,
                     lines.Select(x => x.Replace(TestConstants.PartialFolderPlaceholderDatabaseValue, TestConstants.AllZeroSha))) + Environment.NewLine);
 
             GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, "16", "0");

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFileSystemTests.cs
@@ -22,9 +22,9 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
         private enum CreationDisposition
         {
             CreateNew = 1,        // CREATE_NEW
-            CreateAlways = 2,     // CREATE_ALWAYS    
-            OpenExisting = 3,     // OPEN_EXISTING    
-            OpenAlways = 4,       // OPEN_ALWAYS      
+            CreateAlways = 2,     // CREATE_ALWAYS
+            OpenExisting = 3,     // OPEN_EXISTING
+            OpenAlways = 4,       // OPEN_ALWAYS
             TruncateExisting = 5  // TRUNCATE_EXISTING
         }
 

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -67,8 +67,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
                 return false;
             }
 
-            string output = this.RunProcess(string.Format("/C if exist \"{0}\" (echo {1}) else (echo {2})", path, ShellRunner.SuccessOutput, ShellRunner.FailureOutput)).Trim();  
-                  
+            string output = this.RunProcess(string.Format("/C if exist \"{0}\" (echo {1}) else (echo {2})", path, ShellRunner.SuccessOutput, ShellRunner.FailureOutput)).Trim();
+
             return output.Equals(ShellRunner.SuccessOutput, StringComparison.InvariantCulture);
         }
 
@@ -126,7 +126,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             // to the contents
             this.RunProcess(string.Format("/C echo|set /p =\"{0}\" > {1}", contents, path));
         }
-        
+
         public override void WriteAllTextShouldFail<ExceptionType>(string path, string contents)
         {
             // CmdRunner does nothing special when a failure is expected
@@ -137,7 +137,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             string parentDirectory = Path.GetDirectoryName(path);
             string targetName = Path.GetFileName(path);
-                  
+
             string output = this.RunProcess(string.Format("/C dir /A:d /B {0}", parentDirectory));
             string[] directories = output.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -7,7 +7,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
     {
         private static FileSystemRunner defaultRunner = new SystemIORunner();
 
-        public static object[] AllWindowsRunners { get; } = 
+        public static object[] AllWindowsRunners { get; } =
             new[]
             {
                 new object[] { new SystemIORunner() },
@@ -16,7 +16,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
                 new object[] { new BashRunner() },
             };
 
-        public static object[] AllMacRunners { get; } = 
+        public static object[] AllMacRunners { get; } =
             new[]
             {
                 new object[] { new SystemIORunner() },
@@ -28,7 +28,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             {
                 new object[] { defaultRunner }
             };
-        
+
         public static object[] Runners
         {
             get { return GVFSTestConfig.FileSystemRunners; }
@@ -43,7 +43,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         }
 
         // File methods
-        public abstract bool FileExists(string path);       
+        public abstract bool FileExists(string path);
         public abstract string MoveFile(string sourcePath, string targetPath);
 
         /// <summary>
@@ -110,5 +110,5 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public abstract string DeleteDirectory(string path);
         public abstract void DeleteDirectory_DirectoryShouldNotBeFound(string path);
         public abstract void DeleteDirectory_ShouldBeBlockedByProcess(string path);
-    }   
+    }
 }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -91,7 +91,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             output.Length.ShouldBeAtLeast(2);
             output.Substring(output.Length - 2).ShouldEqual("\r\n");
             output = output.Remove(output.Length - 2, 2);
-        
+
             return output;
         }
 

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -9,7 +9,7 @@ namespace GVFS.FunctionalTests
         public static bool NoSharedCache { get; set; }
 
         public static string LocalCacheRoot { get; set; }
-        
+
         public static object[] FileSystemRunners { get; set; }
 
         public static object[] GitRepoTestsValidateWorkTree { get; set; }
@@ -23,8 +23,8 @@ namespace GVFS.FunctionalTests
             get
             {
                 return
-                    TestGVFSOnPath ? 
-                    Properties.Settings.Default.PathToGVFS : 
+                    TestGVFSOnPath ?
+                    Properties.Settings.Default.PathToGVFS :
                     Path.Combine(Properties.Settings.Default.CurrentDirectory, Properties.Settings.Default.PathToGVFS);
             }
         }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -56,12 +56,12 @@ namespace GVFS.FunctionalTests
             }
             else
             {
-                GVFSTestConfig.GitRepoTestsValidateWorkTree = 
-                    new object[] 
-                    { 
-                        new object[] { true } 
+                GVFSTestConfig.GitRepoTestsValidateWorkTree =
+                    new object[]
+                    {
+                        new object[] { true }
                     };
-            
+
                 excludeCategories.Add(Categories.FullSuiteOnly);
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
@@ -89,7 +89,7 @@ namespace GVFS.FunctionalTests
             GVFSTestConfig.RepoToClone =
                 runner.GetCustomArgWithParam("--repo-to-clone")
                 ?? Properties.Settings.Default.RepoToClone;
-            
+
             RunBeforeAnyTests();
             Environment.ExitCode = runner.RunTests(includeCategories, excludeCategories);
             RunAfterAllTests();

--- a/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
+++ b/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
@@ -198,9 +198,9 @@ namespace GVFS.FunctionalTests.Should
             }
 
             public DirectoryAdapter WithDeepStructure(
-                FileSystemRunner fileSystem, 
+                FileSystemRunner fileSystem,
                 string otherPath,
-                bool ignoreCase = false, 
+                bool ignoreCase = false,
                 bool compareContent = false)
             {
                 otherPath.ShouldBeADirectory(this.runner);
@@ -252,10 +252,10 @@ namespace GVFS.FunctionalTests.Should
             }
 
             private static void CompareDirectories(
-                FileSystemRunner fileSystem, 
-                string expectedPath, 
+                FileSystemRunner fileSystem,
+                string expectedPath,
                 string actualPath,
-                bool ignoreCase, 
+                bool ignoreCase,
                 bool compareContent)
             {
                 IEnumerable<FileSystemInfo> expectedEntries = new DirectoryInfo(expectedPath).EnumerateFileSystemInfos("*", SearchOption.AllDirectories);
@@ -270,7 +270,7 @@ namespace GVFS.FunctionalTests.Should
                     .Where(x => !x.FullName.Contains(dotGitFolder))
                     .OrderBy(x => x.FullName)
                     .GetEnumerator();
-                
+
                 bool expectedMoved = expectedEnumerator.MoveNext();
                 bool actualMoved = actualEnumerator.MoveNext();
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -166,16 +166,16 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
                 FileAttributes attributesLessProjFS = attributes & (FileAttributes)~(FileAttributeSparseFile | FileAttributeReparsePoint | FileAttributeRecallOnDataAccess);
 
                 attributesLessProjFS.ShouldEqual(
-                    FileAttributes.Hidden, 
+                    FileAttributes.Hidden,
                     $"Attributes (ignoring ProjFS attributes) do not match, expected: {FileAttributes.Hidden} actual: {attributesLessProjFS}");
-                
+
                 ++retryCount;
                 Thread.Sleep(500);
 
                 info.Refresh();
                 attributes = info.Attributes & ~FileAttributes.Archive;
             }
-                   
+
             attributes.ShouldEqual(FileAttributes.Hidden, $"Attributes do not match, expected: {FileAttributes.Hidden} actual: {attributes}");
         }
 
@@ -242,7 +242,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             FileInfo fileInfo = new FileInfo(virtualFilePath);
             fileInfo.Attributes = FileAttributes.ReadOnly;
             virtualFilePath.ShouldBeAFile(fileSystem).WithAttribute(FileAttributes.ReadOnly);
-            
+
             // Clear read only
             fileInfo.Attributes = FileAttributes.Normal;
             virtualFilePath.ShouldBeAFile(fileSystem).WithoutAttribute(FileAttributes.ReadOnly);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -10,7 +10,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public class CloneTests : TestsWithEnlistmentPerFixture
     {
         private const int GVFSGenericError = 3;
-        
+
         [TestCase]
         public void CloneInsideMountedEnlistment()
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -24,11 +24,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private enum MoveFileFlags : uint
         {
             MoveFileReplaceExisting = 0x00000001,    // MOVEFILE_REPLACE_EXISTING
-            MoveFileCopyAllowed = 0x00000002,        // MOVEFILE_COPY_ALLOWED           
-            MoveFileDelayUntilReboot = 0x00000004,   // MOVEFILE_DELAY_UNTIL_REBOOT     
-            MoveFileWriteThrough = 0x00000008,       // MOVEFILE_WRITE_THROUGH          
-            MoveFileCreateHardlink = 0x00000010,     // MOVEFILE_CREATE_HARDLINK        
-            MoveFileFailIfNotTrackable = 0x00000020, // MOVEFILE_FAIL_IF_NOT_TRACKABLE  
+            MoveFileCopyAllowed = 0x00000002,        // MOVEFILE_COPY_ALLOWED
+            MoveFileDelayUntilReboot = 0x00000004,   // MOVEFILE_DELAY_UNTIL_REBOOT
+            MoveFileWriteThrough = 0x00000008,       // MOVEFILE_WRITE_THROUGH
+            MoveFileCreateHardlink = 0x00000010,     // MOVEFILE_CREATE_HARDLINK
+            MoveFileFailIfNotTrackable = 0x00000020, // MOVEFILE_FAIL_IF_NOT_TRACKABLE
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
@@ -16,7 +16,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private FileSystemRunner fileSystem;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
-        // the cache 
+        // the cache
         public GitCorruptObjectTests()
             : base(forcePerRepoObjectCache: true)
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -218,7 +218,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.VerifyWorktreeBit(fileToRenameEntry, LsFilesStatus.SkipWorktree);
 
             this.fileSystem.MoveFile(
-                this.Enlistment.GetVirtualPathTo(fileToRenameEntry), 
+                this.Enlistment.GetVirtualPathTo(fileToRenameEntry),
                 this.Enlistment.GetVirtualPathTo(fileToRenameTargetEntry));
             this.Enlistment.WaitForBackgroundOperations();
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -97,8 +97,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.Enlistment.GetVirtualPathTo(existingFilename).ShouldBeAFile(this.fileSystem);
 
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
-                this.Enlistment.RepoRoot, 
-                "add " + existingFilename, 
+                this.Enlistment.RepoRoot,
+                "add " + existingFilename,
                 new string[] { });
 
             // Status should be correct
@@ -132,8 +132,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.Enlistment.GetVirtualPathTo(existingFilename).ShouldBeAFile(this.fileSystem);
 
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
-                this.Enlistment.RepoRoot, 
-                "reset HEAD " + existingFilename, 
+                this.Enlistment.RepoRoot,
+                "reset HEAD " + existingFilename,
                 new string[] { });
 
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
@@ -183,7 +183,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             string filename = "GitStatusAfterRenameFileIntoRepo.cs";
 
-            // Create the test file in this.Enlistment.EnlistmentRoot as it's outside of src 
+            // Create the test file in this.Enlistment.EnlistmentRoot as it's outside of src
             // and is cleaned up when the functional tests run
             string filePath = Path.Combine(this.Enlistment.EnlistmentRoot, filename);
 
@@ -207,7 +207,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             string existingFilename = Path.Combine("Test_EPF_MoveRenameFileTests", "ChangeUnhydratedFileName", "Program.cs");
 
-            // Move the test file to this.Enlistment.EnlistmentRoot as it's outside of src 
+            // Move the test file to this.Enlistment.EnlistmentRoot as it's outside of src
             // and is cleaned up when the functional tests run
             this.fileSystem.MoveFile(this.Enlistment.GetVirtualPathTo(existingFilename), Path.Combine(this.Enlistment.EnlistmentRoot, "Program.cs"));
             this.Enlistment.GetVirtualPathTo(existingFilename).ShouldNotExistOnDisk(this.fileSystem);
@@ -223,7 +223,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             string folderName = "GitStatusAfterRenameFolderIntoRepo";
 
-            // Create the test folder in this.Enlistment.EnlistmentRoot as it's outside of src 
+            // Create the test folder in this.Enlistment.EnlistmentRoot as it's outside of src
             // and is cleaned up when the functional tests run
             string folderPath = Path.Combine(this.Enlistment.EnlistmentRoot, folderName);
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
@@ -16,7 +16,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private FileSystemRunner fileSystem;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
-        // the cache 
+        // the cache
         public LooseObjectStepTests()
             : base(forcePerRepoObjectCache: true)
         {
@@ -41,7 +41,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             Assert.AreNotEqual(0, this.GetLooseObjectFiles().Count);
             this.GetLooseObjectFiles().Count.ShouldBeAtLeast(1);
             this.CountPackFiles().ShouldEqual(1);
-     
+
             // Cleanup should delete all loose objects, since they are in the packfile
             this.Enlistment.LooseObjectStep();
 
@@ -144,9 +144,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             using (FileStream packFileStream = File.OpenRead(packFile))
             {
                 string output = GitProcess.InvokeProcess(
-                    this.Enlistment.RepoRoot, 
-                    "unpack-objects", 
-                    new Dictionary<string, string>() { { "GIT_OBJECT_DIRECTORY", this.GitObjectRoot } }, 
+                    this.Enlistment.RepoRoot,
+                    "unpack-objects",
+                    new Dictionary<string, string>() { { "GIT_OBJECT_DIRECTORY", this.GitObjectRoot } },
                     inputStream: packFileStream).Output;
             }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -305,7 +305,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         private class MountSubfolders
-        {            
+        {
             public const string MountFolders = "Folders";
             private static object[] mountFolders =
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests.cs
@@ -131,10 +131,10 @@ namespace GVFS.StressTests
         }
 
         private void ChangeUnhydratedFileCase(
-            string oldName, 
-            string oldVirtualPath, 
-            string newName, 
-            string newVirtualPath, 
+            string oldName,
+            string oldVirtualPath,
+            string newName,
+            string newVirtualPath,
             string knownFileContents)
         {
             this.fileSystem.MoveFile(oldVirtualPath, newVirtualPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFileTests_2.cs
@@ -130,10 +130,10 @@ IF ""%1""=="""" (SET ""Configuration=Debug"") ELSE (SET ""Configuration=%1"")
             string targetFileContents = "The Target";
 
             string sourceFilename = Path.Combine(
-                TestFileFolder, 
-                "MoveUnhydratedFileToOverwriteFullFileAndWrite", 
+                TestFileFolder,
+                "MoveUnhydratedFileToOverwriteFullFileAndWrite",
                 "MoveUnhydratedFileToOverwriteFullFileAndWrite.txt");
-            
+
             string sourceFileContents =
 @"<?xml version=""1.0"" encoding=""utf-8""?>
 <packages>

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -8,7 +8,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixtureSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
     public class MoveRenameFolderTests : TestsWithEnlistmentPerFixture
-    {       
+    {
         private const string TestFileContents =
 @"// dllmain.cpp : Defines the entry point for the DLL application.
 #include ""stdafx.h""
@@ -221,11 +221,11 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(newFolderName, "ChangeNestedUnhydratedFileNameCase", "Program.cs")
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents(MoveRenameFileTests.TestFileContents);
-            
+
             this.Enlistment.GetVirtualPathTo(newFolderName, "ChangeUnhydratedFileName", "Program.cs")
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents(MoveRenameFileTests.TestFileContents);
-            
+
             this.Enlistment.GetVirtualPathTo(newFolderName, "MoveUnhydratedFileToDotGitFolder", "Program.cs")
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents(MoveRenameFileTests.TestFileContents);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MultithreadedReadWriteTests.cs
@@ -20,7 +20,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // other tests in this class. That applies to every directory in the path, as well as the leaf file name.
             // Otherwise, this test loses most of its value because there will be no races occurring on creating the
             // placeholder directories, enumerating them, and then creating a placeholder file and hydrating it.
-            
+
             string fileName = Path.Combine("GVFS", "GVFS.FunctionalTests", "Tests", "LongRunningEnlistment", "GitMoveRenameTests.cs");
             string virtualPath = this.Enlistment.GetVirtualPathTo(fileName);
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -22,7 +22,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private FileSystemRunner fileSystem;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
-        // the cache 
+        // the cache
         public PrefetchVerbWithoutSharedCacheTests()
             : base(forcePerRepoObjectCache: true, skipPrefetchDuringClone: true)
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SymbolicLinkTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SymbolicLinkTests.cs
@@ -181,7 +181,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 "status",
                 "On branch FunctionalTests/20180925_SymLinksPart4",
                 "nothing to commit, working tree clean");
-            
+
             string testFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(TestFolderName, TestFileName));
             testFilePath.ShouldBeAFile(this.bashRunner).WithContents(GrandChildFileContents);
             this.bashRunner.IsSymbolicLink(testFilePath).ShouldBeTrue($"{testFilePath} should be a symlink");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
@@ -8,7 +8,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     {
         private readonly bool forcePerRepoObjectCache;
         private readonly bool skipPrefetchDuringClone;
-        
+
         public TestsWithEnlistmentPerFixture(bool forcePerRepoObjectCache = false, bool skipPrefetchDuringClone = false)
         {
             this.forcePerRepoObjectCache = forcePerRepoObjectCache;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UpdatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UpdatePlaceholderTests.cs
@@ -137,7 +137,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string placeholderDatabase = Path.Combine(this.Enlistment.DotGVFSRoot, "databases", "PlaceholderList.dat");
             string placeholdersBefore = GVFSHelpers.ReadAllTextFromWriteLockedFile(placeholderDatabase);
-            
+
             this.fileSystem.CreateEmptyFile(testFile);
 
             this.Enlistment.WaitForBackgroundOperations();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -67,7 +67,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileVirtualPath))
             {
-                // Length of the Byte-order-mark that will be at the start of the memory mapped file.  
+                // Length of the Byte-order-mark that will be at the start of the memory mapped file.
                 // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd374101(v=vs.85).aspx
                 int bomOffset = 3;
 
@@ -130,7 +130,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileVirtualPath))
             {
-                // Length of the Byte-order-mark that will be at the start of the memory mapped file.  
+                // Length of the Byte-order-mark that will be at the start of the memory mapped file.
                 // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd374101(v=vs.85).aspx
                 int bomOffset = 3;
 
@@ -186,13 +186,13 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             StringBuilder contentsBuilder = new StringBuilder();
 
-            // Length of the Byte-order-mark that will be at the start of the memory mapped file.  
+            // Length of the Byte-order-mark that will be at the start of the memory mapped file.
             // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd374101(v=vs.85).aspx
             int bomOffset = 3;
 
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(fileVirtualPath))
             {
-                // The text length of StreamAndRandomAccessReadWriteMemoryMappedProjectedFile.cs was determined 
+                // The text length of StreamAndRandomAccessReadWriteMemoryMappedProjectedFile.cs was determined
                 // outside of this test so that the test would not hydrate the file before we access via MemoryMappedFile
                 int fileTextLength = 13762;
 
@@ -309,7 +309,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             string fileName = "Readme.md";
             string parentFolderPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(fileName));
             parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
-            
+
             // Hydrate file with a request using different file name case
             string wrongCaseFilePath = this.Enlistment.GetVirtualPathTo(fileName.ToUpper());
             string fileContents = wrongCaseFilePath.ShouldBeAFile(this.fileSystem).WithContents();
@@ -483,7 +483,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             // Set the contents of objectPath to all NULL
             FileInfo objectFileInfo = new FileInfo(objectPath);
-            File.WriteAllBytes(objectPath, Enumerable.Repeat<byte>(0, (int)objectFileInfo.Length).ToArray());            
+            File.WriteAllBytes(objectPath, Enumerable.Repeat<byte>(0, (int)objectFileInfo.Length).ToArray());
 
             // Read the original path and verify its contents are correct
             this.Enlistment.GetVirtualPathTo("Test_EPF_WorkingDirectoryTests", "AllNullObjectRedownloaded.txt").ShouldBeAFile(this.fileSystem).WithContents(testFileContents);
@@ -527,7 +527,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             {
                 for (int i = 0; i < (objectStream.Length - 16); ++i)
                 {
-                    truncatedObjectStream.WriteByte((byte)objectStream.ReadByte());    
+                    truncatedObjectStream.WriteByte((byte)objectStream.ReadByte());
                 }
             }
 
@@ -635,7 +635,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             [DllImport("GVFS.NativeTests.dll", CharSet = CharSet.Ansi)]
             public static extern bool PlaceHolderHasVersionInfo(
-                string virtualPath, 
+                string virtualPath,
                 int version,
                 [MarshalAs(UnmanagedType.LPWStr)]string sha);
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/PersistedWorkingDirectoryTests.cs
@@ -34,7 +34,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             string enumerateDirectoryPath = this.Enlistment.GetVirtualPathTo(enumerateDirectoryName);
             fileSystem.DirectoryExists(enumerateDirectoryPath).ShouldEqual(true);
-            
+
             foreach (string folder in subFolders)
             {
                 string directoryPath = this.Enlistment.GetVirtualPathTo(folder);
@@ -125,7 +125,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string childFileToAdd = Path.Combine("GVFS", "ChildFileToAdd.txt");
             string childFileToAddContent = "This is new child file in the GVFS folder.";
             string childFileToAddPath = this.Enlistment.GetVirtualPathTo(childFileToAdd);
-            fileSystem.WriteAllText(childFileToAddPath, childFileToAddContent);              
+            fileSystem.WriteAllText(childFileToAddPath, childFileToAddContent);
 
             // Remount
             this.Enlistment.UnmountGVFS();
@@ -166,12 +166,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string postMountChildFile = "PostMountChildFile.txt";
             string postMountChildFileContent = "This is new child file added after the mount";
             string postMountChildFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(childFolder, postMountChildFile));
-            fileSystem.WriteAllText(postMountChildFilePath, postMountChildFileContent); // Verify we can create files in subfolders of GVFS  
+            fileSystem.WriteAllText(postMountChildFilePath, postMountChildFileContent); // Verify we can create files in subfolders of GVFS
             postMountChildFilePath.ShouldBeAFile(fileSystem).WithContents().ShouldEqual(postMountChildFileContent);
 
             // 663045 - Ensure that folder can be deleted after a new file is added and GVFS is remounted
             fileSystem.DeleteDirectory(childFolderPath);
             childFolderPath.ShouldNotExistOnDisk(fileSystem);
-        }        
+        }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
@@ -151,7 +151,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             this.Enlistment.Repair(confirm: true);
             ProcessResult result = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "remote add origin " + this.Enlistment.RepoUrl);
-            result.ExitCode.ShouldEqual(0, result.Errors);            
+            result.ExitCode.ShouldEqual(0, result.Errors);
             this.Enlistment.MountGVFS();
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -57,7 +57,7 @@ namespace GVFS.FunctionalTests.Tests
         {
             RepositoryHelpers.DeleteTestDirectory(this.fastFetchControlRoot);
         }
-        
+
         [TestCase]
         public void CanFetchIntoEmptyGitRepoAndCheckoutWithGit()
         {
@@ -90,7 +90,7 @@ namespace GVFS.FunctionalTests.Tests
 
             this.fastFetchRepoRoot.ShouldBeADirectory(FileSystemRunner.DefaultRunner);
             List<string> dirs = Directory.EnumerateFileSystemEntries(this.fastFetchRepoRoot).ToList();
-            dirs.SequenceEqual(new[] 
+            dirs.SequenceEqual(new[]
             {
                 Path.Combine(this.fastFetchRepoRoot, ".git"),
                 Path.Combine(this.fastFetchRepoRoot, "GVFS"),
@@ -125,7 +125,7 @@ namespace GVFS.FunctionalTests.Tests
                 .ShouldEqual(345);
             this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
 
-            // Run a second time in the same repo on the same branch with more folders. 
+            // Run a second time in the same repo on the same branch with more folders.
             this.RunFastFetch($"--checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force-checkout");
             dirs = Directory.EnumerateFileSystemEntries(this.fastFetchRepoRoot).ToList();
             dirs.SequenceEqual(new[]
@@ -213,7 +213,7 @@ namespace GVFS.FunctionalTests.Tests
             this.RunFastFetch("--checkout -b " + Settings.Default.Commitish);
 
             this.CurrentBranchShouldEqual(Settings.Default.Commitish);
-            
+
             this.fastFetchRepoRoot.ShouldBeADirectory(FileSystemRunner.DefaultRunner)
                 .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot);
         }
@@ -250,7 +250,7 @@ namespace GVFS.FunctionalTests.Tests
             // Verify that the final results are the same as the intial fetch results
             lsfilesAfterUpdate2.ShouldEqual(lsfilesAfterFirstFetch, "Incremental update should not change index");
         }
-        
+
         [TestCase]
         public void IncrementalChangesLeaveGoodStatus()
         {
@@ -274,7 +274,7 @@ namespace GVFS.FunctionalTests.Tests
 
             // There must be modified files in these commits.  Modified files must
             // be updated with valid metadata (times, sizes) or 'git status' will
-            // show them as modified when they were not actually modified. 
+            // show them as modified when they were not actually modified.
             Regex.IsMatch(changes, @"^M\s", RegexOptions.Multiline).ShouldEqual(true, "Data does not meet requirements");
         }
 
@@ -283,7 +283,7 @@ namespace GVFS.FunctionalTests.Tests
         {
             this.RunFastFetch("--checkout -b " + Settings.Default.Commitish);
             this.CurrentBranchShouldEqual(Settings.Default.Commitish);
-            
+
             // Switch to another branch
             this.RunFastFetch("--checkout -b FunctionalTests/20170602");
             this.CurrentBranchShouldEqual("FunctionalTests/20170602");
@@ -291,7 +291,7 @@ namespace GVFS.FunctionalTests.Tests
             // And back
             this.RunFastFetch("--checkout -b " + Settings.Default.Commitish);
             this.CurrentBranchShouldEqual(Settings.Default.Commitish);
-            
+
             this.fastFetchRepoRoot.ShouldBeADirectory(FileSystemRunner.DefaultRunner)
                 .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot);
         }
@@ -301,7 +301,7 @@ namespace GVFS.FunctionalTests.Tests
         {
             this.RunFastFetch("--checkout -b " + Settings.Default.Commitish);
             this.CurrentBranchShouldEqual(Settings.Default.Commitish);
-            
+
             this.RunFastFetch(" -b " + Settings.Default.Commitish).Output.ShouldContain("\"TotalMissingObjects\":0");
             this.RunFastFetch("--checkout -b " + Settings.Default.Commitish).Output.ShouldContain("\"RequiredBlobsCount\":0");
 
@@ -316,7 +316,7 @@ namespace GVFS.FunctionalTests.Tests
             // The delta between these two is the same as the UnitTest "caseChange.txt" data file.
             this.RunFastFetch("--checkout -c b3ddcf43b997cba3fbf9d2341b297e22bf48601a");
             this.RunFastFetch("--checkout -c e637c874f6a914ae83cd5668bcdd07293fef961d");
-            
+
             GitProcess.Invoke(this.fastFetchControlRoot, "checkout e637c874f6a914ae83cd5668bcdd07293fef961d");
 
             try
@@ -510,12 +510,12 @@ namespace GVFS.FunctionalTests.Tests
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
             processInfo.RedirectStandardError = true;
-            
+
             ProcessResult result = ProcessHelper.Run(processInfo);
 
             return result;
         }
-        
+
         private string GetShaFromLsLine(string line)
         {
             string output = line.Substring(line.LastIndexOf('\t') - 40, 40);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/AddStageTests.cs
@@ -9,7 +9,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class AddStageTests : GitRepoTests
     {
-        public AddStageTests(bool validateWorkingTree) 
+        public AddStageTests(bool validateWorkingTree)
             : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -15,7 +15,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class CheckoutTests : GitRepoTests
     {
-        public CheckoutTests(bool validateWorkingTree) 
+        public CheckoutTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }
@@ -366,7 +366,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         [TestCase]
         public void ModifyAndCheckoutFirstOfSeveralFilesWhoseNamesAppearBeforeDot()
         {
-            // Commit cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47 has the files (a).txt and (z).txt 
+            // Commit cb2d05febf64e3b0df50bd8d3fe8f05c0e2caa47 has the files (a).txt and (z).txt
             // in the DeleteFileWithNameAheadOfDotAndSwitchCommits folder
             string originalContent = "Test contents for (a).txt";
             string newContent = "content to append";
@@ -385,11 +385,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictSourceBranch);
 
-            // Commit db95d631e379d366d26d899523f8136a77441914 was prior to the additional of these 
+            // Commit db95d631e379d366d26d899523f8136a77441914 was prior to the additional of these
             // three files in commit 51d15f7584e81d59d44c1511ce17d7c493903390:
             //    Test_ConflictTests/AddedFiles/AddedByBothDifferentContent.txt
             //    Test_ConflictTests/AddedFiles/AddedByBothSameContent.txt
-            //    Test_ConflictTests/AddedFiles/AddedBySource.txt            
+            //    Test_ConflictTests/AddedFiles/AddedBySource.txt
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
             this.ValidateGitCommand("reset --mixed 51d15f7584e81d59d44c1511ce17d7c493903390");
 
@@ -410,7 +410,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // three files in commit 51d15f7584e81d59d44c1511ce17d7c493903390:
             //    Test_ConflictTests/AddedFiles/AddedByBothDifferentContent.txt
             //    Test_ConflictTests/AddedFiles/AddedByBothSameContent.txt
-            //    Test_ConflictTests/AddedFiles/AddedBySource.txt            
+            //    Test_ConflictTests/AddedFiles/AddedBySource.txt
             this.ValidateGitCommand("checkout db95d631e379d366d26d899523f8136a77441914");
 
             // Files should not exist
@@ -483,7 +483,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             fileLocked.IsSet.ShouldBeTrue("Failed to obtain exclusive file handle.  Exclusive handle required to validate behavior");
 
             try
-            {                
+            {
                 this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
             }
             catch (Exception)
@@ -538,7 +538,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             fileLocked.IsSet.ShouldBeTrue("Failed to obtain exclusive file handle.  Exclusive handle required to validate behavior");
 
             try
-            {                
+            {
                 this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
             }
             catch (Exception)
@@ -597,7 +597,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             fileLocked.IsSet.ShouldBeTrue("Failed to obtain file handle.  Handle required to validate behavior");
 
             try
-            {                
+            {
                 this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
             }
             catch (Exception)
@@ -656,7 +656,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             folderLocked.IsSet.ShouldBeTrue("Failed to obtain exclusive file handle.  Handle required to validate behavior");
 
             try
-            {                
+            {
                 this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
             }
             catch (Exception)
@@ -719,7 +719,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FolderShouldHaveCaseMatchingName(folderName, "GVFlt_MultiThreadTest");
             this.DeleteFolder(folderName);
 
-            // 4141dc6023b853740795db41a06b278ebdee0192 is the commit prior to deleting GVFLT_MultiThreadTest 
+            // 4141dc6023b853740795db41a06b278ebdee0192 is the commit prior to deleting GVFLT_MultiThreadTest
             // and re-adding it as as GVFlt_MultiThreadTest
             this.ValidateGitCommand("checkout 4141dc6023b853740795db41a06b278ebdee0192");
             this.FolderShouldHaveCaseMatchingName(folderName, "GVFLT_MultiThreadTest");
@@ -893,8 +893,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ControlGitRepo.Fetch(GitRepoTests.DeepDirectoryWithOneDifferentFile);
             this.ValidateGitCommand($"checkout {GitRepoTests.DeepDirectoryWithOneFile}");
             this.FileShouldHaveContents(
-                "TestFile1\n", 
-                "GitCommandsTests", 
+                "TestFile1\n",
+                "GitCommandsTests",
                 "CheckoutBranchDirectoryWithOneDeepFile",
                 "FolderDepth1",
                 "FolderDepth2",
@@ -905,7 +905,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // delete the file (and its parent directories) when
             // changing branches
             this.EditFile(
-                "Change file", 
+                "Change file",
                 "GitCommandsTests",
                 "CheckoutBranchDirectoryWithOneDeepFile",
                 "FolderDepth1",

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CherryPickConflictTests.cs
@@ -6,7 +6,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class CherryPickConflictTests : GitRepoTests
     {
-        public CherryPickConflictTests(bool validateWorkingTree) 
+        public CherryPickConflictTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CreatePlaceholderTests.cs
@@ -13,7 +13,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     {
         private static readonly string FileToRead = Path.Combine("GVFS", "GVFS", "Program.cs");
 
-        public CreatePlaceholderTests(bool validateWorkingTree) 
+        public CreatePlaceholderTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/EnumerationMergeTest.cs
@@ -6,11 +6,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class EnumerationMergeTest : GitRepoTests
     {
-        // Commit that found GvFlt Bug 12258777: Entries are sometimes skipped during 
+        // Commit that found GvFlt Bug 12258777: Entries are sometimes skipped during
         // enumeration when they don't fit in a user's buffer
         private const string EnumerationReproCommitish = "FunctionalTests/20170602";
 
-        public EnumerationMergeTest(bool validateWorkingTree) 
+        public EnumerationMergeTest(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -25,8 +25,8 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         private static readonly string RenameFilePathTo = Path.Combine("GVFS", "GVFS.Common", "Physical", "FileSystem", "FileProperties2.cs");
         private static readonly string RenameFolderPathFrom = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacks");
         private static readonly string RenameFolderPathTo = Path.Combine("GVFS", "GVFS.Common", "PrefetchPacksRenamed");
-       
-        public GitCommandsTests(bool validateWorkingTree) 
+
+        public GitCommandsTests(bool validateWorkingTree)
             : base(enlistmentPerTest: false, validateWorkingTree: validateWorkingTree)
         {
         }
@@ -266,27 +266,27 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "1", "#test");
             this.MoveFile(
-                Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#test"),
                 Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#testRenamed"));
 
             this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "2", "$test");
             this.MoveFile(
-                Path.Combine("GitCommandsTests", "RenameFileTests", "2", "$test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "2", "$test"),
                 Path.Combine("GitCommandsTests", "RenameFileTests", "2", "$testRenamed"));
 
             this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "3", ")");
             this.MoveFile(
-                Path.Combine("GitCommandsTests", "RenameFileTests", "3", ")"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "3", ")"),
                 Path.Combine("GitCommandsTests", "RenameFileTests", "3", ")Renamed"));
 
             this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "4", "+.test");
             this.MoveFile(
-                Path.Combine("GitCommandsTests", "RenameFileTests", "4", "+.test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "4", "+.test"),
                 Path.Combine("GitCommandsTests", "RenameFileTests", "4", "+.testRenamed"));
 
             this.FolderShouldExistAndHaveFile("GitCommandsTests", "RenameFileTests", "5", "-.test");
             this.MoveFile(
-                Path.Combine("GitCommandsTests", "RenameFileTests", "5", "-.test"), 
+                Path.Combine("GitCommandsTests", "RenameFileTests", "5", "-.test"),
                 Path.Combine("GitCommandsTests", "RenameFileTests", "5", "-.testRenamed"));
 
             this.ValidateGitCommand("status");
@@ -303,9 +303,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
 
             // 14cf226119766146b1fa5c5aa4cd0896d05f6b63 is the commit prior to creating (1).txt, it has two different files with
-            // names that start with '(': 
-            // (a).txt 
-            // (z).txt 
+            // names that start with '(':
+            // (a).txt
+            // (z).txt
             this.ValidateGitCommand("checkout 14cf226119766146b1fa5c5aa4cd0896d05f6b63");
             this.DeleteFile("DeleteFileWithNameAheadOfDotAndSwitchCommits", "(a).txt");
             this.ValidateGitCommand("checkout -- DeleteFileWithNameAheadOfDotAndSwitchCommits/(a).txt");
@@ -420,7 +420,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string testFileContents = "0123456789";
             string filename = "MoveFileFromOutsideRepoToInsideRepo.cs";
 
-            // Create the test files in this.Enlistment.EnlistmentRoot as it's outside of src and the control 
+            // Create the test files in this.Enlistment.EnlistmentRoot as it's outside of src and the control
             // repo and is cleaned up when the functional tests run
             string oldFilePath = Path.Combine(this.Enlistment.EnlistmentRoot, filename);
             string controlFilePath = Path.Combine(this.ControlGitRepo.RootPath, filename);
@@ -454,7 +454,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             string filename = "MoveFolderFromOutsideRepoToInsideRepoAndAdd.cs";
             string folderName = "GitCommand_MoveFolderFromOutsideRepoToInsideRepoAndAdd";
 
-            // Create the test folders in this.Enlistment.EnlistmentRoot as it's outside of src and the control 
+            // Create the test folders in this.Enlistment.EnlistmentRoot as it's outside of src and the control
             // repo and is cleaned up when the functional tests run
             string oldFolderPath = Path.Combine(this.Enlistment.EnlistmentRoot, folderName);
             string oldFilePath = Path.Combine(this.Enlistment.EnlistmentRoot, folderName, filename);
@@ -766,7 +766,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetSoftTwice");
 
-            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and 
+            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and
             // the subsequent commit 60d19c87328120d11618ad563c396044a50985b2
             this.ValidateGitCommand("reset --soft 60d19c87328120d11618ad563c396044a50985b2");
             this.ValidateGitCommand("reset --soft 99fc72275f950b0052c8548bbcf83a851f2b4467");
@@ -777,7 +777,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetMixedTwice");
 
-            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and 
+            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and
             // the subsequent commit 60d19c87328120d11618ad563c396044a50985b2
             this.ValidateGitCommand("reset --mixed 60d19c87328120d11618ad563c396044a50985b2");
             this.ValidateGitCommand("reset --mixed 99fc72275f950b0052c8548bbcf83a851f2b4467");
@@ -788,7 +788,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.ValidateGitCommand("checkout -b tests/functional/ResetMixed2Twice");
 
-            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and 
+            // A folder rename occured between 99fc72275f950b0052c8548bbcf83a851f2b4467 and
             // the subsequent commit 60d19c87328120d11618ad563c396044a50985b2
             this.ValidateGitCommand("reset 60d19c87328120d11618ad563c396044a50985b2");
             this.ValidateGitCommand("reset 99fc72275f950b0052c8548bbcf83a851f2b4467");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/HashObjectTests.cs
@@ -9,7 +9,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class HashObjectTests : GitRepoTests
     {
-        public HashObjectTests() 
+        public HashObjectTests()
             : base(enlistmentPerTest: false, validateWorkingTree: false)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/MergeConflictTests.cs
@@ -47,7 +47,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("merge --abort");
             this.FilesShouldMatchCheckoutOfTargetBranch();
         }
-        
+
         [TestCase]
         public void MergeConflict_UsingOurs()
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -39,7 +39,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // command will not report modified and deleted files
             this.RunGitCommand("checkout -b tests/functional/ResetMixedAndCheckoutNewBranch");
             this.FilesShouldMatchCheckoutOfTargetBranch();
-            this.ValidateGitCommand("status");            
+            this.ValidateGitCommand("status");
         }
 
         [TestCase]
@@ -83,7 +83,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
             this.ValidateGitCommand("reset --mixed HEAD~1");
 
-            // This will reset all the files except the files that were added 
+            // This will reset all the files except the files that were added
             // and are untracked to make sure we error out with those using sparse-checkout
             this.ValidateGitCommand("checkout -f");
             this.ValidateGitCommand("checkout " + GitRepoTests.ConflictSourceBranch);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/RmTests.cs
@@ -24,7 +24,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.Enlistment.UnmountGVFS();
             this.Enlistment.GetVirtualPathTo(filePath).ShouldNotExistOnDisk(this.FileSystem);
             this.Enlistment.MountGVFS();
-                    
+
             this.ValidateGitCommand("rm --dry-run " + GitHelpers.ConvertPathToGitFormat(filePath));
             this.FileContentsShouldMatch(filePath);
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -15,7 +15,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.FlakyTest)] 
+        [Category(Categories.MacTODO.FlakyTest)]
         public void MoveFileIntoDotGitDirectory()
         {
             string srcPath = @"Readme.md";
@@ -26,7 +26,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M4)]   
+        [Category(Categories.MacTODO.M4)]
         public void ModifyingAndDeletingRepositoryExcludeFileInvalidatesCache()
         {
             string repositoryExcludeFile = Path.Combine(".git", "info", "exclude");
@@ -52,7 +52,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M4)]  
+        [Category(Categories.MacTODO.M4)]
         public void NewRepositoryExcludeFileInvalidatesCache()
         {
             string repositoryExcludeFileRelativePath = Path.Combine(".git", "info", "exclude");
@@ -73,7 +73,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M4)]  
+        [Category(Categories.MacTODO.M4)]
         public void ModifyingHeadSymbolicRefInvalidatesCache()
         {
             this.ValidateGitCommand("status");
@@ -89,7 +89,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M4)]  
+        [Category(Categories.MacTODO.M4)]
         public void ModifyingHeadRefInvalidatesCache()
         {
             this.ValidateGitCommand("status");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -6,7 +6,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
     [Category(Categories.GitCommands)]
     public class UpdateRefTests : GitRepoTests
     {
-        public UpdateRefTests(bool validateWorkingTree) 
+        public UpdateRefTests(bool validateWorkingTree)
             : base(enlistmentPerTest: true, validateWorkingTree: validateWorkingTree)
         {
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
@@ -88,8 +88,8 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         private void RunServiceCommandAndCheckOutput(string argument, string[] expectedRepoRoots, string[] unexpectedRepoRoots = null)
         {
             GVFSProcess gvfsProcess = new GVFSProcess(
-                GVFSTestConfig.PathToGVFS, 
-                enlistmentRoot: null, 
+                GVFSTestConfig.PathToGVFS,
+                enlistmentRoot: null,
                 localCacheRoot: null);
 
             string result = gvfsProcess.RunServiceVerb(argument);

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -286,7 +286,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         // Override OnTearDownEnlistmentsDeleted rathern than using [TearDown] as the enlistments need to be unmounted before
-        // localCacheParentPath can be deleted (as the SQLite blob sizes database cannot be deleted while GVFS is mounted) 
+        // localCacheParentPath can be deleted (as the SQLite blob sizes database cannot be deleted while GVFS is mounted)
         protected override void OnTearDownEnlistmentsDeleted()
         {
             RepositoryHelpers.DeleteTestDirectory(this.localCacheParentPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/TestResultsHelper.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/TestResultsHelper.cs
@@ -38,7 +38,7 @@ namespace GVFS.FunctionalTests.Tests
                 Console.WriteLine("Unable to read logfile at {0}: {1}", filename, ex.ToString());
             }
         }
-        
+
         public static IEnumerable<string> GetAllFilesInDirectory(string folderName)
         {
             DirectoryInfo directory = new DirectoryInfo(folderName);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -19,13 +19,13 @@ namespace GVFS.FunctionalTests.Tools
         private static readonly string ZeroBackgroundOperations = "Background operations: 0" + Environment.NewLine;
 
         private GVFSProcess gvfsProcess;
-        
+
         private GVFSFunctionalTestEnlistment(string pathToGVFS, string enlistmentRoot, string repoUrl, string commitish, string localCacheRoot = null)
         {
             this.EnlistmentRoot = enlistmentRoot;
             this.RepoUrl = repoUrl;
             this.Commitish = commitish;
-            
+
             if (localCacheRoot == null)
             {
                 if (GVFSTestConfig.NoSharedCache)
@@ -44,7 +44,7 @@ namespace GVFS.FunctionalTests.Tools
             this.LocalCacheRoot = localCacheRoot;
             this.gvfsProcess = new GVFSProcess(pathToGVFS, this.EnlistmentRoot, this.LocalCacheRoot);
         }
-        
+
         public string EnlistmentRoot
         {
             get; private set;
@@ -54,7 +54,7 @@ namespace GVFS.FunctionalTests.Tools
         {
             get; private set;
         }
-        
+
         public string LocalCacheRoot { get; }
 
         public string RepoRoot
@@ -121,18 +121,18 @@ namespace GVFS.FunctionalTests.Tools
             Path.Combine(this.LocalCacheRoot, "mapping.dat").ShouldBeAFile(fileSystem);
 
             HashSet<string> allowedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { 
-                "mapping.dat", 
+            {
+                "mapping.dat",
                 "mapping.dat.lock" // mapping.dat.lock can be present, but doesn't have to be present
             };
 
-            this.LocalCacheRoot.ShouldBeADirectory(fileSystem).WithFiles().ShouldNotContain(f => !allowedFileNames.Contains(f.Name)); 
-                                                                                            
+            this.LocalCacheRoot.ShouldBeADirectory(fileSystem).WithFiles().ShouldNotContain(f => !allowedFileNames.Contains(f.Name));
+
             DirectoryInfo[] directories = this.LocalCacheRoot.ShouldBeADirectory(fileSystem).WithDirectories().ToArray();
             directories.Length.ShouldEqual(
-                1, 
+                1,
                 this.LocalCacheRoot + " is expected to have only one folder. Actual folders: " + string.Join<DirectoryInfo>(",", directories));
-            
+
             return Path.Combine(directories[0].FullName, "gitObjects");
         }
 
@@ -278,7 +278,7 @@ namespace GVFS.FunctionalTests.Tools
                 objectHash.Substring(0, 2),
                 objectHash.Substring(2));
         }
-        
+
         private static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string enlistmentRoot, string commitish, string localCacheRoot, bool skipPrefetch = false)
         {
             GVFSFunctionalTestEnlistment enlistment = new GVFSFunctionalTestEnlistment(

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -94,7 +94,7 @@ namespace GVFS.FunctionalTests.Tools
 
         public static string ReadAllTextFromWriteLockedFile(string filename)
         {
-            // File.ReadAllText and others attempt to open for read and FileShare.None, which always fail on 
+            // File.ReadAllText and others attempt to open for read and FileShare.None, which always fail on
             // the placeholder db and other files that open for write and only share read access
             using (StreamReader reader = new StreamReader(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSServiceProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSServiceProcess.cs
@@ -61,7 +61,7 @@ namespace GVFS.FunctionalTests.Tools
         {
             ServiceController testService = ServiceController.GetServices().SingleOrDefault(service => service.ServiceName == TestServiceName);
             testService.ShouldNotBeNull($"{TestServiceName} does not exist as a service");
-            
+
             using (ServiceController controller = new ServiceController(TestServiceName))
             {
                 controller.Start(new[] { ServiceNameArgument });
@@ -121,7 +121,7 @@ namespace GVFS.FunctionalTests.Tools
             else
             {
                 return Path.Combine(
-                    Properties.Settings.Default.CurrentDirectory, 
+                    Properties.Settings.Default.CurrentDirectory,
                     Properties.Settings.Default.PathToGVFSService);
             }
         }

--- a/GVFS/GVFS.FunctionalTests/Tools/ProjFSFilterInstaller.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ProjFSFilterInstaller.cs
@@ -56,7 +56,7 @@ namespace GVFS.FunctionalTests.Tools
 
         private static void StartService(string serviceName)
         {
-            ProcessResult result = ProcessHelper.Run("sc.exe", $"start {serviceName}");            
+            ProcessResult result = ProcessHelper.Run("sc.exe", $"start {serviceName}");
             Console.WriteLine($"sc start {serviceName} Output: {result.Output}");
             Console.WriteLine($"sc start {serviceName} Errors: {result.Errors}");
             result.ExitCode.ShouldEqual(0, $"Failed to start {serviceName}");
@@ -76,7 +76,7 @@ namespace GVFS.FunctionalTests.Tools
 
         private static void DisableAndRemoveInboxProjFS()
         {
-            ProcessResult disableFeatureResult = CallPowershellCommand("Disable-WindowsOptionalFeature -Online -FeatureName " + OptionalFeatureName + " -Remove");            
+            ProcessResult disableFeatureResult = CallPowershellCommand("Disable-WindowsOptionalFeature -Online -FeatureName " + OptionalFeatureName + " -Remove");
             Console.WriteLine($"Disable ProjfS Output: {disableFeatureResult.Output}");
             Console.WriteLine($"Disable ProjfS Errors: {disableFeatureResult.Errors}");
             disableFeatureResult.ExitCode.ShouldEqual(0, "Error when disabling ProjFS");
@@ -97,7 +97,7 @@ namespace GVFS.FunctionalTests.Tools
         {
             string installPathPrjflt = Path.Combine(PrjfltInfInstallFolder, PrjfltSysName);
             string system32Prjflt = Path.Combine(System32DriversPath, PrjfltSysName);
-            ProcessResult result = ProcessHelper.Run("fc.exe", $"/b \"{installPathPrjflt}\" \"{system32Prjflt}\"");            
+            ProcessResult result = ProcessHelper.Run("fc.exe", $"/b \"{installPathPrjflt}\" \"{system32Prjflt}\"");
             result.ExitCode.ShouldEqual(0, $"fc failed to validate prjflt.sys");
             result.Output.ShouldContain("no differences encountered");
         }

--- a/GVFS/GVFS.GVFlt/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.GVFlt/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.GVFlt")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -105,9 +105,9 @@ namespace GVFS.Hooks
 
         private static void RemindUpgradeAvailable()
         {
-            // The idea is to generate a random number between 0 and 100. To make 
-            // sure that the reminder is displayed only 10% of the times a git 
-            // command is run, check that the random number is between 0 and 10, 
+            // The idea is to generate a random number between 0 and 100. To make
+            // sure that the reminder is displayed only 10% of the times a git
+            // command is run, check that the random number is between 0 and 10,
             // which will have a probability of 10/100 == 10%.
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
@@ -172,7 +172,7 @@ namespace GVFS.Hooks
         }
 
         private static void RunLockRequest(string[] args, bool unattended, LockRequestDelegate requestToRun)
-        { 
+        {
             try
             {
                 if (ShouldLock(args))
@@ -292,7 +292,7 @@ namespace GVFS.Hooks
                     }
                 },
                 gvfsEnlistmentRoot: null,
-                waitingMessage: "Waiting for GVFS to parse index and update placeholder files", 
+                waitingMessage: "Waiting for GVFS to parse index and update placeholder files",
                 spinnerDelay: PostCommandSpinnerDelayMs);
         }
 

--- a/GVFS/GVFS.Hooks/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.Hooks/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.Hooks")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -67,7 +67,7 @@ namespace GVFS.Mount
         {
             this.currentState = MountState.Mounting;
 
-            // We must initialize repo metadata before starting the pipe server so it 
+            // We must initialize repo metadata before starting the pipe server so it
             // can immediately handle status requests
             string error;
             if (!RepoMetadata.TryInitialize(this.tracer, this.enlistment.DotGVFSRoot, out error))
@@ -581,7 +581,7 @@ namespace GVFS.Mount
                 this.maintenanceScheduler.Dispose();
                 this.maintenanceScheduler = null;
             }
-            
+
             if (this.heartbeat != null)
             {
                 this.heartbeat.Stop();

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace GVFS.Mount
 {
     [Verb("mount", HelpText = "Starts the background mount process")]
-    public class InProcessMountVerb 
+    public class InProcessMountVerb
     {
         private TextWriter output;
 
@@ -61,7 +61,7 @@ namespace GVFS.Mount
                 MetaName = "Enlistment Root Path",
                 HelpText = "Full or relative path to the GVFS enlistment root")]
         public string EnlistmentRootPathParameter { get; set; }
-        
+
         public void InitializeDefaultParameterValues()
         {
             this.Verbosity = GVFSConstants.VerbParameters.Mount.DefaultVerbosity;
@@ -77,7 +77,7 @@ namespace GVFS.Mount
             this.ParseEnumArgs(out verbosity, out keywords);
 
             JsonTracer tracer = this.CreateTracer(enlistment, verbosity, keywords);
-            
+
             CacheServerInfo cacheServer = CacheServerResolver.GetCacheServerFromConfig(enlistment);
 
             tracer.WriteStartEvent(

--- a/GVFS/GVFS.Mount/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.Mount/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.Mount")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Platform.Mac/MacFileBasedLock.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileBasedLock.cs
@@ -15,7 +15,7 @@ namespace GVFS.Platform.Mac
             PhysicalFileSystem fileSystem,
             ITracer tracer,
             string lockPath)
-            : base(fileSystem, tracer, lockPath) 
+            : base(fileSystem, tracer, lockPath)
         {
             this.lockFileDescriptor = NativeMethods.InvalidFileDescriptor;
         }
@@ -27,8 +27,8 @@ namespace GVFS.Platform.Mac
                 this.FileSystem.CreateDirectory(Path.GetDirectoryName(this.LockPath));
 
                 this.lockFileDescriptor = NativeMethods.Open(
-                    this.LockPath, 
-                    NativeMethods.OpenCreate | NativeMethods.OpenWriteOnly, 
+                    this.LockPath,
+                    NativeMethods.OpenCreate | NativeMethods.OpenWriteOnly,
                     NativeMethods.FileMode644);
 
                 if (this.lockFileDescriptor == NativeMethods.InvalidFileDescriptor)
@@ -38,7 +38,7 @@ namespace GVFS.Platform.Mac
                     this.Tracer.RelatedWarning(
                         metadata,
                         $"{nameof(MacFileBasedLock)}.{nameof(this.TryAcquireLock)}: Failed to open lock file");
-                    
+
                     return false;
                 }
             }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -168,7 +168,7 @@ namespace GVFS.Platform.Mac
                     fileMode,
                     (UpdateType)updateFlags,
                     out failureCause);
-                
+
                 failureReason = (UpdateFailureReason)failureCause;
                 return new FileSystemResult(ResultToFSResult(result), unchecked((int)result));
             }
@@ -244,7 +244,7 @@ namespace GVFS.Platform.Mac
         }
 
         /// <summary>
-        /// Gets the target of the symbolic link. 
+        /// Gets the target of the symbolic link.
         /// </summary>
         /// <param name="sha">SHA of the loose object containing the target path of the symbolic link</param>
         /// <param name="symLinkTarget">Target path of the symbolic link</param>
@@ -463,7 +463,7 @@ namespace GVFS.Platform.Mac
                     string fileName;
                     bool isPathProjected = this.FileSystemCallbacks.GitIndexProjection.IsPathProjected(relativePath, out fileName, out isFolder);
                     if (isPathProjected)
-                    {                        
+                    {
                         this.FileSystemCallbacks.OnFileConvertedToFull(relativePath);
                     }
                 }
@@ -541,8 +541,8 @@ namespace GVFS.Platform.Mac
                             this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.OnNewFileCreated)}_GitCreatedFolder", metadata);
 
                             // Record this folder as expanded so that GitIndexProjection will re-expand the folder
-                            // when the projection change completes.  
-                            // 
+                            // when the projection change completes.
+                            //
                             // Git creates new folders when there are files that it needs to create.
                             // However, git will only create files that are in ModifiedPaths.dat.  There could
                             // be other files in the projection (that were not created by git) and so VFS must re-expand the
@@ -567,22 +567,22 @@ namespace GVFS.Platform.Mac
                 this.LogUnhandledExceptionAndExit(nameof(this.OnNewFileCreated), metadata);
             }
         }
-        
+
         private void OnFileRenamed(string relativeDestinationPath, bool isDirectory)
         {
             // ProjFS for Mac *could* be updated to provide us with relativeSourcePath as well,
             // but because VFSForGit doesn't need the source path on Mac for correct behavior
             // the relativeSourcePath is left out of the notification to keep the kext simple
             this.OnFileRenamed(
-                relativeSourcePath: string.Empty, 
-                relativeDestinationPath: relativeDestinationPath, 
+                relativeSourcePath: string.Empty,
+                relativeDestinationPath: relativeDestinationPath,
                 isDirectory: isDirectory);
         }
 
         private void OnHardLinkCreated(string relativeNewLinkPath)
         {
             this.OnHardLinkCreated(
-                relativeExistingFilePath: string.Empty, 
+                relativeExistingFilePath: string.Empty,
                 relativeNewLinkPath: relativeNewLinkPath);
         }
 

--- a/GVFS/GVFS.Platform.Mac/ProcessLauncher.cs
+++ b/GVFS/GVFS.Platform.Mac/ProcessLauncher.cs
@@ -55,7 +55,7 @@ namespace GVFS.Platform.Mac
 
         private static unsafe void RunChildProcess(
             ITracer tracer,
-            string programName, 
+            string programName,
             byte** argvPtr = null,
             byte** envpPtr = null)
         {

--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -58,7 +58,7 @@ namespace GVFS.Platform.Windows
         }
 
         /// <summary>
-        /// Advances the enumerator to the next element of the collection (that is being projected).   
+        /// Advances the enumerator to the next element of the collection (that is being projected).
         /// If a filter string is set, MoveNext will advance to the next entry that matches the filter.
         /// </summary>
         /// <returns>

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
@@ -43,7 +43,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                     string workingDirectoryRoot = Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName);
 
                     // Run through the folder placeholders adding to the placeholder list
-                    IEnumerable<PlaceholderListDatabase.PlaceholderData> folderPlaceholderPaths = 
+                    IEnumerable<PlaceholderListDatabase.PlaceholderData> folderPlaceholderPaths =
                         GetFolderPlaceholdersFromDisk(tracer, new PhysicalFileSystem(), workingDirectoryRoot)
                         .Select(x => x.Substring(workingDirectoryRoot.Length + 1))
                         .Select(x => new PlaceholderListDatabase.PlaceholderData(x, GVFSConstants.AllZeroSha));
@@ -101,7 +101,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                         }
                         else if (result != HResult.FileNotFound)
                         {
-                            // FileNotFound is returned for tombstones when the filter is attached to the volume so we want to 
+                            // FileNotFound is returned for tombstones when the filter is attached to the volume so we want to
                             // just skip those folders.  Any other HResults may cause valid folder placeholders not to be written
                             // to the placeholder database so we want to error out on those.
                             throw new InvalidDataException($"Error getting on disk file state. HResult = {result} for {directory}");

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout15to16Upgrade_GitStatusCache.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout15to16Upgrade_GitStatusCache.cs
@@ -6,7 +6,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
     /// <summary>
     /// This is a no-op upgrade step. It is here to prevent users from downgrading to a previous
     /// version of GVFS that is not GitStatusCache aware.
-    /// 
+    ///
     /// This is because GVFS will set git config entries for the location of the git status cache when mounting,
     /// but does not unset them when unmounting (even if it did, it might not reliably unset these values).
     /// If a user downgrades, and they have a status cache file on disk, and git is configured to use the cache,

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout8to9Upgrade_RepoMetadataToJson.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout8to9Upgrade_RepoMetadataToJson.cs
@@ -33,7 +33,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
             return true;
         }
-        
+
         private bool UpdateRepoMetadata(ITracer tracer, string dotGVFSRoot)
         {
             string esentRepoMetadata = Path.Combine(dotGVFSRoot, WindowsDiskLayoutUpgradeData.EsentRepoMetadataName);

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout9to10Upgrade_BackgroundAndPlaceholderListToFileBased.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout9to10Upgrade_BackgroundAndPlaceholderListToFileBased.cs
@@ -36,7 +36,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
             {
                 return false;
             }
-            
+
             if (!this.TryIncrementMajorVersion(tracer, enlistmentRoot))
             {
                 return false;
@@ -92,7 +92,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                     tracer.RelatedError("Placeholder database appears to be from an older version of GVFS and corrupted: " + ex.Message);
                     return false;
                 }
-                
+
                 string backupName;
                 if (this.TryRenameFolderForDelete(tracer, esentPlaceholderFolder, out backupName))
                 {
@@ -142,8 +142,8 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                                 tracer.RelatedInfo("Copying ESENT entry: {0} = {1}", kvp.Key, kvp.Value);
                                 newBackgroundOps.EnqueueAndFlush(
                                     new FileSystemTask(
-                                        (FileSystemTask.OperationType)kvp.Value.Operation, 
-                                        kvp.Value.VirtualPath, 
+                                        (FileSystemTask.OperationType)kvp.Value.Operation,
+                                        kvp.Value.VirtualPath,
                                         kvp.Value.OldVirtualPath));
                             }
                         }
@@ -159,7 +159,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                     tracer.RelatedError("BackgroundOperations appears to be from an older version of GVFS and corrupted: " + ex.Message);
                     return false;
                 }
-                
+
                 string backupName;
                 if (this.TryRenameFolderForDelete(tracer, esentBackgroundOpsFolder, out backupName))
                 {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/WindowsDiskLayoutUpgradeData.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/WindowsDiskLayoutUpgradeData.cs
@@ -15,7 +15,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         {
             get
             {
-                return new DiskLayoutUpgrade[] 
+                return new DiskLayoutUpgrade[]
                 {
                     new DiskLayout7to8Upgrade_NewOperationType(),
                     new DiskLayout8to9Upgrade_RepoMetadataToJson(),

--- a/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
+++ b/GVFS/GVFS.Platform.Windows/ETWTelemetryEventListener.cs
@@ -12,16 +12,16 @@ namespace GVFS.Platform.Windows
     /// <summary>
     /// This class implements optional logging of ETW events, and it is disabled by default.
     /// See the CreateTelemetryListenerIfEnabled method for implementation details.
-    /// 
+    ///
     /// IF the user creates the gvfs.telemetry-id config setting, this class will:
     ///   * Listen for tracer events with the Telemetry keyword
     ///   * Record them as local ETW events
     ///   * Specify the value of the gvfs.telemetry-id config setting as a trait on the ETW events
-    ///   
-    /// In addition, if the gvfs.telemetry-id happens to contain a particular (and unpublished) GUID, 
-    /// Windows will upload those ETW events to its telemetry stream as a background process. This is intended 
+    ///
+    /// In addition, if the gvfs.telemetry-id happens to contain a particular (and unpublished) GUID,
+    /// Windows will upload those ETW events to its telemetry stream as a background process. This is intended
     /// for use only by teams internal to Microsoft who have access to the special GUID.
-    /// 
+    ///
     /// For any other teams who want to collect telemetry, what you will need to do is:
     ///   * Write any arbitrary value to the gvfs.telemetry-id config setting
     ///   * This will cause GVFS to write its telemetry events to local ETW, but nothing will get uploaded
@@ -36,9 +36,9 @@ namespace GVFS.Platform.Windows
         private string mountId;
         private string ikey;
 
-        private ETWTelemetryEventListener(string providerName, string[] traitsList, string enlistmentId, string mountId, string ikey) 
+        private ETWTelemetryEventListener(string providerName, string[] traitsList, string enlistmentId, string mountId, string ikey)
             : base(EventLevel.Verbose, Keywords.Telemetry)
-        {           
+        {
             this.eventSource = new EventSource(providerName, EventSourceSettings.EtwSelfDescribingEventFormat, traitsList);
             this.enlistmentId = enlistmentId;
             this.mountId = mountId;

--- a/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
+++ b/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
@@ -12,7 +12,7 @@ namespace GVFS.Platform.Windows
         {
             FileNotAvailable = unchecked((int)0xC0000467) | FacilityNtBit,       // STATUS_FILE_NOT_AVAILABLE
             FileClosed = unchecked((int)0xC0000128) | FacilityNtBit,             // STATUS_FILE_CLOSED
-            IoReparseTagNotHandled = unchecked((int)0xC0000279) | FacilityNtBit, // STATUS_IO_REPARSE_TAG_NOT_HANDLED 
+            IoReparseTagNotHandled = unchecked((int)0xC0000279) | FacilityNtBit, // STATUS_IO_REPARSE_TAG_NOT_HANDLED
             DeviceNotReady = unchecked((int)0xC00000A3L) | FacilityNtBit,        // STATUS_DEVICE_NOT_READY
         }
 

--- a/GVFS/GVFS.Platform.Windows/PatternMatcher.cs
+++ b/GVFS/GVFS.Platform.Windows/PatternMatcher.cs
@@ -158,7 +158,7 @@ namespace GVFS.Platform.Windows
             }
 
             // If this class is ever exposed for generic use,
-            // we need to make sure that name doesn't contain wildcards. Currently 
+            // we need to make sure that name doesn't contain wildcards. Currently
             // the only component that calls this method is FileSystemWatcher and
             // it will never pass a name that contains a wildcard.
 

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -47,8 +47,8 @@ namespace GVFS.Platform.Windows
 
         public bool EnumerationExpandsDirectories { get; } = false;
 
-        public string LogsFolderPath 
-        { 
+        public string LogsFolderPath
+        {
             get
             {
                 return Path.Combine(Environment.ExpandEnvironmentVariables(System32LogFilesRoot), ProjFSFilter.ServiceName);
@@ -105,9 +105,9 @@ namespace GVFS.Platform.Windows
         }
 
         public static bool IsServiceRunningAndInstalled(
-            ITracer tracer, 
-            PhysicalFileSystem fileSystem, 
-            out bool isServiceInstalled, 
+            ITracer tracer,
+            PhysicalFileSystem fileSystem,
+            out bool isServiceInstalled,
             out bool isDriverFileInstalled,
             out bool isNativeLibInstalled)
         {
@@ -137,7 +137,7 @@ namespace GVFS.Platform.Windows
 
             return isRunning;
         }
-        
+
         public static bool TryStartService(ITracer tracer)
         {
             try
@@ -176,7 +176,7 @@ namespace GVFS.Platform.Windows
                 {
                     tracer.RelatedError($"{nameof(IsAutoLoggerEnabled)}: Failed to find current Start value setting");
                     return false;
-                }                
+                }
             }
             catch (UnauthorizedAccessException e)
             {
@@ -232,7 +232,7 @@ namespace GVFS.Platform.Windows
         }
 
         public static bool TryEnableOrInstallDriver(
-            ITracer tracer, 
+            ITracer tracer,
             PhysicalFileSystem fileSystem,
             out uint windowsBuildNumber,
             out bool isInboxProjFSFinalAPI,
@@ -295,7 +295,7 @@ namespace GVFS.Platform.Windows
         {
             warning = null;
             error = null;
-           
+
             string pathRoot = Path.GetPathRoot(normalizedEnlistmentRootPath);
             DriveInfo rootDriveInfo = DriveInfo.GetDrives().FirstOrDefault(x => x.Name == pathRoot);
             string requiredFormat = "NTFS";
@@ -397,7 +397,7 @@ namespace GVFS.Platform.Windows
                 tracer.RelatedInfo($"{nameof(TryGetIsInboxProjFSFinalAPI)}: Build number = {windowsBuildNumber}");
             }
             catch (Win32Exception e)
-            {                
+            {
                 tracer.RelatedError(CreateEventMetadata(e), $"{nameof(TryGetIsInboxProjFSFinalAPI)}: Exception while trying to get Windows build number");
                 return false;
             }
@@ -415,7 +415,7 @@ namespace GVFS.Platform.Windows
             if (!TryCopyNativeLibToAppDirectory(tracer, fileSystem, gvfsAppDirectory))
             {
                 return false;
-            }            
+            }
 
             ProcessResult result = ProcessHelper.Run("RUNDLL32.EXE", $"SETUPAPI.DLL,InstallHinfSection DefaultInstall 128 {gvfsAppDirectory}\\Filter\\prjflt.inf");
             if (result.ExitCode == 0)
@@ -514,7 +514,7 @@ namespace GVFS.Platform.Windows
         private static void GetNativeLibPaths(string gvfsAppDirectory, out string installFilePath, out string appFilePath)
         {
             installFilePath = Path.Combine(gvfsAppDirectory, "ProjFS", ProjFSNativeLibFileName);
-            appFilePath = Path.Combine(gvfsAppDirectory, ProjFSNativeLibFileName);            
+            appFilePath = Path.Combine(gvfsAppDirectory, ProjFSNativeLibFileName);
         }
 
         private static bool TryEnableProjFSOptionalFeature(ITracer tracer, PhysicalFileSystem fileSystem, out bool isProjFSFeatureAvailable)
@@ -534,16 +534,16 @@ namespace GVFS.Platform.Windows
                     isProjFSFeatureAvailable = false;
                     break;
 
-                case (int)ProjFSInboxStatus.Enabled:                    
+                case (int)ProjFSInboxStatus.Enabled:
                     tracer.RelatedEvent(
-                        EventLevel.Informational, 
-                        $"{nameof(TryEnableProjFSOptionalFeature)}_ClientProjFSAlreadyEnabled", 
-                        metadata, 
+                        EventLevel.Informational,
+                        $"{nameof(TryEnableProjFSOptionalFeature)}_ClientProjFSAlreadyEnabled",
+                        metadata,
                         Keywords.Network);
                     projFSEnabled = true;
                     break;
 
-                case (int)ProjFSInboxStatus.Disabled:                    
+                case (int)ProjFSInboxStatus.Disabled:
                     ProcessResult enableOptionalFeatureResult = CallPowershellCommand("try {Enable-WindowsOptionalFeature -Online -FeatureName " + OptionalFeatureName + " -NoRestart}catch{exit 1}");
                     metadata.Add("enableOptionalFeatureResult.Output", enableOptionalFeatureResult.Output.Trim().Replace("\r\n", ","));
                     metadata.Add("enableOptionalFeatureResult.Errors", enableOptionalFeatureResult.Errors);

--- a/GVFS/GVFS.Platform.Windows/WindowsFileBasedLock.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileBasedLock.cs
@@ -25,7 +25,7 @@ namespace GVFS.Platform.Windows
         /// <param name="lockPath">Path to lock file</param>
         /// <param name="signature">Text to write in lock file</param>
         /// <remarks>
-        /// GVFS keeps an exclusive write handle open to lock files that it creates with FileBasedLock.  This means that 
+        /// GVFS keeps an exclusive write handle open to lock files that it creates with FileBasedLock.  This means that
         /// FileBasedLock still ensures exclusivity when the lock file is used only for coordination between multiple GVFS processes.
         /// </remarks>
         public WindowsFileBasedLock(

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.Shared.cs
@@ -30,7 +30,7 @@ namespace GVFS.Platform.Windows
 
                 normalizedPath = NativeMethods.GetFinalPathName(parentPath);
 
-                // normalizedPath now consists of all parts of the path currently on disk, re-add any parts of the path that were popped off 
+                // normalizedPath now consists of all parts of the path currently on disk, re-add any parts of the path that were popped off
                 while (removedPathParts.Count > 0)
                 {
                     normalizedPath = Path.Combine(normalizedPath, removedPathParts.Pop());

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -32,16 +32,16 @@ namespace GVFS.Platform.Windows
         private IVirtualizationInstance virtualizationInstance;
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations;
         private ConcurrentDictionary<int, CancellationTokenSource> activeCommands;
-       
+
         public WindowsFileSystemVirtualizer(GVFSContext context, GVFSGitObjects gitObjects)
             : this(
-                  context, 
+                  context,
                   gitObjects,
                   virtualizationInstance: null,
                   numWorkerThreads: FileSystemVirtualizer.DefaultNumWorkerThreads)
         {
         }
-        
+
         public WindowsFileSystemVirtualizer(
             GVFSContext context,
             GVFSGitObjects gitObjects,
@@ -218,7 +218,7 @@ namespace GVFS.Platform.Windows
                 new NotificationMapping(Notifications.FilesAndFoldersInRefsHeads, GVFSConstants.DotGit.Refs.Heads.Root),
             };
 
-            // We currently use twice as many threads as connections to allow for 
+            // We currently use twice as many threads as connections to allow for
             // non-network operations to possibly succeed despite the connection limit
             HResult result = this.virtualizationInstance.StartVirtualizationInstance(
                 this.Context.Enlistment.WorkingDirectoryRoot,
@@ -304,7 +304,7 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        // TODO: Need ProjFS 13150199 to be fixed so that GVFS doesn't leak memory if the enumeration cancelled.  
+        // TODO: Need ProjFS 13150199 to be fixed so that GVFS doesn't leak memory if the enumeration cancelled.
         // Currently EndDirectoryEnumerationHandler must be called to remove the ActiveEnumeration from this.activeEnumerations
         private HResult StartDirectoryEnumerationHandler(int commandId, Guid enumerationId, string virtualPath)
         {
@@ -326,7 +326,7 @@ namespace GVFS.Platform.Windows
                     if (!this.activeEnumerations.TryAdd(enumerationId, activeEnumeration))
                     {
                         this.Context.Tracer.RelatedError(
-                            this.CreateEventMetadata(enumerationId, virtualPath), 
+                            this.CreateEventMetadata(enumerationId, virtualPath),
                             nameof(this.StartDirectoryEnumerationHandler) + ": Failed to add enumeration ID to active collection");
 
                         return HResult.InternalError;
@@ -354,7 +354,7 @@ namespace GVFS.Platform.Windows
 
                 Exception e;
                 if (!this.TryScheduleFileOrNetworkRequest(startDirectoryEnumerationHandler, out e))
-                { 
+                {
                     EventMetadata metadata = this.CreateEventMetadata(virtualPath, e);
                     metadata.Add("commandId", commandId);
                     metadata.Add(TracingConstants.MessageKey.WarningMessage, nameof(this.StartDirectoryEnumerationHandler) + ": Failed to schedule async handler");
@@ -375,11 +375,11 @@ namespace GVFS.Platform.Windows
             return HResult.Pending;
         }
 
-        private void StartDirectoryEnumerationAsyncHandler(            
+        private void StartDirectoryEnumerationAsyncHandler(
             CancellationToken cancellationToken,
             BlobSizes.BlobSizesConnection blobSizesConnection,
             int commandId,
-            Guid enumerationId, 
+            Guid enumerationId,
             string virtualPath)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -395,7 +395,7 @@ namespace GVFS.Platform.Windows
                 if (!this.activeEnumerations.TryAdd(enumerationId, activeEnumeration))
                 {
                     this.Context.Tracer.RelatedError(
-                        this.CreateEventMetadata(enumerationId, virtualPath), 
+                        this.CreateEventMetadata(enumerationId, virtualPath),
                         nameof(this.StartDirectoryEnumerationAsyncHandler) + ": Failed to add enumeration ID to active collection");
 
                     result = HResult.InternalError;
@@ -446,8 +446,8 @@ namespace GVFS.Platform.Windows
 
                 ActiveEnumeration activeEnumeration;
                 bool activeEnumerationsUpdated = this.activeEnumerations.TryRemove(enumerationId, out activeEnumeration);
-                metadata.Add("activeEnumerationsUpdated", activeEnumerationsUpdated);                
-                this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}_CommandAlreadyCanceled", metadata);                
+                metadata.Add("activeEnumerationsUpdated", activeEnumerationsUpdated);
+                this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}_CommandAlreadyCanceled", metadata);
             }
         }
 
@@ -459,12 +459,12 @@ namespace GVFS.Platform.Windows
                 if (!this.activeEnumerations.TryRemove(enumerationId, out activeEnumeration))
                 {
                     this.Context.Tracer.RelatedWarning(
-                        this.CreateEventMetadata(enumerationId), 
-                        nameof(this.EndDirectoryEnumerationHandler) + ": Failed to remove enumeration ID from active collection", 
+                        this.CreateEventMetadata(enumerationId),
+                        nameof(this.EndDirectoryEnumerationHandler) + ": Failed to remove enumeration ID from active collection",
                         Keywords.Telemetry);
 
                     return HResult.InternalError;
-                }                
+                }
             }
             catch (Exception e)
             {
@@ -553,7 +553,7 @@ namespace GVFS.Platform.Windows
             catch (Win32Exception e)
             {
                 this.Context.Tracer.RelatedWarning(
-                    this.CreateEventMetadata(enumerationId, relativePath: null, exception: e), 
+                    this.CreateEventMetadata(enumerationId, relativePath: null, exception: e),
                     nameof(this.GetDirectoryEnumerationHandler) + " caught Win32Exception");
 
                 return HResultExtensions.HResultFromWin32(e.NativeErrorCode);
@@ -749,7 +749,7 @@ namespace GVFS.Platform.Windows
                 ProjectedFileInfo fileInfo;
                 string parentFolderPath;
                 try
-                {                    
+                {
                     fileInfo = this.FileSystemCallbacks.GitIndexProjection.GetProjectedFileInfo(cancellationToken, blobSizesConnection, virtualPath, out parentFolderPath);
                     if (fileInfo == null)
                     {
@@ -762,8 +762,8 @@ namespace GVFS.Platform.Windows
                     EventMetadata metadata = this.CreateEventMetadata(virtualPath);
                     metadata.Add(TracingConstants.MessageKey.InfoMessage, nameof(this.GetPlaceholderInformationAsyncHandler) + ": Operation cancelled");
                     this.Context.Tracer.RelatedEvent(
-                        EventLevel.Informational, 
-                        $"{nameof(this.GetPlaceholderInformationAsyncHandler)}_{nameof(this.FileSystemCallbacks.GitIndexProjection.GetProjectedFileInfo)}_Cancelled", 
+                        EventLevel.Informational,
+                        $"{nameof(this.GetPlaceholderInformationAsyncHandler)}_{nameof(this.FileSystemCallbacks.GitIndexProjection.GetProjectedFileInfo)}_Cancelled",
                         metadata);
                     return;
                 }
@@ -868,8 +868,8 @@ namespace GVFS.Platform.Windows
             long byteOffset,
             uint length,
             Guid streamGuid,
-            byte[] contentId, 
-            byte[] providerId,            
+            byte[] contentId,
+            byte[] providerId,
             uint triggeringProcessId,
             string triggeringProcessImageFileName)
         {
@@ -1045,7 +1045,7 @@ namespace GVFS.Platform.Windows
 
                                         case HResult.FileNotFound:
                                             // WriteFile may return STATUS_OBJECT_NAME_NOT_FOUND if the stream guid provided is not valid (doesn’t exist in the stream table).
-                                            // For each file expansion, ProjFS creates a new get stream session with a new stream guid, the session starts at the beginning of the 
+                                            // For each file expansion, ProjFS creates a new get stream session with a new stream guid, the session starts at the beginning of the
                                             // file expansion, and ends after the GetFileStream command returns or times out.
                                             //
                                             // If we hit this in GVFS, the most common explanation is that we're calling WriteFile after the ProjFS thread waiting on the respose
@@ -1081,7 +1081,7 @@ namespace GVFS.Platform.Windows
             {
                 requestMetadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.GetFileStreamHandlerAsyncHandler)}: Operation cancelled");
                 this.Context.Tracer.RelatedEvent(
-                    EventLevel.Informational, 
+                    EventLevel.Informational,
                     nameof(this.GetFileStreamHandlerAsyncHandler) + "_OperationCancelled",
                     requestMetadata);
 
@@ -1124,10 +1124,10 @@ namespace GVFS.Platform.Windows
                         {
                             string directoryPath = Path.Combine(this.Context.Enlistment.WorkingDirectoryRoot, virtualPath);
                             HResult hr = this.virtualizationInstance.ConvertDirectoryToPlaceholder(
-                                directoryPath, 
-                                FolderContentId, 
+                                directoryPath,
+                                FolderContentId,
                                 PlaceholderVersionId);
-                            
+
                             if (hr == HResult.Ok)
                             {
                                 this.FileSystemCallbacks.OnPlaceholderFolderCreated(virtualPath);
@@ -1267,7 +1267,7 @@ namespace GVFS.Platform.Windows
         }
 
         private void NotifyFileHandleClosedFileModifiedOrDeletedHandler(
-            string virtualPath, 
+            string virtualPath,
             bool isDirectory,
             bool isFileModified,
             bool isFileDeleted)
@@ -1355,7 +1355,7 @@ namespace GVFS.Platform.Windows
                     }
                     catch (AggregateException e)
                     {
-                        // An aggregate exception containing all the exceptions thrown by 
+                        // An aggregate exception containing all the exceptions thrown by
                         // the registered callbacks on the associated CancellationToken
 
                         foreach (Exception innerException in e.Flatten().InnerExceptions)
@@ -1401,7 +1401,7 @@ namespace GVFS.Platform.Windows
                 NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileModified;
 
-            public const NotificationType LogsHeadFile = 
+            public const NotificationType LogsHeadFile =
                 NotificationType.FileRenamed |
                 NotificationType.HardlinkCreated |
                 NotificationType.FileHandleClosedFileModified;

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -25,7 +25,7 @@ namespace GVFS.Platform.Windows
 
         public WindowsPlatform()
             : base(
-                executableExtension: ".exe", 
+                executableExtension: ".exe",
                 installerExtension: ".exe",
                 underConstruction: new UnderConstructionFlags(requiresDeprecatedGitHooksLoader: true))
         {
@@ -85,7 +85,7 @@ namespace GVFS.Platform.Windows
         public override void InitializeEnlistmentACLs(string enlistmentPath)
         {
             // The following permissions are typically present on deskop and missing on Server
-            //                  
+            //
             //   ACCESS_ALLOWED_ACE_TYPE: NT AUTHORITY\Authenticated Users
             //          [OBJECT_INHERIT_ACE]
             //          [CONTAINER_INHERIT_ACE]
@@ -248,7 +248,7 @@ namespace GVFS.Platform.Windows
 
             string gitHooksloaderPath = Path.Combine(executingDirectory, GVFSConstants.DotGit.Hooks.LoaderExecutable);
             if (!HooksInstaller.TryHooksInstallationAction(
-                () => HooksInstaller.CopyHook(context, gitHooksloaderPath, commandHookPath + GVFSPlatform.Instance.Constants.ExecutableExtension), 
+                () => HooksInstaller.CopyHook(context, gitHooksloaderPath, commandHookPath + GVFSPlatform.Instance.Constants.ExecutableExtension),
                 out errorMessage))
             {
                 errorMessage = "Failed to copy " + GVFSConstants.DotGit.Hooks.LoaderExecutable + " to " + commandHookPath + GVFSPlatform.Instance.Constants.ExecutableExtension + "\n" + errorMessage;
@@ -256,7 +256,7 @@ namespace GVFS.Platform.Windows
             }
 
             if (!HooksInstaller.TryHooksInstallationAction(
-                () => WindowsGitHooksInstaller.CreateHookCommandConfig(context, hookName, commandHookPath), 
+                () => WindowsGitHooksInstaller.CreateHookCommandConfig(context, hookName, commandHookPath),
                 out errorMessage))
             {
                 errorMessage = "Failed to create " + commandHookPath + GVFSConstants.GitConfig.HooksExtension + "\n" + errorMessage;

--- a/GVFS/GVFS.Service.UI/Program.cs
+++ b/GVFS/GVFS.Service.UI/Program.cs
@@ -19,12 +19,12 @@ namespace GVFS.Service.UI
         private const string ServiceAppId = "GVFS";
 
         private readonly ITracer tracer;
-        
+
         public GVFSServiceUI(ITracer tracer)
         {
             this.tracer = tracer;
         }
-        
+
         public static void Main(string[] args)
         {
             GVFSPlatformLoader.Initialize();
@@ -35,7 +35,7 @@ namespace GVFS.Service.UI
                     Environment.GetEnvironmentVariable("LocalAppData"),
                     GVFSConstants.Service.UIName,
                     "serviceUI.log");
-                
+
                 tracer.AddLogFileEventListener(logLocation, EventLevel.Informational, Keywords.Any);
                 GVFSServiceUI process = new GVFSServiceUI(tracer);
                 process.Start(args);
@@ -60,7 +60,7 @@ namespace GVFS.Service.UI
                 this.tracer.RelatedInfo("{0} stop detected -- exiting UI.", GVFSConstants.Service.ServiceName);
             }
         }
-        
+
         private void HandleRequest(ITracer tracer, string request, NamedPipeServer.Connection connection)
         {
             try

--- a/GVFS/GVFS.Service.UI/XmlList.cs
+++ b/GVFS/GVFS.Service.UI/XmlList.cs
@@ -17,7 +17,7 @@ namespace GVFS.Service.UI
         {
             throw new NotImplementedException();
         }
-        
+
         public void WriteXml(XmlWriter writer)
         {
             XmlSerializerNamespaces ns = new XmlSerializerNamespaces();

--- a/GVFS/GVFS.Service/Configuration.cs
+++ b/GVFS/GVFS.Service/Configuration.cs
@@ -7,7 +7,7 @@ namespace GVFS.Service
     {
         private static Configuration instance = new Configuration();
         private static string assemblyPath = null;
-        
+
         private Configuration()
         {
             this.GVFSLocation = Path.Combine(AssemblyPath, GVFSPlatform.Instance.Constants.GVFSExecutableName);

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -205,7 +205,7 @@ namespace GVFS.Service
             this.serviceThread = new Thread(this.Run);
 
             this.serviceThread.Start();
-        }        
+        }
 
         private void HandleRequest(ITracer tracer, string request, NamedPipeServer.Connection connection)
         {
@@ -290,7 +290,7 @@ namespace GVFS.Service
         /// <summary>
         /// To work around a behavior in ProjFS where notification masks on files that have been opened in virtualization instance are not invalidated
         /// when the virtualization instance is restarted, GVFS waits until after there has been a reboot before enabling the GitStatusCache.
-        /// GVFS.Service signals that there has been a reboot since installing a version of GVFS that supports the GitStatusCache via 
+        /// GVFS.Service signals that there has been a reboot since installing a version of GVFS that supports the GitStatusCache via
         /// the existence of the file "EnableGitStatusCacheToken.dat" in {CommonApplicationData}\GVFS\GVFS.Service
         /// (i.e. ProgramData\GVFS\GVFS.Service\EnableGitStatusCacheToken.dat on Windows).
         /// </summary>
@@ -351,8 +351,8 @@ namespace GVFS.Service
         private void EnableAccessToAuthenticatedUsers(string rootDirectory)
         {
             // GVFS Config is written to a temporary file and then renamed to its final destination.
-            // For this rename operation to succeed, user needs to have delete permission on the 
-            // destination file, in case it is pre-existing. If the pre-existing file was created 
+            // For this rename operation to succeed, user needs to have delete permission on the
+            // destination file, in case it is pre-existing. If the pre-existing file was created
             // by a different user, then the delete will fail.
             // Reference: https://stackoverflow.com/questions/22107812/privileges-owner-issue-when-writing-in-c-programdata
             // This work around allows safe write to succeed in C:\ProgramData directory.

--- a/GVFS/GVFS.Service/Handlers/NotificationHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/NotificationHandler.cs
@@ -8,7 +8,7 @@ namespace GVFS.Service.Handlers
 {
     public class NotificationHandler
     {
-        // NotificationHandler uses a singleton so in the future, we can create callback actions 
+        // NotificationHandler uses a singleton so in the future, we can create callback actions
         // from responses sent by GVFS.Service.UI when a user clicks on a notification.
         private static NotificationHandler instance = new NotificationHandler();
 

--- a/GVFS/GVFS.Service/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.Service/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.Service")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.Service/RepoRegistration.cs
+++ b/GVFS/GVFS.Service/RepoRegistration.cs
@@ -31,10 +31,10 @@ namespace GVFS.Service
 
         public override string ToString()
         {
-            return 
+            return
                 string.Format(
-                    "({0} - {1}) {2}", 
-                    this.IsActive ? "Active" : "Inactive", 
+                    "({0} - {1}) {2}",
+                    this.IsActive ? "Active" : "Inactive",
                     this.OwnerSID,
                     this.EnlistmentRoot);
         }

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -243,7 +243,7 @@ namespace GVFS.Service
                                         metadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.ReadRegistry)}: Mapping registered enlistment root to final path");
                                         this.tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.ReadRegistry)}_NormalizedPathMapping", metadata);
                                     }
-                                }                                    
+                                }
                                 else
                                 {
                                     EventMetadata metadata = new EventMetadata();

--- a/GVFS/GVFS.Tests/NUnitRunner.cs
+++ b/GVFS/GVFS.Tests/NUnitRunner.cs
@@ -22,7 +22,7 @@ namespace GVFS.Tests
             {
                 return null;
             }
-            
+
             this.args.Remove(match);
             return match.Substring(arg.Length + 1);
         }

--- a/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
+++ b/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
@@ -66,7 +66,7 @@ namespace GVFS.Tests.Should
         public static IEnumerable<T> ShouldContain<T>(this IEnumerable<T> group, IEnumerable<T> expectedValues, Func<T, T, bool> predicate)
         {
             List<T> groupList = new List<T>(group);
-            
+
             foreach (T expectedValue in expectedValues)
             {
                 Assert.IsTrue(groupList.Any(item => predicate(item, expectedValue)));

--- a/GVFS/GVFS.UnitTests.Windows/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS.UnitTests.Windows")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -27,7 +27,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             RemountRepos = 0x20,
             IsServiceInstalledAndNotRunning = 0x40,
         }
-        
+
         public void SetReturnFalseOnCheck(FailOnCheckType prerunCheck)
         {
             this.failOnCheck |= prerunCheck;
@@ -71,7 +71,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         {
             return this.FakedResultOfCheck(FailOnCheckType.UnattendedMode);
         }
-        
+
         protected override bool IsBlockingProcessRunning(out HashSet<string> processes)
         {
             processes = new HashSet<string>();
@@ -87,7 +87,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         }
 
         protected override bool TryRunGVFSWithArgs(string args, out string error)
-        {            
+        {
             if (string.CompareOrdinal(args, "service --unmount-all") == 0)
             {
                 bool result = this.FakedResultOfCheck(FailOnCheckType.UnMountRepos);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProductUpgrader.cs
@@ -137,7 +137,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             {
                 validAsset = false;
             }
-            
+
             if (validAsset)
             {
                 string fakeDownloadDirectory = @"C:\ProgramData\GVFS\GVFS.Upgrade\Downloads";

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
@@ -121,15 +121,15 @@ namespace GVFS.UnitTests.Windows.Mock
         }
 
         public HResult WritePlaceholderInformation(
-            string relativePath, 
-            DateTime creationTime, 
-            DateTime lastAccessTime, 
-            DateTime lastWriteTime, 
-            DateTime changeTime, 
-            uint fileAttributes, 
-            long endOfFile, 
-            bool isDirectory, 
-            byte[] contentId, 
+            string relativePath,
+            DateTime creationTime,
+            DateTime lastAccessTime,
+            DateTime lastWriteTime,
+            DateTime changeTime,
+            uint fileAttributes,
+            long endOfFile,
+            bool isDirectory,
+            byte[] contentId,
             byte[] epochId)
         {
             this.CreatedPlaceholders.Add(relativePath);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -26,7 +26,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.Output = new MockTextWriter();
             this.PrerunChecker = new MockInstallerPrerunChecker(this.Tracer);
             this.Upgrader = new MockProductUpgrader(LocalGVFSVersion, this.Tracer);
-     
+
             this.PrerunChecker.Reset();
             this.Upgrader.PretendNewReleaseAvailableAtRemote(
                 upgradeVersion: NewerThanLocalVersion,

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
@@ -60,7 +60,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             using (WindowsFileSystemVirtualizer virtualizer = new WindowsFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects, mockVirtualization, numWorkThreads))
             {
                 mockVirtualization.NegativePathCacheCount = InitialNegativePathCacheCount;
-                
+
                 uint totalEntryCount;
                 virtualizer.ClearNegativePathCache(out totalEntryCount).ShouldEqual(new FileSystemResult(FSResult.Ok, (int)HResult.Ok));
                 totalEntryCount.ShouldEqual(InitialNegativePathCacheCount);
@@ -103,7 +103,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (WindowsFileSystemVirtualizer virtualizer = new WindowsFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects, mockVirtualization, numWorkThreads))
-            { 
+            {
                 UpdateFailureReason failureReason = UpdateFailureReason.NoFailure;
 
                 mockVirtualization.UpdatePlaceholderIfNeededResult = HResult.Ok;
@@ -364,7 +364,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
                     gitIndexProjection.UnblockGetProjectedFileInfo();
 
                     // Cancelling in the middle of GetPlaceholderInformation still allows it to create placeholders when the cancellation does not
-                    // interrupt network requests                
+                    // interrupt network requests
                     mockVirtualization.WaitForPlaceholderCreate();
                     gitIndexProjection.WaitForPlaceholderCreate();
                     mockVirtualization.CreatedPlaceholders.ShouldContain(entry => entry == "test.txt");

--- a/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
+++ b/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
@@ -20,8 +20,8 @@ namespace GVFS.UnitTests.CommandLine
         {
             Assert.Throws<HooksInstaller.HooksConfigurationException>(
                 () => HooksInstaller.MergeHooksData(
-                    new string[] { "first", GVFSPlatform.Instance.Constants.GVFSHooksExecutableName }, 
-                    Filename, 
+                    new string[] { "first", GVFSPlatform.Instance.Constants.GVFSHooksExecutableName },
+                    Filename,
                     GVFSConstants.DotGit.Hooks.PreCommandHookName));
         }
 

--- a/GVFS/GVFS.UnitTests/Common/BackgroundTaskQueueTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/BackgroundTaskQueueTests.cs
@@ -24,7 +24,7 @@ namespace GVFS.UnitTests.Common
 
         private static readonly FileSystemTask Item1Payload = new FileSystemTask(FileSystemTask.OperationType.Invalid, "mock:\\VirtualPath", NonAsciiString);
         private static readonly FileSystemTask Item2Payload = new FileSystemTask(FileSystemTask.OperationType.OnFileCreated, "mock:\\VirtualPath2", "mock:\\OldVirtualPath2");
-        
+
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ReturnsFalseWhenOpenFails()
@@ -63,7 +63,7 @@ namespace GVFS.UnitTests.Common
             FileSystemTaskQueue dut = CreateFileBasedQueue(fs, string.Empty);
 
             dut.EnqueueAndFlush(Item1Payload);
-            
+
             fs.File.ReadAsString().ShouldEqual(Item1EntryText);
         }
 
@@ -83,7 +83,7 @@ namespace GVFS.UnitTests.Common
         {
             MockFileSystem fs = new MockFileSystem();
             FileSystemTaskQueue dut = CreateFileBasedQueue(fs, CorruptEntryText);
-            
+
             fs.File.ReadAsString().ShouldEqual(Item1EntryText);
             dut.Count.ShouldEqual(1);
         }
@@ -95,7 +95,7 @@ namespace GVFS.UnitTests.Common
 
             MockFileSystem fs = new MockFileSystem();
             FileSystemTaskQueue dut = CreateFileBasedQueue(fs, Item1EntryText);
-            
+
             // Add a second entry to keep FileBasedQueue from setting the stream length to 0
             dut.EnqueueAndFlush(Item2Payload);
 
@@ -123,7 +123,7 @@ namespace GVFS.UnitTests.Common
             fs.File.TruncateWrites = true;
 
             Assert.Throws<FileBasedCollectionException>(() => dut.EnqueueAndFlush(Item2Payload));
-            
+
             fs.File.TruncateWrites = false;
             fs.File.ReadAt(fs.File.Length - 2, 2).ShouldNotEqual("\r\n", "Bad Test: The file is supposed to be corrupt.");
 
@@ -156,7 +156,7 @@ namespace GVFS.UnitTests.Common
 
             public string ExpectedPath { get; set; }
             public ReusableMemoryStream File { get; set; }
-            
+
             public override void CreateDirectory(string path)
             {
             }

--- a/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
@@ -195,7 +195,7 @@ namespace GVFS.UnitTests.Common
         {
             MockGitProcess gitProcess = new MockGitProcess();
             gitProcess.SetExpectedCommandResult(
-                "config --local gvfs.cache-server", 
+                "config --local gvfs.cache-server",
                 () => new GitProcess.Result(newConfigValue ?? string.Empty, string.Empty, newConfigValue != null ? GitProcess.Result.SuccessCode : GitProcess.Result.GenericFailureCode));
             gitProcess.SetExpectedCommandResult(
                 "config gvfs.mock:..repourl.cache-server-url",

--- a/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
@@ -57,7 +57,7 @@ namespace GVFS.UnitTests.Common
             FileBasedDictionaryFileSystem fs = new FileBasedDictionaryFileSystem();
             FileBasedDictionary<string, string> dut = CreateFileBasedDictionary(fs, string.Empty);
             dut.SetValuesAndFlush(
-                new[] 
+                new[]
                 {
                     new KeyValuePair<string, string>(TestKey, TestValue),
                     new KeyValuePair<string, string>(TestKey2, TestValue2),
@@ -92,7 +92,7 @@ namespace GVFS.UnitTests.Common
             FileBasedDictionary<string, string> dut = CreateFileBasedDictionary(fs, string.Empty);
 
             dut.SetValuesAndFlush(
-                new[] 
+                new[]
                 {
                     new KeyValuePair<string, string>(TestKey, TestValue),
                     new KeyValuePair<string, string>(TestKey2, TestValue2),
@@ -156,7 +156,7 @@ namespace GVFS.UnitTests.Common
             FileBasedDictionaryFileSystem fs = new FileBasedDictionaryFileSystem(
                 openFileStreamFailurePath: null,
                 maxOpenFileStreamFailures: 0,
-                fileExistsFailurePath: MockEntryFileName + ".tmp", 
+                fileExistsFailurePath: MockEntryFileName + ".tmp",
                 maxFileExistsFailures: 5,
                 maxMoveAndOverwriteFileFailures: 0);
 
@@ -245,14 +245,14 @@ namespace GVFS.UnitTests.Common
             dut.ShouldNotBeNull();
 
             // FileBasedDictionary should only open a file stream to the non-tmp file when being created.  At all other times it should
-            // write to a tmp file and overwrite the non-tmp file  
+            // write to a tmp file and overwrite the non-tmp file
             fs.ExpectedOpenFileStreams.Remove(MockEntryFileName);
 
             return dut;
         }
 
         private void FileBasedDictionaryFileSystemShouldContain(
-            FileBasedDictionaryFileSystem fs, 
+            FileBasedDictionaryFileSystem fs,
             IList<string> expectedEntries)
         {
             string delimiter = "\r\n";
@@ -295,7 +295,7 @@ namespace GVFS.UnitTests.Common
             public FileBasedDictionaryFileSystem(
                 string openFileStreamFailurePath,
                 int maxOpenFileStreamFailures,
-                string fileExistsFailurePath, 
+                string fileExistsFailurePath,
                 int maxFileExistsFailures,
                 int maxMoveAndOverwriteFileFailures)
             {

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentTests.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Common
                     () => new GitProcess.Result(MountId, string.Empty, GitProcess.Result.SuccessCode));
                 this.gitProcess.SetExpectedCommandResult(
                     "config --local gvfs.enlistment-id",
-                    () => new GitProcess.Result(EnlistmentId, string.Empty, GitProcess.Result.SuccessCode));                  
+                    () => new GitProcess.Result(EnlistmentId, string.Empty, GitProcess.Result.SuccessCode));
             }
 
             public override GitProcess CreateGitProcess()

--- a/GVFS/GVFS.UnitTests/Common/JsonTracerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/JsonTracerTests.cs
@@ -64,7 +64,7 @@ namespace GVFS.UnitTests.Common
                 tracer.RelatedEvent(EventLevel.Verbose, "ShouldAlsoReceive", metadata: null);
                 listener.EventNamesRead.ShouldContain(name => name.Equals("ShouldAlsoReceive"));
             }
-             
+
             // None filters everything out (including events marked as none)
             using (JsonTracer tracer = new JsonTracer("Microsoft-GVFS-Test", "EventsAreFilteredByKeyword3", disableTelemetry: true))
             using (MockListener listener = new MockListener(EventLevel.Verbose, Keywords.None))

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeStreamReaderWriterTests.cs
@@ -79,7 +79,7 @@ namespace GVFS.UnitTests.Common
             string readMessage = this.streamReader.ReadMessage();
             readMessage.ShouldEqual(message, "The message read from the stream reader is not the same as the message that was sent.");
         }
-        
+
         private void TestTransmitMessages(string[] messages)
         {
             long pos = this.ReadStreamPosition();
@@ -88,7 +88,7 @@ namespace GVFS.UnitTests.Common
             {
                 this.streamWriter.WriteMessage(message);
             }
-            
+
             this.SetStreamPosition(pos);
 
             foreach (string message in messages)

--- a/GVFS/GVFS.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
@@ -194,7 +194,7 @@ namespace GVFS.UnitTests.Common
 
             mockTracer.RelatedWarningEvents.Count.ShouldEqual(5, "There should be five warning events, the first and last, and the 4th, 7th, and 10th");
             mockTracer.RelatedWarningEvents[0].ShouldContain(
-                new[] 
+                new[]
                 {
                     "Failed to delete file, retrying ...",
                     "\"failureCount\":1",
@@ -232,7 +232,7 @@ namespace GVFS.UnitTests.Common
         }
 
         private class DeleteTestsFileSystem : PhysicalFileSystem
-        {            
+        {
             private bool allFilesExist;
             private bool noOpDelete;
 
@@ -286,7 +286,7 @@ namespace GVFS.UnitTests.Common
 
                 if (!this.noOpDelete)
                 {
-                    if (this.DeleteException != null && 
+                    if (this.DeleteException != null &&
                         (this.MaxDeleteFileExceptions == -1 || this.MaxDeleteFileExceptions >= this.DeleteFileCallCount))
                     {
                         throw this.DeleteException;

--- a/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
@@ -135,11 +135,11 @@ namespace GVFS.UnitTests.Common
             fs.ExpectedFiles.Add(MockEntryFileName + ".tmp", new ReusableMemoryStream(string.Empty));
 
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedGitIgnoreEntry);
-            
+
             List<PlaceholderListDatabase.PlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
 
             dut.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
-            
+
             dut.WriteAllEntriesAndFlush(existingEntries);
             fs.ExpectedFiles[MockEntryFileName].ReadAsString().ShouldEqual(ExpectedTwoEntries);
         }
@@ -155,7 +155,7 @@ namespace GVFS.UnitTests.Common
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedTwoEntries);
 
             List<PlaceholderListDatabase.PlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
-            
+
             dut.RemoveAndFlush(InputGitAttributesPath);
 
             dut.WriteAllEntriesAndFlush(existingEntries);

--- a/GVFS/GVFS.UnitTests/Common/RefLogEntryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/RefLogEntryTests.cs
@@ -48,7 +48,7 @@ namespace GVFS.UnitTests.Common
 
             output.ShouldBeNull();
         }
-        
+
         [TestCase]
         public void FailsForNull()
         {

--- a/GVFS/GVFS.UnitTests/Common/RetryWrapperTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/RetryWrapperTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.UnitTests.Common
             Assert.Throws<OperationCanceledException>(
                 () =>
                 {
-                    RetryWrapper<bool>.InvocationResult output = dut.Invoke(tryCount => 
+                    RetryWrapper<bool>.InvocationResult output = dut.Invoke(tryCount =>
                     {
                         ++actualTries;
                         return new RetryWrapper<bool>.CallbackResult(true);

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -48,9 +48,9 @@ namespace GVFS.UnitTests.Git
                 GVFSGitObjects dut = this.CreateTestableGVFSGitObjects(httpObjects, fileSystem);
 
                 dut.TryCopyBlobContentStream(
-                    ValidTestObjectFileContents, 
+                    ValidTestObjectFileContents,
                     new CancellationToken(),
-                    GVFSGitObjects.RequestSource.FileStreamCallback, 
+                    GVFSGitObjects.RequestSource.FileStreamCallback,
                     (stream, length) => Assert.Fail("Should not be able to call copy stream callback"))
                     .ShouldEqual(false);
             }
@@ -155,7 +155,7 @@ namespace GVFS.UnitTests.Git
 
         private class MockHttpGitObjects : GitObjectsHttpRequestor
         {
-            public MockHttpGitObjects() 
+            public MockHttpGitObjects()
                 : this(new MockGVFSEnlistment())
             {
             }
@@ -198,10 +198,10 @@ namespace GVFS.UnitTests.Git
                 bool preferBatchedLooseObjects)
             {
                 using (GitEndPointResponseData response = new GitEndPointResponseData(
-                    HttpStatusCode.OK, 
-                    this.MediaType, 
-                    this.InputStream, 
-                    message: null, 
+                    HttpStatusCode.OK,
+                    this.MediaType,
+                    this.InputStream,
+                    message: null,
                     onResponseDisposed: null))
                 {
                     onSuccess(0, response);

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -21,7 +21,7 @@ namespace GVFS.UnitTests.Git
             string authString;
             string error;
 
-            dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");            
+            dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
 
             dut.Revoke(authString);
             dut.IsBackingOff.ShouldEqual(false, "Should not backoff after credentials initially revoked");
@@ -45,11 +45,11 @@ namespace GVFS.UnitTests.Git
 
             string authString;
             string error;
-        
+
             for (int i = 0; i < 5; ++i)
             {
-                dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get credential on iteration " + i + ": " + error);            
-                dut.Revoke(authString);            
+                dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get credential on iteration " + i + ": " + error);
+                dut.Revoke(authString);
                 dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to retry getting credential on iteration " + i + ": " + error);
                 dut.ConfirmCredentialsWorked(authString);
                 dut.IsBackingOff.ShouldEqual(false, "Should reset backoff after successfully refreshing credentials");
@@ -67,7 +67,7 @@ namespace GVFS.UnitTests.Git
 
             string authString;
             string error;
-        
+
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
             dut.Revoke(authString);
 
@@ -100,7 +100,7 @@ namespace GVFS.UnitTests.Git
             // Simulate a 401 error on two threads
             dut.Revoke(authString);
             dut.Revoke(authString);
-        
+
             // Both threads should still be able to get a PAT for retry purposes
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "The second thread caused back off when it shouldn't");
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true);
@@ -126,12 +126,12 @@ namespace GVFS.UnitTests.Git
             // Simulate a 401 error on one threads
             dut.Revoke(thread1Auth);
 
-            // That thread then retries            
+            // That thread then retries
             dut.TryGetCredentials(tracer, out thread1Auth, out error).ShouldEqual(true);
-            
+
             // The second thread fails with the old PAT
             dut.Revoke(thread2Auth);
-        
+
             // The second thread should be able to get a PAT
             dut.TryGetCredentials(tracer, out thread2Auth, out error).ShouldEqual(true, error);
         }

--- a/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
@@ -87,7 +87,7 @@ namespace GVFS.UnitTests.Maintenance
         {
             this.TestSetup(DateTime.UtcNow.AddDays(-7));
 
-            // Verify with valid Objects 
+            // Verify with valid Objects
             LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: false);
             step.WriteLooseObjectIds(new StreamWriter(new MemoryStream())).ShouldEqual(3);
             this.tracer.RelatedErrorEvents.Count.ShouldEqual(0);
@@ -122,8 +122,8 @@ namespace GVFS.UnitTests.Maintenance
             string directoryName = "AB";
             string fileName = "830bb79cd4fadb2e73e780e452dc71db909001";
             step.TryGetLooseObjectId(
-                directoryName, 
-                Path.Combine(this.context.Enlistment.GitObjectsRoot, directoryName, fileName), 
+                directoryName,
+                Path.Combine(this.context.Enlistment.GitObjectsRoot, directoryName, fileName),
                 out string objectId).ShouldBeTrue();
             objectId.ShouldEqual(directoryName + fileName);
 
@@ -163,8 +163,8 @@ namespace GVFS.UnitTests.Maintenance
 
             // Create Hex Folder 1 with 1 File
             MockDirectory hex1 = new MockDirectory(
-                Path.Combine(enlistment.GitObjectsRoot, "AA"), 
-                null, 
+                Path.Combine(enlistment.GitObjectsRoot, "AA"),
+                null,
                 new List<MockFile>()
                 {
                      new MockFile(Path.Combine(enlistment.GitObjectsRoot, "AA", "1156f4f2b850673090c285289ea8475d629fe1"), string.Empty)
@@ -172,8 +172,8 @@ namespace GVFS.UnitTests.Maintenance
 
             // Create Hex Folder 2 with 2 Files
             MockDirectory hex2 = new MockDirectory(
-                Path.Combine(enlistment.GitObjectsRoot, "F1"), 
-                null, 
+                Path.Combine(enlistment.GitObjectsRoot, "F1"),
+                null,
                 new List<MockFile>()
                 {
                      new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "1156f4f2b850673090c285289ea8475d629fe2"), string.Empty),
@@ -182,8 +182,8 @@ namespace GVFS.UnitTests.Maintenance
 
             // Create NonHex Folder with 4 Files
             MockDirectory nonhex = new MockDirectory(
-                Path.Combine(enlistment.GitObjectsRoot, "ZZ"), 
-                null, 
+                Path.Combine(enlistment.GitObjectsRoot, "ZZ"),
+                null,
                 new List<MockFile>()
                 {
                      new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe4"), string.Empty),

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
@@ -14,7 +14,7 @@ namespace GVFS.UnitTests.Mock.Common
             : base(tracer, enlistment, objectRequestor, fileSystem)
         {
         }
-        
+
         public override string WriteLooseObject(Stream responseStream, string sha, bool overwriteExisting, byte[] sharedBuf = null)
         {
             using (StreamReader reader = new StreamReader(responseStream))

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockDirectory.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockDirectory.cs
@@ -73,7 +73,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
             }
 
             MockFile existingFileAtPath = parentDirectory.FindFile(path);
-            
+
             if (existingFileAtPath != null)
             {
                 parentDirectory.Files.Remove(path);
@@ -173,7 +173,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         public MockDirectory CreateDirectory(string path)
         {
             int lastSlashIdx = path.LastIndexOf(Path.DirectorySeparatorChar);
-            
+
             if (lastSlashIdx <= 0)
             {
                 return this;
@@ -227,7 +227,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
             MockDirectory sourceDirectory;
             MockDirectory sourceDirectoryParent;
             this.TryGetDirectoryAndParent(sourcePath, out sourceDirectory, out sourceDirectoryParent).ShouldEqual(true);
-            
+
             int endPathIndex = targetPath.LastIndexOf(Path.DirectorySeparatorChar);
             string targetDirectoryPath = targetPath.Substring(0, endPathIndex);
 
@@ -238,7 +238,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
             sourceDirectory.FullName = targetPath;
 
-            targetDirectory.AddDirectory(sourceDirectory);            
+            targetDirectory.AddDirectory(sourceDirectory);
         }
 
         public void RemoveDirectory(MockDirectory directory)
@@ -297,6 +297,6 @@ namespace GVFS.UnitTests.Mock.FileSystem
             directory = null;
             parentDirectory = null;
             return false;
-        }        
+        }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFile.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFile.cs
@@ -13,7 +13,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
             this.FullName = fullName;
             this.Name = Path.GetFileName(this.FullName);
-            
+
             this.FileProperties = FileProperties.DefaultFile;
 
             this.contentStream = new ReusableMemoryStream(contents);
@@ -30,10 +30,10 @@ namespace GVFS.UnitTests.Mock.FileSystem
                 // The underlying content stream is the correct/true source of the file length
                 // Create a new copy of the properties to make sure the length is set correctly.
                 FileProperties newProperties = new FileProperties(
-                    this.fileProperties.FileAttributes, 
-                    this.fileProperties.CreationTimeUTC, 
-                    this.fileProperties.LastAccessTimeUTC, 
-                    this.fileProperties.LastWriteTimeUTC, 
+                    this.fileProperties.FileAttributes,
+                    this.fileProperties.CreationTimeUTC,
+                    this.fileProperties.LastAccessTimeUTC,
+                    this.fileProperties.LastWriteTimeUTC,
                     this.contentStream.Length);
 
                 this.fileProperties = newProperties;

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -62,7 +62,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
             this.RootDirectory.RemoveFile(path);
         }
-        
+
         public override void MoveAndOverwriteFile(string sourcePath, string destinationPath)
         {
             if (sourcePath == null || destinationPath == null)
@@ -220,7 +220,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         }
 
         public override void SetAttributes(string path, FileAttributes fileAttributes)
-        {            
+        {
         }
 
         public override void MoveFile(string sourcePath, string targetPath)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
@@ -34,7 +34,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
             return this.OnOpenFileStream(path, fileMode, fileAccess);
         }
-        
+
         public override void WriteAllText(string path, string contents)
         {
         }

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockBatchHttpGitObjects.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockBatchHttpGitObjects.cs
@@ -31,7 +31,7 @@ namespace GVFS.UnitTests.Mock.Git
         {
             throw new NotImplementedException();
         }
-        
+
         public override RetryWrapper<GitObjectTaskResult>.InvocationResult TryDownloadObjects(
             Func<IEnumerable<string>> objectIdGenerator,
             Func<int, GitEndPointResponseData, RetryWrapper<GitObjectTaskResult>.CallbackResult> onSuccess,
@@ -105,7 +105,7 @@ namespace GVFS.UnitTests.Mock.Git
 
             return new RetryWrapper<GitObjectTaskResult>.InvocationResult(this.RetryConfig.MaxAttempts, null);
         }
-        
+
         private byte[] SHA1BytesFromString(string s)
         {
             s.Length.ShouldEqual(40);

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGVFSGitObjects.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGVFSGitObjects.cs
@@ -50,7 +50,7 @@ namespace GVFS.UnitTests.Mock.Git
             }
 
             writeAction(
-                new MemoryStream(new byte[this.FileLength]), 
+                new MemoryStream(new byte[this.FileLength]),
                 this.FileLength);
 
             return true;

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitRepo.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitRepo.cs
@@ -12,7 +12,7 @@ namespace GVFS.UnitTests.Mock.Git
     {
         private Dictionary<string, MockGitObject> objects = new Dictionary<string, MockGitObject>();
         private string rootSha;
-        
+
         public MockGitRepo(ITracer tracer, Enlistment enlistment, PhysicalFileSystem fileSystem)
             : base(tracer)
         {
@@ -59,7 +59,7 @@ namespace GVFS.UnitTests.Mock.Git
             this.AddChildBySha(parentSha, newSha);
             return newSha;
         }
-        
+
         /// <summary>
         /// Adds an parented tree to the "repo"
         /// </summary>
@@ -75,7 +75,7 @@ namespace GVFS.UnitTests.Mock.Git
         {
             return this.rootSha;
         }
-        
+
         public override bool TryGetBlobLength(string blobSha, out long size)
         {
             MockGitObject obj;

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockHttpGitObjects.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockHttpGitObjects.cs
@@ -50,9 +50,9 @@ namespace GVFS.UnitTests.Mock.Git
         }
 
         public override RetryWrapper<GitObjectTaskResult>.InvocationResult TryDownloadObjects(
-            Func<IEnumerable<string>> objectIdGenerator, 
-            Func<int, GitEndPointResponseData, RetryWrapper<GitObjectTaskResult>.CallbackResult> onSuccess, 
-            Action<RetryWrapper<GitObjectTaskResult>.ErrorEventArgs> onFailure, 
+            Func<IEnumerable<string>> objectIdGenerator,
+            Func<int, GitEndPointResponseData, RetryWrapper<GitObjectTaskResult>.CallbackResult> onSuccess,
+            Action<RetryWrapper<GitObjectTaskResult>.ErrorEventArgs> onFailure,
             bool preferBatchedLooseObjects)
         {
             return this.TryDownloadObjects(objectIdGenerator(), onSuccess, onFailure, preferBatchedLooseObjects);
@@ -87,7 +87,7 @@ namespace GVFS.UnitTests.Mock.Git
                 {
                     RetryWrapper<GitObjectTaskResult>.CallbackResult result = onSuccess(1, response);
                     return new RetryWrapper<GitObjectTaskResult>.InvocationResult(1, true, result.Result);
-                }                
+                }
             }
 
             if (onFailure != null)

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockLibGit2Repo.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockLibGit2Repo.cs
@@ -7,7 +7,7 @@ namespace GVFS.UnitTests.Mock.Git
 {
     public class MockLibGit2Repo : LibGit2Repo
     {
-        public MockLibGit2Repo(ITracer tracer) 
+        public MockLibGit2Repo(ITracer tracer)
             : base()
         {
         }

--- a/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
@@ -85,7 +85,7 @@ namespace GVFS.UnitTests.Mock.Mac
         }
 
         public override Result WriteSymLink(
-            string relativePath, 
+            string relativePath,
             string symLinkTarget)
         {
             this.CreatedSymLinks.Add(relativePath);
@@ -111,9 +111,9 @@ namespace GVFS.UnitTests.Mock.Mac
         }
 
         public override Result ReplacePlaceholderFileWithSymLink(
-            string relativePath, 
-            string symLinkTarget, 
-            UpdateType updateFlags, 
+            string relativePath,
+            string symLinkTarget,
+            UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
             this.CreatedSymLinks.Add(relativePath);

--- a/GVFS/GVFS.UnitTests/Mock/ReusableMemoryStream.cs
+++ b/GVFS/GVFS.UnitTests/Mock/ReusableMemoryStream.cs
@@ -48,7 +48,7 @@ namespace GVFS.UnitTests.Mock
         {
             // noop
         }
-        
+
         public string ReadAsString()
         {
             return Encoding.UTF8.GetString(this.contents, 0, (int)this.length);

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/BlobSize/MockBlobSizesDatabase.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/BlobSize/MockBlobSizesDatabase.cs
@@ -6,7 +6,7 @@ using System;
 namespace GVFS.UnitTests.Mock.Virtualization.BlobSize
 {
     public class MockBlobSizes : BlobSizes
-    { 
+    {
         public MockBlobSizes()
             : base("mock:\\blobSizeDatabase", fileSystem: null, tracer: new MockTracer())
         {

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
@@ -177,7 +177,7 @@ namespace GVFS.UnitTests.Mock.Virtualization.Projection
 
         public override List<ProjectedFileInfo> GetProjectedItems(
             CancellationToken cancellationToken,
-            BlobSizes.BlobSizesConnection blobSizesConnection, 
+            BlobSizes.BlobSizesConnection blobSizesConnection,
             string folderPath)
         {
             this.waitForGetProjectedItems.Set();
@@ -210,9 +210,9 @@ namespace GVFS.UnitTests.Mock.Virtualization.Projection
         }
 
         public override ProjectedFileInfo GetProjectedFileInfo(
-            CancellationToken cancellationToken, 
-            BlobSizes.BlobSizesConnection blobSizesConnection, 
-            string virtualPath, 
+            CancellationToken cancellationToken,
+            BlobSizes.BlobSizesConnection blobSizesConnection,
+            string virtualPath,
             out string parentFolderPath)
         {
             this.waitForGetProjectedFileInfo.Set();

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
@@ -100,9 +100,9 @@ namespace GVFS.UnitTests.Platform.Mac
                 virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    UpdatePlaceholderFileName, 
+                    UpdatePlaceholderFileName,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode644));
-                
+
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
 
@@ -185,15 +185,15 @@ namespace GVFS.UnitTests.Platform.Mac
                 virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    WriteSymLinkFileName, 
+                    WriteSymLinkFileName,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.SymLink, fileMode: 0));
 
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
 
                 virtualizer.WritePlaceholderFile(
-                    WriteSymLinkFileName, 
-                    endOfFile: 0, 
+                    WriteSymLinkFileName,
+                    endOfFile: 0,
                     sha: string.Empty).ShouldEqual(new FileSystemResult(FSResult.Ok, (int)Result.Success));
 
                 mockVirtualization.CreatedPlaceholders.ShouldBeEmpty();
@@ -227,9 +227,9 @@ namespace GVFS.UnitTests.Platform.Mac
                 virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    PlaceholderToLinkFileName, 
+                    PlaceholderToLinkFileName,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.SymLink, fileMode: 0));
-                
+
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
 
@@ -299,7 +299,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 fileSystemVirtualizer: virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    testFilePath, 
+                    testFilePath,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode644));
 
                 string error;
@@ -322,7 +322,7 @@ namespace GVFS.UnitTests.Platform.Mac
             string testFilePath = Path.Combine(TestFolderName, TestFileName);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
-                
+
             // Don't include TestFolderName as MockGitIndexProjection returns the same list of files regardless of what folder name
             // it is passed
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { TestFileName }))
@@ -337,7 +337,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 fileSystemVirtualizer: virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    testFilePath, 
+                    testFilePath,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode644));
 
                 string error;
@@ -380,13 +380,13 @@ namespace GVFS.UnitTests.Platform.Mac
                 fileSystemVirtualizer: virtualizer))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    testFile644Path, 
+                    testFile644Path,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode644));
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    testFile664Path, 
+                    testFile664Path,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode664));
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
-                    testFile755Path, 
+                    testFile755Path,
                     ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType.Regular, GitIndexProjection.FileMode755));
 
                 string error;

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -21,7 +21,7 @@ namespace GVFS.UnitTests.Prefetch
         }
 
         public bool IncludeSymLinks { get; set; }
-        
+
         // Make two commits. The first should look like this:
         // recursiveDelete
         // recursiveDelete/subfolder
@@ -45,7 +45,7 @@ namespace GVFS.UnitTests.Prefetch
         // eg. recursiveDelete should run "rmdir /s/q recursiveDelete"
         // eg. folderToBeFile should be deleted and replaced with a file of the same name
         // Note that each childFile.txt should have unique contents, but is only a placeholder to force git to add a folder.
-        // 
+        //
         // Then to generate the diffs, run:
         // git diff-tree -r -t Head~1 Head > forward.txt
         // git diff-tree -r -t Head Head ~1 > backward.txt
@@ -68,7 +68,7 @@ namespace GVFS.UnitTests.Prefetch
             // Includes children of: Recursive delete folder, deleted folder, renamed folder, and folder => file
             diffForwards.TotalFileDeletes.ShouldEqual(8);
 
-            // Folder created, folder edited, folder deleted, folder renamed (add + delete), 
+            // Folder created, folder edited, folder deleted, folder renamed (add + delete),
             // folder => file, file => folder, recursive delete (top-level only)
             diffForwards.DirectoryOperations.Count.ShouldEqual(8);
 
@@ -94,7 +94,7 @@ namespace GVFS.UnitTests.Prefetch
             // Also includes, the children of: Folder added, folder renamed, file => folder
             diffBackwards.TotalFileDeletes.ShouldEqual(7);
 
-            // Folder created, folder edited, folder deleted, folder renamed (add + delete), 
+            // Folder created, folder edited, folder deleted, folder renamed (add + delete),
             // folder => file, file => folder, recursive delete (include subfolder)
             diffBackwards.TotalDirectoryOperations.ShouldEqual(9);
         }
@@ -107,13 +107,13 @@ namespace GVFS.UnitTests.Prefetch
             MockTracer tracer = new MockTracer();
             DiffHelper diffBackwards = new DiffHelper(tracer, new Mock.Common.MockGVFSEnlistment(), new List<string>(), new List<string>(), includeSymLinks: this.IncludeSymLinks);
             diffBackwards.ParseDiffFile(GetDataPath("caseChange.txt"), "xx:\\fakeRepo");
-            
+
             diffBackwards.RequiredBlobs.Count.ShouldEqual(2);
             diffBackwards.FileAddOperations.Sum(list => list.Value.Count).ShouldEqual(2);
 
             diffBackwards.FileDeleteOperations.Count.ShouldEqual(0);
             diffBackwards.TotalFileDeletes.ShouldEqual(0);
-            
+
             diffBackwards.DirectoryOperations.ShouldNotContain(entry => entry.Operation == DiffTreeResult.Operations.Delete);
             diffBackwards.TotalDirectoryOperations.ShouldEqual(3);
         }

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -18,7 +18,7 @@ namespace GVFS.UnitTests
             {
                 excludeCategories.Add(CategoryConstants.ExceptionExpected);
             }
-            
+
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);
 
             if (Debugger.IsAttached)

--- a/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
+++ b/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
@@ -36,7 +36,7 @@ namespace GVFS.UnitTests.Virtual
 
             this.FileSystem = new MockFileSystem(enlistmentDirectory);
             this.Repository = new MockGitRepo(
-                tracer, 
+                tracer,
                 enlistment,
                 this.FileSystem);
             CreateStandardGitTree(this.Repository);
@@ -46,18 +46,18 @@ namespace GVFS.UnitTests.Virtual
             this.HttpObjects = new MockHttpGitObjects(tracer, enlistment);
             this.GitObjects = new MockGVFSGitObjects(this.Context, this.HttpObjects);
         }
-        
+
         public GVFSContext Context { get; private set; }
 
         public string GitParentPath { get; private set; }
-        
+
         public string GVFSMetadataPath { get; private set; }
         public GVFSGitObjects GitObjects { get; private set; }
 
         public MockGitRepo Repository { get; private set; }
         public MockHttpGitObjects HttpObjects { get; private set; }
         public MockFileSystem FileSystem { get; private set; }
-        
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/GVFS/GVFS.UnitTests/Virtual/TestsWithCommonRepo.cs
+++ b/GVFS/GVFS.UnitTests/Virtual/TestsWithCommonRepo.cs
@@ -16,9 +16,9 @@ namespace GVFS.UnitTests.Virtual
 
             string error;
             RepoMetadata.TryInitialize(
-                new MockTracer(), 
+                new MockTracer(),
                 this.Repo.Context.FileSystem,
-                this.Repo.Context.Enlistment.DotGVFSRoot, 
+                this.Repo.Context.Enlistment.DotGVFSRoot,
                 out error);
         }
 

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -247,9 +247,9 @@ namespace GVFS.UnitTests.Virtualization
                 fileSystemVirtualizer: null))
             {
                 this.CallbackSchedulesBackgroundTask(
-                    backgroundTaskRunner, 
-                    (path) => fileSystemCallbacks.OnFileConvertedToFull(path), 
-                    "OnFileConvertedToFull.txt", 
+                    backgroundTaskRunner,
+                    (path) => fileSystemCallbacks.OnFileConvertedToFull(path),
+                    "OnFileConvertedToFull.txt",
                     FileSystemTask.OperationType.OnFileConvertedToFull);
 
                 this.CallbackSchedulesBackgroundTask(
@@ -360,9 +360,9 @@ namespace GVFS.UnitTests.Virtualization
         }
 
         private void CallbackSchedulesBackgroundTask(
-            MockBackgroundFileSystemTaskRunner backgroundTaskRunner, 
-            Action<string> callback, 
-            string path, 
+            MockBackgroundFileSystemTaskRunner backgroundTaskRunner,
+            Action<string> callback,
+            string path,
             FileSystemTask.OperationType operationType)
         {
             callback(path);

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
@@ -188,7 +188,7 @@ namespace GVFS.UnitTests.Virtualization.Git
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseInsensitiveCompare));
                 });
         }
-        
+
         [TestCase]
         public unsafe void PoolSizeCheck()
         {

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -18,7 +18,7 @@ namespace GVFS.Upgrader
         private bool mount;
 
         public UpgradeOrchestrator(
-            ProductUpgrader upgrader, 
+            ProductUpgrader upgrader,
             ITracer tracer,
             InstallerPreRunChecker preRunChecker,
             TextReader input,
@@ -141,7 +141,7 @@ namespace GVFS.Upgrader
                 consoleError = null;
                 loaded = true;
             }
-            
+
             ring = this.upgrader.Ring;
             return loaded;
         }
@@ -241,7 +241,7 @@ namespace GVFS.Upgrader
             consoleError = null;
             return true;
         }
-        
+
         private bool TryMountRepositories(out string consoleError)
         {
             string errorMessage = string.Empty;
@@ -326,14 +326,14 @@ namespace GVFS.Upgrader
 
                 activity.RelatedInfo("Successfully checked for new release. {0}", newestVersion);
             }
-            
+
             return true;
         }
 
         private bool TryDownloadUpgrade(Version version, out string consoleError)
         {
             using (ITracer activity = this.tracer.StartActivity(
-                $"{nameof(this.TryDownloadUpgrade)}({version.ToString()})", 
+                $"{nameof(this.TryDownloadUpgrade)}({version.ToString()})",
                 EventLevel.Informational))
             {
                 if (!this.upgrader.TryDownloadNewestVersion(out consoleError))
@@ -356,7 +356,7 @@ namespace GVFS.Upgrader
             using (ITracer activity = this.tracer.StartActivity(
                 $"{nameof(this.TryInstallGitUpgrade)}({version.ToString()})",
                 EventLevel.Informational))
-            {                
+            {
                 if (!this.upgrader.TryRunGitInstaller(out installSuccess, out consoleError) ||
                     !installSuccess)
                 {

--- a/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
+++ b/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
@@ -177,7 +177,7 @@ namespace GVFS.Virtualization.Background
                     int tasksProcessed = 0;
                     while (this.backgroundTasks.TryPeek(out backgroundTask))
                     {
-                        if (tasksProcessed % LogUpdateTaskThreshold == 0 && 
+                        if (tasksProcessed % LogUpdateTaskThreshold == 0 &&
                             (tasksProcessed >= LogUpdateTaskThreshold || this.backgroundTasks.Count >= LogUpdateTaskThreshold))
                         {
                             this.LogTaskProcessingStatus(tasksProcessed);
@@ -194,7 +194,7 @@ namespace GVFS.Virtualization.Background
                         FileSystemTaskResult callbackResult = this.callback(backgroundTask);
                         switch (callbackResult)
                         {
-                            case FileSystemTaskResult.Success:                                
+                            case FileSystemTaskResult.Success:
                                 this.backgroundTasks.DequeueAndFlush(backgroundTask);
                                 ++tasksProcessed;
                                 break;

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
@@ -14,10 +14,10 @@ namespace GVFS.Virtualization.Background
         private const char ValueTerminatorChar = '\0';
 
         private readonly ConcurrentQueue<KeyValuePair<long, FileSystemTask>> data = new ConcurrentQueue<KeyValuePair<long, FileSystemTask>>();
-        
+
         private long entryCounter = 0;
 
-        private FileSystemTaskQueue(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath) 
+        private FileSystemTaskQueue(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: true)
         {
         }
@@ -26,7 +26,7 @@ namespace GVFS.Virtualization.Background
         {
             get { return this.data.Count; }
         }
-        
+
         public static bool TryCreate(ITracer tracer, string dataDirectory, PhysicalFileSystem fileSystem, out FileSystemTaskQueue output, out string error)
         {
             output = new FileSystemTaskQueue(tracer, fileSystem, dataDirectory);
@@ -50,7 +50,7 @@ namespace GVFS.Virtualization.Background
                 KeyValuePair<long, FileSystemTask> kvp = new KeyValuePair<long, FileSystemTask>(
                     Interlocked.Increment(ref this.entryCounter),
                     value);
-                
+
                 this.WriteAddEntry(
                     kvp.Key + ValueTerminator + this.Serialize(kvp.Value),
                     () => this.data.Enqueue(kvp));
@@ -159,7 +159,7 @@ namespace GVFS.Virtualization.Background
                 value = default(FileSystemTask);
                 return false;
             }
-            
+
             value = new FileSystemTask(
                 operationType,
                 parts[1],

--- a/GVFS/GVFS.Virtualization/BlobSize/BlobSizes.cs
+++ b/GVFS/GVFS.Virtualization/BlobSize/BlobSizes.cs
@@ -107,12 +107,12 @@ namespace GVFS.Virtualization.BlobSize
                 using (SqliteCommand pragmaWalCommand = connection.CreateCommand())
                 {
                     // Advantages of using WAL ("Write-Ahead Log")
-                    // 1. WAL is significantly faster in most scenarios. 
-                    // 2. WAL provides more concurrency as readers do not block writers and a writer does not block readers. 
-                    //    Reading and writing can proceed concurrently. 
-                    // 3. Disk I/O operations tends to be more sequential using WAL. 
-                    // 4. WAL uses many fewer fsync() operations and is thus less vulnerable to problems on systems 
-                    //    where the fsync() system call is broken. 
+                    // 1. WAL is significantly faster in most scenarios.
+                    // 2. WAL provides more concurrency as readers do not block writers and a writer does not block readers.
+                    //    Reading and writing can proceed concurrently.
+                    // 3. Disk I/O operations tends to be more sequential using WAL.
+                    // 4. WAL uses many fewer fsync() operations and is thus less vulnerable to problems on systems
+                    //    where the fsync() system call is broken.
                     // http://www.sqlite.org/wal.html
                     pragmaWalCommand.CommandText = $"PRAGMA journal_mode=WAL;";
                     pragmaWalCommand.ExecuteNonQuery();
@@ -130,7 +130,7 @@ namespace GVFS.Virtualization.BlobSize
 
                 using (SqliteCommand userVersionCommand = connection.CreateCommand())
                 {
-                    // The user_version pragma will to get or set the value of the user-version integer at offset 60 in the database header. 
+                    // The user_version pragma will to get or set the value of the user-version integer at offset 60 in the database header.
                     // The user-version is an integer that is available to applications to use however they want. SQLite makes no use of the user-version itself.
                     // https://sqlite.org/pragma.html#pragma_user_version
                     userVersionCommand.CommandText = $"PRAGMA user_version;";
@@ -145,7 +145,7 @@ namespace GVFS.Virtualization.BlobSize
                     }
                     else
                     {
-                        databaseMetadata.Add("user_version", Convert.ToInt64(userVersion));                        
+                        databaseMetadata.Add("user_version", Convert.ToInt64(userVersion));
                     }
                 }
 
@@ -315,10 +315,10 @@ namespace GVFS.Virtualization.BlobSize
 
                     using (SqliteCommand pragmaReadUncommittedCommand = this.connection.CreateCommand())
                     {
-                        // A database connection in read-uncommitted mode does not attempt to obtain read-locks 
-                        // before reading from database tables as described above. This can lead to inconsistent 
-                        // query results if another database connection modifies a table while it is being read, 
-                        // but it also means that a read-transaction opened by a connection in read-uncommitted 
+                        // A database connection in read-uncommitted mode does not attempt to obtain read-locks
+                        // before reading from database tables as described above. This can lead to inconsistent
+                        // query results if another database connection modifies a table while it is being read,
+                        // but it also means that a read-transaction opened by a connection in read-uncommitted
                         // mode can neither block nor be blocked by any other connection
                         // http://www.sqlite.org/pragma.html#pragma_read_uncommitted
                         pragmaReadUncommittedCommand.CommandText = $"PRAGMA read_uncommitted=1;";

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemResult.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemResult.cs
@@ -14,5 +14,5 @@
         /// Underlying result. The value of RawResult varies based on the operating system.
         /// </summary>
         public int RawResult { get; }
-    }    
+    }
 }

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -135,7 +135,7 @@ namespace GVFS.Virtualization.FileSystem
         /// If a git-status or git-add is running, we don't want to fail placeholder creation because users will
         /// want to be able to run those commands during long running builds. Allow lock acquisition to be deferred
         /// until background thread actually needs it.
-        /// 
+        ///
         /// git-mv is also allowed to defer since it needs to create the files it moves.
         /// </remarks>
         protected bool CanCreatePlaceholder()
@@ -217,7 +217,7 @@ namespace GVFS.Virtualization.FileSystem
 
             this.FileSystemCallbacks.InvalidateGitStatusCache();
         }
-        
+
         protected void OnFileRenamed(string relativeSourcePath, string relativeDestinationPath, bool isDirectory)
         {
             try
@@ -388,7 +388,7 @@ namespace GVFS.Virtualization.FileSystem
         protected class FileOrNetworkRequest
         {
             /// <summary>
-            /// FileOrNetworkRequest constructor 
+            /// FileOrNetworkRequest constructor
             /// </summary>
             /// <param name="work">Action that requires file and\or network access</param>
             /// <param name="cleanup">Cleanup action to take after performing work</param>

--- a/GVFS/GVFS.Virtualization/FileSystem/UpdateFailureReason.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/UpdateFailureReason.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace GVFS.Virtualization.FileSystem
-{    
+{
     [Flags]
     public enum UpdateFailureReason : uint
     {

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -272,7 +272,7 @@ namespace GVFS.Virtualization
 
             // Even though we're returning true and saying it's safe to ask for the lock
             // there is no guarantee that the lock will be acquired, because GVFS itself
-            // could obtain the lock before the external holder gets it. Setting up an 
+            // could obtain the lock before the external holder gets it. Setting up an
             // appropriate error message in case that happens
             denyMessage = "Waiting for GVFS to release the lock";
 
@@ -313,7 +313,7 @@ namespace GVFS.Virtualization
 
             metadata.Add(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
             metadata.Add(
-                "PhysicalDiskInfo", 
+                "PhysicalDiskInfo",
                 GVFSPlatform.Instance.GetPhysicalDiskInfo(
                     this.context.Enlistment.WorkingDirectoryRoot,
                     sizeStatsOnly: true));
@@ -462,7 +462,7 @@ namespace GVFS.Virtualization
 
             // Note: Because OnPlaceholderFileCreated is not synchronized on all platforms it is possible that GVFS will double count
             // the creation of file placeholders if multiple requests for the same file are received at the same time on different
-            // threads.                         
+            // threads.
             this.placeHolderCreationCount.AddOrUpdate(
                 triggeringProcessImageFileName,
                 (imageName) => { return new PlaceHolderCreateCounter(); },
@@ -486,7 +486,7 @@ namespace GVFS.Virtualization
 
         public FileProperties GetLogsHeadFileProperties()
         {
-            // Use a temporary FileProperties in case another thread sets this.logsHeadFileProperties before this 
+            // Use a temporary FileProperties in case another thread sets this.logsHeadFileProperties before this
             // method returns
             FileProperties properties = this.logsHeadFileProperties;
             if (properties == null)
@@ -655,7 +655,7 @@ namespace GVFS.Virtualization
 
                     // An empty destination path means the folder was renamed to somewhere outside of the repo
                     // Note that only full folders can be moved\renamed, and so there will already be a recursive
-                    // sparse-checkout entry for the virtualPath of the folder being moved (meaning that no 
+                    // sparse-checkout entry for the virtualPath of the folder being moved (meaning that no
                     // additional work is needed for any files\folders inside the folder being moved)
                     if (result == FileSystemTaskResult.Success && !string.IsNullOrEmpty(gitUpdate.VirtualPath))
                     {

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
@@ -57,7 +57,7 @@ namespace GVFS.Virtualization.Projection
 
                 lock (this)
                 {
-                    // Check ChildrenHaveSizes again in case another 
+                    // Check ChildrenHaveSizes again in case another
                     // thread has already done the work of setting the sizes
                     if (this.ChildrenHaveSizes)
                     {

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexEntry.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexEntry.cs
@@ -8,10 +8,10 @@ namespace GVFS.Virtualization.Projection
     public partial class GitIndexProjection
     {
         /// <summary>
-        /// Data for an entry in the git index 
+        /// Data for an entry in the git index
         /// </summary>
         /// <remarks>
-        /// GitIndexEntry should not be used for storing projection data. It's designed for 
+        /// GitIndexEntry should not be used for storing projection data. It's designed for
         /// temporary storage of a single entry from the index.
         /// </remarks>
         internal class GitIndexEntry
@@ -79,7 +79,7 @@ namespace GVFS.Virtualization.Projection
 
                 // The index to start looking for the next path separator
                 // Because the previous final separator is stored and we know where the previous path will be replaced
-                // the code can use the previous final separator to start looking from that point instead of having to 
+                // the code can use the previous final separator to start looking from that point instead of having to
                 // run through the entire path to break it apart
                 /* Example:
                  * Previous path = folder/where/previous/separator/is/used/file.txt
@@ -102,7 +102,7 @@ namespace GVFS.Virtualization.Projection
                     {
                         // Only need to parse the last part, because the rest of the string is unchanged
 
-                        // The logical thing to do would be to start the for loop at previousFinalSeparatorIndex+1, but two 
+                        // The logical thing to do would be to start the for loop at previousFinalSeparatorIndex+1, but two
                         // repeated / characters would make an invalid path, so we'll assume that git would not have stored that path
                         forLoopStartIndex = this.buildingProjectionPreviousFinalSeparatorIndex + 2;
 
@@ -146,7 +146,7 @@ namespace GVFS.Virtualization.Projection
             }
 
             /// <summary>
-            /// Parses the path from the index as platform-specific relative path. 
+            /// Parses the path from the index as platform-specific relative path.
             /// It should only be called when running a background task.
             /// </summary>
             public unsafe void BackgroundTask_ParsePath()
@@ -228,7 +228,7 @@ namespace GVFS.Virtualization.Projection
             {
                 return this.backgroundTaskRelativePath;
             }
-            
+
             private unsafe bool RangeContains(byte* bufferPtr, int count, byte value)
             {
                 byte* indexPtr = bufferPtr;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
@@ -68,11 +68,11 @@ namespace GVFS.Virtualization.Projection
 
                 this.projection.ClearProjectionCaches();
                 FileSystemTaskResult result = this.ParseIndex(
-                    tracer, 
-                    indexStream, 
-                    this.resuableProjectionBuildingIndexEntry, 
+                    tracer,
+                    indexStream,
+                    this.resuableProjectionBuildingIndexEntry,
                     this.AddIndexEntryToProjection);
-                
+
                 if (result != FileSystemTaskResult.Success)
                 {
                     // RebuildProjection should always result in FileSystemTaskResult.Success (or a thrown exception)
@@ -99,13 +99,13 @@ namespace GVFS.Virtualization.Projection
                     {
                         { "FilePlaceholderCount", filePlaceholders.Count }
                     });
-            
+
                 FileSystemTaskResult result = this.ParseIndex(
                     tracer,
                     indexStream,
                     this.resuableBackgroundTaskThreadIndexEntry,
                     (data) => this.AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded(data, filePlaceholders));
-                
+
                 if (result != FileSystemTaskResult.Success)
                 {
                     return result;
@@ -160,7 +160,7 @@ namespace GVFS.Virtualization.Projection
             /// <param name="filePlaceholders">
             /// Dictionary of file placeholders.  AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded will
             /// remove enties from filePlaceholders as they are found in the index.  After
-            /// AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded is called for all entries in the index 
+            /// AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded is called for all entries in the index
             /// filePlaceholders will contain only those placeholders that are not in the index.
             /// </param>
             private FileSystemTaskResult AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded(
@@ -211,8 +211,8 @@ namespace GVFS.Virtualization.Projection
             /// case of a corrupt index)
             /// </remarks>
             private FileSystemTaskResult ParseIndex(
-                ITracer tracer, 
-                Stream indexStream, 
+                ITracer tracer,
+                Stream indexStream,
                 GitIndexEntry resuableParsedIndexEntry,
                 Func<GitIndexEntry, FileSystemTaskResult> entryAction)
             {
@@ -267,8 +267,8 @@ namespace GVFS.Virtualization.Projection
                         switch (typeAndMode.Type)
                         {
                             case FileType.Regular:
-                                if (typeAndMode.Mode != FileMode755 && 
-                                    typeAndMode.Mode != FileMode644 && 
+                                if (typeAndMode.Mode != FileMode755 &&
+                                    typeAndMode.Mode != FileMode644 &&
                                     typeAndMode.Mode != FileMode664)
                                 {
                                     throw new InvalidDataException($"Invalid file mode {typeAndMode.GetModeAsOctalString()} found for regular file in index");
@@ -288,7 +288,7 @@ namespace GVFS.Virtualization.Projection
                             default:
                                 throw new InvalidDataException($"Invalid file type {typeAndMode.Type:X} found in index");
                         }
-                                    
+
                         resuableParsedIndexEntry.TypeAndMode = typeAndMode;
 
                         this.Skip(12);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.ObjectPool.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.ObjectPool.cs
@@ -111,7 +111,7 @@ namespace GVFS.Virtualization.Projection
                     int previousSize = this.pool.Length;
 
                     // The values for shrinking and expanding are currently set to prevent the pool from shrinking after expanding
-                    // 
+                    //
                     // Example using
                     // ExpandPoolNewObjects = 0.15
                     // ShrinkExtraObjects = 1.1

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -28,13 +28,13 @@ namespace GVFS.Virtualization.Projection
 
         private const int IndexFileStreamBufferSize = 512 * 1024;
 
-        private const UpdatePlaceholderType FolderPlaceholderDeleteFlags = 
-            UpdatePlaceholderType.AllowDirtyMetadata | 
-            UpdatePlaceholderType.AllowReadOnly | 
+        private const UpdatePlaceholderType FolderPlaceholderDeleteFlags =
+            UpdatePlaceholderType.AllowDirtyMetadata |
+            UpdatePlaceholderType.AllowReadOnly |
             UpdatePlaceholderType.AllowTombstone;
 
-        private const UpdatePlaceholderType FilePlaceholderUpdateFlags = 
-            UpdatePlaceholderType.AllowDirtyMetadata | 
+        private const UpdatePlaceholderType FilePlaceholderUpdateFlags =
+            UpdatePlaceholderType.AllowDirtyMetadata |
             UpdatePlaceholderType.AllowReadOnly;
 
         private const string EtwArea = "GitIndexProjection";
@@ -71,8 +71,8 @@ namespace GVFS.Virtualization.Projection
         // git from creating a placeholder (since the last time the cache was cleared)
         private int negativePathCacheUpdatedForGitCount;
 
-        // modifiedFilesInvalid: If true, a change to the index that did not trigger a new projection 
-        // has been made and GVFS has not yet validated that all entries whose skip-worktree bit is  
+        // modifiedFilesInvalid: If true, a change to the index that did not trigger a new projection
+        // has been made and GVFS has not yet validated that all entries whose skip-worktree bit is
         // cleared are in the ModifiedFilesDatabase
         private volatile bool modifiedFilesInvalid;
 
@@ -195,7 +195,7 @@ namespace GVFS.Virtualization.Projection
                     this.CopyIndexFileAndBuildProjection();
                 }
                 else
-                {                    
+                {
                     this.BuildProjection();
                 }
             }
@@ -217,7 +217,7 @@ namespace GVFS.Virtualization.Projection
                 this.projectionParseComplete.Set();
             }
 
-            this.indexParsingThread = Task.Factory.StartNew(this.ParseIndexThreadMain, TaskCreationOptions.LongRunning);            
+            this.indexParsingThread = Task.Factory.StartNew(this.ParseIndexThreadMain, TaskCreationOptions.LongRunning);
         }
 
         public virtual void Shutdown()
@@ -392,7 +392,7 @@ namespace GVFS.Virtualization.Projection
 
         public virtual List<ProjectedFileInfo> GetProjectedItems(
             CancellationToken cancellationToken,
-            BlobSizes.BlobSizesConnection blobSizesConnection, 
+            BlobSizes.BlobSizesConnection blobSizesConnection,
             string folderPath)
         {
             this.projectionReadWriteLock.EnterReadLock();
@@ -403,10 +403,10 @@ namespace GVFS.Virtualization.Projection
                 if (this.TryGetOrAddFolderDataFromCache(folderPath, out folderData))
                 {
                     folderData.PopulateSizes(
-                        this.context.Tracer, 
-                        this.gitObjects, 
-                        blobSizesConnection, 
-                        availableSizes: null, 
+                        this.context.Tracer,
+                        this.gitObjects,
+                        blobSizesConnection,
+                        availableSizes: null,
                         cancellationToken: cancellationToken);
 
                     return ConvertToProjectedFileInfos(folderData.ChildEntries);
@@ -426,8 +426,8 @@ namespace GVFS.Virtualization.Projection
             string parentKey;
             this.GetChildNameAndParentKey(virtualPath, out fileName, out parentKey);
             FolderEntryData data = this.GetProjectedFolderEntryData(
-                blobSizesConnection: null, 
-                childName: fileName, 
+                blobSizesConnection: null,
+                childName: fileName,
                 parentKey: parentKey);
 
             if (data != null)
@@ -442,7 +442,7 @@ namespace GVFS.Virtualization.Projection
         public virtual ProjectedFileInfo GetProjectedFileInfo(
             CancellationToken cancellationToken,
             BlobSizes.BlobSizesConnection blobSizesConnection,
-            string virtualPath, 
+            string virtualPath,
             out string parentFolderPath)
         {
             string childName;
@@ -454,8 +454,8 @@ namespace GVFS.Virtualization.Projection
                 cancellationToken,
                 blobSizesConnection,
                 availableSizes: null,
-                childName: childName, 
-                parentKey: parentKey, 
+                childName: childName,
+                parentKey: parentKey,
                 gitCasedChildName: out gitCasedChildName);
 
             if (data != null)
@@ -526,7 +526,7 @@ namespace GVFS.Virtualization.Projection
                 if (this.modifiedFilesInvalid)
                 {
                     using (ITracer activity = this.context.Tracer.StartActivity(
-                        nameof(this.indexParser.AddMissingModifiedFilesAndRemoveThemFromPlaceholderList), 
+                        nameof(this.indexParser.AddMissingModifiedFilesAndRemoveThemFromPlaceholderList),
                         EventLevel.Informational))
                     {
                         FileSystemTaskResult result = this.indexParser.AddMissingModifiedFilesAndRemoveThemFromPlaceholderList(
@@ -713,8 +713,8 @@ namespace GVFS.Virtualization.Projection
         {
             sha = string.Empty;
             FileData data = this.GetProjectedFolderEntryData(
-                blobSizesConnection: null, 
-                childName: childName, 
+                blobSizesConnection: null,
+                childName: childName,
                 parentKey: parentKey) as FileData;
 
             if (data != null && !data.IsFolder)
@@ -768,14 +768,14 @@ namespace GVFS.Virtualization.Projection
         /// <remarks>This method will create and add any intermediate FolderDatas that are
         /// required but not already in the tree.  For example, if the tree was completely empty
         /// and AddFileToTree was called for the path \A\B\C.txt:
-        /// 
+        ///
         ///    pathParts -> { "A", "B", "C.txt"}
-        /// 
+        ///
         ///    AddFileToTree would create new FolderData entries in the tree for "A" and "B"
         ///    and return the FolderData entry for "B"
         /// </remarks>
         private FolderData AddFileToTree(GitIndexEntry indexEntry)
-        {            
+        {
             FolderData parentFolder = this.rootFolderData;
             for (int pathIndex = 0; pathIndex < indexEntry.BuildingProjection_NumParts - 1; ++pathIndex)
             {
@@ -808,13 +808,13 @@ namespace GVFS.Virtualization.Projection
 
             return parentFolder;
         }
-        
+
         private FolderEntryData GetProjectedFolderEntryData(
             CancellationToken cancellationToken,
             BlobSizes.BlobSizesConnection blobSizesConnection,
             Dictionary<string, long> availableSizes,
-            string childName, 
-            string parentKey, 
+            string childName,
+            string parentKey,
             out string gitCasedChildName)
         {
             this.projectionReadWriteLock.EnterReadLock();
@@ -864,17 +864,17 @@ namespace GVFS.Virtualization.Projection
         /// <returns>FolderEntryData for the specified childName and parentKey or null if no FolderEntryData exists for them in the projection</returns>
         /// <remarks><see cref="GetChildNameAndParentKey"/> can be used for getting child name and parent key from a file path</remarks>
         private FolderEntryData GetProjectedFolderEntryData(
-            BlobSizes.BlobSizesConnection blobSizesConnection, 
-            string childName, 
+            BlobSizes.BlobSizesConnection blobSizesConnection,
+            string childName,
             string parentKey)
         {
             string casedChildName;
             return this.GetProjectedFolderEntryData(
                 CancellationToken.None,
                 blobSizesConnection,
-                availableSizes: null, 
-                childName: childName, 
-                parentKey: parentKey, 
+                availableSizes: null,
+                childName: childName,
+                parentKey: parentKey,
                 gitCasedChildName: out casedChildName);
         }
 
@@ -882,10 +882,10 @@ namespace GVFS.Virtualization.Projection
         /// Try to get the FolderData for the specified folder path from the projectionFolderCache
         /// cache.  If the  folder is not already in projectionFolderCache, search for it in the tree and
         /// then add it to projectionData
-        /// </summary>        
+        /// </summary>
         /// <returns>True if the folder could be found, and false otherwise</returns>
         private bool TryGetOrAddFolderDataFromCache(
-            string folderPath, 
+            string folderPath,
             out FolderData folderData)
         {
             if (!this.projectionFolderCache.TryGetValue(folderPath, out folderData))
@@ -939,7 +939,7 @@ namespace GVFS.Virtualization.Projection
 
         /// <summary>
         /// Finds the FolderEntryData at the specified depth of the path provided.  If depth == pathParts.Length
-        /// TryGetFolderEntryDataFromTree will find the FolderEntryData specified in pathParts.  If 
+        /// TryGetFolderEntryDataFromTree will find the FolderEntryData specified in pathParts.  If
         /// depth is less than pathParts.Length, then TryGetFolderEntryDataFromTree will return an ancestor folder of
         /// childPathParts.
         /// </summary>
@@ -987,7 +987,7 @@ namespace GVFS.Virtualization.Projection
                     this.projectionReadWriteLock.EnterWriteLock();
 
                     // Record if the projection needed to be updated to ensure that placeholders and the negative cache
-                    // are only updated when required (i.e. only updated when the projection was updated) 
+                    // are only updated when required (i.e. only updated when the projection was updated)
                     bool updatedProjection = this.projectionInvalid;
 
                     try
@@ -1037,10 +1037,10 @@ namespace GVFS.Virtualization.Projection
                     }
 
                     // Avoid unnecessary updates by checking if the projection actually changed.  Some git commands (e.g. cherry-pick)
-                    // update the index multiple times which can result in the outer 'while (true)' loop executing twice.  This happens 
+                    // update the index multiple times which can result in the outer 'while (true)' loop executing twice.  This happens
                     // because this.wakeUpThread is set again after this thread has woken up but before it's done any processing (because it's
-                    // still waiting for the git command to complete).  If the projection is still valid during the second execution of 
-                    // the loop there's no need to clear the negative cache or update placeholders a second time. 
+                    // still waiting for the git command to complete).  If the projection is still valid during the second execution of
+                    // the loop there's no need to clear the negative cache or update placeholders a second time.
                     if (updatedProjection)
                     {
                         this.ClearNegativePathCache();
@@ -1127,13 +1127,13 @@ namespace GVFS.Virtualization.Projection
                     updatedPlaceholderBag = new ConcurrentBag<PlaceholderListDatabase.PlaceholderData>();
                     addPlaceholderToUpdatedPlaceholders = (data) => updatedPlaceholderBag.Add(data);
                 }
-                
+
                 this.ProcessListOnThreads(
                     numThreads,
                     placeholderFilesListCopy,
-                    (placeholderBatch, start, end, blobSizesConnection, availableSizes) => 
+                    (placeholderBatch, start, end, blobSizesConnection, availableSizes) =>
                         this.BatchPopulateMissingSizesFromRemote(blobSizesConnection, placeholderBatch, start, end, availableSizes),
-                    (placeholder, blobSizesConnection, availableSizes) => 
+                    (placeholder, blobSizesConnection, availableSizes) =>
                         this.UpdateOrDeleteFilePlaceholder(blobSizesConnection, placeholder, addPlaceholderToUpdatedPlaceholders, folderPlaceholdersToKeep, availableSizes));
 
                 this.blobSizes.Flush();
@@ -1141,11 +1141,11 @@ namespace GVFS.Virtualization.Projection
                 using (BlobSizes.BlobSizesConnection blobSizesConnection = this.blobSizes.CreateConnection())
                 {
                     // A hash of the folder placeholders is only required if the platform expands directories
-                    HashSet<string> folderPlaceholders = 
+                    HashSet<string> folderPlaceholders =
                         GVFSPlatform.Instance.KernelDriver.EnumerationExpandsDirectories ?
-                        new HashSet<string>(placeholderFoldersListCopy.Select(x => x.Path), StringComparer.OrdinalIgnoreCase) : 
+                        new HashSet<string>(placeholderFoldersListCopy.Select(x => x.Path), StringComparer.OrdinalIgnoreCase) :
                         null;
-                    
+
                     // Order the folders in decscending order so that we walk the tree from bottom up.
                     // Traversing the folders in this order:
                     //  1. Ensures child folders are deleted before their parents
@@ -1201,8 +1201,8 @@ namespace GVFS.Virtualization.Projection
 
         private void ProcessListOnThreads<T>(
             int numThreads,
-            List<T> list, 
-            Action<List<T>, int, int, BlobSizes.BlobSizesConnection, Dictionary<string, long>> preProcessBatch, 
+            List<T> list,
+            Action<List<T>, int, int, BlobSizes.BlobSizesConnection, Dictionary<string, long>> preProcessBatch,
             Action<T, BlobSizes.BlobSizesConnection, Dictionary<string, long>> processItem)
         {
             if (numThreads > 1)
@@ -1220,7 +1220,7 @@ namespace GVFS.Virtualization.Projection
                         {
                             // We have a top-level try\catch for any unhandled exceptions thrown in the newly created thread
                             try
-                            {                                
+                            {
                                 this.ProcessListThreadCallback(preProcessBatch, processItem, list, start, end);
                             }
                             catch (Exception e)
@@ -1244,10 +1244,10 @@ namespace GVFS.Virtualization.Projection
         }
 
         private void ProcessListThreadCallback<T>(
-            Action<List<T>, int, int, BlobSizes.BlobSizesConnection, Dictionary<string, long>> preProcessBatch, 
-            Action<T, BlobSizes.BlobSizesConnection, Dictionary<string, long>> processItem, 
-            List<T> placeholderList, 
-            int start, 
+            Action<List<T>, int, int, BlobSizes.BlobSizesConnection, Dictionary<string, long>> preProcessBatch,
+            Action<T, BlobSizes.BlobSizesConnection, Dictionary<string, long>> processItem,
+            List<T> placeholderList,
+            int start,
             int end)
         {
             using (BlobSizes.BlobSizesConnection blobSizesConnection = this.blobSizes.CreateConnection())
@@ -1267,14 +1267,14 @@ namespace GVFS.Virtualization.Projection
         }
 
         private void BatchPopulateMissingSizesFromRemote(
-            BlobSizes.BlobSizesConnection blobSizesConnection, 
-            List<PlaceholderListDatabase.PlaceholderData> placeholderList, 
-            int start, 
-            int end, 
+            BlobSizes.BlobSizesConnection blobSizesConnection,
+            List<PlaceholderListDatabase.PlaceholderData> placeholderList,
+            int start,
+            int end,
             Dictionary<string, long> availableSizes)
         {
             int maxObjectsInHTTPRequest = 2000;
-            
+
             for (int index = start; index < end; index += maxObjectsInHTTPRequest)
             {
                 int count = Math.Min(maxObjectsInHTTPRequest, end - index);
@@ -1294,7 +1294,7 @@ namespace GVFS.Virtualization.Projection
                         availableSizes[downloadedSizeId] = downloadedSize.Size;
                     }
                 }
-            }           
+            }
         }
 
         private IEnumerable<string> GetShasWithoutSizeAndNeedingUpdate(BlobSizes.BlobSizesConnection blobSizesConnection, Dictionary<string, long> availableSizes, List<PlaceholderListDatabase.PlaceholderData> placeholders, int start, int end)
@@ -1302,7 +1302,7 @@ namespace GVFS.Virtualization.Projection
             for (int index = start; index < end; index++)
             {
                 string projectedSha = this.GetNewProjectedShaForPlaceholder(placeholders[index].Path);
-                
+
                 if (!string.IsNullOrEmpty(projectedSha))
                 {
                     long blobSize = 0;
@@ -1424,7 +1424,7 @@ namespace GVFS.Virtualization.Projection
         /// Removes the folder placeholder from disk if it's empty.
         /// </summary>
         /// <returns>
-        /// <c>true</c>If the folder placeholder was deleted 
+        /// <c>true</c>If the folder placeholder was deleted
         /// <c>false</c>If RemoveFolderPlaceholderIfEmpty did not attempt to remove the folder placeholder
         /// </returns>
         /// <remarks>
@@ -1449,8 +1449,8 @@ namespace GVFS.Virtualization.Projection
                 //
                 // If enumeration does not expand directories there is no harm in deleting empty
                 // folder placeholders that are in the projection as they will be re-projected during
-                // enumeration.  Additionally, there may be folder tombstones on disk that need to be 
-                // cleaned up (e.g. git might have deleted a folder placeholder that was not in 
+                // enumeration.  Additionally, there may be folder tombstones on disk that need to be
+                // cleaned up (e.g. git might have deleted a folder placeholder that was not in
                 // ModifiedPaths.dat, resulting in a tombstone getting created).
 
                 FolderData folderData;
@@ -1480,7 +1480,7 @@ namespace GVFS.Virtualization.Projection
                     metadata.Add("Folder Path", placeholder.Path);
                     metadata.Add("result.Result", result.Result.ToString());
                     metadata.Add("result.RawResult", result.RawResult);
-                    metadata.Add("UpdateFailureCause", failureReason.ToString());                    
+                    metadata.Add("UpdateFailureCause", failureReason.ToString());
                     this.context.Tracer.RelatedEvent(EventLevel.Informational, nameof(this.RemoveFolderPlaceholderIfEmpty) + "_DeleteFileFailure", metadata);
 
                     // TODO(Mac): Issue #245, handle failures DeleteFile on Mac.  If we don't do anything we could leave an untracked folder
@@ -1509,13 +1509,13 @@ namespace GVFS.Virtualization.Projection
                 UpdateFailureReason failureReason = UpdateFailureReason.NoFailure;
                 FileSystemResult result = this.fileSystemVirtualizer.DeleteFile(placeholder.Path, FilePlaceholderUpdateFlags, out failureReason);
                 this.ProcessGvUpdateDeletePlaceholderResult(
-                    placeholder, 
-                    string.Empty, 
-                    result, 
-                    addPlaceholderToUpdatedPlaceholders, 
-                    failureReason, 
-                    parentKey, 
-                    folderPlaceholdersToKeep, 
+                    placeholder,
+                    string.Empty,
+                    result,
+                    addPlaceholderToUpdatedPlaceholders,
+                    failureReason,
+                    parentKey,
+                    folderPlaceholdersToKeep,
                     deleteOperation: true);
             }
             else
@@ -1552,13 +1552,13 @@ namespace GVFS.Virtualization.Projection
                     }
 
                     this.ProcessGvUpdateDeletePlaceholderResult(
-                        placeholder, 
-                        projectedSha, 
-                        result, 
-                        addPlaceholderToUpdatedPlaceholders, 
-                        failureReason, 
-                        parentKey, 
-                        folderPlaceholdersToKeep, 
+                        placeholder,
+                        projectedSha,
+                        result,
+                        addPlaceholderToUpdatedPlaceholders,
+                        failureReason,
+                        parentKey,
+                        folderPlaceholdersToKeep,
                         deleteOperation: false);
                 }
                 else
@@ -1605,22 +1605,22 @@ namespace GVFS.Virtualization.Projection
                     metadata.Add(TracingConstants.MessageKey.InfoMessage, "UpdateOrDeletePlaceholder: StatusIoReparseTagNotHandled");
                     this.context.Tracer.RelatedEvent(EventLevel.Informational, "UpdatePlaceholders_StatusIoReparseTagNotHandled", metadata);
 
-                    break;                
+                    break;
 
                 case FSResult.VirtualizationInvalidOperation:
-                    // GVFS attempted to update\delete a file that is no longer partial.  
+                    // GVFS attempted to update\delete a file that is no longer partial.
                     // This can occur if:
                     //
                     //    - A file is converted from partial to full (or tombstone) while a git command is running.
-                    //      Any tasks scheduled during the git command to update the placeholder list have not yet 
+                    //      Any tasks scheduled during the git command to update the placeholder list have not yet
                     //      completed at this point.
                     //
                     //    - A placeholder file was converted to full without being in the index.  This can happen if 'git update-index --remove'
-                    //      is used to remove a file from the index before converting the file to full.  Because a skip-worktree bit 
+                    //      is used to remove a file from the index before converting the file to full.  Because a skip-worktree bit
                     //      is not cleared when this file file is converted to full, FileSystemCallbacks assumes that there is no placeholder
                     //      that needs to be removed removed from the list
                     //
-                    //    - When there is a merge conflict the conflicting file will get the skip worktree bit removed. In some cases git 
+                    //    - When there is a merge conflict the conflicting file will get the skip worktree bit removed. In some cases git
                     //      will not make any changes to the file in the working directory. In order to handle this case we have to check
                     //      the merge stage in the index and add that entry to the placeholder list. In doing so the files that git did
                     //      update in the working directory will be full files but we will have a placeholder entry for them as well.
@@ -1663,8 +1663,8 @@ namespace GVFS.Virtualization.Projection
                         metadata.Add("result.RawResult", result.RawResult);
                         metadata.Add("failureReason", failureReason.ToString());
                         this.context.Tracer.RelatedWarning(metadata, "UpdateOrDeletePlaceholder: did not succeed");
-                    }       
-                             
+                    }
+
                     break;
             }
         }
@@ -1681,8 +1681,8 @@ namespace GVFS.Virtualization.Projection
         }
 
         private void AddFileToUpdateDeletePlaceholderFailureReport(
-            bool deleteOperation, 
-            PlaceholderListDatabase.PlaceholderData placeholder, 
+            bool deleteOperation,
+            PlaceholderListDatabase.PlaceholderData placeholder,
             out string gitPath)
         {
             gitPath = placeholder.Path.TrimStart(Path.DirectorySeparatorChar).Replace(Path.DirectorySeparatorChar, GVFSConstants.GitPathSeparator);

--- a/GVFS/GVFS.Virtualization/Projection/ProjectedFileInfo.cs
+++ b/GVFS/GVFS.Virtualization/Projection/ProjectedFileInfo.cs
@@ -15,7 +15,7 @@ namespace GVFS.Virtualization.Projection
         public string Name { get; }
         public long Size { get; }
         public bool IsFolder { get; }
-        
+
         public Sha1Id Sha { get; }
     }
 }

--- a/GVFS/GVFS/CommandLine/CacheServerVerb.cs
+++ b/GVFS/GVFS/CommandLine/CacheServerVerb.cs
@@ -12,7 +12,7 @@ namespace GVFS.CommandLine
     public class CacheServerVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string CacheVerbName = "cache-server";
-        
+
         [Option(
             "set",
             Default = null,
@@ -22,7 +22,7 @@ namespace GVFS.CommandLine
 
         [Option("get", Required = false, HelpText = "Outputs the current cache server information. This is the default.")]
         public bool OutputCurrentInfo { get; set; }
-        
+
         [Option(
             "list",
             Required = false,
@@ -33,7 +33,7 @@ namespace GVFS.CommandLine
         {
             get { return CacheVerbName; }
         }
-        
+
         protected override void Execute(GVFSEnlistment enlistment)
         {
             this.BlockEmptyCacheServerUrl(this.CacheToSet);

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -85,7 +85,7 @@ namespace GVFS.CommandLine
             this.ValidatePathParameter(this.EnlistmentRootPathParameter);
             this.ValidatePathParameter(this.LocalCacheRoot);
 
-            string fullEnlistmentRootPathParameter; 
+            string fullEnlistmentRootPathParameter;
             string normalizedEnlistmentRootPath = this.GetCloneRoot(out fullEnlistmentRootPathParameter);
 
             if (!string.IsNullOrWhiteSpace(this.LocalCacheRoot))
@@ -145,7 +145,7 @@ namespace GVFS.CommandLine
                                 { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
                                 { nameof(fullEnlistmentRootPathParameter), fullEnlistmentRootPathParameter },
                             });
-                        
+
                         CacheServerResolver cacheServerResolver = new CacheServerResolver(tracer, enlistment);
                         cacheServer = cacheServerResolver.ParseUrlOrFriendlyName(this.CacheServerUrl);
 
@@ -178,7 +178,7 @@ namespace GVFS.CommandLine
                         cacheServer = this.ResolveCacheServer(tracer, cacheServer, cacheServerResolver, serverGVFSConfig);
 
                         this.ValidateClientVersions(tracer, enlistment, serverGVFSConfig, showWarnings: true);
-                       
+
                         this.ShowStatusWhileRunning(
                             () =>
                             {
@@ -276,12 +276,12 @@ namespace GVFS.CommandLine
 
         private Result TryCreateEnlistment(
             string fullEnlistmentRootPathParameter,
-            string normalizedEnlistementRootPath, 
+            string normalizedEnlistementRootPath,
             out GVFSEnlistment enlistment)
         {
             enlistment = null;
 
-            // Check that EnlistmentRootPath is empty before creating a tracer and LogFileEventListener as 
+            // Check that EnlistmentRootPath is empty before creating a tracer and LogFileEventListener as
             // LogFileEventListener will create a file in EnlistmentRootPath
             if (Directory.Exists(normalizedEnlistementRootPath) && Directory.EnumerateFileSystemEntries(normalizedEnlistementRootPath).Any())
             {
@@ -298,7 +298,7 @@ namespace GVFS.CommandLine
             {
                 return new Result(GVFSConstants.GitIsNotInstalledError);
             }
-            
+
             string hooksPath = this.GetGVFSHooksPathAndCheckVersion(tracer: null, hooksVersion: out _);
 
             enlistment = new GVFSEnlistment(
@@ -307,15 +307,15 @@ namespace GVFS.CommandLine
                 gitBinPath,
                 hooksPath,
                 authentication: null);
-            
+
             return new Result(true);
         }
-        
+
         private Result TryClone(
-            JsonTracer tracer, 
-            GVFSEnlistment enlistment, 
-            CacheServerInfo cacheServer, 
-            RetryConfig retryConfig, 
+            JsonTracer tracer,
+            GVFSEnlistment enlistment,
+            CacheServerInfo cacheServer,
+            RetryConfig retryConfig,
             ServerGVFSConfig serverGVFSConfig,
             string resolvedLocalCacheRoot)
         {
@@ -326,7 +326,7 @@ namespace GVFS.CommandLine
                 {
                     return pipeResult;
                 }
-                                
+
                 using (GitObjectsHttpRequestor objectRequestor = new GitObjectsHttpRequestor(tracer, enlistment, cacheServer, retryConfig))
                 {
                     GitRefs refs = objectRequestor.QueryInfoRefs(this.SingleBranch ? this.Branch : null);
@@ -445,7 +445,7 @@ namespace GVFS.CommandLine
             string errorMessage;
             string existingEnlistmentRoot;
             if (GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(normalizedEnlistmentRootPath, out existingEnlistmentRoot, out errorMessage))
-            { 
+            {
                 this.ReportErrorAndExit("Error: You can't clone inside an existing GVFS repo ({0})", existingEnlistmentRoot);
             }
         }
@@ -505,7 +505,7 @@ namespace GVFS.CommandLine
             {
                 return new Result("Error configuring alternate: " + errorMessage);
             }
-            
+
             GitRepo gitRepo = new GitRepo(tracer, enlistment, fileSystem);
             GVFSContext context = new GVFSContext(tracer, fileSystem, gitRepo, enlistment);
             GVFSGitObjects gitObjects = new GVFSGitObjects(context, objectRequestor);

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -143,7 +143,7 @@ namespace GVFS.CommandLine
                                 ProductUpgrader.DownloadDirectory,
                                 "downloaded-assets.txt");
                         }
-                     
+
                         return true;
                     },
                     "Copying logs");
@@ -192,9 +192,9 @@ namespace GVFS.CommandLine
         }
 
         private void CopyAllFiles(
-            string sourceRoot, 
-            string targetRoot, 
-            string folderName, 
+            string sourceRoot,
+            string targetRoot,
+            string folderName,
             bool copySubFolders,
             bool hideErrorsFromStdout = false,
             string targetFolderName = null)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -67,7 +67,7 @@ namespace GVFS.CommandLine
                     catch (JsonReaderException e)
                     {
                         this.ReportErrorAndExit("Failed to parse InternalParameters: {0}.\n {1}", value, e);
-                    }                    
+                    }
                 }
             }
         }
@@ -350,7 +350,7 @@ namespace GVFS.CommandLine
             }
 
             return serverGVFSConfig;
-        }        
+        }
 
         protected void ValidateClientVersions(ITracer tracer, GVFSEnlistment enlistment, ServerGVFSConfig gvfsConfig, bool showWarnings)
         {

--- a/GVFS/GVFS/CommandLine/LogVerb.cs
+++ b/GVFS/GVFS/CommandLine/LogVerb.cs
@@ -38,7 +38,7 @@ namespace GVFS.CommandLine
             string errorMessage;
             string enlistmentRoot;
             if (!GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(this.EnlistmentRootPathParameter, out enlistmentRoot, out errorMessage))
-            { 
+            {
                 this.ReportErrorAndExit(
                     "Error: '{0}' is not a valid GVFS enlistment",
                     this.EnlistmentRootPathParameter);
@@ -103,7 +103,7 @@ namespace GVFS.CommandLine
                 .First()
                 .FullName;
         }
-        
+
         private static string GetLogFilePatternForType(string logFileType)
         {
             return "gvfs_" + logFileType + "_*.log";

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -69,7 +69,7 @@ namespace GVFS.CommandLine
                     }
                 }
             }
-            
+
             if (!DiskLayoutUpgrade.TryRunAllUpgrades(enlistmentRoot))
             {
                 this.ReportErrorAndExit("Failed to upgrade repo disk layout. " + ConsoleHelper.GetGVFSLogMessage(enlistmentRoot));
@@ -230,7 +230,7 @@ namespace GVFS.CommandLine
             errorMessage = string.Empty;
             mountExecutableLocation = string.Empty;
 
-            // We have to parse these parameters here to make sure they are valid before 
+            // We have to parse these parameters here to make sure they are valid before
             // handing them to the background process which cannot tell the user when they are bad
             EventLevel verbosity;
             Keywords keywords;
@@ -295,7 +295,7 @@ namespace GVFS.CommandLine
         }
 
         private bool RegisterMount(GVFSEnlistment enlistment, out string errorMessage)
-        {   
+        {
             errorMessage = string.Empty;
 
             NamedPipeMessages.RegisterRepoRequest request = new NamedPipeMessages.RegisterRepoRequest();

--- a/GVFS/GVFS/CommandLine/RepairVerb.cs
+++ b/GVFS/GVFS/CommandLine/RepairVerb.cs
@@ -20,7 +20,7 @@ namespace GVFS.CommandLine
             MetaName = "Enlistment Root Path",
             HelpText = "Full or relative path to the GVFS enlistment root")]
         public override string EnlistmentRootPathParameter { get; set; }
-        
+
         [Option(
             "confirm",
             Default = false,
@@ -73,7 +73,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
             if (!ConsoleHelper.ShowStatusWhileRunning(
                 () =>
                 {
-                    // Don't use 'gvfs status' here. The repo may be corrupt such that 'gvfs status' cannot run normally, 
+                    // Don't use 'gvfs status' here. The repo may be corrupt such that 'gvfs status' cannot run normally,
                     // causing repair to continue when it shouldn't.
                     using (NamedPipeClient pipeClient = new NamedPipeClient(enlistment.NamedPipeName))
                     {
@@ -114,7 +114,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
                     });
 
                 List<RepairJob> jobs = new List<RepairJob>();
-                
+
                 // Repair databases
                 jobs.Add(new BackgroundOperationDatabaseRepairJob(tracer, this.Output, enlistment));
                 jobs.Add(new RepoMetadataDatabaseRepairJob(tracer, this.Output, enlistment));
@@ -202,7 +202,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
                 }
             }
         }
-        
+
         private void WriteMessage(ITracer tracer, string message)
         {
             tracer.RelatedEvent(EventLevel.Informational, "RepairInfo", new EventMetadata { { TracingConstants.MessageKey.InfoMessage, message } });

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -99,7 +99,7 @@ namespace GVFS.CommandLine
                 {
                     string errorString = $"The following repos failed to mount:{Environment.NewLine}{string.Join("\r\n", failedRepoRoots.ToArray())}";
                     Console.Error.WriteLine(errorString);
-                    this.ReportErrorAndExit(Environment.NewLine + errorString);                    
+                    this.ReportErrorAndExit(Environment.NewLine + errorString);
                 }
             }
             else if (this.UnmountAll)

--- a/GVFS/GVFS/CommandLine/UnmountVerb.cs
+++ b/GVFS/GVFS/CommandLine/UnmountVerb.cs
@@ -57,7 +57,7 @@ namespace GVFS.CommandLine
                 this.ReportErrorAndExit(errorMessage);
             }
 
-            if (!this.Unattended && 
+            if (!this.Unattended &&
                 !this.SkipUnregister &&
                 GVFSPlatform.Instance.UnderConstruction.SupportsGVFSService)
             {
@@ -216,9 +216,9 @@ namespace GVFS.CommandLine
                     string result = null;
                     if (!GVFSLock.TryAcquireGVFSLockForProcess(
                             this.Unattended,
-                            pipeClient, 
-                            "gvfs unmount", 
-                            currentProcess.Id, 
+                            pipeClient,
+                            "gvfs unmount",
+                            currentProcess.Id,
                             GVFSPlatform.Instance.IsElevated(),
                             isConsoleOutputRedirectedToFile: GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
                             checkAvailabilityOnly: false,

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -48,7 +48,7 @@ namespace GVFS.CommandLine
         {
             get { return UpgradeVerbName; }
         }
-        
+
         public override void Execute()
         {
             ReturnCode exitCode = ReturnCode.Success;
@@ -118,7 +118,7 @@ namespace GVFS.CommandLine
                 this.upgrader.CleanupDownloadDirectory();
                 return true;
             }
-                        
+
             if (!this.TryRunUpgradeChecks(out newestVersion, out error))
             {
                 this.Output.WriteLine(errorOutputFormat, error);
@@ -162,16 +162,16 @@ namespace GVFS.CommandLine
                         GVFSConstants.UpgradeVerbMessages.UnmountRepoWarning,
                         GVFSConstants.UpgradeVerbMessages.UpgradeInstallAdvice);
                 this.ReportInfoToConsole(upgradeAvailableMessage + Environment.NewLine + Environment.NewLine + message + Environment.NewLine);
-            }          
+            }
 
             return true;
         }
-        
+
         private bool TryLoadUpgradeRing(out ProductUpgrader.RingType ring, out string consoleError)
         {
             bool loaded = false;
             if (!this.upgrader.TryLoadRingConfig(out consoleError))
-            {                
+            {
                 this.tracer.RelatedError($"{nameof(this.TryLoadUpgradeRing)} failed. {consoleError}");
             }
             else
@@ -268,13 +268,13 @@ namespace GVFS.CommandLine
 
                 activity.RelatedInfo("Successfully launched upgrade tool.");
             }
-                
+
             consoleError = null;
             return true;
         }
 
         private bool TryCheckUpgradeAvailable(
-            out Version latestVersion, 
+            out Version latestVersion,
             out string consoleError)
         {
             latestVersion = null;
@@ -313,7 +313,7 @@ namespace GVFS.CommandLine
 
                 activity.RelatedInfo("Upgrade is installable.");
             }
-            
+
             return true;
         }
 
@@ -326,7 +326,7 @@ namespace GVFS.CommandLine
         {
             public ProcessLauncher()
             {
-                this.Process = new Process();                
+                this.Process = new Process();
             }
 
             public Process Process { get; private set; }
@@ -352,7 +352,7 @@ namespace GVFS.CommandLine
                 exception = null;
 
                 try
-                {   
+                {
                     return this.Process.Start();
                 }
                 catch (Exception ex)

--- a/GVFS/GVFS/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("GVFS")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/GVFS/GVFS/RepairJobs/BackgroundOperationDatabaseRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/BackgroundOperationDatabaseRepairJob.cs
@@ -21,7 +21,7 @@ namespace GVFS.RepairJobs
         {
             get { return "Background Operation Database"; }
         }
-        
+
         public override IssueType HasIssue(List<string> messages)
         {
             string error;
@@ -39,7 +39,7 @@ namespace GVFS.RepairJobs
 
             return IssueType.None;
         }
-        
+
         public override FixResult TryFixIssues(List<string> messages)
         {
             return FixResult.Failure;

--- a/GVFS/GVFS/RepairJobs/BlobSizeDatabaseRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/BlobSizeDatabaseRepairJob.cs
@@ -41,7 +41,7 @@ namespace GVFS.RepairJobs
             finally
             {
                 RepoMetadata.Shutdown();
-            }           
+            }
 
             if (BlobSizes.HasIssue(this.blobSizeRoot, new PhysicalFileSystem(), out error))
             {

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -81,7 +81,7 @@ namespace GVFS.RepairJobs
             {
                 return FixResult.Failure;
             }
-            
+
             File.WriteAllText(configPath, string.Empty);
             this.Tracer.RelatedInfo("Created empty file: " + configPath);
 
@@ -97,7 +97,7 @@ namespace GVFS.RepairJobs
             // Don't output the validation output unless it turns out we couldn't fix the problem
             List<string> validationMessages = new List<string>();
 
-            // HasIssue should return CantFix because we can't set the repo url ourselves, 
+            // HasIssue should return CantFix because we can't set the repo url ourselves,
             // but getting Fixable means that we still failed
             if (this.HasIssue(validationMessages) == IssueType.Fixable)
             {

--- a/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
@@ -10,7 +10,7 @@ namespace GVFS.RepairJobs
 {
     public class GitHeadRepairJob : RepairJob
     {
-        public GitHeadRepairJob(ITracer tracer, TextWriter output, GVFSEnlistment enlistment) 
+        public GitHeadRepairJob(ITracer tracer, TextWriter output, GVFSEnlistment enlistment)
             : base(tracer, output, enlistment)
         {
         }
@@ -19,7 +19,7 @@ namespace GVFS.RepairJobs
         {
             get { return @".git\HEAD"; }
         }
-        
+
         public override IssueType HasIssue(List<string> messages)
         {
             if (TryParseHead(this.Enlistment, messages))
@@ -31,7 +31,7 @@ namespace GVFS.RepairJobs
             {
                 return IssueType.CantFix;
             }
-            
+
             return IssueType.Fixable;
         }
 
@@ -109,7 +109,7 @@ namespace GVFS.RepairJobs
             error = null;
             return true;
         }
-        
+
         private static bool TryParseHead(Enlistment enlistment, List<string> messages)
         {
             string refPath = Path.Combine(enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Head);

--- a/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
@@ -9,7 +9,7 @@ namespace GVFS.RepairJobs
     public class GitIndexRepairJob : RepairJob
     {
         private readonly string indexPath;
-        
+
         public GitIndexRepairJob(ITracer tracer, TextWriter output, GVFSEnlistment enlistment)
             : base(tracer, output, enlistment)
         {

--- a/GVFS/GVFS/RepairJobs/RepoMetadataDatabaseRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/RepoMetadataDatabaseRepairJob.cs
@@ -16,7 +16,7 @@ namespace GVFS.RepairJobs
         {
             get { return "Repo Metadata Database"; }
         }
-        
+
         public override IssueType HasIssue(List<string> messages)
         {
             string error;
@@ -35,7 +35,7 @@ namespace GVFS.RepairJobs
 
             return IssueType.None;
         }
-        
+
         public override FixResult TryFixIssues(List<string> messages)
         {
             return FixResult.Failure;

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -31,12 +31,12 @@ namespace PrjFSLib.Mac.Interop
             byte[] contentId,
             ulong fileSize,
             ushort fileMode);
-        
+
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WriteSymLink")]
         public static extern Result WriteSymLink(
             string relativePath,
             string symLinkTarget);
-        
+
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_UpdatePlaceholderFileIfNeeded")]
         public static extern Result UpdatePlaceholderFileIfNeeded(
             string relativePath,

--- a/Scripts/Mac/GenerateCommonAssemblyVersion.sh
+++ b/Scripts/Mac/GenerateCommonAssemblyVersion.sh
@@ -4,7 +4,7 @@ GVFSPROPS=$VFS_SRCDIR/GVFS/GVFS.Build/GVFS.props
 VERSIONNUMBER="$(cat $GVFSPROPS | grep GVFSVersion | grep -Eo '[0-9.]+(-\w+)?')"
 
 cat >$VFS_OUTPUTDIR/CommonAssemblyVersion.cs <<TEMPLATE
-using System.Reflection; 
+using System.Reflection;
 
 [assembly: AssemblyVersion("$VERSIONNUMBER")]
 [assembly: AssemblyFileVersion("$VERSIONNUMBER")]


### PR DESCRIPTION
@kewillford had suggested that we open issues to start driving down the number of rules that we have disable in our StyleCop ruleset - and this is a step in that direction. I wanted to see how people felt about this rule, fixing up violations in our code base, and seeing if this will cause disruption to work that is currently in flight. My hope is that the diff itself will be easy to look through, as it only contains whitespace differences for all but 1 file (`GVFS.ruleset`, where I remove the override for this rule).

Clean up existing instances of trailing whitespace in our codebase and
stop suppressing StyleCop rule SA1028 which enforces no trailing
whitespace:

    https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md

These changes were generated by applying the StyleCop automatic fixup for SA1028.

