### PR TITLE
Configure Visual Studio 2019 to use expected version of Git

### DIFF
--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -201,7 +201,11 @@ namespace GVFS.Platform.Windows
         public override void ConfigureVisualStudio(string gitBinPath, ITracer tracer)
         {
             const string GitBinPathEnd = "\\cmd\\git.exe";
-            const string GitVSRegistryKeyName = "HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\15.0\\TeamFoundation\\GitSourceControl";
+            string[] gitVSRegistryKeyNames =
+            {
+                "HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\15.0\\TeamFoundation\\GitSourceControl",
+                "HKEY_CURRENT_USER\\Software\\Microsoft\\VSCommon\\16.0\\TeamFoundation\\GitSourceControl"
+            };
             const string GitVSRegistryValueName = "GitPath";
 
             if (!gitBinPath.EndsWith(GitBinPathEnd))
@@ -214,7 +218,10 @@ namespace GVFS.Platform.Windows
             }
 
             string regKeyValue = gitBinPath.Substring(0, gitBinPath.Length - GitBinPathEnd.Length);
-            Registry.SetValue(GitVSRegistryKeyName, GitVSRegistryValueName, regKeyValue);
+            foreach (string registryKeyName in gitVSRegistryKeyNames)
+            {
+                Registry.SetValue(registryKeyName, GitVSRegistryValueName, regKeyValue);
+            }
         }
 
         public override bool TryGetGVFSHooksPathAndVersion(out string hooksPath, out string hooksVersion, out string error)


### PR DESCRIPTION
Set registry key that Visual Studio 2019 uses to set path to git.exe so
it uses the expected version of git.