### PR TITLE
PackfileMaintenanceStep

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181219.1</GitPackageVersion>
+    <GitPackageVersion>2.20181221.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Security;
 using System.Threading;
 
 namespace GVFS.Common.FileSystem
@@ -71,6 +72,27 @@ namespace GVFS.Common.FileSystem
         public virtual void WriteAllText(string path, string contents)
         {
             File.WriteAllText(path, contents);
+        }
+
+        public virtual bool TryWriteAllText(string path, string contents)
+        {
+            try
+            {
+                this.WriteAllText(path, contents);
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (SecurityException)
+            {
+                return false;
+            }
         }
 
         public Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare shareMode, bool callFlushFileBuffers)

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -477,10 +477,20 @@ namespace GVFS.Common.Git
         public Result PrunePacked(string gitObjectDirectory)
         {
             return this.InvokeGitAgainstDotGitFolder(
-                "prune-packed -q", 
+                "prune-packed -q",
                 writeStdIn: null,
                 parseStdOutLine: null,
                 gitObjectsDirectory: gitObjectDirectory);
+        }
+
+        public Result MultiPackIndexExpire(string gitObjectDirectory)
+        {
+            return this.InvokeGitAgainstDotGitFolder($"multi-pack-index expire --object-dir=\"{gitObjectDirectory}\"");
+        }
+
+        public Result MultiPackIndexRepack(string gitObjectDirectory, string batchSize)
+        {
+            return this.InvokeGitAgainstDotGitFolder($"-c pack.depth=0 -c pack.window=0 multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize}");
         }
 
         public Process GetGitProcess(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, bool redirectStandardError, string gitObjectsDirectory)

--- a/GVFS/GVFS.Common/InternalVerbParameters.cs
+++ b/GVFS/GVFS.Common/InternalVerbParameters.cs
@@ -4,16 +4,22 @@ namespace GVFS.Common
 {
     public class InternalVerbParameters
     {
-        public InternalVerbParameters(string serviceName, bool startedByService, string maintenanceJob)
+        public InternalVerbParameters(
+            string serviceName = null,
+            bool startedByService = true,
+            string maintenanceJob = null,
+            string packfileMaintenanceBatchSize = null)
         {
             this.ServiceName = serviceName;
             this.StartedByService = startedByService;
             this.MaintenanceJob = maintenanceJob;
+            this.PackfileMaintenanceBatchSize = packfileMaintenanceBatchSize;
         }
 
         public string ServiceName { get; private set; }
         public bool StartedByService { get; private set; }
         public string MaintenanceJob { get; private set; }
+        public string PackfileMaintenanceBatchSize { get; private set; }
 
         public static InternalVerbParameters FromJson(string json)
         {

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceScheduler.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceScheduler.cs
@@ -9,6 +9,10 @@ namespace GVFS.Common.Maintenance
     {
         private readonly TimeSpan looseObjectsDueTime = TimeSpan.FromMinutes(5);
         private readonly TimeSpan looseObjectsPeriod = TimeSpan.FromHours(6);
+
+        private readonly TimeSpan packfileDueTime = TimeSpan.FromMinutes(30);
+        private readonly TimeSpan packfilePeriod = TimeSpan.FromHours(12);
+
         private readonly TimeSpan prefetchPeriod = TimeSpan.FromMinutes(15);
 
         private List<Timer> stepTimers;
@@ -54,16 +58,22 @@ namespace GVFS.Common.Maintenance
             {
                 TimeSpan prefetchPeriod = TimeSpan.FromMinutes(15);
                 this.stepTimers.Add(new Timer(
-                    (state) => this.queue.TryEnqueue(new PrefetchStep(this.context, this.gitObjects, requireCacheLock: true)),
+                    (state) => this.queue.TryEnqueue(new PrefetchStep(this.context, this.gitObjects)),
                     state: null,
                     dueTime: this.prefetchPeriod,
                     period: this.prefetchPeriod));
 
                 this.stepTimers.Add(new Timer(
-                    (state) => this.queue.TryEnqueue(new LooseObjectsStep(this.context, requireCacheLock: true)),
+                    (state) => this.queue.TryEnqueue(new LooseObjectsStep(this.context)),
                     state: null,
                     dueTime: this.looseObjectsDueTime,
                     period: this.looseObjectsPeriod));
+
+                this.stepTimers.Add(new Timer(
+                    (state) => this.queue.TryEnqueue(new PackfileMaintenanceStep(this.context)),
+                    state: null,
+                    dueTime: this.packfileDueTime,
+                    period: this.packfilePeriod));
             }
         }
     }

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -13,10 +13,9 @@ namespace GVFS.Common.Maintenance
         public const string ObjectCacheLock = "git-maintenance-step.lock";
         private readonly object gitProcessLock = new object();
 
-        public GitMaintenanceStep(GVFSContext context, GitObjects gitObjects, bool requireObjectCacheLock)
+        public GitMaintenanceStep(GVFSContext context, bool requireObjectCacheLock)
         {
             this.Context = context;
-            this.GitObjects = gitObjects;
             this.RequireObjectCacheLock = requireObjectCacheLock;
         }
 
@@ -24,7 +23,6 @@ namespace GVFS.Common.Maintenance
         protected virtual TimeSpan TimeBetweenRuns { get; }
         protected virtual string LastRunTimeFilePath { get; set; }
         protected GVFSContext Context { get; }
-        protected GitObjects GitObjects { get; }
         protected GitProcess GitProcess { get; private set; }
         protected bool Stopping { get; private set; }
         protected bool RequireObjectCacheLock { get; }

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -3,7 +3,6 @@ using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -17,8 +16,8 @@ namespace GVFS.Common.Maintenance
         public const string LooseObjectsLastRunFileName = "loose-objects.time";
         private readonly bool forceRun;
 
-        public LooseObjectsStep(GVFSContext context, bool requireCacheLock, bool forceRun = false)
-            : base(context, gitObjects: null, requireObjectCacheLock: requireCacheLock)
+        public LooseObjectsStep(GVFSContext context, bool requireCacheLock = true, bool forceRun = false)
+            : base(context, requireObjectCacheLock: requireCacheLock)
         {
             this.forceRun = forceRun;
         }

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -1,0 +1,167 @@
+﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.Common.Maintenance
+{
+    /// <summary>
+    /// This step maintains the packfiles in the object cache.
+    ///
+    /// This is done in two steps:
+    ///
+    /// git multi-pack-index expire: This deletes the pack-files whose objects
+    /// appear in newer pack-files. The multi-pack-index prevents git from
+    /// looking at these packs. Rewrites the multi-pack-index to no longer
+    /// refer to these (deleted) packs.
+    ///
+    /// git multi-pack-index repack --batch-size= inspects packs covered by the
+    /// multi-pack-index in modified-time order(ascending). Greedily selects a
+    /// batch of packs whose file sizes are all less than "size", but that sum
+    /// up to at least "size". Then generate a new pack-file containing the
+    /// objects that are uniquely referenced by the multi-pack-index.
+    /// </summary>
+    public class PackfileMaintenanceStep : GitMaintenanceStep
+    {
+        public const string PackfileLastRunFileName = "pack-maintenance.time";
+        public const string DefaultBatchSize = "2g";
+        private readonly bool forceRun;
+        private readonly string batchSize;
+
+        public PackfileMaintenanceStep(
+            GVFSContext context,
+            bool requireObjectCacheLock = true,
+            bool forceRun = false,
+            string batchSize = DefaultBatchSize)
+            : base(context, requireObjectCacheLock)
+        {
+            this.forceRun = forceRun;
+            this.batchSize = batchSize;
+        }
+
+        public override string Area => nameof(PackfileMaintenanceStep);
+        protected override string LastRunTimeFilePath => Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", PackfileLastRunFileName);
+        protected override TimeSpan TimeBetweenRuns => TimeSpan.FromDays(1);
+
+        // public only for unit tests
+        public void GetPackFilesInfo(out int count, out long size, out bool hasKeep)
+        {
+            count = 0;
+            size = 0;
+            hasKeep = false;
+
+            foreach (DirectoryItemInfo info in this.Context.FileSystem.ItemsInDirectory(this.Context.Enlistment.GitPackRoot))
+            {
+                string extension = Path.GetExtension(info.Name);
+
+                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                {
+                    count++;
+                    size += info.Length;
+                }
+                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasKeep = true;
+                }
+            }
+        }
+
+        // public only for unit tests
+        public List<string> CleanStaleIdxFiles(out int numDeletionBlocked)
+        {
+            List<DirectoryItemInfo> packDirContents = this.Context
+                                                          .FileSystem
+                                                          .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
+                                                          .ToList();
+
+            numDeletionBlocked = 0;
+            List<string> deletedIdxFiles = new List<string>();
+
+            // If something (probably VFS for Git) has a handle open to a ".idx" file, then
+            // the 'git multi-pack-index expire' command cannot delete it. We should come in
+            // later and try to clean these up. Count those that we are able to delete and
+            // those we still can't.
+
+            foreach (DirectoryItemInfo info in packDirContents)
+            {
+                if (string.Equals(Path.GetExtension(info.Name), ".idx", StringComparison.OrdinalIgnoreCase))
+                {
+                    string pairedPack = Path.ChangeExtension(info.FullName, ".pack");
+
+                    if (!this.Context.FileSystem.FileExists(pairedPack))
+                    {
+                        if (this.Context.FileSystem.TryDeleteFile(info.FullName))
+                        {
+                            deletedIdxFiles.Add(info.Name);
+                        }
+                        else
+                        {
+                            numDeletionBlocked++;
+                        }
+                    }
+                }
+            }
+
+            return deletedIdxFiles;
+        }
+
+        protected override void PerformMaintenance()
+        {
+            using (ITracer activity = this.Context.Tracer.StartActivity(this.Area, EventLevel.Informational, Keywords.Telemetry, metadata: null))
+            {
+                // forceRun is only currently true for functional tests
+                if (!this.forceRun)
+                {
+                    if (!this.EnoughTimeBetweenRuns())
+                    {
+                        activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to not enough time between runs");
+                        return;
+                    }
+
+                    IEnumerable<int> processIds = this.RunningGitProcessIds();
+                    if (processIds.Any())
+                    {
+                        activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);
+                        return;
+                    }
+                }
+
+                this.GetPackFilesInfo(out int beforeCount, out long beforeSize, out bool hasKeep);
+
+                if (!hasKeep)
+                {
+                    activity.RelatedWarning(this.CreateEventMetadata(), "Skiping pack maintenance due to no .keep file.");
+                    return;
+                }
+
+                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot));
+                List<string> staleIdxFiles = this.CleanStaleIdxFiles(out int numDeletionBlocked);
+                this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
+                GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize));
+                this.GetPackFilesInfo(out int afterCount, out long afterSize, out hasKeep);
+
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("GitObjectsRoot", this.Context.Enlistment.GitObjectsRoot);
+                metadata.Add("BatchSize", this.batchSize);
+                metadata.Add(nameof(beforeCount), beforeCount);
+                metadata.Add(nameof(beforeSize), beforeSize);
+                metadata.Add(nameof(expireCount), expireCount);
+                metadata.Add(nameof(expireSize), expireSize);
+                metadata.Add(nameof(afterCount), afterCount);
+                metadata.Add(nameof(afterSize), afterSize);
+                metadata.Add("ExpireOutput", expireResult.Output);
+                metadata.Add("ExpireErrors", expireResult.Errors);
+                metadata.Add("RepackOutput", repackResult.Output);
+                metadata.Add("RepackErrors", repackResult.Errors);
+                metadata.Add("NumStaleIdxFiles", staleIdxFiles.Count);
+                metadata.Add("NumIdxDeletionsBlocked", numDeletionBlocked);
+                activity.RelatedEvent(EventLevel.Informational, $"{this.Area}_{nameof(this.PerformMaintenance)}", metadata, Keywords.Telemetry);
+
+                this.SaveLastRunTimeToFile();
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -133,7 +133,7 @@ namespace GVFS.Common.Maintenance
 
                 if (!hasKeep)
                 {
-                    activity.RelatedWarning(this.CreateEventMetadata(), "Skiping pack maintenance due to no .keep file.");
+                    activity.RelatedWarning(this.CreateEventMetadata(), "Skipping pack maintenance due to no .keep file.");
                     return;
                 }
 

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -11,8 +11,8 @@ namespace GVFS.Common.Maintenance
         private const string MultiPackIndexLock = "multi-pack-index.lock";
         private List<string> packIndexes;
 
-        public PostFetchStep(GVFSContext context, GitObjects gitObjects, List<string> packIndexes)
-            : base(context, gitObjects, requireObjectCacheLock: true)
+        public PostFetchStep(GVFSContext context, List<string> packIndexes)
+            : base(context, requireObjectCacheLock: true)
         {
             this.packIndexes = packIndexes;
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
@@ -1,0 +1,132 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class PackfileMaintenanceStepTests : TestsWithEnlistmentPerFixture
+    {
+        private FileSystemRunner fileSystem;
+
+        // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
+        // the cache
+        public PackfileMaintenanceStepTests()
+            : base(forcePerRepoObjectCache: true)
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        private string GitObjectRoot => this.Enlistment.GetObjectRoot(this.fileSystem);
+        private string PackRoot => this.Enlistment.GetPackRoot(this.fileSystem);
+
+        [TestCase, Order(1)]
+        public void ExpireClonePack()
+        {
+            this.GetPackSizes(out int packCount, out long maxSize, out long totalSize);
+
+            // We should have at least two packs:
+            //
+            // 1. the pack-<hash>.pack from clone.
+            // 2. a prefetch-<timestamp>-<hash>.pack from prefetch.
+            //
+            // The prefetch pack is newer, and covers all the objects in the clone pack,
+            // so the clone pack will be expired when we run the step.
+
+            Directory.GetFiles(this.PackRoot, "*.keep")
+                .Count()
+                .ShouldEqual(1);
+
+            packCount.ShouldEqual(2, message: "Incorrect packfile layout for expire test");
+
+            // Ensure we have a multi-pack-index (not created on clone)
+            GitProcess.InvokeProcess(
+                this.Enlistment.RepoRoot,
+                $"multi-pack-index write --object-dir={this.GitObjectRoot}");
+
+            this.Enlistment.PackfileMaintenanceStep();
+
+            List<string> packs = this.GetPackfiles();
+
+            packs.Count.ShouldEqual(1, $"incorrect number of packs after first step: {packs.Count}");
+
+            Path.GetFileName(packs[0])
+                .StartsWith("prefetch-")
+                .ShouldBeTrue($"packsBetween[0] should start with 'prefetch-': {packs[0]}");
+        }
+
+        [TestCase, Order(2)]
+        public void RepackAllToOnePack()
+        {
+            // Create new pack(s) by prefetching blobs for a folder.
+            // This generates a number of packs, based on the processor number (for parallel downloads).
+            this.Enlistment.Prefetch($"--folders {Path.Combine("GVFS", "GVFS")}");
+
+            // Create a multi-pack-index that covers the prefetch packs
+            // (The post-fetch job creates a multi-pack-index only after a --commits prefetch)
+            GitProcess.InvokeProcess(
+                this.Enlistment.RepoRoot,
+                $"multi-pack-index write --object-dir={this.GitObjectRoot}");
+
+            // Run the step to ensure we don't have any packs that will be expired during the repack step
+            this.Enlistment.PackfileMaintenanceStep();
+
+            this.GetPackSizes(out int afterPrefetchPackCount, out long maxSize, out long totalSize);
+
+            // Cannot be sure of the count, as the prefetch uses parallel threads to get multiple packs
+            afterPrefetchPackCount.ShouldBeAtLeast(2);
+
+            this.Enlistment.PackfileMaintenanceStep(batchSize: totalSize - 1);
+            this.GetPackSizes(out int packCount, out maxSize, out totalSize);
+
+            // We should not have expired any packs, but created a new one with repack
+            packCount.ShouldEqual(afterPrefetchPackCount + 1, $"incorrect number of packs after repack step: {packCount}");
+        }
+
+        [TestCase, Order(3)]
+        public void ExpireAllButOneAndKeep()
+        {
+            string prefetchPack = Directory.GetFiles(this.PackRoot, "prefetch-*.pack")
+                                           .FirstOrDefault();
+
+            prefetchPack.ShouldNotBeNull();
+
+            // We should expire all packs except the one we just created,
+            // and the prefetch pack which is marked as ".keep"
+            this.Enlistment.PackfileMaintenanceStep();
+
+            List<string> packsAfter = this.GetPackfiles();
+
+            packsAfter.Count.ShouldEqual(2, $"incorrect number of packs after final expire step: {packsAfter.Count}");
+            packsAfter.Contains(prefetchPack).ShouldBeTrue($"packsAfter does not contain prefetch pack ({prefetchPack})");
+        }
+
+        private List<string> GetPackfiles()
+        {
+            return Directory.GetFiles(this.PackRoot, "*.pack").ToList();
+        }
+
+        private void GetPackSizes(out int packCount, out long maxSize, out long totalSize)
+        {
+            totalSize = 0;
+            maxSize = 0;
+            packCount = 0;
+
+            foreach (string file in this.GetPackfiles())
+            {
+                packCount++;
+                long size = new FileInfo(Path.Combine(this.PackRoot, file)).Length;
+                totalSize += size;
+
+                if (size > maxSize)
+                {
+                    maxSize = size;
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -217,6 +217,11 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.LooseObjectStep();
         }
 
+        public string PackfileMaintenanceStep(long? batchSize = null)
+        {
+            return this.gvfsProcess.PackfileMaintenanceStep(batchSize);
+        }
+
         public string Status(string trace = null)
         {
             return this.gvfsProcess.Status(trace);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -133,9 +133,12 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
-        public static string GetInternalParameter(string maintenanceJob = "null")
+        public static string GetInternalParameter(string maintenanceJob = "null", string packfileMaintenanceBatchSize = "null")
         {
-            return $"\"{{\\\"ServiceName\\\":\\\"{GVFSServiceProcess.TestServiceName}\\\",\\\"StartedByService\\\":false,\\\"MaintenanceJob\\\":{maintenanceJob}}}\"";
+            return $"\"{{\\\"ServiceName\\\":\\\"{GVFSServiceProcess.TestServiceName}\\\"," +
+                    "\\\"StartedByService\\\":false," +
+                    $"\\\"MaintenanceJob\\\":{maintenanceJob}," +
+                    $"\\\"PackfileMaintenanceBatchSize\\\":{packfileMaintenanceBatchSize}}}\"";
         }
 
         private static string GetModifiedPathsContents(GVFSFunctionalTestEnlistment enlistment, FileSystemRunner fileSystem)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -59,8 +59,18 @@ namespace GVFS.FunctionalTests.Tools
         {
             return this.CallGVFS(
                 "dehydrate \"" + this.enlistmentRoot + "\"",
-                failOnError: false,
+                failOnError: true,
                 internalParameter: GVFSHelpers.GetInternalParameter("\\\"LooseObjects\\\""));
+        }
+
+        public string PackfileMaintenanceStep(long? batchSize)
+        {
+            string sizeString = batchSize.HasValue ? $"\\\"{batchSize.Value}\\\"" : "null";
+            string internalParameter = GVFSHelpers.GetInternalParameter("\\\"PackfileMaintenance\\\"", sizeString);
+            return this.CallGVFS(
+                "dehydrate \"" + this.enlistmentRoot + "\"",
+                failOnError: true,
+                internalParameter: internalParameter);
         }
 
         public string Diagnose()

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -439,7 +439,7 @@ namespace GVFS.Mount
             if (this.currentState == MountState.Ready)
             {
                 List<string> packIndexes = JsonConvert.DeserializeObject<List<string>>(message.Body);
-                this.maintenanceScheduler.EnqueueOneTimeStep(new PostFetchStep(this.context, this.gitObjects, packIndexes));
+                this.maintenanceScheduler.EnqueueOneTimeStep(new PostFetchStep(this.context, packIndexes));
 
                 response = new NamedPipeMessages.RunPostFetchJob.Response(NamedPipeMessages.RunPostFetchJob.QueuedResult);
             }

--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -58,7 +58,7 @@ namespace GVFS.Service
 
         private bool CallGVFSMount(string repoRoot)
         {
-            InternalVerbParameters mountInternal = new InternalVerbParameters(serviceName: null, startedByService: true, maintenanceJob: null);
+            InternalVerbParameters mountInternal = new InternalVerbParameters(startedByService: true);
             return this.CurrentUser.RunAs(
                 Configuration.Instance.GVFSLocation,
                 $"mount {repoRoot} --{GVFSConstants.VerbParameters.InternalUseOnly} {mountInternal.ToJson()}");

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
@@ -48,8 +48,8 @@ namespace GVFS.UnitTests.Maintenance
         {
             this.TestSetup();
 
-            TestGitMaintenanceStep step1 = new TestGitMaintenanceStep(this.context, this.gitObjects);
-            TestGitMaintenanceStep step2 = new TestGitMaintenanceStep(this.context, this.gitObjects);
+            TestGitMaintenanceStep step1 = new TestGitMaintenanceStep(this.context);
+            TestGitMaintenanceStep step2 = new TestGitMaintenanceStep(this.context);
 
             GitMaintenanceQueue queue = new GitMaintenanceQueue(this.context);
 
@@ -74,7 +74,7 @@ namespace GVFS.UnitTests.Maintenance
 
             queue.Stop();
 
-            TestGitMaintenanceStep step = new TestGitMaintenanceStep(this.context, this.gitObjects);
+            TestGitMaintenanceStep step = new TestGitMaintenanceStep(this.context);
             queue.TryEnqueue(step).ShouldEqual(false);
         }
 
@@ -87,14 +87,14 @@ namespace GVFS.UnitTests.Maintenance
 
             // This step stops the queue after the step is started,
             // then checks if Stop() was called.
-            WatchForStopStep watchForStop = new WatchForStopStep(queue, this.context, this.gitObjects);
+            WatchForStopStep watchForStop = new WatchForStopStep(queue, this.context);
 
             queue.TryEnqueue(watchForStop);
             Assert.IsTrue(watchForStop.EventTriggered.WaitOne(this.maxWaitTime));
             watchForStop.SawStopping.ShouldBeTrue();
 
             // Ensure we don't start a job after the Stop() call
-            TestGitMaintenanceStep watchForStart = new TestGitMaintenanceStep(this.context, this.gitObjects);
+            TestGitMaintenanceStep watchForStart = new TestGitMaintenanceStep(this.context);
             queue.TryEnqueue(watchForStart).ShouldBeFalse();
 
             // This only ensures the event didn't happen within maxWaitTime
@@ -136,8 +136,8 @@ namespace GVFS.UnitTests.Maintenance
 
         public class TestGitMaintenanceStep : GitMaintenanceStep
         {
-            public TestGitMaintenanceStep(GVFSContext context, GitObjects gitObjects)
-                : base(context, gitObjects, requireObjectCacheLock: true)
+            public TestGitMaintenanceStep(GVFSContext context)
+                : base(context, requireObjectCacheLock: true)
             {
                 this.EventTriggered = new ManualResetEvent(initialState: false);
             }
@@ -156,8 +156,8 @@ namespace GVFS.UnitTests.Maintenance
 
         private class WatchForStopStep : GitMaintenanceStep
         {
-            public WatchForStopStep(GitMaintenanceQueue queue, GVFSContext context, GitObjects gitObjects)
-                : base(context, gitObjects, requireObjectCacheLock: true)
+            public WatchForStopStep(GitMaintenanceQueue queue, GVFSContext context)
+                : base(context, requireObjectCacheLock: true)
             {
                 this.Queue = queue;
                 this.EventTriggered = new ManualResetEvent(false);

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
@@ -1,6 +1,5 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
-using GVFS.Common.Git;
 using GVFS.Common.Maintenance;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
@@ -14,14 +13,13 @@ namespace GVFS.UnitTests.Maintenance
     public class GitMaintenanceStepTests
     {
         private GVFSContext context;
-        private GitObjects gitObjects;
 
         [TestCase]
         public void GitMaintenanceStepRunsGitAction()
         {
             this.TestSetup();
 
-            CheckMethodStep step = new CheckMethodStep(this.context, this.gitObjects);
+            CheckMethodStep step = new CheckMethodStep(this.context);
             step.Execute();
 
             step.SawWorkInvoked.ShouldBeTrue();
@@ -32,7 +30,7 @@ namespace GVFS.UnitTests.Maintenance
         {
             this.TestSetup();
 
-            CheckMethodStep step = new CheckMethodStep(this.context, this.gitObjects);
+            CheckMethodStep step = new CheckMethodStep(this.context);
 
             step.Stop();
             step.Execute();
@@ -45,7 +43,7 @@ namespace GVFS.UnitTests.Maintenance
         {
             this.TestSetup();
 
-            CheckStopStep step = new CheckStopStep(this.context, this.gitObjects);
+            CheckStopStep step = new CheckStopStep(this.context);
 
             step.Execute();
 
@@ -59,13 +57,12 @@ namespace GVFS.UnitTests.Maintenance
             PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, null, null));
 
             this.context = new GVFSContext(tracer, fileSystem, null, enlistment);
-            this.gitObjects = new MockPhysicalGitObjects(tracer, fileSystem, enlistment, null);
         }
 
         public class CheckMethodStep : GitMaintenanceStep
         {
-            public CheckMethodStep(GVFSContext context, GitObjects gitObjects)
-                : base(context, gitObjects, requireObjectCacheLock: true)
+            public CheckMethodStep(GVFSContext context)
+                : base(context, requireObjectCacheLock: true)
             {
             }
 
@@ -85,8 +82,8 @@ namespace GVFS.UnitTests.Maintenance
 
         public class CheckStopStep : GitMaintenanceStep
         {
-            public CheckStopStep(GVFSContext context, GitObjects gitObjects)
-                : base(context, gitObjects, requireObjectCacheLock: true)
+            public CheckStopStep(GVFSContext context)
+                : base(context, requireObjectCacheLock: true)
             {
             }
 

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -1,0 +1,165 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Maintenance;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using GVFS.UnitTests.Mock.Git;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GVFS.UnitTests.Maintenance
+{
+    [TestFixture]
+    public class PackfileMaintenanceStepTests
+    {
+        private const string StaleIdxName = "pack-stale.idx";
+        private const string KeepName = "pack-3.keep";
+        private MockTracer tracer;
+        private MockGitProcess gitProcess;
+        private GVFSContext context;
+
+        private string ExpireCommand => $"multi-pack-index expire --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string RepackCommand => $"-c pack.depth=0 -c pack.window=0 multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=2g";
+
+        [TestCase]
+        public void PackfileMaintenanceIgnoreTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: true);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(2);
+            commands[0].ShouldEqual(this.ExpireCommand);
+            commands[1].ShouldEqual(this.RepackCommand);
+        }
+
+        [TestCase]
+        public void PackfileMaintenanceFailTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(1);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void PackfileMaintenancePassTimeRestriction()
+        {
+            this.TestSetup(DateTime.UtcNow.AddDays(-1));
+
+            PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(2);
+            commands[0].ShouldEqual(this.ExpireCommand);
+            commands[1].ShouldEqual(this.RepackCommand);
+        }
+
+        [TestCase]
+        public void CountPackFiles()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: false);
+
+            step.GetPackFilesInfo(out int count, out long size, out bool hasKeep);
+            count.ShouldEqual(3);
+            size.ShouldEqual(11);
+            hasKeep.ShouldEqual(true);
+
+            this.context.FileSystem.DeleteFile(Path.Combine(this.context.Enlistment.GitPackRoot, KeepName));
+
+            step.GetPackFilesInfo(out count, out size, out hasKeep);
+            count.ShouldEqual(3);
+            size.ShouldEqual(11);
+            hasKeep.ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void CleanStaleIdxFiles()
+        {
+            this.TestSetup(DateTime.UtcNow);
+
+            PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: false);
+
+            List<string> staleIdx = step.CleanStaleIdxFiles(out int numDeletionBlocked);
+
+            staleIdx.Count.ShouldEqual(1);
+            staleIdx[0].ShouldEqual(StaleIdxName);
+
+            this.context
+                .FileSystem
+                .FileExists(Path.Combine(this.context.Enlistment.GitPackRoot, StaleIdxName))
+                .ShouldBeFalse();
+        }
+
+        private void TestSetup(DateTime lastRun)
+        {
+            string lastRunTime = EpochConverter.ToUnixEpochSeconds(lastRun).ToString();
+
+            this.gitProcess = new MockGitProcess();
+
+            // Create enlistment using git process
+            GVFSEnlistment enlistment = new MockGVFSEnlistment(this.gitProcess);
+
+            // Create a last run time file
+            MockFile timeFile = new MockFile(Path.Combine(enlistment.GitObjectsRoot, "info", PackfileMaintenanceStep.PackfileLastRunFileName), lastRunTime);
+
+            // Create info directory to hold last run time file
+            MockDirectory info = new MockDirectory(
+                Path.Combine(enlistment.GitObjectsRoot, "info"),
+                null,
+                new List<MockFile>() { timeFile });
+
+            // Create pack info
+            MockDirectory pack = new MockDirectory(
+                enlistment.GitPackRoot,
+                null,
+                new List<MockFile>()
+                {
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-1.pack"), "one"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-1.idx"), "1"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-2.pack"), "two"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-2.idx"), "2"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-3.pack"), "three"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, "pack-3.idx"), "3"),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, KeepName), string.Empty),
+                    new MockFile(Path.Combine(enlistment.GitPackRoot, StaleIdxName), "4"),
+                });
+
+            // Create git objects directory
+            MockDirectory gitObjectsRoot = new MockDirectory(enlistment.GitObjectsRoot, new List<MockDirectory>() { info, pack }, null);
+
+            // Add object directory to file System
+            List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, directories, null));
+
+            // Create and return Context
+            this.tracer = new MockTracer();
+            this.context = new GVFSContext(this.tracer, fileSystem, repository: null, enlistment: enlistment);
+
+            this.gitProcess.SetExpectedCommandResult(
+                this.ExpireCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.RepackCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -57,6 +57,11 @@ namespace GVFS.CommandLine
                             this.MaintenanceJob = mountInternal.MaintenanceJob;
                         }
 
+                        if (!string.IsNullOrEmpty(mountInternal.PackfileMaintenanceBatchSize))
+                        {
+                            this.PackfileMaintenanceBatchSize = mountInternal.PackfileMaintenanceBatchSize;
+                        }
+
                         this.StartedByService = mountInternal.StartedByService;
                     }
                     catch (JsonReaderException e)
@@ -70,6 +75,8 @@ namespace GVFS.CommandLine
         public string ServiceName { get; set; }
 
         public string MaintenanceJob { get; set; }
+
+        public string PackfileMaintenanceBatchSize { get; set; }
 
         public bool StartedByService { get; set; }
 


### PR DESCRIPTION
Create a new maintenance step for cleaning up the packfiles in the shared object cache.

This is done in two steps:

1. `git multi-pack-index expire`: This deletes the pack-files whose objects appear in newer pack-files. The multi-pack-index prevents `git` from looking at these packs. Rewrites the `multi-pack-index` to no longer refer to these (deleted) packs.

2. `git multi-pack-index repack --batch-size=<size>` inspects packs covered by the multi-pack-index in modified-time order (ascending). Greedily selects a batch of packs whose file sizes are all less than "size", but that sum up to at least "size". Then generate a new pack-file containing the objects that are uniquely referenced by the `multi-pack-index`.

See [this PR in microsoft/git](https://github.com/Microsoft/git/pull/84) for details of the `git` implementation.

There are some important details:

* The `expire` command will not delete packs that are marked with a `.keep` file. So, we can keep our most-recent prefetch pack around by writing a `.keep` file. This avoids any change to the logic for the most-recent good prefetch timestamp.

* The `expire` command frequently fails to actually delete `.idx` files in a VFS for Git repo. This is due to something holding a handle to the files, as later we are able to delete them; we've seen this problem before with scripts that try to clean up the pack directory. We clean up `.idx` files that are not paired with a `.pack` after we run the `expire` step. This can generate warnings in the `multi-pack-index write` commands as it tries to add the packs based on their `.idx` files. The commands succeed, however.

* According to the [`git pack-objects` documentation](https://git-scm.com/docs/git-pack-objects#git-pack-objects---windowltngt), we should set the `pack.window` and `pack.depth` config settings to zero to avoid delta calculations. This saves significant computation time when our packs contain blobs, as the deltification algorithm can be very slow. If we were packing only commits and trees, the problem is not as significant. It is important that we don't set this globally, that way we actually compute deltas on push. Instead, just set the settings using the `-c` mechanism in Git.