### PR TITLE
Mac kext log daemon

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				4A08257521E77BEB00E21AFD /* PBXTargetDependency */,
 				4391F90521E4362B0008103C /* PBXTargetDependency */,
 				4391F90721E4362B0008103C /* PBXTargetDependency */,
 				4391F90921E4362B0008103C /* PBXTargetDependency */,
@@ -57,6 +58,11 @@
 		4391F8FD21E435720008103C /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4391F8FE21E435810008103C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
 		4391F8FF21E435890008103C /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DA21E430E20008103C /* CoreFoundation.framework */; };
+		4A08257321E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */; };
+		4A08257621E77C4600E21AFD /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DA21E430E20008103C /* CoreFoundation.framework */; };
+		4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
+		4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
+		4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +87,13 @@
 			remoteGlobalIDString = 4391F8F321E4355C0008103C;
 			remoteInfo = "prjfs-log";
 		};
+		4A08257421E77BEB00E21AFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4391F87621E4278C0008103C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A08256721E77B7F00E21AFD;
+			remoteInfo = PrjFSKextLogDaemon;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -90,6 +103,16 @@
 			dstPath = /usr/share/man/man1/;
 			dstSubfolderSpec = 0;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		4A08256621E77B7F00E21AFD /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /Library/LaunchDaemons;
+			dstSubfolderSpec = 0;
+			files = (
+				4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
@@ -134,6 +157,10 @@
 		4391F8E521E435230008103C /* PrjFSLib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSLib.cpp; sourceTree = "<group>"; };
 		4391F8E721E435230008103C /* PrjFSUser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrjFSUser.hpp; sourceTree = "<group>"; };
 		4391F8F421E4355C0008103C /* prjfs-log */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "prjfs-log"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A08256821E77B7F00E21AFD /* PrjFSKextLogDaemon */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = PrjFSKextLogDaemon; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
+		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
+		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +189,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4A08256521E77B7F00E21AFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */,
+				4A08257621E77C4600E21AFD /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -180,6 +216,7 @@
 			children = (
 				4391F8C221E4306D0008103C /* PrjFSLib */,
 				4391F88D21E42AA70008103C /* PrjFSKext */,
+				4A08256921E77B7F00E21AFD /* PrjFSKextLogDaemon */,
 				4391F88021E4278C0008103C /* Products */,
 				4391F8D921E430E10008103C /* Frameworks */,
 			);
@@ -194,6 +231,7 @@
 				4391F87F21E4278C0008103C /* PrjFSKext.kext */,
 				4391F8D521E430CF0008103C /* libPrjFSLib.dylib */,
 				4391F8F421E4355C0008103C /* prjfs-log */,
+				4A08256821E77B7F00E21AFD /* PrjFSKextLogDaemon */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -250,6 +288,16 @@
 				4391F8DA21E430E20008103C /* CoreFoundation.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4A08256921E77B7F00E21AFD /* PrjFSKextLogDaemon */ = {
+			isa = PBXGroup;
+			children = (
+				4A08257221E77BDD00E21AFD /* Info.plist */,
+				4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */,
+				4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */,
+			);
+			path = PrjFSKextLogDaemon;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -338,6 +386,23 @@
 			productReference = 4391F8F421E4355C0008103C /* prjfs-log */;
 			productType = "com.apple.product-type.tool";
 		};
+		4A08256721E77B7F00E21AFD /* PrjFSKextLogDaemon */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4A08256F21E77B7F00E21AFD /* Build configuration list for PBXNativeTarget "PrjFSKextLogDaemon" */;
+			buildPhases = (
+				4A08256421E77B7F00E21AFD /* Sources */,
+				4A08256521E77B7F00E21AFD /* Frameworks */,
+				4A08256621E77B7F00E21AFD /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PrjFSKextLogDaemon;
+			productName = PrjFSKextLogDaemon;
+			productReference = 4A08256821E77B7F00E21AFD /* PrjFSKextLogDaemon */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -359,6 +424,9 @@
 					4391F90021E436210008103C = {
 						CreatedOnToolsVersion = 10.1;
 					};
+					4A08256721E77B7F00E21AFD = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
 				};
 			};
 			buildConfigurationList = 4391F87921E4278C0008103C /* Build configuration list for PBXProject "PrjFS" */;
@@ -376,6 +444,7 @@
 				4391F87E21E4278C0008103C /* PrjFSKext */,
 				4391F8D421E430CF0008103C /* PrjFSLib */,
 				4391F8F321E4355C0008103C /* prjfs-log */,
+				4A08256721E77B7F00E21AFD /* PrjFSKextLogDaemon */,
 				4391F90021E436210008103C /* Build All */,
 			);
 		};
@@ -397,13 +466,9 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 			);
 			name = "Run Script - Check kext linkage";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -452,6 +517,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4A08256421E77B7F00E21AFD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */,
+				4A08257321E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -469,6 +543,11 @@
 			isa = PBXTargetDependency;
 			target = 4391F8F321E4355C0008103C /* prjfs-log */;
 			targetProxy = 4391F90821E4362B0008103C /* PBXContainerItemProxy */;
+		};
+		4A08257521E77BEB00E21AFD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4A08256721E77B7F00E21AFD /* PrjFSKextLogDaemon */;
+			targetProxy = 4A08257421E77BEB00E21AFD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -824,6 +903,37 @@
 			};
 			name = Release;
 		};
+		4A08256C21E77B7F00E21AFD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				INFOPLIST_FILE = PrjFSKextLogDaemon/Info.plist;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		4A08256D21E77B7F00E21AFD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				INFOPLIST_FILE = PrjFSKextLogDaemon/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		4A08256E21E77B7F00E21AFD /* Profiling(Release) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				INFOPLIST_FILE = PrjFSKextLogDaemon/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Profiling(Release)";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -873,6 +983,16 @@
 				4391F90221E436210008103C /* Debug */,
 				4391F90321E436210008103C /* Release */,
 				43057C5621E437F300487681 /* Profiling(Release) */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4A08256F21E77B7F00E21AFD /* Build configuration list for PBXNativeTarget "PrjFSKextLogDaemon" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A08256C21E77B7F00E21AFD /* Debug */,
+				4A08256D21E77B7F00E21AFD /* Release */,
+				4A08256E21E77B7F00E21AFD /* Profiling(Release) */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ProjFS.Mac/PrjFSKext/KextLog.cpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.cpp
@@ -10,8 +10,6 @@
 #include "PrjFSLogUserClient.hpp"
 #include "public/PrjFSLogClientShared.h"
 
-os_log_t __prjfs_log;
-
 static PrjFSLogUserClient* s_currentUserClient;
 static RWLock s_kextLogRWLock = {};
 
@@ -23,14 +21,9 @@ struct KextLog_StackMessageBuffer
 
 bool KextLog_Init()
 {
-    // TODO: The subsystem and category values are not currently working. Our events get logged, but are missing these fields.
-    __prjfs_log = os_log_create("io.gvfs.PrjFS", "Kext");
-
     s_kextLogRWLock = RWLock_Alloc();
     if (!RWLock_IsValid(s_kextLogRWLock))
     {
-        os_release(__prjfs_log);
-        __prjfs_log = nullptr;
         return false;
     }
     return true;
@@ -41,12 +34,6 @@ void KextLog_Cleanup()
     if (RWLock_IsValid(s_kextLogRWLock))
     {
         RWLock_FreeMemory(&s_kextLogRWLock);
-    }
-    
-    if (nullptr != __prjfs_log)
-    {
-        os_release(__prjfs_log);
-        __prjfs_log = nullptr;
     }
 }
 

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -8,8 +8,6 @@
 #include "kernel-header-wrappers/mount.h"
 #include <os/log.h>
 
-extern os_log_t __prjfs_log;
-
 bool KextLog_Init();
 void KextLog_Cleanup();
 

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -6,7 +6,6 @@
 
 #define PrjFSMaxPath            1024
 #define PrjFSKextBundleId       "io.gvfs.PrjFSKext"
-#define PrjFSKernelControlName  "io.gvfs.PrjFSKext.ctl"
 
 #define PrjFSServiceClass       "io_gvfs_PrjFS"
 

--- a/ProjFS.Mac/PrjFSKextLogDaemon/Info.plist
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>org.vfsforgit.prjfs.PrjFSKextLogDaemon</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.1</string>
+	<key>CFBundleName</key>
+	<string>PrjFSKextLogDaemon</string>
+</dict>
+</plist>

--- a/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
@@ -1,0 +1,163 @@
+#include "../PrjFSKext/public/PrjFSLogClientShared.h"
+#include "../PrjFSLib/PrjFSUser.hpp"
+#include <iostream>
+#include <OS/log.h>
+#include <IOKit/IOKitLib.h>
+#include <signal.h>
+
+static const char PrjFSKextLogDaemon_OSLogSubsystem[] = "org.vfsforgit.prjfs.PrjFSKextLogDaemon";
+
+static os_log_t s_daemonLogger, s_kextLogger;
+static IONotificationPortRef s_notificationPort;
+
+static void StartLoggingKextMessages(io_connect_t connection, io_service_t service, os_log_t daemonLogger, os_log_t kextLogger);
+static void SetupExitSignalHandler();
+
+int main(int argc, const char* argv[])
+{
+    s_daemonLogger = os_log_create(PrjFSKextLogDaemon_OSLogSubsystem, "daemon");
+    s_kextLogger = os_log_create(PrjFSKextLogDaemon_OSLogSubsystem, "kext");
+    
+    os_log(s_daemonLogger, "PrjFSKextLogDaemon starting up");
+
+    s_notificationPort = IONotificationPortCreate(kIOMasterPortDefault);
+    IONotificationPortSetDispatchQueue(s_notificationPort, dispatch_get_main_queue());
+
+    PrjFSService_WatchContext* watchContext = PrjFSService_WatchForServiceAndConnect(
+         s_notificationPort,
+         UserClientType_Log,
+         [](io_service_t service, io_connect_t connection, bool serviceVersionMismatch, IOReturn connectResult, PrjFSService_WatchContext* context)
+         {
+             if (connectResult != kIOReturnSuccess || connection == IO_OBJECT_NULL)
+             {
+                io_string_t servicePath = "";
+                IORegistryEntryGetPath(service, kIOServicePlane, servicePath);
+                if (serviceVersionMismatch)
+                {
+                    CFTypeRef kextVersionObj = IORegistryEntryCreateCFProperty(service, CFSTR(PrjFSKextVersionKey), kCFAllocatorDefault, 0);
+                    os_log_error(
+                        s_daemonLogger,
+                        "Failed to connect to newly matched PrjFS kernel service at '%{public}s'; version mismatch. Expected %{public}s, kernel service version %{public}@",
+                        servicePath, PrjFSKextVersion, kextVersionObj);
+                    if (kextVersionObj != nullptr)
+                    {
+                        CFRelease(kextVersionObj);
+                    }
+                }
+                else
+                {
+                    os_log_error(
+                        s_daemonLogger,
+                        "Failed to connect to newly matched PrjFS kernel service at '%{public}s'; connecting failed with error 0x%x",
+                        servicePath, connectResult);
+                }
+             }
+             else
+             {
+                 StartLoggingKextMessages(connection, service, s_daemonLogger, s_kextLogger);
+             }
+         });
+    if (nullptr == watchContext)
+    {
+        os_log_error(s_daemonLogger, "Failed to register for service notifications.");
+        return 1;
+    }
+    
+    SetupExitSignalHandler();
+
+    os_log(s_daemonLogger, "PrjFSKextLogDaemon running");
+
+    CFRunLoopRun();
+
+    os_log(s_daemonLogger, "PrjFSKextLogDaemon shutting down");
+
+    PrjFSService_StopWatching(watchContext);
+    
+    return 0;
+}
+
+static os_log_type_t KextLogLevelAsOSLogType(KextLog_Level level)
+{
+    switch (level)
+    {
+    case KEXTLOG_INFO:
+        return OS_LOG_TYPE_INFO;
+    case KEXTLOG_NOTE:
+        return OS_LOG_TYPE_DEFAULT;
+    case KEXTLOG_ERROR:
+    default:
+        return OS_LOG_TYPE_ERROR;
+    }
+}
+
+static void StartLoggingKextMessages(io_connect_t connection, io_service_t prjfsService, os_log_t daemonLogger, os_log_t kextLogger)
+{
+    uint64_t prjfsServiceEntryID = 0;
+    IORegistryEntryGetRegistryEntryID(prjfsService, &prjfsServiceEntryID);
+
+    std::shared_ptr<DataQueueResources> logDataQueue(new DataQueueResources {});
+    if (!PrjFSService_DataQueueInit(logDataQueue.get(), connection, LogPortType_MessageQueue, LogMemoryType_MessageQueue, dispatch_get_main_queue()))
+    {
+        os_log_error(s_daemonLogger, "Failed to set up log message data queue an connection to service with registry entry 0x%llx", prjfsServiceEntryID);
+        IOServiceClose(connection);
+        return;
+    }
+
+    os_log(s_daemonLogger, "Started logging kext messages from PrjFS IOService with registry entry id 0x%llx", prjfsServiceEntryID);
+
+    dispatch_source_set_event_handler(logDataQueue->dispatchSource, ^{
+        DataQueue_ClearMachNotification(logDataQueue->notificationPort);
+        
+        while (IODataQueueEntry* entry = DataQueue_Peek(logDataQueue->queueMemory))
+        {
+            int messageSize = entry->size;
+            if (messageSize >= sizeof(KextLog_MessageHeader) + 2)
+            {
+                struct KextLog_MessageHeader message = {};
+                memcpy(&message, entry->data, sizeof(KextLog_MessageHeader));
+                int logStringLength = messageSize - sizeof(KextLog_MessageHeader) - 1;
+                os_log_type_t messageLogType = KextLogLevelAsOSLogType(message.level);
+                os_log_with_type(s_kextLogger, messageLogType, "%{public}.*s", logStringLength, entry->data + sizeof(KextLog_MessageHeader));
+            }
+            else
+            {
+                os_log_error(s_daemonLogger, "Malformed message received from kext. messageSize = %d, expecting %zu or more", messageSize, sizeof(KextLog_MessageHeader) + 2);
+            }
+
+            DataQueue_Dequeue(logDataQueue->queueMemory, nullptr, nullptr);
+        }
+    });
+    dispatch_resume(logDataQueue->dispatchSource);
+
+    PrjFSService_WatchForServiceTermination(
+        prjfsService,
+        s_notificationPort,
+        [prjfsServiceEntryID, connection, logDataQueue]()
+        {
+            DataQueue_Dispose(logDataQueue.get(), connection, LogMemoryType_MessageQueue);
+
+            IOServiceClose(connection);
+            os_log(s_daemonLogger, "Stopped logging kext messages from PrjFS IOService with registry entry id 0x%llx", prjfsServiceEntryID);
+        });
+}
+
+static void HandleSigterm(int sig, siginfo_t* info, void* uc)
+{
+    // Does nothing, unlike the default implementation which immediately aborts exits the process
+}
+
+// Sets up handling of SIGTERM so that shutting down the daemon can be logged (at the end of main())
+// This is for clarity, so that we know if absence of logs is because there was nothing logged, or because the log daemon shut down.
+static void SetupExitSignalHandler()
+{
+    dispatch_source_t signalSource =
+        dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0 /* no mask values for signal dispatch sources */, dispatch_get_main_queue());
+    dispatch_source_set_event_handler(signalSource, ^{
+        CFRunLoopStop(CFRunLoopGetMain());
+    });
+    dispatch_resume(signalSource);
+    
+    struct sigaction newAction = { .sa_sigaction = HandleSigterm };
+    struct sigaction oldAction = {};
+    sigaction(SIGTERM, &newAction, &oldAction);
+}

--- a/ProjFS.Mac/PrjFSKextLogDaemon/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.vfsforgit.prjfs.PrjFSKextLogDaemon</string>
+	<key>Program</key>
+	<string>/usr/local/libexec/PrjFSKextLogDaemon</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -125,8 +125,6 @@ static bool IsDirEntChildDirectory(const dirent* directoryEntry);
 
 static Message ParseMessageMemory(const void* messageMemory, uint32_t size);
 
-static void ClearMachNotification(mach_port_t port);
-
 #ifdef DEBUG
 static const char* NotificationTypeToString(PrjFS_NotificationType notificationType);
 #endif
@@ -211,7 +209,7 @@ PrjFS_Result PrjFS_StartVirtualizationInstance(
     s_kernelRequestHandlingConcurrentQueue = dispatch_queue_create("PrjFS Kernel Request Handling", DISPATCH_QUEUE_CONCURRENT);
     
     dispatch_source_set_event_handler(dataQueue.dispatchSource, ^{
-        ClearMachNotification(dataQueue.notificationPort);
+        DataQueue_ClearMachNotification(dataQueue.notificationPort);
         
         while (1)
         {
@@ -1261,14 +1259,6 @@ CleanupAndReturn:
 
 }
 
-static void ClearMachNotification(mach_port_t port)
-{
-    struct {
-        mach_msg_header_t	msgHdr;
-        mach_msg_trailer_t	trailer;
-    } msg;
-    mach_msg(&msg.msgHdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(msg), port, 0, MACH_PORT_NULL);
-}
 
 #ifdef DEBUG
 static const char* NotificationTypeToString(PrjFS_NotificationType notificationType)

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
@@ -22,7 +22,7 @@ struct PrjFSService_WatchContext;
 PrjFSService_WatchContext* PrjFSService_WatchForServiceAndConnect(
     struct IONotificationPort* notificationPort,
     enum PrjFSServiceUserClientType clientType,
-    std::function<void(io_service_t, io_connect_t, PrjFSService_WatchContext*)> discoveryCallback);
+    std::function<void(io_service_t, io_connect_t, bool serviceVersionMismatch, IOReturn connectResult, PrjFSService_WatchContext*)> discoveryCallback);
 void PrjFSService_StopWatching(PrjFSService_WatchContext* context);
 bool PrjFSService_ValidateVersion(io_service_t prjfsService);
 

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
@@ -26,6 +26,9 @@ PrjFSService_WatchContext* PrjFSService_WatchForServiceAndConnect(
 void PrjFSService_StopWatching(PrjFSService_WatchContext* context);
 bool PrjFSService_ValidateVersion(io_service_t prjfsService);
 
+void PrjFSService_WatchForServiceTermination(io_service_t service, struct IONotificationPort* notificationPort, std::function<void()> terminationCallback);
+
+
 bool PrjFSService_DataQueueInit(
     DataQueueResources* outQueue,
     io_connect_t connection,
@@ -36,3 +39,4 @@ void DataQueue_Dispose(DataQueueResources* queueResources, io_connect_t connecti
 
 IODataQueueEntry* DataQueue_Peek(IODataQueueMemory* dataQueue);
 IOReturn DataQueue_Dequeue(IODataQueueMemory* dataQueue, void* data, uint32_t* dataSize);
+void DataQueue_ClearMachNotification(mach_port_t port);

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -27,11 +27,15 @@ int main(int argc, const char * argv[])
 
     PrjFSService_WatchContext* watchContext = PrjFSService_WatchForServiceAndConnect(
         s_notificationPort, UserClientType_Log,
-        [](io_service_t service, io_connect_t connection, PrjFSService_WatchContext* context)
+        [](io_service_t service, io_connect_t connection, bool serviceVersionMismatch, IOReturn connectResult, PrjFSService_WatchContext* context)
         {
             if (connection != IO_OBJECT_NULL)
             {
                 ProcessLogMessagesOnConnection(connection, service);
+            }
+            else
+            {
+                std::cerr << "Failed to connect to matched kernel service; result = 0x" << std::hex << connectResult << std::endl;
             }
         });
     if (nullptr == watchContext)

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -48,43 +48,6 @@ int main(int argc, const char * argv[])
     return 0;
 }
 
-struct TerminationNotificationContext
-{
-    std::function<void()> terminationCallback;
-    io_iterator_t terminatedServiceIterator;
-};
-
-static void ServiceTerminated(void* refcon, io_iterator_t iterator)
-{
-    TerminationNotificationContext* context = static_cast<TerminationNotificationContext*>(refcon);
-    
-    io_service_t terminatedService = IOIteratorNext(iterator);
-    if (terminatedService != IO_OBJECT_NULL)
-    {
-        IOObjectRelease(terminatedService);
-        context->terminationCallback();
-        IOObjectRelease(iterator);
-        delete context;
-    }
-}
-
-static void WatchForServiceTermination(io_service_t service, IONotificationPortRef notificationPort, std::function<void()> terminationCallback)
-{
-    uint64_t serviceEntryID = 0;
-    IORegistryEntryGetRegistryEntryID(service, &serviceEntryID);
-    CFMutableDictionaryRef serviceMatching = IORegistryEntryIDMatching(serviceEntryID);
-    TerminationNotificationContext* context = new TerminationNotificationContext { std::move(terminationCallback), };
-    kern_return_t result = IOServiceAddMatchingNotification(notificationPort, kIOTerminatedNotification, serviceMatching, ServiceTerminated, context, &context->terminatedServiceIterator);
-    if (result != kIOReturnSuccess)
-    {
-        delete context;
-    }
-    else
-    {
-        ServiceTerminated(context, context->terminatedServiceIterator);
-    }
-}
-
 struct LogConnectionState
 {
     DataQueueResources dataQueue;
@@ -110,11 +73,7 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
     ++logState->lineCount;
     
     dispatch_source_set_event_handler(logState->dataQueue.dispatchSource, ^{
-        struct {
-            mach_msg_header_t  msgHdr;
-            mach_msg_trailer_t trailer;
-        } msg;
-        mach_msg(&msg.msgHdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(msg), logState->dataQueue.notificationPort, 0, MACH_PORT_NULL);
+        DataQueue_ClearMachNotification(logState->dataQueue.notificationPort);
         
         while(true)
         {
@@ -152,7 +111,7 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
         timer = StartKextProfilingDataPolling(connection);
     }
 
-    WatchForServiceTermination(
+    PrjFSService_WatchForServiceTermination(
         prjfsService,
         s_notificationPort,
         [timer, connection, logState, prjfsServiceEntryID]()


### PR DESCRIPTION
This implements a kext logging daemon, resolving #396.

This iteration of the daemon writes to the macOS unified logging system, which means the messages turn up in Console.app (they really do, unlike when you call `os_log` functions directly from the kext) and can be searched, archived, etc. using the `log` CLI tool, e.g.:

```
 log show --predicate 'subsystem contains "org.vfsforgit"' --info
```
(Checks the log database)

or
```
 log stream --predicate 'subsystem contains "org.vfsforgit"' --info
```
Live streams the log output directly to stdout.

To install the daemon, the launch plist file (org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist) needs to be installed to /Library/LaunchDaemons; this file expects the binary PrjFSKextLogDaemon to be located in /usr/local/libexec/ which is almost certainly not where we'll eventually install it, but I'm not quite clear on where we *are* installing our tools on deployment systems.