### PR TITLE
Fix VS IDE Builds post FastFetch and Versioning rework

### DIFF
--- a/GVFS.sln
+++ b/GVFS.sln
@@ -180,6 +180,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GVFS.FunctionalTests.LockHolder", "GVFS\GVFS.FunctionalTests.LockHolder\GVFS.FunctionalTests.LockHolder.csproj", "{FA273F69-5762-43D8-AEA1-B4F08090D624}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GVFS.Hooks.Mac", "GVFS\GVFS.Hooks\GVFS.Hooks.Mac.csproj", "{4CC2A90D-D240-4382-B4BF-5E175515E492}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A4984251-840E-4622-AD0C-66DFCE2B2574} = {A4984251-840E-4622-AD0C-66DFCE2B2574}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GVFS.Upgrader", "GVFS\GVFS.Upgrader\GVFS.Upgrader.csproj", "{AECEC217-2499-403D-B0BB-2962B9BE5970}"
 EndProject

--- a/GVFS/GVFS.Build/GVFS.PreBuild.csproj
+++ b/GVFS/GVFS.Build/GVFS.PreBuild.csproj
@@ -182,7 +182,7 @@
           Outputs="$(RestoreTimestampPath)"
           DependsOnTargets="GVFSPreBuild"
           Condition="'$(OS)' == 'Windows_NT'">
-    <Exec Command="call $(MSBuildThisFileDirectory)..\..\Scripts\RestorePackages.bat"
+    <Exec Command="call $(MSBuildThisFileDirectory)..\..\Scripts\RestorePackages.bat $(Configuration)"
           WorkingDirectory="$(MSBuildThisFileDirectory)../../" />
     <Touch Files="$(RestoreTimestampPath)" AlwaysCreate="true" />
   </Target>

--- a/Scripts/RestorePackages.bat
+++ b/Scripts/RestorePackages.bat
@@ -3,6 +3,10 @@ CALL %~dp0\InitializeEnvironment.bat || EXIT /b 10
 
 SETLOCAL
 
+IF "%1"=="" (SET "Configuration=Debug") ELSE (SET "Configuration=%1")
+ 
+SET SolutionConfiguration=%Configuration%.Windows
+
 SET nuget="%VFS_TOOLSDIR%\nuget.exe"
 IF NOT EXIST %nuget% (
   mkdir %nuget%\..


### PR DESCRIPTION
Fixes #634 

RestorePackages.bat now requires the Configuration to be passed into it for `dotnet restore` to be able to restore. For some reason, this works fine in the build script, but it doesn't work implicitly in the IDE. Pass the Configuration through from PreBuild into the script.

Additionally, now that the Versioning refactor is done, GVFS.Hooks.Mac has a dependency on PreBuild to get the CommonAssemblyVersion so we need to add a project dependency there.