### PR TITLE
Mac kext: Fix for vnode leak causing shutdown/reboot hang and fix for memory leak

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/Memory.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/Memory.hpp
@@ -1,6 +1,8 @@
 #ifndef Memory_h
 #define Memory_h
 
+#include <kern/assert.h>
+
 kern_return_t Memory_Init();
 kern_return_t Memory_Cleanup();
 
@@ -19,5 +21,12 @@ T* Memory_AllocArray(uint32_t arrayLength)
     return static_cast<T*>(Memory_Alloc(static_cast<uint32_t>(allocBytes)));
 }
 
+template <typename T>
+void Memory_FreeArray(T* array, uint32_t arrayLength)
+{
+    size_t arrayBytes = arrayLength * sizeof(T);
+    assert(arrayBytes <= UINT32_MAX);
+    Memory_Free(array, static_cast<uint32_t>(arrayBytes));
+}
 
 #endif /* Memory_h */

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -15,7 +15,7 @@ OSDefineMetaClassAndStructors(PrjFSProviderUserClient, IOUserClient);
 static const uint32_t ProviderMessageQueueCapacityBytes = 100 * 1024;
 
 
-static const IOExternalMethodDispatch ProviderUserClientDispatch[] =
+const IOExternalMethodDispatch PrjFSProviderUserClient::ProviderUserClientDispatch[] =
 {
     [ProviderSelector_RegisterVirtualizationRootPath] =
         {

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -80,6 +80,16 @@ CleanupAndFail:
     return false;
 }
 
+void PrjFSProviderUserClient::stop(IOService* provider)
+{
+    // On the code path of process dying or disconnecting, the following is unnecessary,
+    // but if the kext is unloaded with providers attached, clientClose() will never be
+    // called on them so we do the cleanup here.
+    this->cleanupProviderRegistration();
+    
+    this->super::stop(provider);
+}
+
 void PrjFSProviderUserClient::free()
 {
     OSSafeReleaseNULL(this->dataQueueMemory);
@@ -96,15 +106,20 @@ void PrjFSProviderUserClient::free()
 // the connection.
 IOReturn PrjFSProviderUserClient::clientClose()
 {
+    this->cleanupProviderRegistration();
+    
+    this->terminate(0);
+    return kIOReturnSuccess;
+}
+
+void PrjFSProviderUserClient::cleanupProviderRegistration()
+{
     VirtualizationRootHandle root = this->virtualizationRootHandle;
     this->virtualizationRootHandle = RootHandle_None;
     if (RootHandle_None != root)
     {
         ActiveProvider_Disconnect(root);
     }
-    
-    this->terminate(0);
-    return kIOReturnSuccess;
 }
 
 // Called when user process requests memory-mapping of kernel data

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
@@ -17,11 +17,13 @@ private:
     IOSharedDataQueue* dataQueue;
     IOMemoryDescriptor* dataQueueMemory;
     Mutex dataQueueWriterMutex;
-public:
     pid_t pid;
     // The root for which this is the provider; RootHandle_None prior to registration
     VirtualizationRootHandle virtualizationRootHandle;
-    
+
+    static const IOExternalMethodDispatch ProviderUserClientDispatch[];
+
+public:
     // IOUserClient methods:
     virtual bool initWithTask(
         task_t owningTask, void* securityToken, UInt32 type,
@@ -56,7 +58,6 @@ public:
 private:
     void cleanupProviderRegistration();
 
-public:
     // External methods:
     static IOReturn registerVirtualizationRoot(
         OSObject* target,

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/PrjFSProviderUserClient.hpp
@@ -44,12 +44,19 @@ public:
     
     virtual IOReturn clientClose() override;
 
+    // IOService methods:
+    virtual void stop(IOService* provider) override;
+
     // OSObject methods:
     virtual void free() override;
 
 
     void sendMessage(const void* message, uint32_t size);
 
+private:
+    void cleanupProviderRegistration();
+
+public:
     // External methods:
     static IOReturn registerVirtualizationRoot(
         OSObject* target,

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -124,6 +124,13 @@ kern_return_t VirtualizationRoots_Init()
 
 kern_return_t VirtualizationRoots_Cleanup()
 {
+    if (s_virtualizationRoots != nullptr)
+    {
+        Memory_FreeArray(s_virtualizationRoots, s_maxVirtualizationRoots);
+        s_virtualizationRoots = nullptr;
+        s_maxVirtualizationRoots = 0;
+    }
+
     if (RWLock_IsValid(s_virtualizationRootsLock))
     {
         RWLock_FreeMemory(&s_virtualizationRootsLock);

--- a/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSKext/VirtualizationRoots.cpp
@@ -126,6 +126,12 @@ kern_return_t VirtualizationRoots_Cleanup()
 {
     if (s_virtualizationRoots != nullptr)
     {
+        for (uint32_t i = 0; i < s_maxVirtualizationRoots; ++i)
+        {
+            // If there are still providers registered at this point, we will leak vnodes
+            assert(s_virtualizationRoots[i].providerUserClient == nullptr);
+        }
+        
         Memory_FreeArray(s_virtualizationRoots, s_maxVirtualizationRoots);
         s_virtualizationRoots = nullptr;
         s_maxVirtualizationRoots = 0;


### PR DESCRIPTION
This fixes #499, again. Or rather, this second manifestation, where shutdown/reboot was [blocked as a result of virtualisation root vnodes having an iocount](https://github.com/Microsoft/VFSForGit/issues/499#issuecomment-447991612). This iocount was leaked because `clientClose` is not called on the user clients if they are terminated as a result of the kext being unloaded as opposed to the client process explicitly disconnecting or dying. The solution is to do the cleanup in the `stop()` function, which the second commit in this series implements.

While investigating/fixing this problem, I also noticed that the virtualisation roots array memory leaks on kext unload, so the first commit in the series fixes that.

Finally, while adding a private function to the provider user client class, I noticed that some existing functions were marked public which actually do not need to be accessed from outside the class, so the third commit fixes that.

**Reviewer note:** I recommend reviewing each commit individually, this will be easier to follow than reviewing overall changes in each file.