### PR TITLE
Mac kext: log more I/O errors

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -1100,8 +1100,8 @@ static bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t _Nonnull context, ui
     }
     
     assert(VATTR_IS_SUPPORTED(&attributes, va_flags));
-     *flags = attributes.va_flags;
-     return true;
+    *flags = attributes.va_flags;
+    return true;
 }
 
 static inline bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit)

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -353,15 +353,7 @@ static int HandleVnodeOperation(
         }
         else
         {
-            const char* name = vnode_getname(currentVnode);
-            mount_t mount = vnode_mount(currentVnode);
-            vfsstatfs* vfsStat = mount != nullptr ? vfs_statfs(mount) : nullptr;
-
-            KextLog_Error("HandleVnodeOperation: vn_getpath failed for vnode %p, error = %d, name '%s', recycled: %s, on mount point mounted at '%s'", currentVnode, error, name ?: "[NULL]", vnode_isrecycled(currentVnode) ? "yes" : "no", vfsStat ? vfsStat->f_mntonname : "[NULL]");
-            if (name != nullptr)
-            {
-                vnode_putname(name);
-            }
+            KextLog_ErrorVnodeProperties(currentVnode, "HandleVnodeOperation: vn_getpath failed, error = %d", error);
         }
     }
 
@@ -639,11 +631,7 @@ static int HandleFileOpOperation(
         bool fileFlaggedInRoot;
         if (!TryGetFileIsFlaggedAsInRoot(currentVnode, context, &fileFlaggedInRoot))
         {
-            const char* vnode_name = vnode_getname(currentVnode);
-            KextLog_Error("KAUTH_FILEOP_CLOSE: checking file flags failed. Path = '%s' Vnode name: %s, type %d, being recycled: %s",
-                path, vnode_name ?: "[NULL]", vnode_vtype(currentVnode), vnode_isrecycled(currentVnode) ? "yes" : "no");
-            if (vnode_name)
-                vnode_putname(vnode_name);
+            KextLog_ErrorVnodeProperties(currentVnode, "KAUTH_FILEOP_CLOSE: checking file flags failed. Path = '%s'", path);
             
             goto CleanupAndReturn;
         }

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -160,14 +160,7 @@ VirtualizationRootHandle VirtualizationRoot_FindForVnode(
     errno_t error = vnode_get(vnode);
     if (error != 0)
     {
-        const char* name = vnode_getname(vnode);
-        mount_t mount = vnode_mount(vnode);
-        vfsstatfs* vfsStat = mount != nullptr ? vfs_statfs(mount) : nullptr;
-        KextLog_FileError(vnode, "VirtualizationRoot_FindForVnode: vnode_get() failed (error = %d) on vnode we'd expect to be live; name = '%s', recycling = %s, mount point mounted at path '%s'", error, name ?: "[NULL]", vnode_isrecycled(vnode) ? "yes" : "no", vfsStat ? vfsStat->f_mntonname : "[NULL]");
-        if (name != nullptr)
-        {
-            vnode_putname(name);
-        }
+        KextLog_ErrorVnodePathAndProperties(vnode, "VirtualizationRoot_FindForVnode: vnode_get() failed (error = %d) on vnode we'd expect to be live", error);
     }
     
     // Search up the tree until we hit a known virtualization root or THE root of the file system
@@ -226,15 +219,7 @@ static VirtualizationRootHandle FindOrDetectRootAtVnode(vnode_t _Nonnull vnode, 
             errno_t error = vn_getpath(vnode, path, &pathLength);
             if (error != 0)
             {
-                const char* name = vnode_getname(vnode);
-                mount_t mount = vnode_mount(vnode);
-                vfsstatfs* vfsStat = mount != nullptr ? vfs_statfs(mount) : nullptr;
-
-                KextLog_Error("FindOrDetectRootAtVnode: vn_getpath failed (error = %d) for vnode with name '%s', recycled: %s, on mount point mounted at '%s'", error, name ?: "[NULL]", vnode_isrecycled(vnode) ? "yes" : "no", vfsStat ? vfsStat->f_mntonname : "[NULL]");
-                if (name != nullptr)
-                {
-                    vnode_putname(name);
-                }
+                KextLog_ErrorVnodeProperties(vnode, "FindOrDetectRootAtVnode: vn_getpath failed (error = %d)", error);
             }
             
             RWLock_AcquireExclusive(s_virtualizationRootsLock);
@@ -404,15 +389,8 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
             
             if (0 != err)
             {
-                const char* name = vnode_getname(virtualizationRootVNode);
-                mount_t mount = vnode_mount(virtualizationRootVNode);
-                vfsstatfs* vfsStat = mount != nullptr ? vfs_statfs(mount) : nullptr;
-
-                KextLog_Error("VirtualizationRoot_RegisterProviderForPath: vn_getpath failed (error = %d) for vnode looked up from path '%s' with name '%s', recycled: %s, on mount point at '%s'", err, virtualizationRootPath, name ?: "[NULL]", vnode_isrecycled(virtualizationRootVNode) ? "yes" : "no", vfsStat ? vfsStat->f_mntonname : "[NULL]");
-                if (name != nullptr)
-                {
-                    vnode_putname(name);
-                }
+                KextLog_ErrorVnodeProperties(
+                    virtualizationRootVNode, "VirtualizationRoot_RegisterProviderForPath: vn_getpath failed (error = %d) for vnode looked up from path '%s'", err, virtualizationRootPath);
             }
             else
             {

--- a/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
@@ -1,4 +1,5 @@
 #include "VnodeUtilities.hpp"
+#include "KextLog.hpp"
 #include "kernel-header-wrappers/vnode.h"
 #include "kernel-header-wrappers/mount.h"
 #include <sys/xattr.h>
@@ -12,7 +13,11 @@ FsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t context)
     // TODO: check this is correct for hardlinked files
     VATTR_WANTED(&attrs, va_fileid);
 
-    vnode_getattr(vnode, &attrs, context);
+    int errno = vnode_getattr(vnode, &attrs, context);
+    if (0 != errno)
+    {
+        KextLog_FileError(vnode, "Vnode_GetFsidAndInode: vnode_getattr failed with errno %d", errno);
+    }
     
     vfsstatfs* statfs = vfs_statfs(vnode_mount(vnode));
     return { statfs->f_fsid, attrs.va_fileid };


### PR DESCRIPTION
This is a cleaned up and toned-down version of PR #555 in that (hopefully) all I/O calls in the kext are error checked and will log the error if it is unexpected. This is one part of issue #328 - as far as I'm aware, most of these errors should only very rarely be encountered (they're not turning up in my tests)  so I'm mainlining the logging of these remaining error conditions to try and get a better feel for if and when they do turn up.