### PR TITLE
Update Git to include commit-graph BUG statement

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181217.4</GitPackageVersion>
+    <GitPackageVersion>2.20181219.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
This prevents writing bad data to the commit-graph when the list of commits to write is corrupted in-memory.