### PR TITLE
Enable FastFetch to lay out symlinks correctly

### DIFF
--- a/GVFS/FastFetch/NativeUnixMethods.cs
+++ b/GVFS/FastFetch/NativeUnixMethods.cs
@@ -48,6 +48,7 @@ namespace FastFetch
             catch (Win32Exception e)
             {
                 EventMetadata metadata = new EventMetadata();
+                metadata.Add("filemode", mode);
                 metadata.Add("destination", destination);
                 metadata.Add("exception", e.ToString());
                 tracer.RelatedError(metadata, $"Failed to properly create {destination}");


### PR DESCRIPTION
Provide a native UNIX implementation for creating symlinks so that repos that contain files with relative path symlinks (like Bundles: https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW13) can be created correctly on disk.

Since we don't support symlinks yet on Windows (in VFSForGit or FastFetch), I pulled the implementation into WriteFile as we can detect a symlink based on the mode of the path that we're trying to write out.