### PR TITLE
clone/mount point env configurable

### DIFF
--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
@@ -8,7 +8,7 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-PATH_TO_MIRROR="${PATH_TO_MIRROR:=~/PathToMirror}"
-TEST_ROOT="${TEST_ROOT:=~/TestRoot}"
+PATH_TO_MIRROR="${PATH_TO_MIRROR:-~/PathToMirror}"
+TEST_ROOT="${TEST_ROOT:-~/TestRoot}"
 
 dotnet $BUILDDIR/MirrorProvider.Linux.dll clone "$PATH_TO_MIRROR" "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
@@ -8,4 +8,7 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-dotnet $BUILDDIR/MirrorProvider.Linux.dll clone ~/PathToMirror ~/TestRoot
+PATH_TO_MIRROR="${PATH_TO_MIRROR:=~/PathToMirror}"
+TEST_ROOT="${TEST_ROOT:=~/TestRoot}"
+
+dotnet $BUILDDIR/MirrorProvider.Linux.dll clone "$PATH_TO_MIRROR" "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
@@ -8,6 +8,6 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-TEST_ROOT="${TEST_ROOT:=~/TestRoot}"
+TEST_ROOT="${TEST_ROOT:-~/TestRoot}"
 
 dotnet $BUILDDIR/MirrorProvider.Linux.dll mount "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
@@ -8,4 +8,6 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-dotnet $BUILDDIR/MirrorProvider.Linux.dll mount ~/TestRoot
+TEST_ROOT="${TEST_ROOT:=~/TestRoot}"
+
+dotnet $BUILDDIR/MirrorProvider.Linux.dll mount "$TEST_ROOT"


### PR DESCRIPTION
Use `PATH_TO_MIRROR` and `TEST_ROOT` env vars to override paths in Linux MirrorProvider scripts.

/cc @chrisd8088 -- this is for our Docker build tooling