### PR TITLE
Add error message to output when call to gvfs/config endpoint fails

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -163,7 +163,7 @@ namespace GVFS.Common.Git
                 {
                     ServerGVFSConfig gvfsConfig;
                     const bool LogErrors = false;
-                    if (configRequestor.TryQueryGVFSConfig(LogErrors, out gvfsConfig, out httpStatus))
+                    if (configRequestor.TryQueryGVFSConfig(LogErrors, out gvfsConfig, out httpStatus, out _))
                     {
                         querySucceeded = true;
                         isAnonymous = true;

--- a/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
@@ -17,10 +17,11 @@ namespace GVFS.Common.Http
             this.repoUrl = enlistment.RepoUrl;
         }
 
-        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus)
+        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage)
         {
             serverGVFSConfig = null;
             httpStatus = null;
+            errorMessage = null;
 
             Uri gvfsConfigEndpoint;
             string gvfsConfigEndpointString = this.repoUrl + GVFSConstants.Endpoints.GVFSConfig;
@@ -86,6 +87,7 @@ namespace GVFS.Common.Http
             if (httpException != null)
             {
                 httpStatus = httpException.StatusCode;
+                errorMessage = httpException.Message;
             }
 
             return false;

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -327,19 +327,20 @@ namespace GVFS.CommandLine
         protected ServerGVFSConfig QueryGVFSConfig(ITracer tracer, GVFSEnlistment enlistment, RetryConfig retryConfig)
         {
             ServerGVFSConfig serverGVFSConfig = null;
+            string errorMessage = null;
             if (!this.ShowStatusWhileRunning(
                 () =>
                 {
                     using (ConfigHttpRequestor configRequestor = new ConfigHttpRequestor(tracer, enlistment, retryConfig))
                     {
                         const bool LogErrors = true;
-                        return configRequestor.TryQueryGVFSConfig(LogErrors, out serverGVFSConfig, out _);
+                        return configRequestor.TryQueryGVFSConfig(LogErrors, out serverGVFSConfig, out _, out errorMessage);
                     }
                 },
                 "Querying remote for config",
                 suppressGvfsLogMessage: true))
             {
-                this.ReportErrorAndExit(tracer, "Unable to query /gvfs/config");
+                this.ReportErrorAndExit(tracer, "Unable to query /gvfs/config" + Environment.NewLine + errorMessage);
             }
 
             return serverGVFSConfig;


### PR DESCRIPTION
This is to get more information about failures to the gvfs/config endpoint to the user so they have a better idea about what was failing instead of only "Unable to query /gvfs/config".

For example cloning a repo that doesn't exist gives you:
```
Unable to query /gvfs/config
Server returned error code 404 (NotFound). Original error message from server: TF200016: The following project does not exist: XYZProject. Verify that the name of the project is correct and that the project exists on the specified Azure DevOps Server.
```

Other possible error messages are in [the `HttpRequestor` `SendRequest` method](https://github.com/Microsoft/VFSForGit/blob/3330537aa4a489b4f59ed60fc6beaf180acf8fc4/GVFS/GVFS.Common/Http/HttpRequestor.cs#L152).