### PR TITLE
Verify commit-graph and multi-pack-index after writing

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -412,6 +412,12 @@ namespace GVFS.Common.Git
                 });
         }
 
+        public Result VerifyCommitGraph(string objectDir)
+        {
+            string command = "commit-graph verify --object-dir \"" + objectDir + "\"";
+            return this.InvokeGitInWorkingDirectoryRoot(command, useReadObjectHook: true);
+        }
+
         public Result IndexPack(string packfilePath, string idxOutputPath)
         {
             return this.InvokeGitAgainstDotGitFolder($"index-pack -o \"{idxOutputPath}\" \"{packfilePath}\"");
@@ -426,6 +432,12 @@ namespace GVFS.Common.Git
         {
             // We override the config settings so we keep writing the MIDX file even if it is disabled for reads.
             return this.InvokeGitAgainstDotGitFolder("-c core.multiPackIndex=true multi-pack-index write --object-dir=\"" + objectDir + "\"");
+        }
+
+        public Result VerifyMultiPackIndex(string objectDir)
+        {
+            // We override the config settings so we keep writing the MIDX file even if it is disabled for reads.
+            return this.InvokeGitAgainstDotGitFolder("-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"" + objectDir + "\"");
         }
 
         public Result RemoteAdd(string remoteName, string url)

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -436,7 +436,6 @@ namespace GVFS.Common.Git
 
         public Result VerifyMultiPackIndex(string objectDir)
         {
-            // We override the config settings so we keep writing the MIDX file even if it is disabled for reads.
             return this.InvokeGitAgainstDotGitFolder("-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"" + objectDir + "\"");
         }
 

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -140,8 +140,35 @@ namespace GVFS.Common.Maintenance
                 GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot));
                 List<string> staleIdxFiles = this.CleanStaleIdxFiles(out int numDeletionBlocked);
                 this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
+
+                GitProcess.Result verifyResult1 = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                if (verifyResult1.ExitCodeIsFailure)
+                {
+                    EventMetadata errorMetadata = this.CreateEventMetadata();
+                    errorMetadata["MultiPackIndexVerifyOutput"] = verifyResult1.Output;
+                    errorMetadata["MultiPackIndexVerifyErrors"] = verifyResult1.Errors;
+                    string multiPackIndexPath = Path.Combine(this.Context.Enlistment.GitPackRoot, "multi-pack-index");
+                    errorMetadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(multiPackIndexPath);
+                    activity.RelatedError(errorMetadata, "multi-pack-index is corrupt after write. Deleting and rewriting.");
+
+                    this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                }
+
                 GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize));
                 this.GetPackFilesInfo(out int afterCount, out long afterSize, out hasKeep);
+
+                GitProcess.Result verifyResult2 = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                if (verifyResult1.ExitCodeIsFailure)
+                {
+                    EventMetadata errorMetadata = this.CreateEventMetadata();
+                    errorMetadata["MultiPackIndexVerifyOutput"] = verifyResult1.Output;
+                    errorMetadata["MultiPackIndexVerifyErrors"] = verifyResult1.Errors;
+                    string multiPackIndexPath = Path.Combine(this.Context.Enlistment.GitPackRoot, "multi-pack-index");
+                    errorMetadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(multiPackIndexPath);
+                    activity.RelatedError(errorMetadata, "multi-pack-index is corrupt after write. Deleting and rewriting.");
+
+                    this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                }
 
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("GitObjectsRoot", this.Context.Enlistment.GitObjectsRoot);
@@ -154,8 +181,10 @@ namespace GVFS.Common.Maintenance
                 metadata.Add(nameof(afterSize), afterSize);
                 metadata.Add("ExpireOutput", expireResult.Output);
                 metadata.Add("ExpireErrors", expireResult.Errors);
+                metadata.Add("VerifyResult1", verifyResult1.ExitCode);
                 metadata.Add("RepackOutput", repackResult.Output);
                 metadata.Add("RepackErrors", repackResult.Errors);
+                metadata.Add("VerifyResult2", verifyResult2.ExitCode);
                 metadata.Add("NumStaleIdxFiles", staleIdxFiles.Count);
                 metadata.Add("NumIdxDeletionsBlocked", numDeletionBlocked);
                 activity.RelatedEvent(EventLevel.Informational, $"{this.Area}_{nameof(this.PerformMaintenance)}", metadata, Keywords.Telemetry);

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -29,17 +29,9 @@ namespace GVFS.Common.Maintenance
                 this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
 
                 GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
-
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    EventMetadata metadata = this.CreateEventMetadata();
-                    metadata["MultiPackIndexVerifyOutput"] = verifyResult.Output;
-                    metadata["MultiPackIndexVerifyErrors"] = verifyResult.Errors;
-                    string multiPackIndexPath = Path.Combine(this.Context.Enlistment.GitPackRoot, "multi-pack-index");
-                    metadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(multiPackIndexPath);
-                    activity.RelatedError(metadata, "multi-pack-index is corrupt after write. Deleting and rewriting.");
-
-                    this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyResult);
                 }
             }
 
@@ -60,14 +52,7 @@ namespace GVFS.Common.Maintenance
 
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    EventMetadata metadata = this.CreateEventMetadata();
-                    metadata["CommitGraphVerifyOutput"] = verifyResult.Output;
-                    metadata["CommitGraphVerifyErrors"] = verifyResult.Errors;
-                    string commitGraphPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graph");
-                    metadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(commitGraphPath);
-                    activity.RelatedError(metadata, "commit-graph is corrupt after write. Deleting and rewriting.");
-
-                    this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes));
+                    this.LogErrorAndRewriteCommitGraph(activity, verifyResult, this.packIndexes);
                 }
             }
         }

--- a/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
@@ -1,0 +1,164 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Maintenance;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using GVFS.UnitTests.Mock.Git;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace GVFS.UnitTests.Maintenance
+{
+    [TestFixture]
+    public class PostFetchStepTests
+    {
+        private MockTracer tracer;
+        private MockGitProcess gitProcess;
+        private GVFSContext context;
+
+        private string MultiPackIndexWriteCommand => $"-c core.multiPackIndex=true multi-pack-index write --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string MultiPackIndexVerifyCommand => $"-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --append --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphVerifyCommand => $"commit-graph verify --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+
+        [TestCase]
+        public void WriteMultiPackIndexNoGraphOnEmptyPacks()
+        {
+            this.TestSetup();
+
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+
+            PostFetchStep step = new PostFetchStep(this.context, new List<string>());
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            this.tracer.RelatedInfoEvents.Count.ShouldEqual(1);
+
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(2);
+            commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
+            commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
+        }
+
+        [TestCase]
+        public void WriteMultiPackIndexAndGraphWithPacks()
+        {
+            this.TestSetup();
+
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+
+            PostFetchStep step = new PostFetchStep(this.context, new List<string>() { "pack" }, requireObjectCacheLock: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+            this.tracer.RelatedInfoEvents.Count.ShouldEqual(0);
+
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(4);
+            commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
+            commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
+            commands[2].ShouldEqual(this.CommitGraphWriteCommand);
+            commands[3].ShouldEqual(this.CommitGraphVerifyCommand);
+        }
+
+        [TestCase]
+        public void RewriteMultiPackIndexOnBadVerify()
+        {
+            this.TestSetup();
+
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.GenericFailureCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+
+            PostFetchStep step = new PostFetchStep(this.context, new List<string>() { "pack" }, requireObjectCacheLock: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(1);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(5);
+            commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
+            commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
+            commands[2].ShouldEqual(this.MultiPackIndexWriteCommand);
+            commands[3].ShouldEqual(this.CommitGraphWriteCommand);
+            commands[4].ShouldEqual(this.CommitGraphVerifyCommand);
+        }
+
+        [TestCase]
+        public void RewriteCommitGraphOnBadVerify()
+        {
+            this.TestSetup();
+
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.MultiPackIndexVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphWriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
+            this.gitProcess.SetExpectedCommandResult(
+                this.CommitGraphVerifyCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.GenericFailureCode));
+
+            PostFetchStep step = new PostFetchStep(this.context, new List<string>() { "pack" }, requireObjectCacheLock: false);
+            step.Execute();
+
+            this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(1);
+            this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
+
+            List<string> commands = this.gitProcess.CommandsRun;
+            commands.Count.ShouldEqual(5);
+            commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
+            commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
+            commands[2].ShouldEqual(this.CommitGraphWriteCommand);
+            commands[3].ShouldEqual(this.CommitGraphVerifyCommand);
+            commands[4].ShouldEqual(this.CommitGraphWriteCommand);
+        }
+
+        private void TestSetup()
+        {
+            this.gitProcess = new MockGitProcess();
+
+            // Create enlistment using git process
+            GVFSEnlistment enlistment = new MockGVFSEnlistment(this.gitProcess);
+
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, null, null));
+
+            // Create and return Context
+            this.tracer = new MockTracer();
+            this.context = new GVFSContext(this.tracer, fileSystem, repository: null, enlistment: enlistment);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -108,7 +108,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public ITracer StartActivity(string activityName, EventLevel level, Keywords startStopKeywords, EventMetadata metadata)
         {
-            this.StartActivityTracer = new MockTracer();
+            this.StartActivityTracer = this.StartActivityTracer ?? new MockTracer();
             return this.StartActivityTracer;
         }
 


### PR DESCRIPTION
Run the `git commit-graph verify` and `git multi-pack-index verify` commands after any command that would change those files. If these fail, then delete the corrupt file and rewrite.

We've had issues with users data in the past, and this gives us a way to automatically detect and repair these scenarios. The immediate rewrite _should_ work since we will regenerate from the other Git data. Issues we've seen in the past are related to trusting the content in these files and carrying that data forward to future versions of the file.