### PR TITLE
Protoype: UpgradeOrchestrator tests with generalized Upgrader

### DIFF
--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -24,7 +24,7 @@ namespace GVFS.Upgrader
 
         protected string CommandToRerun { private get; set; }
 
-        public bool TryRunPreUpgradeChecks(out string consoleError)
+        public virtual bool TryRunPreUpgradeChecks(out string consoleError)
         {
             using (ITracer activity = this.tracer.StartActivity(nameof(this.TryRunPreUpgradeChecks), EventLevel.Informational))
             {
@@ -50,12 +50,12 @@ namespace GVFS.Upgrader
 
         // TODO: Move repo mount calls to GVFS.Upgrader project.
         // https://github.com/Microsoft/VFSForGit/issues/293
-        public bool TryMountAllGVFSRepos(out string consoleError)
+        public virtual bool TryMountAllGVFSRepos(out string consoleError)
         {
             return this.TryRunGVFSWithArgs("service --mount-all", out consoleError);
         }
 
-        public bool TryUnmountAllGVFSRepos(out string consoleError)
+        public virtual bool TryUnmountAllGVFSRepos(out string consoleError)
         {
             consoleError = null;
 

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Windows\Service\RepoRegistryTests.cs" />
     <Compile Include="Windows\Upgrader\ProductUpgraderTests.cs" />
     <Compile Include="Windows\Upgrader\UpgradeOrchestratorTests.cs" />
+    <Compile Include="Windows\Upgrader\UpgradeOrchestratorUnitTests.cs" />
     <Compile Include="Windows\Upgrader\UpgradeTests.cs" />
     <Compile Include="Windows\Upgrader\UpgradeVerbTests.cs" />
     <Compile Include="Windows\Virtualization\ActiveEnumerationTests.cs" />

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -35,8 +35,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Sqlite, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Data.Sqlite.Core.2.0.0\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -64,7 +70,14 @@
       <HintPath>..\..\..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.7\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorUnitTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorUnitTests.cs
@@ -1,0 +1,168 @@
+﻿using GVFS.Common;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using GVFS.Upgrader;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace GVFS.UnitTests.Upgrader
+{
+    [TestFixture]
+    public class UpgradeOrchestratorUnitTests
+    {
+        private const string OlderThanLocalVersion = "1.0.17000.1";
+        private const string LocalGVFSVersion = "1.0.18115.1";
+        private const string NewerThanLocalVersion = "1.1.18115.1";
+
+        private delegate void TryGetNewerVersionCallback(out System.Version version, out string message);
+        private delegate void TryGetConfigAllowsUpgradeCallback(out bool isConfigError, out string message);
+
+        private Mock<ITracer> MockTracer { get; set; }
+        private Mock<TextWriter> MockOutput { get; set; }
+        private Mock<InstallerPreRunChecker> MockPreRunChecker { get; set; }
+        private Mock<LocalGVFSConfig> MockLocalConfig { get; set; }
+        private Mock<IProductUpgrader> MockUpgrader { get; set; }
+
+        private UpgradeOrchestrator orchestrator { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            string message = string.Empty;
+
+            this.MockTracer = new Mock<ITracer>();
+            this.MockTracer.Setup(foo => foo.StartActivity(It.IsAny<string>(), It.IsAny<EventLevel>())).Returns(this.MockTracer.Object);
+            this.MockTracer.Setup(foo => foo.StartActivity(It.IsAny<string>(), It.IsAny<EventLevel>(), It.IsAny<EventMetadata>())).Returns(this.MockTracer.Object);
+
+            this.MockUpgrader = this.DefaultUpgrader();
+
+            this.MockPreRunChecker = this.DefaultInstallerPreRunChecker(this.MockTracer.Object);
+
+            this.MockOutput = new Mock<TextWriter>();
+
+            this.orchestrator = new UpgradeOrchestrator(
+                this.MockUpgrader.Object,
+                this.MockTracer.Object,
+                this.MockPreRunChecker.Object,
+                input: null,
+                output: this.MockOutput.Object);
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_UpgradesWhenUpgradeAvailable()
+        {
+            this.orchestrator.Execute();
+
+            this.MockUpgrader.Verify(foo => foo.TryGetConfigAllowsUpgrade(out It.Ref<bool>.IsAny, out It.Ref<string>.IsAny), Times.Once());
+            this.MockUpgrader.Verify(foo => foo.TryGetNewerVersion(out It.Ref<System.Version>.IsAny, out It.Ref<string>.IsAny), Times.Once());
+
+            // This Method is not called...
+            // this.MockUpgrader.Verify(foo => foo.TryGetGitVersion(out It.Ref<GitVersion>.IsAny, out It.Ref<string>.IsAny), Times.Once());
+
+            this.MockUpgrader.Verify(foo => foo.TryDownloadNewestVersion(out It.Ref<string>.IsAny), Times.Once());
+            this.MockUpgrader.Verify(foo => foo.TryRunInstaller(It.IsAny<InstallActionWrapper>(), out It.Ref<string>.IsAny), Times.Once());
+            this.MockUpgrader.Verify(foo => foo.TryCleanup(out It.Ref<string>.IsAny), Times.Once());
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_NewVersionNotAvailable()
+        {
+            this.MockUpgrader = this.ProductUpgraderHasNoNewVersion(this.MockUpgrader);
+
+            this.orchestrator.Execute();
+
+            this.MockUpgrader.Verify(foo => foo.TryGetConfigAllowsUpgrade(out It.Ref<bool>.IsAny, out It.Ref<string>.IsAny), Times.Once());
+            this.MockUpgrader.Verify(foo => foo.TryGetNewerVersion(out It.Ref<System.Version>.IsAny, out It.Ref<string>.IsAny), Times.Once());
+
+            this.MockUpgrader.Verify(foo => foo.TryDownloadNewestVersion(out It.Ref<string>.IsAny), Times.Never());
+            this.MockUpgrader.Verify(foo => foo.TryRunInstaller(It.IsAny<InstallActionWrapper>(), out It.Ref<string>.IsAny), Times.Never());
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_FailPrecheck()
+        {
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_DownloadFails()
+        {
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_GetNewVersionFails()
+        {
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_RunInstallerFails()
+        {
+        }
+
+        [TestCase]
+        public void UpgradeOrchestrator_CleanupFails()
+        {
+        }
+
+        public Mock<IProductUpgrader> DefaultUpgrader()
+        {
+            string message = string.Empty;
+            Version version = new Version(NewerThanLocalVersion);
+            GitVersion gitVersion = new GitVersion(2, 1, 0, "Windows", 0, 0);
+
+            Mock<IProductUpgrader> mockUpgrader = new Mock<IProductUpgrader>();
+            mockUpgrader.Setup(foo => foo.TryInitialize(out It.Ref<string>.IsAny)).Returns(true);
+            mockUpgrader.Setup(foo => foo.TryGetConfigAllowsUpgrade(out It.Ref<bool>.IsAny, out It.Ref<string>.IsAny))
+                .Callback(new TryGetConfigAllowsUpgradeCallback((out bool upgradeAllowed, out string delegateMessage) =>
+                {
+                    upgradeAllowed = true;
+                    delegateMessage = string.Empty;
+                }))
+                .Returns(true);
+
+            mockUpgrader.Setup(foo => foo.TryGetNewerVersion(out It.Ref<System.Version>.IsAny, out It.Ref<string>.IsAny))
+                .Callback(new TryGetNewerVersionCallback((out System.Version delegateVersion, out string delegateMessage) =>
+                {
+                    delegateVersion = version;
+                    delegateMessage = string.Empty;
+                }))
+                .Returns(true);
+
+            mockUpgrader.Setup(foo => foo.TryGetGitVersion(out It.Ref<GitVersion>.IsAny, out It.Ref<string>.IsAny)).Returns(true);
+            mockUpgrader.Setup(foo => foo.TryDownloadNewestVersion(out It.Ref<string>.IsAny)).Returns(true);
+            mockUpgrader.Setup(foo => foo.TryRunInstaller(It.IsAny<InstallActionWrapper>(), out message)).Returns(true);
+            mockUpgrader.Setup(foo => foo.TryCleanup(out It.Ref<string>.IsAny)).Returns(true);
+            mockUpgrader.Setup(foo => foo.CleanupDownloadDirectory());
+
+            return mockUpgrader;
+        }
+
+        public Mock<IProductUpgrader> ProductUpgraderHasNoNewVersion(Mock<IProductUpgrader> mockUpgrader)
+        {
+            Version version = new Version(LocalGVFSVersion);
+
+            mockUpgrader.Setup(foo => foo.TryGetNewerVersion(out It.Ref<System.Version>.IsAny, out It.Ref<string>.IsAny))
+                .Callback(new TryGetNewerVersionCallback((out System.Version delegateVersion, out string delegateMessage) =>
+                {
+                    delegateVersion = version;
+                    delegateMessage = string.Empty;
+                }))
+                .Returns(false);
+
+            return mockUpgrader;
+        }
+
+        public Mock<InstallerPreRunChecker> DefaultInstallerPreRunChecker(ITracer tracer)
+        {
+            string message = string.Empty;
+
+            Mock<InstallerPreRunChecker> mockChecker = new Mock<InstallerPreRunChecker>(tracer, string.Empty);
+
+            mockChecker.Setup(foo => foo.TryRunPreUpgradeChecks(out It.Ref<string>.IsAny)).Returns(true);
+            mockChecker.Setup(foo => foo.TryUnmountAllGVFSRepos(out It.Ref<string>.IsAny)).Returns(true);
+
+            return mockChecker;
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests.Windows/packages.config
+++ b/GVFS/GVFS.UnitTests.Windows/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
   <package id="GVFS.ProjFS" version="2018.823.1" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.0.0" targetFramework="net461" />
+  <package id="Moq" version="4.10.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="NUnitLite" version="3.10.1" targetFramework="net461" />
@@ -13,4 +15,6 @@
   <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.7" targetFramework="net461" />
   <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.7" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This is a spike on how we can test the `UpgradeOrchestrator` component with an arbitrary `ProductUpgrader`. It includes a skeleton of scenarios that we could test, along with a couple of examples of how we can test different scenarios. This also leverages the Moq framework (included as an example). The general testing outline does not depend on Moq, but we wanted to include an example of tests using that framework in this prototype. This PR shows examples of using Moq both with Interfaces as well as concrete classes.