### PR TITLE
Update Git to include multi-pack-index expire fix and trace2 v3

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20181221.1</GitPackageVersion>
+    <GitPackageVersion>2.20190104.3</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190104.3</GitPackageVersion>
+    <GitPackageVersion>2.20190104.4</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
* [PR 107 in microsoft/git](https://github.com/Microsoft/git/pull/107) includes a fix for the way we permute the set of packs during a `git multi-pack-index expire` command. Specifically, this fixes an issue when we expire packs and add packs to the multi-pack-index at the same time (and the order of those packs).

* [PR 100 in microsoft/git](https://github.com/Microsoft/git/pull/100) includes updates to trace2.