### PR TITLE
Update Readme to inform users to clone with HTTPS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,7 +152,7 @@ Azure DevOps (https://azure.microsoft.com/services/devops/), and push some conte
   * Your repo must not enable any clean/smudge filters
   * Your repo must have a `.gitattributes` file in the root that includes the line `* -text`
 * `gvfs clone <URL of repo you just created>`
-  * Please specify the URL of **Clone with HTTPS**, not **Clone with SSH**.
+  * Please choose the **Clone with HTTPS** option in the `Clone Repository` dialog in Azure Repos, not **Clone with SSH**.
 * `cd <root>\src`
 * Run git commands as you normally would
 * `gvfs unmount` when done

--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,7 @@ Azure DevOps (https://azure.microsoft.com/services/devops/), and push some conte
   * Your repo must not enable any clean/smudge filters
   * Your repo must have a `.gitattributes` file in the root that includes the line `* -text`
 * `gvfs clone <URL of repo you just created>`
+  * Please specify the URL of **Clone with HTTPS**, not **Clone with SSH**.
 * `cd <root>\src`
 * Run git commands as you normally would
 * `gvfs unmount` when done


### PR DESCRIPTION
I executed a clone using SSH, but the following error occurred.
After that, when I executed the clone using HTTPS, I succeeded, so I think that it is necessary to note that using HTTPS when using `VFS for Git`.
```
C:\Users\xxx\Desktop\repos\VFSforGit>gvfs clone git@github.com:Microsoft/VFSforGit.git
Clone parameters:
  Repo URL:     git@github.com:Microsoft/VFSforGit.git
  Branch:       Default
  Cache Server: Default
  Local Cache:  C:\.gvfsCache
  Destination:  C:\Users\xxx\Desktop\repos\VFSforGit\VFSforGit.git
Authenticating...Failed. Run 'gvfs log C:\Users\xxx\Desktop\repos\VFSforGit\VFSforGit.git' for more info.
Cannot clone because authentication failed

C:\Users\xxx\Desktop\repos\VFSforGit>gvfs clone https://github.com/Microsoft/VFSForGit.git
Error: You can't clone inside an existing GVFS repo (C:\Users\xxx\Desktop\repos\VFSforGit\VFSforGit.git)

**Delete VFSforGit.git by hand**

C:\Users\xxx\Desktop\repos\VFSforGit>gvfs clone https://github.com/Microsoft/VFSForGit.git
Clone parameters:
  Repo URL:     https://github.com/Microsoft/VFSForGit.git
  Branch:       Default
  Cache Server: Default
  Local Cache:  C:\.gvfsCache
  Destination:  C:\Users\xxx\Desktop\repos\VFSforGit\VFSForGit.git
Authenticating...Succeeded
Querying remote for config...Succeeded
Using cache server: None (https://github.com/Microsoft/VFSForGit.git)
Error: Invalid version of git 2.20.1.windows.1.0.  Must use gvfs version.

C:\Users\xxx\Desktop\repos\VFSforGit>
```