### PR TITLE
Safe changes to LibGit2Repo

### DIFF
--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -1,5 +1,4 @@
 ﻿using GVFS.Common.Tracing;
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -115,33 +114,6 @@ namespace GVFS.Common.Git
             return true;
         }
 
-        public virtual bool TryGetObjectSize(string sha, out long size)
-        {
-            size = -1;
-
-            IntPtr objHandle;
-            if (Native.RevParseSingle(out objHandle, this.RepoHandle, sha) != Native.SuccessCode)
-            {
-                return false;
-            }
-
-            try
-            {
-                switch (Native.Object.GetType(objHandle))
-                {
-                    case Native.ObjectTypes.Blob:
-                        size = Native.Blob.GetRawSize(objHandle);
-                        return true;
-                }
-            }
-            finally
-            {
-                Native.Object.Free(objHandle);
-            }
-
-            return false;
-        }
-
         public virtual bool TryCopyBlob(string sha, Action<Stream, long> writeAction)
         {
             IntPtr objHandle;
@@ -224,9 +196,6 @@ namespace GVFS.Common.Git
 
             [DllImport(Git2NativeLibName, EntryPoint = "git_revparse_single")]
             public static extern uint RevParseSingle(out IntPtr objectHandle, IntPtr repoHandle, string oid);
-
-            [DllImport(Git2NativeLibName, EntryPoint = "git_oid_fromstr")]
-            public static extern void OidFromString(ref GitOid oid, string hash);
 
             public static string GetLastError()
             {

--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -256,7 +256,7 @@ namespace GVFS.Common.Git
                 [DllImport(Git2NativeLibName, EntryPoint = "git_repository_open")]
                 public static extern uint Open(out IntPtr repoHandle, string path);
 
-                [DllImport(Git2NativeLibName, EntryPoint = "git_tree_free")]
+                [DllImport(Git2NativeLibName, EntryPoint = "git_repository_free")]
                 public static extern void Free(IntPtr repoHandle);
             }
 

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockLibGit2Repo.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockLibGit2Repo.cs
@@ -26,10 +26,5 @@ namespace GVFS.UnitTests.Mock.Git
         {
             throw new NotSupportedException();
         }
-
-        public override bool TryGetObjectSize(string sha, out long size)
-        {
-            throw new NotSupportedException();
-        }
     }
 }


### PR DESCRIPTION
* Change the native method we call when disposing a repo from `git_tree_free` to `git_repository_free`.

* Delete unused method for getting a blob size.

These were safe changes made as part of #655, but were reverted in #667 due to issues with the pool changes.