### PR TITLE
Remove useless tracing and useless code

### DIFF
--- a/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
+++ b/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
@@ -11,7 +11,6 @@ namespace GVFS.Virtualization.Background
     {
         private const int ActionRetryDelayMS = 50;
         private const int RetryFailuresLogThreshold = 200;
-        private const int MaxCallbackAttemptsOnShutdown = 5;
         private const int LogUpdateTaskThreshold = 25000;
         private static readonly string EtwArea = nameof(BackgroundFileSystemTaskRunner);
 
@@ -297,13 +296,6 @@ namespace GVFS.Virtualization.Background
                         return;
                 }
             }
-        }
-
-        private void LogWarning(string message)
-        {
-            EventMetadata metadata = new EventMetadata();
-            metadata.Add("Area", EtwArea);
-            this.context.Tracer.RelatedWarning(metadata, message);
         }
 
         private void LogErrorAndExit(string message, Exception e = null)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -29,7 +29,6 @@ namespace GVFS.Virtualization
         private readonly string logsHeadPath;
 
         private GVFSContext context;
-        private GVFSGitObjects gitObjects;
         private ModifiedPathsDatabase modifiedPaths;
         private ConcurrentHashSet<string> newlyCreatedFileAndFolderPaths;
         private ConcurrentDictionary<string, PlaceHolderCreateCounter> placeHolderCreationCount;
@@ -66,7 +65,6 @@ namespace GVFS.Virtualization
             this.logsHeadFileProperties = null;
 
             this.context = context;
-            this.gitObjects = gitObjects;
             this.fileSystemVirtualizer = fileSystemVirtualizer;
 
             this.placeHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -39,10 +39,6 @@ namespace GVFS.Virtualization.Projection
 
         private const string EtwArea = "GitIndexProjection";
 
-        private const int ParseIndexRequestTimeoutMs = 50;
-
-        private char[] gitPathSeparatorCharArray = new char[] { GVFSConstants.GitPathSeparator };
-
         private GVFSContext context;
         private RepoMetadata repoMetadata;
         private FileSystemVirtualizer fileSystemVirtualizer;


### PR DESCRIPTION
The `OnGetFileStream()` method is a very busy area of code when hydrating a repo. Don't bog it down with useless tracing that doesn't help anything.

While exploring the code base for this excessive tracing, I found some code that can be safely deleted because it isn't used by anything.