### PR TITLE
LibGit2RepoPool OPTION 1: Use multiple repo objects, dispose as possible

### DIFF
--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -27,7 +27,7 @@ namespace GVFS.Common.Git
             this.libgit2RepoPool = new LibGit2RepoPool(
                 tracer,
                 repoFactory ?? (() => new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryRoot)),
-                Environment.ProcessorCount * 2);
+                2 * Environment.ProcessorCount);
         }
 
         // For Unit Testing
@@ -44,6 +44,8 @@ namespace GVFS.Common.Git
             Corrupt,
             Unknown,
         }
+
+        public bool HasActiveLibGit2Repos => this.libgit2RepoPool != null && this.libgit2RepoPool.NumActiveRepos > 0;
 
         public GVFSLock GVFSLock
         {

--- a/GVFS/GVFS.Common/LibGit2RepoPool.cs
+++ b/GVFS/GVFS.Common/LibGit2RepoPool.cs
@@ -6,31 +6,53 @@ using System.Threading;
 
 namespace GVFS.Common
 {
-    public class LibGit2RepoPool
+    public class LibGit2RepoPool : IDisposable
     {
-        private const int TryAddTimeoutMilliseconds = 10;
-        private const int TryTakeTimeoutMilliseconds = Timeout.Infinite;
+        private const int TryAddTimeoutMilliseconds = 0;
+        private const int TryTakeTimeoutMilliseconds = 0;
 
         private readonly BlockingCollection<LibGit2Repo> pool;
+        private readonly Func<LibGit2Repo> createRepo;
         private readonly ITracer tracer;
 
-        public LibGit2RepoPool(ITracer tracer, Func<LibGit2Repo> createRepo, int size)
+        private readonly Timer repoDisposalTimer;
+        private readonly TimeSpan repoDisposalDueTime = TimeSpan.FromMinutes(15);
+        private readonly TimeSpan repoDisposalPeriod = TimeSpan.FromMinutes(1);
+        private volatile int numActiveRepos;
+
+        public LibGit2RepoPool(
+            ITracer tracer,
+                Func<LibGit2Repo> createRepo,
+                int size,
+                TimeSpan? repoDisposalDueTime = null,
+                TimeSpan? repoDisposalPeriod = null)
         {
-            if (size <= 0)
+            this.createRepo = createRepo;
+            this.tracer = tracer;
+            this.pool = new BlockingCollection<LibGit2Repo>(boundedCapacity: size);
+
+            if (repoDisposalDueTime.HasValue)
             {
-                throw new ArgumentException("ProcessPool: size must be greater than 0");
+                this.repoDisposalDueTime = repoDisposalDueTime.Value;
             }
 
-            this.tracer = tracer;
-            this.pool = new BlockingCollection<LibGit2Repo>();
-            for (int i = 0; i < size; ++i)
+            if (repoDisposalPeriod.HasValue)
             {
-                this.pool.Add(createRepo());
+                this.repoDisposalPeriod = repoDisposalPeriod.Value;
             }
+
+            this.repoDisposalTimer = new Timer(
+                                             (state) => this.TryDropARepo(),
+                                             state: null,
+                                             dueTime: this.repoDisposalDueTime,
+                                             period: this.repoDisposalPeriod);
         }
+
+        public int NumActiveRepos => this.numActiveRepos;
 
         public void Dispose()
         {
+            this.repoDisposalTimer.Dispose();
             this.pool.CompleteAdding();
             this.CleanUpPool();
         }
@@ -67,26 +89,44 @@ namespace GVFS.Common
 
         private LibGit2Repo GetRepoFromPool()
         {
-            LibGit2Repo repo;
-            if (this.pool.TryTake(out repo, TryTakeTimeoutMilliseconds))
+            this.ResetRepoDisposalTimer();
+
+            if (this.pool.TryTake(out LibGit2Repo repo, TryTakeTimeoutMilliseconds))
             {
                 return repo;
             }
 
-            // This should only happen when the pool is shutting down
-            return null;
+            Interlocked.Increment(ref this.numActiveRepos);
+            return this.createRepo();
         }
 
         private void ReturnToPool(LibGit2Repo repo)
         {
             if (repo != null)
             {
+                this.ResetRepoDisposalTimer();
+
                 if (this.pool.IsAddingCompleted ||
                     !this.pool.TryAdd(repo, TryAddTimeoutMilliseconds))
                 {
-                    // No more adding to the pool or trying to add to the pool failed
+                    // No more adding to the pool or the pool is full
+                    Interlocked.Decrement(ref this.numActiveRepos);
                     repo.Dispose();
                 }
+            }
+        }
+
+        private void ResetRepoDisposalTimer()
+        {
+            this.repoDisposalTimer.Change(this.repoDisposalDueTime, this.repoDisposalPeriod);
+        }
+
+        private void TryDropARepo()
+        {
+            if (this.pool.TryTake(out LibGit2Repo repo, TryTakeTimeoutMilliseconds))
+            {
+                Interlocked.Decrement(ref this.numActiveRepos);
+                repo.Dispose();
             }
         }
 

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -127,6 +127,12 @@ namespace GVFS.Common.Maintenance
                         activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);
                         return;
                     }
+
+                    if (this.Context.Repository.HasActiveLibGit2Repos)
+                    {
+                        activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to active libgit2 repos", Keywords.Telemetry);
+                        return;
+                    }
                 }
 
                 this.GetPackFilesInfo(out int beforeCount, out long beforeSize, out bool hasKeep);

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoPoolTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoPoolTests.cs
@@ -1,0 +1,115 @@
+﻿using GVFS.Common;
+using GVFS.Common.Git;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LibGit2RepoPoolTests
+    {
+        [TestCase]
+        public void PoolConstructsThenDisposesRepos()
+        {
+            MockTracer tracer = new MockTracer();
+            int size = 3;
+            int allocations = 2 * size;
+            TimeSpan dueTime = TimeSpan.FromMilliseconds(1);
+            TimeSpan period = TimeSpan.FromMilliseconds(1);
+
+            BlockingCollection<object> threadReady = new BlockingCollection<object>();
+            BlockingCollection<object> threadTriggers = new BlockingCollection<object>();
+            BlockingCollection<object> disposalTriggers = new BlockingCollection<object>();
+
+            using (LibGit2RepoPool pool = new LibGit2RepoPool(tracer, () => new MockLibGit2Repo(disposalTriggers), size, dueTime, period))
+            {
+                for (int i = 0; i < allocations; i++)
+                {
+                    new Thread(() => pool.TryInvoke(
+                        repo =>
+                        {
+                            threadReady.TryAdd(new object(), 0);
+                            return threadTriggers.TryTake(out object _, 5000);
+                        },
+                        out bool result)).Start();
+                    threadReady.TryTake(out object _, 5000);
+                }
+
+                for (int i = 0; i < allocations; i++)
+                {
+                    threadTriggers.TryAdd(new object(), 0);
+                    disposalTriggers.TryTake(out object obj, millisecondsTimeout: 5000).ShouldBeTrue();
+                }
+            }
+
+            disposalTriggers.TryTake(out object _, millisecondsTimeout: 0).ShouldBeFalse();
+            tracer.RelatedWarningEvents.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void PoolReallocatesRepos()
+        {
+            MockTracer tracer = new MockTracer();
+            int size = 3;
+            TimeSpan dueTime = TimeSpan.FromMilliseconds(1);
+            TimeSpan period = TimeSpan.FromMilliseconds(1);
+
+            BlockingCollection<object> threadReady = new BlockingCollection<object>();
+            BlockingCollection<object> threadTriggers = new BlockingCollection<object>();
+            BlockingCollection<object> disposalTriggers = new BlockingCollection<object>();
+
+            using (LibGit2RepoPool pool = new LibGit2RepoPool(tracer, () => new MockLibGit2Repo(disposalTriggers), size, dueTime, period))
+            {
+                for (int i = 0; i < size; i++)
+                {
+                    new Thread(() => pool.TryInvoke(
+                        repo =>
+                        {
+                            threadReady.TryAdd(new object(), 0);
+                            return threadTriggers.TryTake(out object _, 5000);
+                        },
+                        out bool result)).Start();
+                    threadReady.TryTake(out object _, 5000);
+                }
+
+                for (int i = 0; i < size; i++)
+                {
+                    threadReady.TryTake(out object _, 5000);
+                    threadTriggers.TryAdd(new object(), 0);
+                    disposalTriggers.TryTake(out object _, millisecondsTimeout: 5000).ShouldBeTrue();
+                }
+
+                pool.TryInvoke(repo => true, out bool invoked);
+
+                invoked.ShouldBeTrue();
+                disposalTriggers.TryTake(out object _, millisecondsTimeout: 5000).ShouldBeTrue();
+            }
+
+            disposalTriggers.TryTake(out object _, millisecondsTimeout: 0).ShouldBeFalse();
+            tracer.RelatedWarningEvents.Count.ShouldEqual(0);
+        }
+
+        private class MockLibGit2Repo : LibGit2Repo
+        {
+            private readonly BlockingCollection<object> disposalTriggers;
+
+            /// <summary>
+            /// Specifically call the protected empty constructor
+            /// </summary>
+            public MockLibGit2Repo(BlockingCollection<object> disposalTriggers)
+                : base()
+            {
+                this.disposalTriggers = disposalTriggers;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                this.disposalTriggers.Add(new object());
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -183,7 +183,7 @@ namespace GVFS.UnitTests.Maintenance
 
             // Create and return Context
             this.tracer = new MockTracer();
-            this.context = new GVFSContext(this.tracer, fileSystem, repository: null, enlistment: enlistment);
+            this.context = new GVFSContext(this.tracer, fileSystem, repository: new MockGitRepo(this.tracer, enlistment, fileSystem), enlistment: enlistment);
 
             this.gitProcess.SetExpectedCommandResult(
                 this.ExpireCommand,


### PR DESCRIPTION
In #655, we added logic to dispose `LibGit2Repo` objects by reworking `LibGit2RepoPool`.

Then, some large repo builds went red and we reverted the change in #667.

Now, I have been unable to reproduce the failures and have added extra functional tests for parallel hydration issues. This re-does the work from #655.

**Note:** We have another idea to simplify the pool by only creating one `LibGit2Repo` to share across multiple readers. If it works, then that is actually preferred because it simplifies the pool and reduces the native memory footprint. It depends on the thread-safety of libgit2's object cache, but I've heard that it's pretty good for read-only operations like the ones we have here.