### PR TITLE
Verify Installer signature before launching

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -51,6 +51,8 @@ namespace GVFS.Common
         public abstract bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error);
         public abstract bool TryInstallGitCommandHooks(GVFSContext context, string executingDirectory, string hookName, string commandHookPath, out string errorMessage);
 
+        public abstract bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error);
+
         public abstract InProcEventListener CreateTelemetryListenerIfEnabled(string providerName, string enlistmentId, string mountId);
 
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly);

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -56,6 +56,11 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
+        public override bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error)
+        {
+            throw new NotImplementedException();
+        }
+
         public override bool IsProcessActive(int processId)
         {
             return MacPlatform.IsProcessActiveImplementation(processId);

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -56,6 +56,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -6,10 +6,12 @@ using GVFS.Platform.Windows.DiskLayoutUpgrades;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Management.Automation;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.ServiceProcess;
@@ -264,6 +266,30 @@ namespace GVFS.Platform.Windows
             }
 
             return true;
+        }
+
+        public override bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error)
+        {
+            using (PowerShell powershell = PowerShell.Create())
+            {
+                powershell.AddScript($"Get-AuthenticodeSignature -FilePath {path}");
+
+                Collection<PSObject> results = powershell.Invoke();
+                if (powershell.HadErrors || results.Count <= 0)
+                {
+                    subject = null;
+                    issuer = null;
+                    error = $"Powershell Get-AuthenticodeSignature failed, could not verify authenticode for {path}.";
+                    return false;
+                }
+
+                Signature signature = results[0].BaseObject as Signature;
+                bool isValid = signature.Status == SignatureStatus.Valid;
+                subject = signature.SignerCertificate.SubjectName.Name;
+                issuer = signature.SignerCertificate.IssuerName.Name;
+                error = isValid == false ? signature.StatusMessage : null;
+                return isValid;
+            }
         }
 
         public override string GetCurrentUser()

--- a/GVFS/GVFS.Platform.Windows/packages.config
+++ b/GVFS/GVFS.Platform.Windows/packages.config
@@ -8,4 +8,5 @@
   <package id="Microsoft.Diagnostics.Tracing.EventSource" version="1.1.28" targetFramework="net461" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net461" />
 </packages>

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -34,6 +34,8 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             GVFSInstall = 0x20,
             GVFSCleanup = 0x40,
             GitCleanup = 0x80,
+            GitAuthenticodeCheck = 0x100,
+            GVFSAuthenticodeCheck = 0x200
         }
 
         public List<string> DownloadedFiles { get; private set; }
@@ -189,7 +191,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             return true;
         }
 
-        protected override void RunInstaller(string path, string args, out int exitCode, out string error)
+        protected override void RunInstaller(string path, string args, string certCN, string issuerCN, out int exitCode, out string error)
         {
             string fileName = Path.GetFileName(path);
             Dictionary<string, string> installationInfo = new Dictionary<string, string>();
@@ -209,6 +211,12 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
                     error = "Git installation failed";
                 }
 
+                if (this.failActionTypes.HasFlag(ActionType.GitAuthenticodeCheck))
+                {
+                    exitCode = -1;
+                    error = "The contents of file C:\\ProgramData\\GVFS\\GVFS.Upgrade\\Tools\\Git-2.17.1.gvfs.2.1.4.g4385455-64-bit might have been changed by an unauthorized user or process, because the hash of the file does not match the hash stored in the digital signature. The script cannot run on the specified system. For more information, run Get-Help about_Signing.";
+                }
+
                 return;
             }
 
@@ -220,6 +228,12 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
                 {
                     exitCode = -1;
                     error = "GVFS installation failed";
+                }
+
+                if (this.failActionTypes.HasFlag(ActionType.GVFSAuthenticodeCheck))
+                {
+                    exitCode = -1;
+                    error = "The contents of file C:\\ProgramData\\GVFS\\GVFS.Upgrade\\Tools\\SetupGVFS.1.0.18297.1.exe might have been changed by an unauthorized user or process, because the hash of the file does not match the hash stored in the digital signature. The script cannot run on the specified system. For more information, run Get-Help about_Signing.";
                 }
 
                 return;

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -144,6 +144,25 @@ namespace GVFS.UnitTests.Windows.Upgrader
         }
 
         [TestCase]
+        public void GitInstallerAuthenticodeError()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.SetFailOnAction(MockGitHubUpgrader.ActionType.GitAuthenticodeCheck);
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    "hash of the file does not match the hash stored in the digital signature"
+                },
+                expectedErrors: new List<string>
+                {
+                    "hash of the file does not match the hash stored in the digital signature"
+                });
+        }
+
+        [TestCase]
         public void GVFSInstallationArgs()
         {
             this.RunUpgrade().ShouldEqual(ReturnCode.Success);
@@ -173,6 +192,25 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 expectedErrors: new List<string>
                 {
                     "GVFS installation failed"
+                });
+        }
+
+        [TestCase]
+        public void GVFSInstallerAuthenticodeError()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.SetFailOnAction(MockGitHubUpgrader.ActionType.GVFSAuthenticodeCheck);
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    "hash of the file does not match the hash stored in the digital signature"
+                },
+                expectedErrors: new List<string>
+                {
+                    "hash of the file does not match the hash stored in the digital signature"
                 });
         }
 

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -43,6 +43,11 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
+        public override bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error)
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetNamedPipeName(string enlistmentRoot)
         {
             return "GVFS_Mock_PipeName";


### PR DESCRIPTION
#### Goal
Verify code signature of downloaded upgrade installer exes before launching it.

#### Implementation
Signature verification: At a high level, the `upgrader` reads the certificate contained in the signed installer. It then tries to build the certificate chain. If it succeeds, then the `exe` is considered valid and `upgrader` goes on to verify that the certificate CN name matches expected values ("Microsoft Corporation" for VFSForGit and "Johannes Schindelin" for Git). Installer is launched only when signature verification succeeds. To prevent an attacker from modifying installer exe while signature verification is going on, `upgrader` holds an open reference to the exe that is later released. 