### PR TITLE
Use a single LibGit2Repo for multiple requests, dispose if left unused

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -128,6 +128,12 @@ namespace GVFS.Common.Maintenance
                         return;
                     }
 
+                    // If a LibGit2Repo is active, then it may hold handles to the .idx and .pack files we want
+                    // to delete during the 'git multi-pack-index expire' step. If one starts during the step,
+                    // then it can still block those deletions, but we will clean them up in the next run. By
+                    // checking HasActiveLibGit2Repo here, we ensure that we do not run twice with the same
+                    // LibGit2Repo active across two calls. A "new" repo should not hold handles to .idx files
+                    // that do not have corresponding .pack files, so we will clean them up in CleanStaleIdxFiles().
                     if (this.Context.Repository.HasActiveLibGit2Repo)
                     {
                         activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to active libgit2 repo", Keywords.Telemetry);

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -127,6 +127,12 @@ namespace GVFS.Common.Maintenance
                         activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);
                         return;
                     }
+
+                    if (this.Context.Repository.HasActiveLibGit2Repo)
+                    {
+                        activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to active libgit2 repo", Keywords.Telemetry);
+                        return;
+                    }
                 }
 
                 this.GetPackFilesInfo(out int beforeCount, out long beforeSize, out bool hasKeep);

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
@@ -22,6 +22,8 @@ namespace GVFS.UnitTests.Common
         [SetUp]
         public void Setup()
         {
+            this.invoker?.Dispose();
+
             this.tracer = new MockTracer();
             this.invoker = new LibGit2RepoInvoker(this.tracer, this.CreateRepo, this.disposalPeriod);
             this.numConstructors = 0;

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
@@ -1,5 +1,4 @@
-﻿using GVFS.Common;
-using GVFS.Common.Git;
+﻿using GVFS.Common.Git;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using NUnit.Framework;
@@ -10,11 +9,11 @@ using System.Threading;
 namespace GVFS.UnitTests.Common
 {
     [TestFixture]
-    public class LibGit2RepoPoolTests
+    public class LibGit2RepoInvokerTests
     {
         private readonly TimeSpan disposalPeriod = TimeSpan.FromMilliseconds(1);
         private MockTracer tracer;
-        private LibGit2RepoPool pool;
+        private LibGit2RepoInvoker pool;
         public int NumConstructors { get; set; }
         public int NumDisposals { get; set; }
         public BlockingCollection<object> DisposalTriggers { get; set; }
@@ -23,7 +22,7 @@ namespace GVFS.UnitTests.Common
         public void Setup()
         {
             this.tracer = new MockTracer();
-            this.pool = new LibGit2RepoPool(this.tracer, this.CreateRepo, disposalPeriod: this.disposalPeriod);
+            this.pool = new LibGit2RepoInvoker(this.tracer, this.CreateRepo, disposalPeriod: this.disposalPeriod);
             this.NumConstructors = 0;
             this.NumDisposals = 0;
             this.DisposalTriggers = new BlockingCollection<object>();
@@ -154,9 +153,9 @@ namespace GVFS.UnitTests.Common
 
         private class MockLibGit2Repo : LibGit2Repo
         {
-            private readonly LibGit2RepoPoolTests parent;
+            private readonly LibGit2RepoInvokerTests parent;
 
-            public MockLibGit2Repo(LibGit2RepoPoolTests parent)
+            public MockLibGit2Repo(LibGit2RepoInvokerTests parent)
             {
                 this.parent = parent;
             }

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoPoolTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoPoolTests.cs
@@ -1,0 +1,174 @@
+﻿using GVFS.Common;
+using GVFS.Common.Git;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LibGit2RepoPoolTests
+    {
+        private readonly TimeSpan disposalPeriod = TimeSpan.FromMilliseconds(1);
+        private MockTracer tracer;
+        private LibGit2RepoPool pool;
+        public int NumConstructors { get; set; }
+        public int NumDisposals { get; set; }
+        public BlockingCollection<object> DisposalTriggers { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.tracer = new MockTracer();
+            this.pool = new LibGit2RepoPool(this.tracer, this.CreateRepo, disposalPeriod: this.disposalPeriod);
+            this.NumConstructors = 0;
+            this.NumDisposals = 0;
+            this.DisposalTriggers = new BlockingCollection<object>();
+        }
+
+        [TestCase]
+        public void DoesNotCreateRepoOnConstruction()
+        {
+            this.NumConstructors.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void CreatesRepoOnTryInvoke()
+        {
+            this.NumConstructors.ShouldEqual(0);
+
+            this.pool.TryInvoke(repo => { return true; }, out bool result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void DoesNotCreateMultipleRepos()
+        {
+            this.NumConstructors.ShouldEqual(0);
+
+            this.pool.TryInvoke(repo => { return true; }, out bool result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+
+            this.pool.TryInvoke(repo => { return true; }, out result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+
+            this.pool.TryInvoke(repo => { return true; }, out result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void DoesNotCreateRepoAfterDisposal()
+        {
+            this.NumConstructors.ShouldEqual(0);
+            this.pool.Dispose();
+            this.pool.TryInvoke(repo => { return true; }, out bool result);
+            result.ShouldEqual(false);
+            this.NumConstructors.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void DisposesSharedRepo()
+        {
+            this.pool.TryInvoke(repo => { return true; }, out bool result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+
+            this.pool.Dispose();
+            this.NumDisposals.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void UsesOnlyOneRepoMultipleThreads()
+        {
+            this.NumConstructors.ShouldEqual(0);
+
+            Thread[] threads = new Thread[10];
+            BlockingCollection<object> allowNextThreadToContinue = new BlockingCollection<object>();
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(() =>
+                {
+                    this.pool.TryInvoke(
+                        repo =>
+                        {
+                            allowNextThreadToContinue.Take();
+
+                            // Give the timer an opportunity to fire
+                            Thread.Sleep(2);
+
+                            allowNextThreadToContinue.Add(new object());
+                            return true;
+                        },
+                        out bool result);
+                    result.ShouldEqual(true);
+                    this.NumConstructors.ShouldEqual(1);
+                });
+            }
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Start();
+            }
+
+            allowNextThreadToContinue.Add(new object());
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            this.NumConstructors.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void AutomaticallyDisposesAfterNoUse()
+        {
+            this.NumConstructors.ShouldEqual(0);
+
+            this.pool.TryInvoke(repo => { return true; }, out bool result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(1);
+
+            this.DisposalTriggers.TryTake(out object _, (int)this.disposalPeriod.TotalMilliseconds * 100).ShouldBeTrue();
+            this.NumDisposals.ShouldEqual(1);
+            this.NumConstructors.ShouldEqual(1);
+
+            this.pool.TryInvoke(repo => { return true; }, out result);
+            result.ShouldEqual(true);
+            this.NumConstructors.ShouldEqual(2);
+        }
+
+        private LibGit2Repo CreateRepo()
+        {
+            this.NumConstructors++;
+            return new MockLibGit2Repo(this);
+        }
+
+        private class MockLibGit2Repo : LibGit2Repo
+        {
+            private readonly LibGit2RepoPoolTests parent;
+
+            public MockLibGit2Repo(LibGit2RepoPoolTests parent)
+            {
+                this.parent = parent;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    this.parent.NumDisposals++;
+                    this.parent.DisposalTriggers.Add(new object());
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -150,9 +150,11 @@ namespace GVFS.UnitTests.Maintenance
             List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };
             PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, directories, null));
 
+            MockGitRepo repository = new MockGitRepo(this.tracer, enlistment, fileSystem);
+
             // Create and return Context
             this.tracer = new MockTracer();
-            this.context = new GVFSContext(this.tracer, fileSystem, repository: null, enlistment: enlistment);
+            this.context = new GVFSContext(this.tracer, fileSystem, repository, enlistment);
 
             this.gitProcess.SetExpectedCommandResult(
                 this.ExpireCommand,


### PR DESCRIPTION
We use libgit2 to get some information from our Git object database without loading a full `git.exe` process. This allows us to:

* Check for object existence (usually a commit and its tree).
* Get the data out of a blob so we can hydrate a file.

The `LibGit2RepoPool` created 2_N_ copies of a libgit2 repository object, where _N_ is the number of processors available. We then lent these out from the pool to the threads trying to hydrate the repo. This can cause significant memory pressure as the repository objects do not share memory caches.

Since libgit2 doesn't use the multi-pack-index file, it loads handles to all of the .idx files on its first use. It then also holds handles to the .pack files that it reads, which may include packs we want to expire in the `PackfileMaintenanceStep`.

Since the `LibGit2RepoPool` never disposed of the `LibGit2Repo` objects, we never reclaimed the native memory they allocated, and we never cleared the file handles. This meant we could never clear .idx files until unmounting. This may also be a source of out-of-memory errors.

This PR does multiple things to improve our situation:

1. Use only one libgit2 repo. This is safe because we are performing read-only operations on the object database, and libgit2 has mutexes around its object database structures. This is also tested by the full functional test `ParallelHydrationTests.HydrateRepoInParallel`, in addition to performance testing I did on my machine.

2. Dispose of the libgit2 repo if it has not been used for 15 minutes. This number is mostly large enough that we should not dispose during a build that is hydrating the filesystem, but will dispose soon enough to run background maintenance.

3. In `PackfileMaintenanceStep` we now check if there are running libgit2 repos, in which case we do not continue running the step.

Now that we are using only one libgit2 repo, it makes sense to rename `LibGit2RepoPool` to `LibGit2RepoInvoker`. This provides safe logic around accessing the `LibGit2Repo` object (initializing if necessary) and disposing when the timer activates. Also, move the file into the `Git` folder of the `GVFS.Common` project.