### PR TITLE
Adding dry-run and no-verify

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -233,6 +233,7 @@ namespace GVFS.Common
         {
             public const string GVFSUpgrade = "`gvfs upgrade`";
             public const string GVFSUpgradeConfirm = "`gvfs upgrade --confirm`";
+            public const string GVFSUpgradeDryRun = "`gvfs upgrade --dry-run`";
             public const string NoUpgradeCheckPerformed = "No upgrade check was performed.";
             public const string NoneRingConsoleAlert = "Upgrade ring set to \"None\". " + NoUpgradeCheckPerformed;
             public const string NoRingConfigConsoleAlert = "Upgrade ring is not set. " + NoUpgradeCheckPerformed;

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -32,6 +32,7 @@ namespace GVFS.Common
             {
                 UpgraderToolName,
                 UpgraderToolConfigFile,
+                "CommandLine.dll",
                 "GVFS.Common.dll",
                 "GVFS.Platform.Windows.dll",
                 "Microsoft.Diagnostics.Tracing.EventSource.dll",
@@ -305,12 +306,6 @@ namespace GVFS.Common
 
         protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
-            if (this.dryRun)
-            {
-                exception = null;
-                return true;
-            }
-
             return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);
         }
 
@@ -320,7 +315,7 @@ namespace GVFS.Common
 
             string downloadPath = ProductUpgraderInfo.GetAssetDownloadsPath();
             Exception exception;
-            if (!this.dryRun && GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
+            if (!GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
             {
                 errorMessage = exception.Message;
                 this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
@@ -332,11 +327,7 @@ namespace GVFS.Common
 
             try
             {
-                if (!this.dryRun)
-                {
-                    webClient.DownloadFile(asset.DownloadURL, localPath);
-                }
-
+                webClient.DownloadFile(asset.DownloadURL, localPath);
                 asset.LocalPath = localPath;
             }
             catch (WebException webException)

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -45,14 +45,20 @@ namespace GVFS.Common
         private Release newestRelease;
         private PhysicalFileSystem fileSystem;
         private ITracer tracer;
+        private bool dryRun;
+        private bool noVerify;
 
         public GitHubUpgrader(
             string currentVersion,
             ITracer tracer,
-            GitHubUpgraderConfig upgraderConfig)
+            GitHubUpgraderConfig upgraderConfig,
+            bool dryRun = false,
+            bool noVerify = false)
             : this(currentVersion, tracer)
         {
             this.Config = upgraderConfig;
+            this.dryRun = dryRun;
+            this.noVerify = noVerify;
         }
 
         public GitHubUpgrader(string currentVersion, ITracer tracer)
@@ -67,12 +73,12 @@ namespace GVFS.Common
 
         public GitHubUpgraderConfig Config { get; private set; }
 
-        public static GitHubUpgrader Create(ITracer tracer, out string error)
+        public static GitHubUpgrader Create(ITracer tracer, bool dryRun, bool noVerify, out string error)
         {
-            return Create(new LocalGVFSConfig(), tracer, out error);
+            return Create(new LocalGVFSConfig(), tracer, dryRun, noVerify, out error);
         }
 
-        public static GitHubUpgrader Create(LocalGVFSConfig localConfig, ITracer tracer, out string error)
+        public static GitHubUpgrader Create(LocalGVFSConfig localConfig, ITracer tracer, bool dryRun, bool noVerify, out string error)
         {
             GitHubUpgrader upgrader = null;
             GitHubUpgraderConfig gitHubUpgraderConfig = new GitHubUpgraderConfig(tracer, localConfig);
@@ -91,7 +97,9 @@ namespace GVFS.Common
             upgrader = new GitHubUpgrader(
                     ProcessHelper.GetCurrentProcessVersion(),
                     tracer,
-                    gitHubUpgraderConfig);
+                    gitHubUpgraderConfig,
+                    dryRun,
+                    noVerify);
 
             return upgrader;
         }
@@ -297,6 +305,12 @@ namespace GVFS.Common
 
         protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
+            if (this.dryRun)
+            {
+                exception = null;
+                return true;
+            }
+
             return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);
         }
 
@@ -306,7 +320,7 @@ namespace GVFS.Common
 
             string downloadPath = ProductUpgraderInfo.GetAssetDownloadsPath();
             Exception exception;
-            if (!GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
+            if (!this.dryRun && GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
             {
                 errorMessage = exception.Message;
                 this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
@@ -318,12 +332,16 @@ namespace GVFS.Common
 
             try
             {
-                webClient.DownloadFile(asset.DownloadURL, localPath);
+                if (!this.dryRun)
+                {
+                    webClient.DownloadFile(asset.DownloadURL, localPath);
+                }
+
                 asset.LocalPath = localPath;
             }
             catch (WebException webException)
             {
-                errorMessage = "Download error: " + exception.Message;
+                errorMessage = "Download error: " + webException.Message;
                 this.TraceException(webException, nameof(this.TryDownloadAsset), $"Error downloading asset {asset.Name}.");
                 return false;
             }
@@ -366,10 +384,18 @@ namespace GVFS.Common
 
         protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)
         {
-            ProcessResult processResult = ProcessHelper.Run(path, args);
+            if (this.dryRun)
+            {
+                exitCode = 0;
+                error = null;
+            }
+            else
+            {
+                ProcessResult processResult = ProcessHelper.Run(path, args);
 
-            exitCode = processResult.ExitCode;
-            error = processResult.Errors;
+                exitCode = processResult.ExitCode;
+                error = processResult.Errors;
+            }
         }
 
         private static bool TryCreateDirectory(string path, out Exception exception)

--- a/GVFS/GVFS.Common/ProductUpgraderFactory.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderFactory.cs
@@ -11,9 +11,11 @@ namespace GVFS.Common
         public static bool TryCreateUpgrader(
             out IProductUpgrader newUpgrader,
             ITracer tracer,
-            out string error)
+            out string error,
+            bool dryRun = false,
+            bool noVerify = false)
         {
-            newUpgrader = GitHubUpgrader.Create(tracer, out error);
+            newUpgrader = GitHubUpgrader.Create(tracer, dryRun, noVerify, out error);
             if (newUpgrader == null)
             {
                 tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create upgrader. {error}");

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -41,6 +41,11 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
         private Release FakeUpgradeRelease { get; set; }
 
+        public void SetDryRun(bool dryRun)
+        {
+            this.dryRun = dryRun;
+        }
+
         public void SetFailOnAction(ActionType failureType)
         {
             this.failActionTypes |= failureType;
@@ -54,6 +59,11 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         public void ResetFailedAction()
         {
             this.failActionTypes = ActionType.Invalid;
+        }
+
+        public bool RunInstallerInvoked()
+        {
+            return this.InstallerArgs.Count > 0;
         }
 
         public void PretendNewReleaseAvailableAtRemote(string upgradeVersion, GitHubUpgraderConfig.RingType remoteRing)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -38,7 +38,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
         public List<string> DownloadedFiles { get; private set; }
         public Dictionary<string, Dictionary<string, string>> InstallerArgs { get; private set; }
-
+        public bool InstallerExeLaunched { get; set; }
         private Release FakeUpgradeRelease { get; set; }
 
         public void SetDryRun(bool dryRun)
@@ -59,11 +59,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         public void ResetFailedAction()
         {
             this.failActionTypes = ActionType.Invalid;
-        }
-
-        public bool RunInstallerInvoked()
-        {
-            return this.InstallerArgs.Count > 0;
         }
 
         public void PretendNewReleaseAvailableAtRemote(string upgradeVersion, GitHubUpgraderConfig.RingType remoteRing)
@@ -207,6 +202,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             if (fileName.Equals(this.expectedGitAssetName, StringComparison.OrdinalIgnoreCase))
             {
                 this.InstallerArgs.Add("Git", installationInfo);
+                this.InstallerExeLaunched = true;
                 if (this.failActionTypes.HasFlag(ActionType.GitInstall))
                 {
                     exitCode = -1;
@@ -219,6 +215,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             if (fileName.Equals(this.expectedGVFSAssetName, StringComparison.OrdinalIgnoreCase))
             {
                 this.InstallerArgs.Add("GVFS", installationInfo);
+                this.InstallerExeLaunched = true;
                 if (this.failActionTypes.HasFlag(ActionType.GVFSInstall))
                 {
                     exitCode = -1;

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProcessLauncher.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProcessLauncher.cs
@@ -32,7 +32,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             get { return this.exitCode; }
         }
 
-        public override bool TryStart(string path, out Exception exception)
+        public override bool TryStart(string path, string args, out Exception exception)
         {
             this.LaunchPath = path;
             this.IsLaunched = true;

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -231,6 +231,30 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 });
         }
 
+        [TestCase]
+        public void DryRunDoesNotRunInstallerExes()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.SetDryRun(true);
+                    this.SetUpgradeRing("Slow");
+                    this.Upgrader.PretendNewReleaseAvailableAtRemote(
+                        upgradeVersion: NewerThanLocalVersion,
+                        remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow);
+                },
+                expectedReturn: ReturnCode.Success,
+                expectedOutput: new List<string>
+                {
+                    "Installing Git",
+                    "Installing GVFS",
+                    "Upgrade completed successfully."
+                },
+                expectedErrors: null);
+
+            this.Upgrader.RunInstallerInvoked().ShouldBeFalse();
+        }
+
         protected override ReturnCode RunUpgrade()
         {
             this.orchestrator.Execute();

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -238,6 +238,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 configure: () =>
                 {
                     this.Upgrader.SetDryRun(true);
+                    this.Upgrader.InstallerExeLaunched = false;
                     this.SetUpgradeRing("Slow");
                     this.Upgrader.PretendNewReleaseAvailableAtRemote(
                         upgradeVersion: NewerThanLocalVersion,
@@ -252,7 +253,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 },
                 expectedErrors: null);
 
-            this.Upgrader.RunInstallerInvoked().ShouldBeFalse();
+            this.Upgrader.InstallerExeLaunched.ShouldBeFalse();
         }
 
         protected override ReturnCode RunUpgrade()

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -66,7 +66,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
             string expectedError = "Invalid upgrade ring `Invalid` specified in gvfs config.";
             string errorString;
-            GitHubUpgrader.Create(this.LocalConfig, this.Tracer, out errorString).ShouldBeNull();
+            GitHubUpgrader.Create(this.LocalConfig, this.Tracer, dryRun: false, noVerify: false, error: out errorString).ShouldBeNull();
             errorString.ShouldContain(expectedError);
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -213,6 +213,26 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 });
         }
 
+        [TestCase]
+        public void DryRunLaunchesUpgradeTool()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.upgradeVerb.DryRun = true;
+                    this.SetUpgradeRing("Slow");
+                    this.Upgrader.PretendNewReleaseAvailableAtRemote(
+                        upgradeVersion: NewerThanLocalVersion,
+                        remoteRing: GitHubUpgrader.GitHubUpgraderConfig.RingType.Slow);
+                },
+                expectedReturn: ReturnCode.Success,
+                expectedOutput: new List<string>
+                {
+                    "Installer launched in a new window."
+                },
+                expectedErrors: null);
+        }
+
         protected override ReturnCode RunUpgrade()
         {
             try

--- a/GVFS/GVFS.Upgrader/App.config
+++ b/GVFS/GVFS.Upgrader/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/GVFS/GVFS.Upgrader/App.config
+++ b/GVFS/GVFS.Upgrader/App.config
@@ -3,12 +3,4 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
+++ b/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
@@ -32,6 +32,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\CommandLineParser.2.1.1-beta\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/GVFS/GVFS.Upgrader/Program.cs
+++ b/GVFS/GVFS.Upgrader/Program.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.PlatformLoader;
+﻿using CommandLine;
+using GVFS.PlatformLoader;
 
 namespace GVFS.Upgrader
 {
@@ -8,9 +9,8 @@ namespace GVFS.Upgrader
         {
             GVFSPlatformLoader.Initialize();
 
-            UpgradeOrchestrator upgrader = new UpgradeOrchestrator();
-
-            upgrader.Execute();
+            Parser.Default.ParseArguments<UpgradeOrchestrator>(args)
+                    .WithParsed(upgrader => upgrader.Execute());
         }
     }
 }

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -47,6 +47,7 @@ namespace GVFS.Upgrader
                 Keywords.Any);
 
             this.tracer = jsonTracer;
+            this.preRunChecker = new InstallerPreRunChecker(this.tracer, GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm);
             this.output = Console.Out;
             this.input = Console.In;
             this.mount = false;
@@ -143,11 +144,6 @@ namespace GVFS.Upgrader
                 }
 
                 this.upgrader = upgrader;
-            }
-
-            if (this.preRunChecker == null)
-            {
-                this.preRunChecker = new InstallerPreRunChecker(this.tracer, GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm);
             }
 
             errorMessage = null;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -147,7 +147,7 @@ namespace GVFS.Upgrader
 
             if (this.preRunChecker == null)
             {
-                this.preRunChecker = new InstallerPreRunChecker(this.tracer, GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm, this.DryRun);
+                this.preRunChecker = new InstallerPreRunChecker(this.tracer, GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm);
             }
 
             errorMessage = null;

--- a/GVFS/GVFS.Upgrader/packages.config
+++ b/GVFS/GVFS.Upgrader/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -65,6 +65,18 @@ namespace GVFS.CommandLine
 
         public override void Execute()
         {
+            if (this.DryRun)
+            {
+                if (this.Confirmed)
+                {
+                    this.ReportErrorAndExit(this.tracer, ReturnCode.GenericError, "--dry-run and --confirm arguments are not compatible.");
+                }
+                else
+                {
+                    this.Confirmed = true;
+                }
+            }
+
             string error;
             if (!this.TryInitializeUpgrader(out error) || !this.TryRunProductUpgrade())
             {


### PR DESCRIPTION
#### Goal
Create a `--dry-run` `upgrade` arg that will help VFS4Git Developers to run `gvfs upgrade` without actually affecting the state of their PC. New `--no-verify` `upgrade` arg to prevent code signature verification of installers and Nuget packages.

#### Feature details
Dry run - Behaves like a regular `gvfs upgrade --confirm` command, except that the downloaded installer exe's will not be run.

No verify - This is arg is enabled but not implemented right now. 