### PR TITLE
Add PrjFSKext log collection to diagnose verb

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.FileSystem
         bool EnumerationExpandsDirectories { get; }
         string LogsFolderPath { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
-        string FlushLogs();
+        bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
         bool IsGVFSUpgradeSupported();

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common.FileSystem;
+﻿﻿using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
@@ -137,20 +137,17 @@ namespace GVFS.Common
                 bool supportsGVFSService = true,
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool supportsKernelLogs = true,
                 bool requiresDeprecatedGitHooksLoader = false)
             {
                 this.SupportsGVFSService = supportsGVFSService;
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
-                this.SupportsKernelLogs = supportsKernelLogs;
                 this.RequiresDeprecatedGitHooksLoader = requiresDeprecatedGitHooksLoader;
             }
 
             public bool SupportsGVFSService { get; }
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
-            public bool SupportsKernelLogs { get; }
             public bool RequiresDeprecatedGitHooksLoader { get; }
         }
     }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -18,8 +18,7 @@ namespace GVFS.Platform.Mac
                 underConstruction: new UnderConstructionFlags(
                     supportsGVFSService: false,
                     supportsGVFSUpgrade: false,
-                    supportsGVFSConfig: false,
-                    supportsKernelLogs: false))
+                    supportsGVFSConfig: false))
         {
         }
 

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -14,7 +14,13 @@ namespace GVFS.Platform.Mac
 
         public bool EnumerationExpandsDirectories { get; } = true;
 
-        public string LogsFolderPath => throw new NotImplementedException();
+        public string LogsFolderPath
+        {
+            get
+            {
+                return Path.Combine(System.IO.Path.GetTempPath(), "PrjFSKext");
+            }
+        }
 
         public bool IsGVFSUpgradeSupported()
         {
@@ -42,9 +48,14 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public string FlushLogs()
+        public bool TryFlushLogs(out string error)
         {
-            throw new NotImplementedException();
+            Directory.CreateDirectory(this.LogsFolderPath);
+            ProcessResult logShowOutput = ProcessHelper.Run("log", args: "show --predicate \"subsystem contains \'org.vfsforgit\'\" --info", redirectOutput: true);
+            File.WriteAllText(Path.Combine(this.LogsFolderPath, "PrjFSKext.log"), logShowOutput.Output);
+            error = string.Empty;
+
+            return true;
         }
 
         public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -320,7 +320,7 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        public string FlushLogs()
+        public bool TryFlushLogs(out string error)
         {
             StringBuilder sb = new StringBuilder();
             try
@@ -330,14 +330,19 @@ namespace GVFS.Platform.Windows
                 if (result != 0)
                 {
                     sb.AppendFormat($"Failed to flush {ProjFSFilter.ServiceName} log buffers {result}");
+                    error = sb.ToString();
+                    return false;
                 }
             }
             catch (Exception e)
             {
                 sb.AppendFormat($"Failed to flush {ProjFSFilter.ServiceName} log buffers, exception: {e.ToString()}");
+                error = sb.ToString();
+                return false;
             }
 
-            return sb.ToString();
+            error = sb.ToString();
+            return true;
         }
 
         public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -88,11 +88,10 @@ namespace GVFS.CommandLine
                         // .gvfs
                         this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSConstants.DotGVFS.Root, copySubFolders: false);
 
-                        if (GVFSPlatform.Instance.UnderConstruction.SupportsKernelLogs)
+                        // driver
+                        if (this.FlushKernelDriverLogs())
                         {
-                            // driver
-                            this.FlushKernelDriverLogs();
-                            string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
+                             string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
 
                             // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
                             // for the user so we don't write the error message to stdout, just to our own log file.
@@ -473,10 +472,12 @@ namespace GVFS.CommandLine
             }
         }
 
-        private void FlushKernelDriverLogs()
+        private bool FlushKernelDriverLogs()
         {
-            string errors = GVFSPlatform.Instance.KernelDriver.FlushLogs();
+            string errors;
+            bool flushSuccess = GVFSPlatform.Instance.KernelDriver.TryFlushLogs(out errors);
             this.diagnosticLogFileWriter.WriteLine(errors);
+            return flushSuccess;
         }
 
         private void PrintDiskSpaceInfo(string localCacheRoot, string enlistmentRootParameter)


### PR DESCRIPTION
Part of #638 

The new PrjFSKextLogDaemon writes kext log messages out to the os log.
This change updates the diagnose verb to consume the os log via the
`log show` commandline.

This change does not install the daemon as part of the product.

Note that this effectively exports the logs as text rather than
the binary .logarchive format. This was chosen for ease of viewing
on any machine (Console.app and `log` are only on MacOS).

The questions here in my mind are about what args we should pass into `log`. It's very powerful and we could filter by type, content in the message, date, etc. I went with the simplest solution, put everything in the log file. I personally prefer logs structured like this rather than tools that produce separate log files for stdout/warnings/errors, but I'm open to new ideas :)

For more context on the unified logger, check https://developer.apple.com/documentation/os/logging or the manpage for `log`