### PR TITLE
Auto-load PrjFS kext & gvfs bin load error fix.

### DIFF
--- a/GVFS/GVFS.Installer.Mac/GVFS.Installer.Mac.csproj
+++ b/GVFS/GVFS.Installer.Mac/GVFS.Installer.Mac.csproj
@@ -31,7 +31,7 @@
   </Target>
 
   <Target Name="AfterAllPublishing" AfterTargets="Publish">
-    <Message Text="$(ProjectDir)/CreateMacInstaller.sh $(Configuration) $(GVFSVersion) $(OutputPath)" Importance="high"></Message>
-    <Exec Command="$(ProjectDir)/CreateMacInstaller.sh $(Configuration) $(GVFSVersion) $(OutputPath)" />
+    <Message Text="$(ProjectDir)/CreateMacInstaller.sh $(MSBuildProjectDirectory) $(Configuration) $(GVFSVersion) $(OutputPath)" Importance="high"></Message>
+    <Exec Command="$(ProjectDir)/CreateMacInstaller.sh $(MSBuildProjectDirectory) $(Configuration) $(GVFSVersion) $(OutputPath)" />
   </Target>
 </Project>

--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+KEXTFILENAME="PrjFSKext.kext"
+VFSFORDIRECTORY="/usr/local/vfsforgit"
+PRJFSKEXTDIRECTORY="/Library/Extensions"
+GVFSCOMMANDPATH="/usr/local/bin/gvfs"
+UNINSTALLERCOMMANDPATH="/usr/local/bin/uninstall_vfsforgit.sh"
+INSTALLERPACKAGEID="com.vfsforgit.pkg"
+KEXTID="io.gvfs.PrjFSKext"
+
+function UnloadKext()
+{
+    kextLoaded=`/usr/sbin/kextstat -b "$KEXTID" | wc -l`
+    if [ $kextLoaded -eq "2" ]; then
+        unloadCmd="sudo /sbin/kextunload -b $KEXTID"
+        echo "$unloadCmd..."
+        eval $unloadCmd || exit 1
+    fi
+}
+
+function UnInstallVFSForGit()
+{
+    if [ -d "${VFSFORDIRECTORY}" ]; then
+        rmCmd="sudo /bin/rm -Rf ${VFSFORDIRECTORY}"
+        echo "$rmCmd..."
+        eval $rmCmd || exit 1
+    fi
+    
+    if [ -d "${PRJFSKEXTDIRECTORY}/$KEXTFILENAME" ]; then
+        rmCmd="sudo /bin/rm -Rf ${PRJFSKEXTDIRECTORY}/$KEXTFILENAME"
+        echo "$rmCmd..."
+        eval $rmCmd || exit 1
+    fi
+    
+    if [ -s "${GVFSCOMMANDPATH}" ]; then
+        rmCmd="sudo /bin/rm -Rf ${GVFSCOMMANDPATH}"
+        echo "$rmCmd..."
+        eval $rmCmd || exit 1
+    fi
+}
+
+function ForgetPackage()
+{
+    if [ -f "/usr/sbin/pkgutil" ]; then
+        forgetCmd="sudo /usr/sbin/pkgutil --forget $INSTALLERPACKAGEID"
+        echo "$forgetCmd..."
+        eval $forgetCmd
+    fi
+}
+
+function Run()
+{
+    UnloadKext
+    UnInstallVFSForGit
+    ForgetPackage
+    echo "Successfully uninstalled VFSForGit"
+}
+
+Run


### PR DESCRIPTION
#### Auto-load PrjFS kext
Now PrjFS kext will get installed in the standard kernel extensions directory, this will let the Operating System find it and autoload it. 

#### gvfs bin load error fix
Installing libPrjFSLib.dylib in /usr/local/lib directory; this helps fix the issue where some of the vfsforgit binaries fail to launch bcoz of missing libraries in standard lib search paths.

#### Added a basic un-installer
The un-installer unloads PrjFS Kext, deletes vfsforgit binaries and symbolic links. The un-installer does not un-mount any mounted repositories. To un-install run `uninstall_vfsforgit.sh` from Terminal. It will ask you for `Admin` password.