### PR TITLE
Windows build: Only consider dev 15 build tooling

### DIFF
--- a/Scripts/BuildGVFSForWindows.bat
+++ b/Scripts/BuildGVFSForWindows.bat
@@ -21,7 +21,7 @@ SET vswhere=%VFS_PACKAGESDIR%\vswhere.%vswherever%\tools\vswhere.exe
 
 :: Use vswhere to find the latest VS installation (including prerelease installations) with the msbuild component.
 :: See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.Component.NetFX.Core.Runtime Microsoft.VisualStudio.Component.Windows10SDK.10240 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -version "[15.0,16.0)" -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.Component.NetFX.Core.Runtime Microsoft.VisualStudio.Component.Windows10SDK.10240 -property installationPath`) do (
   set VsInstallDir=%%i
 )
 


### PR DESCRIPTION
The windows build script looks for installed versions of Visual Studio
to find msbuild and related tooling. The structure of where this tooling
is located has changed in VS 2019, which causes issues when attempting
to run the BuildGVFSForWindows.bat script when VS 2019 is installed.

This change addresses that issue by only considering VS 2017 when
searching installed build tools.