### PR TITLE
GitHubUpgrader: Use REMOUNTREPOS flag instead of MOUNTREPOS

### DIFF
--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -22,7 +22,7 @@ namespace GVFS.Common
         private const string JSONMediaType = @"application/vnd.github.v3+json";
         private const string UserAgent = @"GVFS_Auto_Upgrader";
         private const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
-        private const string GVFSInstallerArgs = CommonInstallerArgs + " /MOUNTREPOS=false";
+        private const string GVFSInstallerArgs = CommonInstallerArgs + " /REMOUNTREPOS=false";
         private const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
         private const string GitAssetId = "Git";
         private const string GVFSAssetId = "GVFS";

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -154,7 +154,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
             string args;
             gitInstallerInfo.TryGetValue("Args", out args).ShouldBeTrue();
-            args.ShouldContain(new string[] { "/VERYSILENT", "/CLOSEAPPLICATIONS", "/SUPPRESSMSGBOXES", "/NORESTART", "/Log", "/MOUNTREPOS=false" });
+            args.ShouldContain(new string[] { "/VERYSILENT", "/CLOSEAPPLICATIONS", "/SUPPRESSMSGBOXES", "/NORESTART", "/Log", "/REMOUNTREPOS=false" });
         }
 
         [TestCase]


### PR DESCRIPTION
VFSForGit Setup is looking for REMOUNTREPOS instead of MOUNTREPOS.