### PR TITLE
GitMaintenanceStep: inject the dependence on git process ids

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitProcessChecker.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitProcessChecker.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GVFS.Common.Maintenance
+{
+    public class GitProcessChecker
+    {
+        public virtual IEnumerable<int> GetRunningGitProcessIds()
+        {
+            Process[] allProcesses = Process.GetProcesses();
+            return allProcesses
+                .Where(x => x.ProcessName.Equals("git", StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.Id);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -16,8 +16,12 @@ namespace GVFS.Common.Maintenance
         public const string LooseObjectsLastRunFileName = "loose-objects.time";
         private readonly bool forceRun;
 
-        public LooseObjectsStep(GVFSContext context, bool requireCacheLock = true, bool forceRun = false)
-            : base(context, requireObjectCacheLock: requireCacheLock)
+        public LooseObjectsStep(
+            GVFSContext context,
+            bool requireCacheLock = true,
+            bool forceRun = false,
+            GitProcessChecker gitProcessChecker = null)
+            : base(context, requireCacheLock, gitProcessChecker)
         {
             this.forceRun = forceRun;
         }
@@ -134,7 +138,7 @@ namespace GVFS.Common.Maintenance
                             return;
                         }
 
-                        IEnumerable<int> processIds = this.RunningGitProcessIds();
+                        IEnumerable<int> processIds = this.GitProcessChecker.GetRunningGitProcessIds();
                         if (processIds.Any())
                         {
                             activity.RelatedWarning($"Skipping {nameof(LooseObjectsStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -35,8 +35,9 @@ namespace GVFS.Common.Maintenance
             GVFSContext context,
             bool requireObjectCacheLock = true,
             bool forceRun = false,
-            string batchSize = DefaultBatchSize)
-            : base(context, requireObjectCacheLock)
+            string batchSize = DefaultBatchSize,
+            GitProcessChecker gitProcessChecker = null)
+            : base(context, requireObjectCacheLock, gitProcessChecker)
         {
             this.forceRun = forceRun;
             this.batchSize = batchSize;
@@ -121,7 +122,7 @@ namespace GVFS.Common.Maintenance
                         return;
                     }
 
-                    IEnumerable<int> processIds = this.RunningGitProcessIds();
+                    IEnumerable<int> processIds = this.GitProcessChecker.GetRunningGitProcessIds();
                     if (processIds.Any())
                     {
                         activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);

--- a/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj
+++ b/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj
@@ -36,6 +36,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="NUnitLite" Version="3.10.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">


### PR DESCRIPTION
In the GitMaintenanceStep, we had a method "RunningGitProcessIds()" that used the Process API to check running Git processes. This can cause unit tests to fail on a dev machine if they are running Git commands (which may be due to background activity on a VFS mount).

Inject a new GitProcessChecker to the maintenance step, and use that in unit tests to insert the answer we want. We can now check that we do not advance when there are git processes running.