### PR TITLE
Mac/Linux: default MirrorProvider paths to $HOME and permit override

### DIFF
--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Clone.sh
@@ -8,7 +8,7 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-PATH_TO_MIRROR="${PATH_TO_MIRROR:-~/PathToMirror}"
-TEST_ROOT="${TEST_ROOT:-~/TestRoot}"
+PATH_TO_MIRROR="${PATH_TO_MIRROR:-$HOME/PathToMirror}"
+TEST_ROOT="${TEST_ROOT:-$HOME/TestRoot}"
 
 dotnet $BUILDDIR/MirrorProvider.Linux.dll clone "$PATH_TO_MIRROR" "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
+++ b/MirrorProvider/Scripts/Linux/MirrorProvider_Mount.sh
@@ -8,6 +8,6 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Linux/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-TEST_ROOT="${TEST_ROOT:-~/TestRoot}"
+TEST_ROOT="${TEST_ROOT:-$HOME/TestRoot}"
 
 dotnet $BUILDDIR/MirrorProvider.Linux.dll mount "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Mac/MirrorProvider_Clone.sh
+++ b/MirrorProvider/Scripts/Mac/MirrorProvider_Clone.sh
@@ -8,4 +8,7 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Mac/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-dotnet $BUILDDIR/MirrorProvider.Mac.dll clone ~/PathToMirror ~/TestRoot
+PATH_TO_MIRROR="${PATH_TO_MIRROR:-$HOME/PathToMirror}"
+TEST_ROOT="${TEST_ROOT:-$HOME/TestRoot}"
+
+dotnet $BUILDDIR/MirrorProvider.Mac.dll clone "$PATH_TO_MIRROR" "$TEST_ROOT"

--- a/MirrorProvider/Scripts/Mac/MirrorProvider_Mount.sh
+++ b/MirrorProvider/Scripts/Mac/MirrorProvider_Mount.sh
@@ -8,4 +8,6 @@ fi
 SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 BUILDDIR=$SCRIPTDIR/../../../../BuildOutput/MirrorProvider.Mac/bin/$CONFIGURATION/x64/netcoreapp2.1
 
-dotnet $BUILDDIR/MirrorProvider.Mac.dll mount ~/TestRoot
+TEST_ROOT="${TEST_ROOT:-$HOME/TestRoot}"
+
+dotnet $BUILDDIR/MirrorProvider.Mac.dll mount "$TEST_ROOT"


### PR DESCRIPTION
Bring the MirrorProvider scripts for macOS in sync with the changes from the Linux scripts (see commits f9fdb09, 1bd487e, a223566).  This adds support for non-default paths to be supplied
via environment variables when cloning or mounting the MirrorProvider.

Also use `$HOME` in the definition of the default ~/TestRoot and ~/PathToMirror paths instead of the tilde character, as Bash won't expand it when it's inside a quoted string.