### PR TITLE
File system common methods

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -260,6 +260,51 @@ namespace GVFS.Common.FileSystem
             }
         }
 
+        public bool TryCreateDirectory(string path, out Exception exception)
+        {
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (Exception e) when (e is IOException ||
+                                      e is UnauthorizedAccessException ||
+                                      e is ArgumentException ||
+                                      e is NotSupportedException)
+            {
+                exception = e;
+                return false;
+            }
+
+            exception = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Recursively deletes a directory and all contained contents.
+        /// </summary>
+        public bool TryDeleteDirectory(string path, out Exception exception)
+        {
+            try
+            {
+                this.DeleteDirectory(path);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // The directory does not exist - follow the
+                // convention of this class and report success
+            }
+            catch (Exception e) when (e is IOException ||
+                                      e is UnauthorizedAccessException ||
+                                      e is ArgumentException)
+            {
+                exception = e;
+                return false;
+            }
+
+            exception = null;
+            return true;
+        }
+
         /// <summary>
         /// Attempts to delete a file
         /// </summary>

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -12,10 +12,6 @@ namespace GVFS.Common.FileSystem
     {
         public const int DefaultStreamBufferSize = 8192;
 
-        // https://msdn.microsoft.com/en-us/library/system.io.filesystemwatcher.internalbuffersize(v=vs.110).aspx:
-        // Max FileSystemWatcher.InternalBufferSize is 64 KB
-        private const int WatcherBufferSize = 64 * 1024;
-
         public static void RecursiveDelete(string path)
         {
             if (!Directory.Exists(path))

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -239,7 +239,7 @@ namespace GVFS.Common
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
             Exception exception;
-            if (TryCreateDirectory(toolsDirectoryPath, out exception))
+            if (this.fileSystem.TryCreateDirectory(toolsDirectoryPath, out exception))
             {
                 string currentPath = ProcessHelper.GetCurrentProcessLocation();
                 error = null;
@@ -316,7 +316,7 @@ namespace GVFS.Common
 
             string downloadPath = ProductUpgraderInfo.GetAssetDownloadsPath();
             Exception exception;
-            if (!GitHubUpgrader.TryCreateDirectory(downloadPath, out exception))
+            if (!this.fileSystem.TryCreateDirectory(downloadPath, out exception))
             {
                 errorMessage = exception.Message;
                 this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
@@ -380,27 +380,6 @@ namespace GVFS.Common
 
             exitCode = processResult.ExitCode;
             error = processResult.Errors;
-        }
-
-        private static bool TryCreateDirectory(string path, out Exception exception)
-        {
-            try
-            {
-                Directory.CreateDirectory(path);
-            }
-            catch (IOException e)
-            {
-                exception = e;
-                return false;
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                exception = e;
-                return false;
-            }
-
-            exception = null;
-            return true;
         }
 
         private bool TryGetGitVersion(out GitVersion gitVersion, out string error)


### PR DESCRIPTION
To reduce some of the code changes in the `NuGetUpgrader` code change, I am moving some of the encapsulated changes into their own PR. This PR moves / introduces a couple of helper methods around file system operations.

1) `TryCreateDirectory` is a general helper method that exists in `GitHubUpgrader` today, but seems like it is generally useful and could live in `PhysicalFileSystem`. The upcoming `NuGetUpgrader` change will leverage this method as well.

2) `TryDeleteDirectory` is not used today, but will be used by the `NuGetUpgrader` change. I wanted t

Also  removes an unused const while we are in here.