### PR TITLE
[DO NOT REVIEW] Mac kext: explicit check for profile data size in external method

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
@@ -19,7 +19,7 @@ static const IOExternalMethodDispatch LogUserClientDispatch[] =
             .checkScalarInputCount =    0,
             .checkStructureInputSize =  0,
             .checkScalarOutputCount =   0,
-            .checkStructureOutputSize = PrjFSPerfCounter_Count * sizeof(PrjFSPerfCounterResult), // array of results
+            .checkStructureOutputSize = kIOUCVariableStructureSize, // array of results
         },
 };
 


### PR DESCRIPTION
Instead of getting IOUserClient to silently perform the check, let any size through IOUserClient and allow PerfTracing_ExportDataUserClient()'s check to kick in, which writes details to the kext log when it fails.