### PR TITLE
Try to load the kext if not loaded

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -11,6 +11,7 @@ namespace GVFS.Common.FileSystem
         bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
+        bool TryLoad(ITracer tracer, string enlistmentRoot, out string error);
         bool IsGVFSUpgradeSupported();
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -11,8 +11,7 @@ namespace GVFS.Common.FileSystem
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
-        bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
-        bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string error);
+        bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error);
         bool IsGVFSUpgradeSupported();
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common.Tracing;
 using System;
+using System.IO;
 
 namespace GVFS.Common.FileSystem
 {
@@ -11,7 +12,7 @@ namespace GVFS.Common.FileSystem
         bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
-        bool TryLoad(ITracer tracer, string enlistmentRoot, out string error);
+        bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string error);
         bool IsGVFSUpgradeSupported();
     }
 }

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -93,7 +93,7 @@ namespace GVFS.Platform.Mac
             ProcessResult loadKext = ProcessHelper.Run("sudo", "/sbin/kextload -b " + DriverName);
             if (loadKext.ExitCode == LoadKext_ExitCode_Success)
             {
-                tracer.RelatedWarning(metadata, $"{DriverName} was successfully loaded.", Keywords.Telemetry);
+                tracer.RelatedWarning(metadata, $"{DriverName} was successfully loaded but should have been autoloaded.", Keywords.Telemetry);
                 errorMessage = null;
                 return true;
             }

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -81,8 +81,9 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public bool TryLoad(ITracer tracer, string enlistmentRoot, out string errorMessage)
+        public bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string errorMessage)
         {
+            output?.WriteLine("Driver not loaded.  Attempting to load. You may be prompted for sudo password...");
             EventMetadata metadata = new EventMetadata();
             ProcessResult loadKext = ProcessHelper.Run("sudo", "/sbin/kextload -b " + DriverName);
             if (loadKext.ExitCode == LoadKext_ExitCode_Success)
@@ -104,7 +105,7 @@ System Preferences -> Security & Privacy";
                 metadata.Add("Errors", loadKext.Errors);
                 tracer.RelatedError(metadata, "Failed to load kext");
 
-                errorMessage = DriverName + " is not loaded. Make sure the driver is loaded and try again.";
+                errorMessage = DriverName + " is not loaded. Make sure the kext is loaded and try again.";
             }
 
             return false;

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -84,7 +84,7 @@ namespace GVFS.Platform.Mac
         public bool TryLoad(ITracer tracer, string enlistmentRoot, out string errorMessage)
         {
             EventMetadata metadata = new EventMetadata();
-            ProcessResult loadKext = ProcessHelper.Run("sudo", "kextutil -b " + DriverName);
+            ProcessResult loadKext = ProcessHelper.Run("sudo", "/sbin/kextload -b " + DriverName);
             if (loadKext.ExitCode == LoadKext_ExitCode_Success)
             {
                 tracer.RelatedWarning(metadata, $"{DriverName} was successfully loaded.", Keywords.Telemetry);

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -13,6 +13,9 @@ namespace GVFS.Platform.Mac
     {
         private const string DriverName = "io.gvfs.PrjFSKext";
         private const int LoadKext_ExitCode_Success = 0;
+
+        // This exit code was found in the following article
+        // https://developer.apple.com/library/archive/technotes/tn2459/_index.html
         private const int LoadKext_ExitCode_NotApproved = 27;
 
         public bool EnumerationExpandsDirectories { get; } = true;

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -64,10 +64,12 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)
+        public bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error)
         {
             error = null;
-            return this.IsKextLoaded();
+            return
+                this.IsKextLoaded() ||
+                this.TryLoad(tracer, output, out error);
         }
 
         public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)
@@ -84,7 +86,7 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string errorMessage)
+        private bool TryLoad(ITracer tracer, TextWriter output, out string errorMessage)
         {
             output?.WriteLine("Driver not loaded.  Attempting to load. You may be prompted for sudo password...");
             EventMetadata metadata = new EventMetadata();

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -382,11 +382,10 @@ namespace GVFS.Platform.Windows
             error = string.Empty;
             return
                 IsServiceRunning(tracer) &&
-                IsNativeLibInstalled(tracer, new PhysicalFileSystem()) &&
-                TryAttach(enlistmentRoot, out error);
+                IsNativeLibInstalled(tracer, new PhysicalFileSystem());
         }
 
-        public bool TryLoad(ITracer tracer, string enlistmentRoot, out string errorMessage)
+        public bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string errorMessage)
         {
             return TryAttach(enlistmentRoot, out errorMessage);
         }

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -386,6 +386,11 @@ namespace GVFS.Platform.Windows
                 TryAttach(enlistmentRoot, out error);
         }
 
+        public bool TryLoad(ITracer tracer, string enlistmentRoot, out string errorMessage)
+        {
+            return TryAttach(enlistmentRoot, out errorMessage);
+        }
+
         private static bool IsInboxAndEnabled()
         {
             ProcessResult getOptionalFeatureResult = GetProjFSOptionalFeatureStatus();

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -377,17 +377,13 @@ namespace GVFS.Platform.Windows
 
         // TODO 1050199: Once the service is an optional component, GVFS should only attempt to attach
         // the filter via the service if the service is present\enabled
-        public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)
+        public bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error)
         {
             error = string.Empty;
             return
                 IsServiceRunning(tracer) &&
-                IsNativeLibInstalled(tracer, new PhysicalFileSystem());
-        }
-
-        public bool TryLoad(ITracer tracer, string enlistmentRoot, TextWriter output, out string errorMessage)
-        {
-            return TryAttach(enlistmentRoot, out errorMessage);
+                IsNativeLibInstalled(tracer, new PhysicalFileSystem()) &&
+                TryAttach(enlistmentRoot, out error);
         }
 
         private static bool IsInboxAndEnabled()

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -138,11 +138,11 @@ namespace GVFS.CommandLine
                     else
                     {
                         tracer.RelatedEvent(
-                            EventLevel.Error,
+                            EventLevel.Informational,
                             $"{nameof(MountVerb)}_{nameof(this.Execute)}",
                             new EventMetadata
                             {
-                                { "KernelDriver.TryLoad_Error", errorMessage },
+                                { "KernelDriver.IsReady_Error", errorMessage },
                             });
 
                         this.ReportErrorAndExit(tracer, ReturnCode.FilterError, errorMessage);

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -137,15 +137,19 @@ namespace GVFS.CommandLine
                     }
                     else
                     {
-                        tracer.RelatedEvent(
-                            EventLevel.Informational,
-                            $"{nameof(MountVerb)}_{nameof(this.Execute)}",
-                            new EventMetadata
-                            {
-                                { "KernelDriver.IsReady_Error", errorMessage },
-                            });
+                        this.Output.WriteLine("Driver not loaded.  Attempting to load. You may be prompted for sudo password...");
+                        if (!GVFSPlatform.Instance.KernelDriver.TryLoad(tracer, enlistment.EnlistmentRoot, out errorMessage))
+                        {
+                            tracer.RelatedEvent(
+                                EventLevel.Informational,
+                                $"{nameof(MountVerb)}_{nameof(this.Execute)}",
+                                new EventMetadata
+                                {
+                                    { "KernelDriver.TryLoad_Error", errorMessage },
+                                });
 
-                        this.ReportErrorAndExit(tracer, ReturnCode.FilterError, errorMessage);
+                            this.ReportErrorAndExit(tracer, ReturnCode.FilterError, errorMessage);
+                        }
                     }
                 }
 


### PR DESCRIPTION
When the kext is not loaded we can try and load it and check the return code to know if it was loaded successfully or if the user has not approved the certificate in Security & Privacy or it could not load for some other reason.