### PR TITLE
MirrorProvider: handle mount error when enlistment missing

### DIFF
--- a/MirrorProvider/MirrorProvider/MountVerb.cs
+++ b/MirrorProvider/MirrorProvider/MountVerb.cs
@@ -22,6 +22,7 @@ namespace MirrorProvider
             if (this.enlistment == null)
             {
                 Console.WriteLine("Error: Unable to load enlistment");
+		return;
             }
 
             Console.WriteLine();


### PR DESCRIPTION
Currently, MirrorProvider will try to proceed to try to mount the enlistment even if the enlistment configuration file was not found, leading to errors, so instead we exit early on this condition.