### PR TITLE
Linux: add filesystem mount handle to placeholder write methods

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -28,10 +28,12 @@ namespace PrjFSLib.Linux.Interop
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderDirectory")]
         public static extern Result WritePlaceholderDirectory(
+            IntPtr mountHandle,
             string relativePath);
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderFile")]
         public static extern Result WritePlaceholderFile(
+            IntPtr mountHandle,
             string relativePath,
             [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
             byte[] providerId,

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -95,7 +95,9 @@ namespace PrjFSLib.Linux
         public virtual Result WritePlaceholderDirectory(
             string relativePath)
         {
-            return Interop.PrjFSLib.WritePlaceholderDirectory(relativePath);
+            return Interop.PrjFSLib.WritePlaceholderDirectory(
+                mountHandle,
+                relativePath);
         }
 
         public virtual Result WritePlaceholderFile(
@@ -112,6 +114,7 @@ namespace PrjFSLib.Linux
             }
 
             return Interop.PrjFSLib.WritePlaceholderFile(
+                mountHandle,
                 relativePath,
                 providerId,
                 contentId,


### PR DESCRIPTION
Pass the Linux filesystem mount handle to the lower-level library when writing placeholder files and directories.

This allows the low-level Linux library to be able to locate its mount point and then execute internal file or directory write requests such that these internal writes don't trigger recursive enumeration or hydration requests back up to the C# calling code.