### PR TITLE
Fix removal from modified paths when path should not be removed

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -26,6 +26,19 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        public void DeleteThenCreateThenDeleteFile()
+        {
+            string srcPath = @"Readme.md";
+
+            this.DeleteFile(srcPath);
+            this.ValidateGitCommand("status");
+            this.CreateFile("Testing", srcPath);
+            this.ValidateGitCommand("status");
+            this.DeleteFile(srcPath);
+            this.ValidateGitCommand("status");
+        }
+
+        [TestCase]
         [Category(Categories.MacTODO.M4)]
         public void ModifyingAndDeletingRepositoryExcludeFileInvalidatesCache()
         {


### PR DESCRIPTION
Fixes #725

For this fix I check to see if the path is in the modified paths before adding it to the newly created list.  This makes sure that if a file that was tracked was deleted it will not be added as a newly created list because it will be in the modified paths.

There will be some edge cases where a temp or newly created file will not get added to the list and should have been, for example modifying a file so it gets in the modified paths and committing then checking out a commit where the file does not exist.  In most cases I don't think these will matter too much with regards to keeping the modified paths clean.  

There is also the issue with an older enlistment that hasn't had their modified paths cleaned up and they have entries for temp files they are creating and deleting.  These will not get removed now.

Other thoughts were to keep track of deleted files and folders and check against that list but that is what the modified paths already is.  Also could check the index but that seemed like an expensive operation in this case.

