### PR TITLE
[features/upgrade_extensibility] Restrict ACLs on VFS4G ProgramData and update verbs as needed

### DIFF
--- a/GVFS/GVFS.Common/LocalGVFSConfig.cs
+++ b/GVFS/GVFS.Common/LocalGVFSConfig.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common
 {
     public class LocalGVFSConfig
     {
-        private const string FileName = "gvfs.config";
+        public const string FileName = "gvfs.config";
         private readonly string configFile;
         private readonly PhysicalFileSystem fileSystem;
         private FileBasedDictionary<string, string> allSettings;

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -360,11 +360,11 @@ namespace GVFS.Service
             // Protect the access rules from inheritance
             programDataSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
-            // Everyone gets read access
-            SecurityIdentifier authenticatedUsers = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+            // All users gets read access
+            SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
             programDataSecurity.AddAccessRule(
                 new FileSystemAccessRule(
-                    authenticatedUsers,
+                    allUsers,
                     FileSystemRights.Read,
                     InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
                     PropagationFlags.None,

--- a/GVFS/GVFS/CommandLine/ConfigVerb.cs
+++ b/GVFS/GVFS/CommandLine/ConfigVerb.cs
@@ -75,6 +75,11 @@ namespace GVFS.CommandLine
             }
             else if (!string.IsNullOrEmpty(this.KeyToDelete))
             {
+                if (!GVFSPlatform.Instance.IsElevated())
+                {
+                    this.ReportErrorAndExit("`gvfs config` must be run from an elevated command prompt when deleting settings.");
+                }
+
                 if (!this.localConfig.TryRemoveConfig(this.KeyToDelete, out error))
                 {
                     this.ReportErrorAndExit(error);
@@ -85,6 +90,11 @@ namespace GVFS.CommandLine
                 bool valueSpecified = !string.IsNullOrEmpty(this.Value);
                 if (valueSpecified)
                 {
+                    if (!GVFSPlatform.Instance.IsElevated())
+                    {
+                        this.ReportErrorAndExit("`gvfs config` must be run from an elevated command prompt when configuring settings.");
+                    }
+
                     if (!this.localConfig.TrySetConfig(this.Key, this.Value, out error))
                     {
                         this.ReportErrorAndExit(error);

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -144,6 +144,11 @@ namespace GVFS.CommandLine
                                 "downloaded-assets.txt");
                         }
 
+                        if (GVFSPlatform.Instance.UnderConstruction.SupportsGVFSConfig)
+                        {
+                            this.CopyFile(Paths.GetServiceDataRoot(string.Empty), archiveFolderPath, LocalGVFSConfig.FileName);
+                        }
+
                         return true;
                     },
                     "Copying logs");
@@ -189,6 +194,34 @@ namespace GVFS.CommandLine
         {
             string information = GVFSPlatform.Instance.GetOSVersionInformation();
             this.diagnosticLogFileWriter.WriteLine(information);
+        }
+
+        private void CopyFile(
+            string sourceRoot,
+            string targetRoot,
+            string fileName)
+        {
+            string sourceFile = Path.Combine(sourceRoot, fileName);
+            string targetFile = Path.Combine(targetRoot, fileName);
+
+            try
+            {
+                if (!File.Exists(sourceFile))
+                {
+                    return;
+                }
+
+                File.Copy(sourceFile, targetFile);
+            }
+            catch (Exception e)
+            {
+                this.WriteMessage(
+                    string.Format(
+                        "Failed to copy file {0} in {1} with exception {2}",
+                        fileName,
+                        sourceRoot,
+                        e));
+            }
         }
 
         private void CopyAllFiles(


### PR DESCRIPTION
Part of the work for #717

Updated GVFS.Service to set the ACLs on C:\ProgramData\GVFS as follows:

- Everyone has read access
- Administrators have read/modify/delete access

Also made the following tweaks:

- Updated GVFS.Service to log its version
- Updated `gvfs diagnose` to capture the `gvfs.config` file
- Updated `gvfs config` to require elevation when setting or deleting config values

Completed manual tests:
- Validated that `C:\ProgramData\GVFS` ACLs are set as expected when installing VFS43g fresh
- Validated that `C:\ProgramData\GVFS` ACLs are set as expected when upgrading from a previous version of VFS4G

Remaining manual tests:
- [ ] Test installation scenarios on Windows Server
- [ ] Test installation scenarios on a clean machine
- [ ] Test `gvfs upgrade` against GitHub and NuGet