### PR TITLE
NuGetUpgrader: verify integrity of downloaded NuGet package

### DIFF
--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.165" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NuGet.Commands" Version="4.9.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -508,6 +508,7 @@ namespace GVFS.Common.NuGetUpgrade
 
             public string FeedUrl { get; private set; }
             public string PackageFeedName { get; private set; }
+            public string CertificateFingerprint { get; private set; }
 
             /// <summary>
             /// Check if the NuGetUpgrader is ready for use. A

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -311,6 +311,17 @@ namespace GVFS.Common.NuGetUpgrade
                 }
             }
 
+            if (!this.noVerify)
+            {
+                if (!this.nuGetFeed.VerifyPackage(this.DownloadedPackagePath))
+                {
+                    errorMessage = "Package signature validation failed. Check the upgrade logs for more details.";
+                    this.tracer.RelatedError(errorMessage);
+                    this.fileSystem.DeleteFile(this.DownloadedPackagePath);
+                    return false;
+                }
+            }
+
             errorMessage = null;
             return true;
         }
@@ -334,6 +345,17 @@ namespace GVFS.Common.NuGetUpgrade
                     if (!this.TryRecursivelyDeleteInstallerDirectory(out error))
                     {
                         return false;
+                    }
+
+                    if (!this.noVerify)
+                    {
+                        if (!this.nuGetFeed.VerifyPackage(this.DownloadedPackagePath))
+                        {
+                            error = "Package signature validation failed. Check the upgrade logs for more details.";
+                            activity.RelatedError(error);
+                            this.fileSystem.DeleteFile(this.DownloadedPackagePath);
+                            return false;
+                        }
                     }
 
                     this.UnzipPackage();

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -38,6 +38,7 @@ namespace GVFS.Common
                 "System.Net.Http.dll",
                 "Newtonsoft.Json.dll",
                 "CommandLine.dll",
+                "NuGet.Commands.dll",
                 "NuGet.Common.dll",
                 "NuGet.Configuration.dll",
                 "NuGet.Frameworks.dll",

--- a/GVFS/GVFS.Installer.Windows/Setup.iss
+++ b/GVFS/GVFS.Installer.Windows/Setup.iss
@@ -1,4 +1,4 @@
-; This script requires Inno Setup Compiler 5.5.9 or later to compile
+﻿; This script requires Inno Setup Compiler 5.5.9 or later to compile
 ; The Inno Setup Compiler (and IDE) can be found at http://www.jrsoftware.org/isinfo.php
 
 ; General documentation on how to use InnoSetup scripts: http://www.jrsoftware.org/ishelp/index.php
@@ -156,6 +156,7 @@ DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\GitVirtualFileSystem.
 DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\GVFS.exe" 
 
 ; NuGet support DLLs
+DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\NuGet.Commands.dll"
 DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\NuGet.Common.dll"
 DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\NuGet.Configuration.dll"
 DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\NuGet.Frameworks.dll"

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -175,7 +175,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
             this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
             this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(testDownloadPath);
-            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>())).Returns(true);
 
             bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
 
@@ -186,6 +186,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
             downloadSuccessful.ShouldBeTrue();
             this.upgrader.DownloadedPackagePath.ShouldEqual(testDownloadPath);
+            this.mockNuGetFeed.Verify(nuGetFeed => nuGetFeed.VerifyPackage(It.IsAny<string>()), Times.Once());
         }
 
         [TestCase]
@@ -230,7 +231,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
 
             this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(It.IsAny<string>())).ReturnsAsync(availablePackages);
             this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.IsAny<PackageIdentity>())).Throws(new Exception("Network Error"));
-            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>())).Returns(true);
 
             bool success = this.upgrader.TryQueryNewestVersion(out newVersion, out message);
 
@@ -353,6 +354,72 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
             this.upgrader.TrySetupToolsDirectory(out string upgraderToolsPath, out string error).ShouldBeFalse();
             this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+        }
+
+        [TestCase]
+        public void DownloadFailsOnNuGetPackageVerificationFailure()
+        {
+            Version actualNewestVersion;
+            string message;
+            List<IPackageSearchMetadata> availablePackages = new List<IPackageSearchMetadata>()
+            {
+                this.GeneratePackageSeachMetadata(new Version(CurrentVersion)),
+                this.GeneratePackageSeachMetadata(new Version(NewerVersion)),
+            };
+
+            IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
+
+            string downloadPath = "c:\\test_download_path";
+            this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
+            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(downloadPath);
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>())).Returns(false);
+
+            bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
+            success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
+            actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
+
+            bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
+            this.mockNuGetFeed.Verify(nuGetFeed => nuGetFeed.VerifyPackage(this.upgrader.DownloadedPackagePath), Times.Once());
+            downloadSuccessful.ShouldBeFalse("Failure to verify NuGet package should cause download to fail.");
+        }
+
+        [TestCase]
+        public void DoNotVerifyNuGetPackageWhenNoVerifyIsSpecified()
+        {
+            NuGetUpgrader.NuGetUpgraderConfig nuGetUpgraderConfig =
+                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName);
+
+            NuGetUpgrader nuGetUpgrader = new NuGetUpgrader(
+                CurrentVersion,
+                this.tracer,
+                false,
+                true,
+                this.mockFileSystem,
+                nuGetUpgraderConfig,
+                this.mockNuGetFeed.Object);
+
+            Version actualNewestVersion;
+            string message;
+            List<IPackageSearchMetadata> availablePackages = new List<IPackageSearchMetadata>()
+            {
+                this.GeneratePackageSeachMetadata(new Version(CurrentVersion)),
+                this.GeneratePackageSeachMetadata(new Version(NewerVersion)),
+            };
+
+            IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
+
+            string downloadPath = "c:\\test_download_path";
+            this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
+            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(downloadPath);
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>())).Returns(false);
+
+            bool success = nuGetUpgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
+            success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
+            actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
+
+            bool downloadSuccessful = nuGetUpgrader.TryDownloadNewestVersion(out message);
+            this.mockNuGetFeed.Verify(nuGetFeed => nuGetFeed.VerifyPackage(It.IsAny<string>()), Times.Never());
+            downloadSuccessful.ShouldBeTrue("Should be able to download package with verification issues when noVerify is specified");
         }
 
         private IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -175,6 +175,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
             this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
             this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(testDownloadPath);
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 
             bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
 
@@ -229,6 +230,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
 
             this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(It.IsAny<string>())).ReturnsAsync(availablePackages);
             this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.IsAny<PackageIdentity>())).Throws(new Exception("Network Error"));
+            this.mockNuGetFeed.Setup(foo => foo.VerifyPackage(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 
             bool success = this.upgrader.TryQueryNewestVersion(out newVersion, out message);
 

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -172,7 +172,17 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
             if (this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed)
             {
-                this.RootDirectory.CreateDirectory(directoryPath);
+                // TryCreateDirectoryWithAdminOnlyModify is typically called for paths in C:\ProgramData\GVFS, it's called
+                // for one of those paths remap the paths to be inside the mock: root
+                string mockDirectoryPath = directoryPath;
+                string gvfsProgramData = @"C:\ProgramData\GVFS";
+                if (directoryPath.StartsWith(gvfsProgramData, StringComparison.OrdinalIgnoreCase))
+                {
+                    mockDirectoryPath = mockDirectoryPath.Substring(gvfsProgramData.Length);
+                    mockDirectoryPath = "mock:" + mockDirectoryPath;
+                }
+
+                this.RootDirectory.CreateDirectory(mockDirectoryPath);
                 return true;
             }
 

--- a/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
+++ b/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
@@ -38,20 +38,35 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Commands, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Commands.4.9.2\lib\net46\NuGet.Commands.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Common, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Common.4.9.2\lib\net46\NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Configuration, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Configuration.4.9.2\lib\net46\NuGet.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Credentials, Version=4.9.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Credentials.4.9.2\lib\net46\NuGet.Credentials.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.DependencyResolver.Core.4.9.2\lib\net46\NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Frameworks, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Frameworks.4.9.2\lib\net46\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.LibraryModel, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.LibraryModel.4.9.2\lib\net46\NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Packaging, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Packaging.4.9.2\lib\net46\NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Packaging.Core, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Packaging.Core.4.9.2\lib\net46\NuGet.Packaging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ProjectModel, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.ProjectModel.4.9.2\lib\net46\NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Protocol, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Protocol.4.9.2\lib\net46\NuGet.Protocol.dll</HintPath>

--- a/GVFS/GVFS.Upgrader/packages.config
+++ b/GVFS/GVFS.Upgrader/packages.config
@@ -2,11 +2,16 @@
 <packages>
   <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="NuGet.Commands" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Common" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Configuration" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.Credentials" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.DependencyResolver.Core" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Frameworks" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.LibraryModel" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Packaging" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Packaging.Core" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.ProjectModel" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Protocol" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Versioning" version="4.9.2" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />

--- a/GVFS/GVFS/GVFS.Windows.csproj
+++ b/GVFS/GVFS/GVFS.Windows.csproj
@@ -45,20 +45,35 @@
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NuGet.Commands, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Commands.4.9.2\lib\net46\NuGet.Commands.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Common, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Common.4.9.2\lib\net46\NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Configuration, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Configuration.4.9.2\lib\net46\NuGet.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Credentials, Version=4.9.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.Credentials.4.9.2\lib\net46\NuGet.Credentials.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.DependencyResolver.Core.4.9.2\lib\net46\NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Frameworks, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Frameworks.4.9.2\lib\net46\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.LibraryModel, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.LibraryModel.4.9.2\lib\net46\NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Packaging, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Packaging.4.9.2\lib\net46\NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Packaging.Core, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Packaging.Core.4.9.2\lib\net46\NuGet.Packaging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ProjectModel, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NuGet.ProjectModel.4.9.2\lib\net46\NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Protocol, Version=4.9.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NuGet.Protocol.4.9.2\lib\net46\NuGet.Protocol.dll</HintPath>

--- a/GVFS/GVFS/packages.config
+++ b/GVFS/GVFS/packages.config
@@ -5,11 +5,16 @@
   <package id="Microsoft.Data.Sqlite" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="NuGet.Commands" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Common" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Configuration" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.Credentials" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.DependencyResolver.Core" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Frameworks" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.LibraryModel" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Packaging" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Packaging.Core" version="4.9.2" targetFramework="net461" />
+  <package id="NuGet.ProjectModel" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Protocol" version="4.9.2" targetFramework="net461" />
   <package id="NuGet.Versioning" version="4.9.2" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.7" targetFramework="net461" />


### PR DESCRIPTION
Verify the integrity / signature of NuGet packages. The NuGet upgrader will
rely on the services provided by the NuGet client library to verify downloaded
NuGet packages.

Relies on the high level command `VerifyCommandRunner` exposed by NuGet client
library to actually perform NuGet package verification.