### PR TITLE
Add ShouldIgnoreVnodeType + FlaggedFileAsInRoot test

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -174,6 +174,8 @@
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPrjFSKextTestable.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = PrjFSKextTests.exp; sourceTree = "<group>"; };
+		F557623E22009F0E005DE35E /* KextLogMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KextLogMock.h; sourceTree = "<group>"; };
+		F55762472200DA2A005DE35E /* KauthHandlerHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KauthHandlerHelper.h; sourceTree = "<group>"; };
 		F5E39C7721F1118D006D65C2 /* PrjFSKextTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrjFSKextTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5E39C7921F1118D006D65C2 /* KauthHandlerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = KauthHandlerTests.mm; sourceTree = "<group>"; };
 		F5E39C7B21F1118D006D65C2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 			children = (
 				4391F88F21E42AC40008103C /* Info.plist */,
 				4391F89321E42AC40008103C /* KauthHandler.cpp */,
+				F55762472200DA2A005DE35E /* KauthHandlerHelper.h */,
 				4391F8A421E42AC50008103C /* KauthHandler.hpp */,
 				F5E39C8121F11556006D65C2 /* KauthHandlerTestable.hpp */,
 				4391F89021E42AC40008103C /* kernel-header-wrappers */,
@@ -342,6 +345,7 @@
 				F5E39C7921F1118D006D65C2 /* KauthHandlerTests.mm */,
 				F5E39C7B21F1118D006D65C2 /* Info.plist */,
 				4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */,
+				F557623E22009F0E005DE35E /* KextLogMock.h */,
 			);
 			path = PrjFSKextTests;
 			sourceTree = "<group>";

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerHelper.h
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerHelper.h
@@ -1,0 +1,34 @@
+#ifndef KauthHandlerHelper_h
+#define KauthHandlerHelper_h
+
+
+static errno_t GetVNodeAttributes(vnode_t vn, vfs_context_t _Nonnull context, struct vnode_attr* attrs)
+{
+    VATTR_INIT(attrs);
+    VATTR_WANTED(attrs, va_flags);
+    
+    return vnode_getattr(vn, attrs, context);
+}
+
+static bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t _Nonnull context, uint32_t* flags)
+{
+    struct vnode_attr attributes = {};
+    *flags = 0;
+    errno_t err = GetVNodeAttributes(vn, context, &attributes);
+    if (0 != err)
+    {
+        // TODO(Mac): May fail on some file system types? Perhaps we should early-out depending on mount point anyway.
+        // We should also consider:
+        //   - Logging this error
+        //   - Falling back on vnode lookup (or custom cache) to determine if file is in the root
+        //   - Assuming files are empty if we can't read the flags
+        KextLog_FileError(vn, "ReadVNodeFileFlags: GetVNodeAttributes failed with error %d; vnode type: %d, recycled: %s", err, vnode_vtype(vn), vnode_isrecycled(vn) ? "yes" : "no");
+        return false;
+    }
+    
+    assert(VATTR_IS_SUPPORTED(&attributes, va_flags));
+    *flags = attributes.va_flags;
+    return true;
+}
+
+#endif

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
@@ -1,5 +1,7 @@
 #include "public/PrjFSCommon.h"
 #include <sys/kernel_types.h>
+#include <sys/vnode.h>
+#include "../PrjFSKextTests/KextLogMock.h"
 
 #ifndef __cplusplus
 #error None of the kext code is set up for being called from C or Objective-C; change the including file to C++ or Objective-C++
@@ -12,4 +14,6 @@
 KEXT_STATIC_INLINE bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 KEXT_STATIC bool IsFileSystemCrawler(const char* procname);
-
+KEXT_STATIC bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode);
+KEXT_STATIC_INLINE bool TryGetFileIsFlaggedAsInRoot(vnode_t vnode, vfs_context_t context, bool* flaggedInRoot);
+bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t context, uint32_t* flags);

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -1,10 +1,21 @@
 #import <XCTest/XCTest.h>
 #include "../PrjFSKext/KauthHandlerTestable.hpp"
+#include <sys/vnode.h>
 
 @interface KauthHandlerTests : XCTestCase
 @end
 
 @implementation KauthHandlerTests
+
+//Mock for TryReadVNodeFileFlags
+static uint32_t mockFileFlag;
+static bool mockReturnBool;
+bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t context, uint32_t* flags);
+bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t context, uint32_t* flags)
+{
+    *flags = mockFileFlag;
+    return mockReturnBool;
+}
 
 - (void)testActionBitIsSet {
     XCTAssertTrue(ActionBitIsSet(KAUTH_VNODE_READ_DATA, KAUTH_VNODE_READ_DATA));
@@ -30,6 +41,35 @@
     XCTAssertTrue(FileFlagsBitIsSet(FileFlags_IsInVirtualizationRoot, FileFlags_IsInVirtualizationRoot));
     XCTAssertFalse(FileFlagsBitIsSet(FileFlags_IsInVirtualizationRoot, FileFlags_IsEmpty));
     XCTAssertFalse(FileFlagsBitIsSet(FileFlags_IsInVirtualizationRoot, FileFlags_Invalid));
+}
+
+- (void)testShouldIgnoreVnodeType {
+    XCTAssertTrue(ShouldIgnoreVnodeType(VNON, NULL));
+    XCTAssertTrue(ShouldIgnoreVnodeType(VBLK, NULL));
+    XCTAssertTrue(ShouldIgnoreVnodeType(VCHR, NULL));
+    XCTAssertTrue(ShouldIgnoreVnodeType(VSOCK, NULL));
+    XCTAssertTrue(ShouldIgnoreVnodeType(VFIFO, NULL));
+    XCTAssertTrue(ShouldIgnoreVnodeType(VBAD, NULL));
+    XCTAssertFalse(ShouldIgnoreVnodeType(VREG, NULL));
+    XCTAssertFalse(ShouldIgnoreVnodeType(VDIR, NULL));
+    XCTAssertFalse(ShouldIgnoreVnodeType(VLNK, NULL));
+    XCTAssertFalse(ShouldIgnoreVnodeType(VSTR, NULL));
+    XCTAssertFalse(ShouldIgnoreVnodeType(VCPLX, NULL));
+}
+
+- (void)testFileFlaggedInRoot {
+    bool fileFlaggedInRoot;
+    mockReturnBool = false;
+    mockFileFlag = FileFlags_IsInVirtualizationRoot;
+    XCTAssertFalse(TryGetFileIsFlaggedAsInRoot(reinterpret_cast<vnode_t>(static_cast<uintptr_t>(1)), NULL, &fileFlaggedInRoot));
+
+    mockReturnBool = true;
+    XCTAssertTrue(TryGetFileIsFlaggedAsInRoot(reinterpret_cast<vnode_t>(static_cast<uintptr_t>(1)), NULL, &fileFlaggedInRoot));
+    XCTAssertTrue(fileFlaggedInRoot);
+
+    mockFileFlag = FileFlags_IsEmpty;
+    XCTAssertTrue(TryGetFileIsFlaggedAsInRoot(reinterpret_cast<vnode_t>(static_cast<uintptr_t>(1)), NULL, &fileFlaggedInRoot));
+    XCTAssertFalse(fileFlaggedInRoot);
 }
 
 @end

--- a/ProjFS.Mac/PrjFSKextTests/KextLogMock.h
+++ b/ProjFS.Mac/PrjFSKextTests/KextLogMock.h
@@ -1,0 +1,10 @@
+#ifndef KextLogMock_h
+#define KextLogMock_h
+
+inline void KextLog_Error(const char* fmt, ...) {}
+inline void KextLog_ErrorVnodeProperties(struct vnode* vnode, const char* fmt, ...) {}
+inline void KextLog_FileInfo(struct vnode* vnode, const char* fmt, ...) {}
+inline void KextLog_FileNote(struct vnode* vnode, const char* fmt, ...) {}
+inline void KextLog_FileError(struct vnode* vnode, const char* fmt, ...) {}
+
+#endif 


### PR DESCRIPTION
ShouldIgnoreVnodeType is pretty straightforward

FlaggedFileAsInRoot shows the complexities when dealing with kernal types.  Here I overwrote the return types for TryReadVNodeFileFlags to facilitate testing.  Since TryReadVNodeFileFlags is a lookup it seems like a valid workaround.

