### PR TITLE
Mac: Support Version Number overrides

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -125,7 +125,7 @@ function CreateMetaInstaller()
     echo "$mountCmd"
     eval $mountCmd || exit 1
     
-    MOUNTEDVOLUME=`/usr/bin/find /Volumes -type d -name "Git $GITVERSIONSTRING*"`
+    MOUNTEDVOLUME=`/usr/bin/find /Volumes -maxdepth 1 -type d -name "Git $GITVERSIONSTRING*"`
     GITINSTALLERPATH=`/usr/bin/find "$MOUNTEDVOLUME" -type f -name "git-$GITVERSIONSTRING*.pkg"`
     
     if [ ! -f "$GITINSTALLERPATH" ]; then

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -7,6 +7,11 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
+VERSION=$2
+if [ -z $VERSION ]; then
+  VERSION="0.2.173.2"
+fi
+
 if [ ! -d $VFS_OUTPUTDIR ]; then
   mkdir $VFS_OUTPUTDIR
 fi
@@ -33,8 +38,8 @@ if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
   CONFIGURATION=Release
 fi
 
-echo 'Generating CommonAssemblyVersion.cs...'
-$VFS_SCRIPTDIR/GenerateCommonAssemblyVersion.sh || exit 1
+echo "Generating CommonAssemblyVersion.cs as $VERSION..."
+$VFS_SCRIPTDIR/GenerateCommonAssemblyVersion.sh $VERSION || exit 1
 
 # /warnasmessage:MSB4011. Reference: https://bugzilla.xamarin.com/show_bug.cgi?id=58564
 # Visual Studio Mac does not support explicit import of Sdks. GVFS.Installer.Mac.csproj

--- a/Scripts/Mac/GenerateCommonAssemblyVersion.sh
+++ b/Scripts/Mac/GenerateCommonAssemblyVersion.sh
@@ -1,11 +1,16 @@
 . "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
 
-GVFSPROPS=$VFS_SRCDIR/GVFS/GVFS.Build/GVFS.props
-VERSIONNUMBER="$(cat $GVFSPROPS | grep GVFSVersion | grep -Eo '[0-9.]+(-\w+)?')"
+if [ -z $1 ]; then
+  echo "Version Number not defined for CommonAssemblyVersion.cs"
+fi
 
+# Update the version number in GVFS.props for other consumers of GVFSVersion
+sed -i "" -E "s@<GVFSVersion>[0-9]+(\.[0-9]+)*</GVFSVersion>@<GVFSVersion>$1</GVFSVersion>@g" $VFS_SRCDIR/GVFS/GVFS.Build/GVFS.props
+
+# Then generate CommonAssemblyVersion.cs
 cat >$VFS_OUTPUTDIR/CommonAssemblyVersion.cs <<TEMPLATE
 using System.Reflection;
 
-[assembly: AssemblyVersion("$VERSIONNUMBER")]
-[assembly: AssemblyFileVersion("$VERSIONNUMBER")]
+[assembly: AssemblyVersion("$1")]
+[assembly: AssemblyFileVersion("$1")]
 TEMPLATE


### PR DESCRIPTION
Currently, we don't have a solution for building a version of VFSForGit on MacOS that has a build number other than the dev number that is hardcoded into GVFS.props.

On Windows, we support taking the Version as an argument to the build script and plumb it through to MSBuild. The same approach works on MacOS but the way that we handle the version number (custom scripts instead of GVFS.PreBuild) makes this a little less straightforward. We'll repurpose `GenerateCommonAssemblyVersion.sh` to also update the `GVFS.props` file with the new version as it's consumed by other things than `CommonAssemblyVersion.cs` (The Installers are a good example)

Our build definitions will need to be updated to get a version number from Azure Pipelines and to pass that into BuildGVFSForMac.sh.

Also: Fix an issue with the meta package installer where a find command would dig through your entire drive hierarchy to find a folder mounted at /Volumes/Git <Number>. Set -maxdepth to 1 to get the intended behavior.