### PR TITLE
Add listener for OPEN event

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -286,6 +286,16 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             Assert.Fail("Unlike the other runners, bash.exe does not check folder handle before recusively deleting");
         }
 
+        public override void CreateFileWithoutClose(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        {
+            throw new NotImplementedException();
+        }
+
         private bool FileExistsOnDisk(string path, FileType type)
         {
             string checkArgument = string.Empty;

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -228,5 +228,15 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             throw new NotSupportedException();
         }
+
+        public override void CreateFileWithoutClose(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -75,6 +75,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         /// <param name="path">Path to file</param>
         /// <param name="contents">File contents</param>
         public abstract void WriteAllText(string path, string contents);
+        public abstract void CreateFileWithoutClose(string path);
+        public abstract void OpenFileAndWriteWithoutClose(string path, string data);
 
         /// <summary>
         /// Append the specified contents to the specified file.  By calling this method the caller is

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -205,6 +205,16 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             throw new System.NotSupportedException();
         }
 
+        public override void CreateFileWithoutClose(string path)
+        {
+            throw new System.NotSupportedException();
+        }
+
+        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        {
+            throw new System.NotSupportedException();
+        }
+
         protected override string RunProcess(string command, string workingDirectory = "", string errorMsgDelimeter = "")
         {
             return base.RunProcess("-NoProfile " + command, workingDirectory, errorMsgDelimeter);

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -19,6 +20,17 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             File.Move(sourcePath, targetPath);
             return string.Empty;
+        }
+
+        public override void CreateFileWithoutClose(string path)
+        {
+            File.Create(path);
+        }
+
+        public override void OpenFileAndWriteWithoutClose(string path, string content)
+        {
+            StreamWriter file = new StreamWriter(path);
+            file.Write(content);
         }
 
         public override void MoveFileShouldFail(string sourcePath, string targetPath)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -235,6 +235,22 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.WriteAllText(controlFile, content);
         }
 
+        protected void CreateFileWithoutClose(string path)
+        {
+            string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
+            string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
+            this.FileSystem.CreateFileWithoutClose(virtualFile);
+            this.FileSystem.CreateFileWithoutClose(controlFile);
+        }
+
+        protected void OpenFileAndWriteWithoutClose(string path, string contents)
+        {
+            string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
+            string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
+            this.FileSystem.OpenFileAndWriteWithoutClose(virtualFile, contents);
+            this.FileSystem.OpenFileAndWriteWithoutClose(controlFile, contents);
+        }
+
         protected void CreateFolder(string folderPath)
         {
             string virtualFolder = Path.Combine(this.Enlistment.RepoRoot, folderPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -39,6 +39,23 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        public void CreateFileWithoutClose()
+        {
+            string srcPath = @"CreateFileWithoutClose.md";
+            this.CreateFileWithoutClose(srcPath);
+            this.ValidateGitCommand("status");
+        }
+
+        [Ignore("This test exposes a bug we don't yet have a fix for")]
+        [TestCase]
+        public void WriteWithoutClose()
+        {
+            string srcPath = @"Readme.md";
+            this.OpenFileAndWriteWithoutClose(srcPath, "More Stuff");
+            this.ValidateGitCommand("status");
+        }
+
+        [TestCase]
         [Category(Categories.MacTODO.M4)]
         public void ModifyingAndDeletingRepositoryExcludeFileInvalidatesCache()
         {


### PR DESCRIPTION
Previously we only listened to the CLOSE event and then checked for KAUTH_FILEOP_CLOSE_MODIFIED or NewFile (fileFlaggedInRoot == false) to determine if we should send an event.  With this change, we do the NewFile check on OPEN which allows us to get the event earlier.  

The underlying issue is a file handle can be opened and not closed by the process.

This addresses #721. 
