### PR TITLE
[features/upgrade_extensibility] Additional ACL changes

### DIFF
--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -20,6 +20,7 @@ namespace FastFetch
 
         private ITracer tracer;
         private Enlistment enlistment;
+        private PhysicalFileSystem fileSystem;
         private string targetCommitSha;
         private bool forceCheckout;
 
@@ -39,6 +40,7 @@ namespace FastFetch
         {
             this.tracer = tracer.StartActivity(AreaPath, EventLevel.Informational, Keywords.Telemetry, metadata: null);
             this.enlistment = enlistment;
+            this.fileSystem = new PhysicalFileSystem();
             this.diff = new DiffHelper(tracer, enlistment, new string[0], folderList, includeSymLinks: true);
             this.targetCommitSha = targetCommitSha;
             this.forceCheckout = forceCheckout;
@@ -186,7 +188,7 @@ namespace FastFetch
                         {
                             if (Directory.Exists(treeOp.TargetPath))
                             {
-                                PhysicalFileSystem.RecursiveDelete(treeOp.TargetPath);
+                                this.fileSystem.RecursiveDelete(treeOp.TargetPath);
                             }
                         }
                         catch (Exception ex)

--- a/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
@@ -122,7 +122,8 @@ namespace GVFS.DiskLayoutUpgrades
         {
             try
             {
-                PhysicalFileSystem.RecursiveDelete(folderName);
+                PhysicalFileSystem fileSystem = new PhysicalFileSystem();
+                fileSystem.RecursiveDelete(folderName);
             }
             catch (Exception e)
             {

--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -13,6 +13,6 @@ namespace GVFS.Common.FileSystem
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
-        bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error);
+        bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error);
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -13,6 +13,6 @@ namespace GVFS.Common.FileSystem
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
-        bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error);
+        bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error);
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -1,4 +1,6 @@
-﻿namespace GVFS.Common.FileSystem
+﻿using GVFS.Common.Tracing;
+
+namespace GVFS.Common.FileSystem
 {
     public interface IPlatformFileSystem
     {
@@ -11,5 +13,6 @@
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
+        bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error);
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common.FileSystem
     {
         public const int DefaultStreamBufferSize = 8192;
 
-        public static void RecursiveDelete(string path)
+        public virtual void RecursiveDelete(string path)
         {
             if (!Directory.Exists(path))
             {
@@ -29,7 +29,7 @@ namespace GVFS.Common.FileSystem
 
             foreach (DirectoryInfo subDirectory in directory.GetDirectories())
             {
-                RecursiveDelete(subDirectory.FullName);
+                this.RecursiveDelete(subDirectory.FullName);
             }
 
             directory.Delete();
@@ -118,7 +118,7 @@ namespace GVFS.Common.FileSystem
 
         public virtual void DeleteDirectory(string path, bool recursive = false)
         {
-            RecursiveDelete(path);
+            this.RecursiveDelete(path);
         }
 
         public virtual bool IsSymLink(string path)

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -116,6 +116,11 @@ namespace GVFS.Common.FileSystem
             Directory.CreateDirectory(path);
         }
 
+        public virtual bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        {
+            return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(tracer, directoryPath, out error);
+        }
+
         public virtual void DeleteDirectory(string path, bool recursive = false)
         {
             this.RecursiveDelete(path);

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -49,17 +49,22 @@ namespace GVFS.Common
 
         public GitHubUpgraderConfig Config { get; private set; }
 
-        public static GitHubUpgrader Create(ITracer tracer, PhysicalFileSystem fileSystem, bool dryRun, bool noVerify, out string error)
-        {
-            return Create(new LocalGVFSConfig(), tracer, fileSystem, dryRun, noVerify, out error);
-        }
-
         public static GitHubUpgrader Create(
-            LocalGVFSConfig localConfig,
             ITracer tracer,
             PhysicalFileSystem fileSystem,
             bool dryRun,
             bool noVerify,
+            out string error)
+        {
+            return Create(tracer, fileSystem, dryRun, noVerify, new LocalGVFSConfig(), out error);
+        }
+
+        public static GitHubUpgrader Create(
+            ITracer tracer,
+            PhysicalFileSystem fileSystem,
+            bool dryRun,
+            bool noVerify,
+            LocalGVFSConfig localConfig,
             out string error)
         {
             GitHubUpgrader upgrader = null;

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -238,11 +238,9 @@ namespace GVFS.Common
             errorMessage = null;
 
             string downloadPath = ProductUpgraderInfo.GetAssetDownloadsPath();
-            Exception exception;
-            if (!this.fileSystem.TryCreateDirectory(downloadPath, out exception))
+            if (!this.fileSystem.DirectoryExists(downloadPath))
             {
-                errorMessage = exception.Message;
-                this.TraceException(exception, nameof(this.TryDownloadAsset), $"Error creating download directory {downloadPath}.");
+                errorMessage = $"Download directory `{downloadPath}` does not exist";
                 return false;
             }
 

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -35,10 +35,11 @@ namespace GVFS.Common
         public GitHubUpgrader(
             string currentVersion,
             ITracer tracer,
+            PhysicalFileSystem fileSystem,
             GitHubUpgraderConfig upgraderConfig,
             bool dryRun = false,
             bool noVerify = false)
-            : base(currentVersion, tracer, dryRun, noVerify, new PhysicalFileSystem())
+            : base(currentVersion, tracer, dryRun, noVerify, fileSystem)
         {
             this.Config = upgraderConfig;
 
@@ -48,12 +49,18 @@ namespace GVFS.Common
 
         public GitHubUpgraderConfig Config { get; private set; }
 
-        public static GitHubUpgrader Create(ITracer tracer, bool dryRun, bool noVerify, out string error)
+        public static GitHubUpgrader Create(ITracer tracer, PhysicalFileSystem fileSystem, bool dryRun, bool noVerify, out string error)
         {
-            return Create(new LocalGVFSConfig(), tracer, dryRun, noVerify, out error);
+            return Create(new LocalGVFSConfig(), tracer, fileSystem, dryRun, noVerify, out error);
         }
 
-        public static GitHubUpgrader Create(LocalGVFSConfig localConfig, ITracer tracer, bool dryRun, bool noVerify, out string error)
+        public static GitHubUpgrader Create(
+            LocalGVFSConfig localConfig,
+            ITracer tracer,
+            PhysicalFileSystem fileSystem,
+            bool dryRun,
+            bool noVerify,
+            out string error)
         {
             GitHubUpgrader upgrader = null;
             GitHubUpgraderConfig gitHubUpgraderConfig = new GitHubUpgraderConfig(tracer, localConfig);
@@ -72,6 +79,7 @@ namespace GVFS.Common
             upgrader = new GitHubUpgrader(
                     ProcessHelper.GetCurrentProcessVersion(),
                     tracer,
+                    fileSystem,
                     gitHubUpgraderConfig,
                     dryRun,
                     noVerify);

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -130,6 +130,12 @@ namespace GVFS.Common
 
         public override bool TryDownloadNewestVersion(out string errorMessage)
         {
+            if (!this.TryCreateAndConfigureDownloadDirectory(this.tracer, out errorMessage))
+            {
+                this.tracer.RelatedError($"{nameof(GitHubUpgrader)}.{nameof(this.TryCreateAndConfigureDownloadDirectory)} failed. {errorMessage}");
+                return false;
+            }
+
             bool downloadedGit = false;
             bool downloadedGVFS = false;
 
@@ -246,12 +252,6 @@ namespace GVFS.Common
             errorMessage = null;
 
             string downloadPath = ProductUpgraderInfo.GetAssetDownloadsPath();
-            if (!this.fileSystem.DirectoryExists(downloadPath))
-            {
-                errorMessage = $"Download directory `{downloadPath}` does not exist";
-                return false;
-            }
-
             string localPath = Path.Combine(downloadPath, asset.Name);
             WebClient webClient = new WebClient();
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/InstallActionInfo.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/InstallActionInfo.cs
@@ -1,4 +1,4 @@
-namespace GVFS.Common.NuGetUpgrader
+namespace GVFS.Common.NuGetUpgrade
 {
     public class InstallActionInfo
     {

--- a/GVFS/GVFS.Common/NuGetUpgrade/InstallManifest.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/InstallManifest.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 
-namespace GVFS.Common.NuGetUpgrader
+namespace GVFS.Common.NuGetUpgrade
 {
     /// <summary>
     /// Details on the upgrade included in this package, including information

--- a/GVFS/GVFS.Common/NuGetUpgrade/InstallManifestPlatform.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/InstallManifestPlatform.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GVFS.Common.NuGetUpgrader
+namespace GVFS.Common.NuGetUpgrade
 {
     public class InstallManifestPlatform
     {

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GVFS.Common.NuGetUpgrader
+namespace GVFS.Common.NuGetUpgrade
 {
     /// <summary>
     /// Handles interactions with a NuGet Feed.

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -9,7 +9,7 @@ using System.IO.Compression;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-namespace GVFS.Common.NuGetUpgrader
+namespace GVFS.Common.NuGetUpgrade
 {
     public class NuGetUpgrader : ProductUpgrader
     {

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetFeed.cs
@@ -21,7 +21,6 @@ namespace GVFS.Common.NuGetUpgrader
         private readonly ITracer tracer;
         private readonly string feedUrl;
         private readonly string feedName;
-        private readonly string downloadFolder;
 
         private SourceRepository sourceRepository;
         private string personalAccessToken;
@@ -37,7 +36,7 @@ namespace GVFS.Common.NuGetUpgrader
         {
             this.feedUrl = feedUrl;
             this.feedName = feedName;
-            this.downloadFolder = downloadFolder;
+            this.DownloadFolder = downloadFolder;
             this.personalAccessToken = personalAccessToken;
             this.tracer = tracer;
 
@@ -56,6 +55,8 @@ namespace GVFS.Common.NuGetUpgrader
                 this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken);
             }
         }
+
+        public string DownloadFolder { get; }
 
         public void Dispose()
         {
@@ -99,10 +100,10 @@ namespace GVFS.Common.NuGetUpgrader
         /// <returns>Path to the downloaded package.</returns>
         public virtual async Task<string> DownloadPackageAsync(PackageIdentity packageId)
         {
-            string downloadPath = Path.Combine(this.downloadFolder, $"{this.feedName}.zip");
+            string downloadPath = Path.Combine(this.DownloadFolder, $"{this.feedName}.zip");
             PackageDownloadContext packageDownloadContext = new PackageDownloadContext(
                 this.sourceCacheContext,
-                this.downloadFolder,
+                this.DownloadFolder,
                 true);
 
             DownloadResource downloadResource = await this.sourceRepository.GetResourceAsync<DownloadResource>();

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetFeed.cs
@@ -21,6 +21,7 @@ namespace GVFS.Common.NuGetUpgrader
         private readonly ITracer tracer;
         private readonly string feedUrl;
         private readonly string feedName;
+        private readonly string downloadFolder;
 
         private SourceRepository sourceRepository;
         private string personalAccessToken;
@@ -36,7 +37,7 @@ namespace GVFS.Common.NuGetUpgrader
         {
             this.feedUrl = feedUrl;
             this.feedName = feedName;
-            this.DownloadFolder = downloadFolder;
+            this.downloadFolder = downloadFolder;
             this.personalAccessToken = personalAccessToken;
             this.tracer = tracer;
 
@@ -55,8 +56,6 @@ namespace GVFS.Common.NuGetUpgrader
                 this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken);
             }
         }
-
-        public string DownloadFolder { get; }
 
         public void Dispose()
         {
@@ -100,10 +99,10 @@ namespace GVFS.Common.NuGetUpgrader
         /// <returns>Path to the downloaded package.</returns>
         public virtual async Task<string> DownloadPackageAsync(PackageIdentity packageId)
         {
-            string downloadPath = Path.Combine(this.DownloadFolder, $"{this.feedName}.zip");
+            string downloadPath = Path.Combine(this.downloadFolder, $"{this.feedName}.zip");
             PackageDownloadContext packageDownloadContext = new PackageDownloadContext(
                 this.sourceCacheContext,
-                this.DownloadFolder,
+                this.downloadFolder,
                 true);
 
             DownloadResource downloadResource = await this.sourceRepository.GetResourceAsync<DownloadResource>();

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -67,6 +67,8 @@ namespace GVFS.Common.NuGetUpgrader
 
             this.nuGetFeed = nuGetFeed;
 
+            // Extract the folder inside ProductUpgraderInfo.GetAssetDownloadsPath to ensure the
+            // correct ACLs are in place
             this.ExtractedInstallerPath = Path.Combine(
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 ExtractedInstallerDirectoryName);

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -423,8 +423,8 @@ namespace GVFS.Common.NuGetUpgrader
                 {
                     this.TraceException(
                         e,
-                        nameof(this.TryRunInstaller),
-                        "Exception encountered trying to delete download directory in preperation for download.");
+                        nameof(this.TryRecursivelyDeleteInstallerDirectory),
+                        $"Exception encountered while deleting {this.ExtractedInstallerPath}.");
                 }
 
                 error = e?.Message ?? "Failed to delete directory, but no error was specified.";

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -24,6 +24,7 @@ namespace GVFS.Common.NuGetUpgrader
         public NuGetUpgrader(
             string currentVersion,
             ITracer tracer,
+            PhysicalFileSystem fileSystem,
             bool dryRun,
             bool noVerify,
             NuGetUpgraderConfig config,
@@ -34,7 +35,7 @@ namespace GVFS.Common.NuGetUpgrader
                 tracer,
                 dryRun,
                 noVerify,
-                new PhysicalFileSystem(),
+                fileSystem,
                 config,
                 new NuGetFeed(
                     config.FeedUrl,
@@ -91,6 +92,7 @@ namespace GVFS.Common.NuGetUpgrader
         /// </summary>
         public static bool TryCreate(
             ITracer tracer,
+            PhysicalFileSystem fileSystem,
             bool dryRun,
             bool noVerify,
             out NuGetUpgrader nuGetUpgrader,
@@ -135,6 +137,7 @@ namespace GVFS.Common.NuGetUpgrader
             nuGetUpgrader = new NuGetUpgrader(
                 ProcessHelper.GetCurrentProcessVersion(),
                 tracer,
+                fileSystem,
                 dryRun,
                 noVerify,
                 upgraderConfig,

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -259,9 +259,9 @@ namespace GVFS.Common.NuGetUpgrader
                 return false;
             }
 
-            if (!this.fileSystem.DirectoryExists(this.nuGetFeed.DownloadFolder))
+            if (!this.TryCreateAndConfigureDownloadDirectory(this.tracer, out errorMessage))
             {
-                errorMessage = $"Download directory `{this.nuGetFeed.DownloadFolder}` does not exist";
+                this.tracer.RelatedError($"{nameof(NuGetUpgrader)}.{nameof(this.TryCreateAndConfigureDownloadDirectory)} failed. {errorMessage}");
                 return false;
             }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -115,7 +115,7 @@ namespace GVFS.Common
         /// Deletes any previously downloaded installers in the Upgrader Download directory.
         /// This can include old installers which were downloaded but never installed.
         /// </summary>
-        public virtual void DeleteAllInstallerDownloads(ITracer tracer = null)
+        public virtual void DeleteAllInstallerDownloads(ITracer tracer)
         {
             try
             {
@@ -123,10 +123,7 @@ namespace GVFS.Common
             }
             catch (Exception ex)
             {
-                if (tracer != null)
-                {
-                    tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
-                }
+                tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
             }
         }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -73,13 +73,14 @@ namespace GVFS.Common
         public static bool TryCreateUpgrader(
             out ProductUpgrader newUpgrader,
             ITracer tracer,
+            PhysicalFileSystem fileSystem,
             out string error,
             bool dryRun = false,
             bool noVerify = false)
         {
             // Prefer to use the NuGet upgrader if it is configured. If the NuGet upgrader is not configured,
             // then try to use the GitHubUpgrader.
-            if (NuGetUpgrader.NuGetUpgrader.TryCreate(tracer, dryRun, noVerify, out NuGetUpgrader.NuGetUpgrader nuGetUpgrader, out bool isConfigured, out error))
+            if (NuGetUpgrader.NuGetUpgrader.TryCreate(tracer, fileSystem, dryRun, noVerify, out NuGetUpgrader.NuGetUpgrader nuGetUpgrader, out bool isConfigured, out error))
             {
                 // We were successfully able to load a NuGetUpgrader - use that.
                 newUpgrader = nuGetUpgrader;
@@ -100,7 +101,7 @@ namespace GVFS.Common
                 // Try to load other upgraders as appropriate.
             }
 
-            newUpgrader = GitHubUpgrader.Create(tracer, dryRun, noVerify, out error);
+            newUpgrader = GitHubUpgrader.Create(tracer, fileSystem, dryRun, noVerify, out error);
             if (newUpgrader == null)
             {
                 tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create upgrader. {error}");
@@ -114,17 +115,17 @@ namespace GVFS.Common
         /// Deletes any previously downloaded installers in the Upgrader Download directory.
         /// This can include old installers which were downloaded but never installed.
         /// </summary>
-        public static void DeleteAllInstallerDownloads(ITracer tracer = null)
+        public virtual void DeleteAllInstallerDownloads(ITracer tracer = null)
         {
             try
             {
-                PhysicalFileSystem.RecursiveDelete(ProductUpgraderInfo.GetAssetDownloadsPath());
+                this.fileSystem.RecursiveDelete(ProductUpgraderInfo.GetAssetDownloadsPath());
             }
             catch (Exception ex)
             {
                 if (tracer != null)
                 {
-                    tracer.RelatedError($"{nameof(DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
+                    tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
                 }
             }
         }

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -129,6 +129,14 @@ namespace GVFS.Common
             }
         }
 
+        public static bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
+        {
+            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(
+                tracer,
+                ProductUpgraderInfo.GetAssetDownloadsPath(),
+                out error);
+        }
+
         public abstract bool UpgradeAllowed(out string message);
 
         public abstract bool TryQueryNewestVersion(out Version newVersion, out string message);

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -1,4 +1,5 @@
 using GVFS.Common.FileSystem;
+using GVFS.Common.NuGetUpgrade;
 using GVFS.Common.Tracing;
 using System;
 using System.IO;
@@ -78,7 +79,7 @@ namespace GVFS.Common
         {
             // Prefer to use the NuGet upgrader if it is configured. If the NuGet upgrader is not configured,
             // then try to use the GitHubUpgrader.
-            if (NuGetUpgrader.NuGetUpgrader.TryCreate(tracer, fileSystem, dryRun, noVerify, out NuGetUpgrader.NuGetUpgrader nuGetUpgrader, out bool isConfigured, out error))
+            if (NuGetUpgrader.TryCreate(tracer, fileSystem, dryRun, noVerify, out NuGetUpgrader nuGetUpgrader, out bool isConfigured, out error))
             {
                 // We were successfully able to load a NuGetUpgrader - use that.
                 newUpgrader = nuGetUpgrader;

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -149,15 +149,13 @@ namespace GVFS.Common
         {
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
-            Exception exception;
-            if (!this.fileSystem.TryCreateDirectory(toolsDirectoryPath, out exception))
+
+            if (!GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(
+                    this.tracer,
+                    toolsDirectoryPath,
+                    out error))
             {
                 upgraderToolPath = null;
-                error = exception.Message;
-                this.TraceException(
-                    exception,
-                    nameof(this.TrySetupToolsDirectory),
-                    $"Error creating upgrade tools directory {toolsDirectoryPath}.");
                 return false;
             }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -71,12 +71,12 @@ namespace GVFS.Common
         }
 
         public static bool TryCreateUpgrader(
-            out ProductUpgrader newUpgrader,
             ITracer tracer,
             PhysicalFileSystem fileSystem,
-            out string error,
-            bool dryRun = false,
-            bool noVerify = false)
+            bool dryRun,
+            bool noVerify,
+            out ProductUpgrader newUpgrader,
+            out string error)
         {
             // Prefer to use the NuGet upgrader if it is configured. If the NuGet upgrader is not configured,
             // then try to use the GitHubUpgrader.

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -131,7 +131,7 @@ namespace GVFS.Common
 
         public static bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
         {
-            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(
+            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
                 tracer,
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 out error);
@@ -150,7 +150,7 @@ namespace GVFS.Common
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
 
-            if (!GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(
+            if (!GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
                     this.tracer,
                     toolsDirectoryPath,
                     out error))

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -129,14 +129,6 @@ namespace GVFS.Common
             }
         }
 
-        public static bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
-        {
-            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
-                tracer,
-                ProductUpgraderInfo.GetAssetDownloadsPath(),
-                out error);
-        }
-
         public abstract bool UpgradeAllowed(out string message);
 
         public abstract bool TryQueryNewestVersion(out Version newVersion, out string message);
@@ -144,6 +136,14 @@ namespace GVFS.Common
         public abstract bool TryDownloadNewestVersion(out string errorMessage);
 
         public abstract bool TryRunInstaller(InstallActionWrapper installActionWrapper, out string error);
+
+        public virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
+        {
+            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
+                tracer,
+                ProductUpgraderInfo.GetAssetDownloadsPath(),
+                out error);
+        }
 
         public virtual bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
         {

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -135,14 +135,6 @@ namespace GVFS.Common
 
         public abstract bool TryRunInstaller(InstallActionWrapper installActionWrapper, out string error);
 
-        public virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
-        {
-            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
-                tracer,
-                ProductUpgraderInfo.GetAssetDownloadsPath(),
-                out error);
-        }
-
         public virtual bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
         {
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
@@ -215,6 +207,14 @@ namespace GVFS.Common
 
         public virtual void Dispose()
         {
+        }
+
+        protected virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
+        {
+            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
+                tracer,
+                ProductUpgraderInfo.GetAssetDownloadsPath(),
+                out error);
         }
 
         protected virtual void RunInstaller(string path, string args, out int exitCode, out string error)

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -1,8 +1,6 @@
 using GVFS.Common.FileSystem;
-using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace GVFS.Common
@@ -115,7 +113,7 @@ namespace GVFS.Common
         /// Deletes any previously downloaded installers in the Upgrader Download directory.
         /// This can include old installers which were downloaded but never installed.
         /// </summary>
-        public virtual void DeleteAllInstallerDownloads(ITracer tracer)
+        public virtual void DeleteAllInstallerDownloads()
         {
             try
             {
@@ -123,7 +121,8 @@ namespace GVFS.Common
             }
             catch (Exception ex)
             {
-                tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
+                this.tracer.RelatedError(
+                    $"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
             }
         }
 
@@ -140,7 +139,7 @@ namespace GVFS.Common
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
 
-            if (!GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
+            if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(
                     this.tracer,
                     toolsDirectoryPath,
                     out error))
@@ -211,7 +210,7 @@ namespace GVFS.Common
 
         protected virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
         {
-            return GVFSPlatform.Instance.FileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModify(
+            return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(
                 tracer,
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 out error);

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -140,7 +140,7 @@ namespace GVFS.Common
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
 
-            if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(
+            if (!this.fileSystem.TryCreateDirectoryWithAdminOnlyModify(
                     this.tracer,
                     toolsDirectoryPath,
                     out error))
@@ -211,7 +211,7 @@ namespace GVFS.Common
 
         protected virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
         {
-            return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(
+            return this.fileSystem.TryCreateDirectoryWithAdminOnlyModify(
                 tracer,
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 out error);

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -57,7 +57,7 @@ namespace GVFS.Platform.Mac
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -54,6 +55,11 @@ namespace GVFS.Platform.Mac
         {
             NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
             return NativeStat.IsSock(statBuffer.Mode);
+        }
+
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
+        {
+            throw new NotImplementedException();
         }
 
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -57,7 +57,7 @@ namespace GVFS.Platform.Mac
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -57,7 +57,7 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             try
             {
@@ -114,7 +114,7 @@ namespace GVFS.Platform.Windows
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("Exception", e.ToString());
-                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions)}: IOException while creating/configuring directory");
+                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyModify)}: IOException while creating/configuring directory");
 
                 error = e.Message;
                 return false;
@@ -123,7 +123,7 @@ namespace GVFS.Platform.Windows
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("Exception", e.ToString());
-                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions)}: SystemException while creating/configuring directory");
+                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyModify)}: SystemException while creating/configuring directory");
 
                 error = e.Message;
                 return false;

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -1,9 +1,12 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 
 namespace GVFS.Platform.Windows
 {
@@ -52,6 +55,82 @@ namespace GVFS.Platform.Windows
         public bool IsSocket(string fileName)
         {
             return false;
+        }
+
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
+        {
+            try
+            {
+                DirectorySecurity directorySecurity;
+                if (Directory.Exists(directoryPath))
+                {
+                    directorySecurity = Directory.GetAccessControl(directoryPath);
+                }
+                else
+                {
+                    directorySecurity = new DirectorySecurity();
+                }
+
+                // Protect the access rules from inheritance
+                directorySecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+                // Remove any rules already set for the directory
+                AuthorizationRuleCollection currentRules = directorySecurity.GetAccessRules(includeExplicit: true, includeInherited: true, targetType: typeof(NTAccount));
+                foreach (AuthorizationRule authorizationRule in currentRules)
+                {
+                    FileSystemAccessRule fileSystemRule = authorizationRule as FileSystemAccessRule;
+                    if (fileSystemRule != null)
+                    {
+                        directorySecurity.RemoveAccessRule(fileSystemRule);
+                    }
+                }
+
+                // All users gets read access
+                SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+                directorySecurity.AddAccessRule(
+                    new FileSystemAccessRule(
+                        allUsers,
+                        FileSystemRights.Read,
+                        InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                        PropagationFlags.None,
+                        AccessControlType.Allow));
+
+                // Only administrators have Execute/Modify/Delete access
+                SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                directorySecurity.AddAccessRule(
+                    new FileSystemAccessRule(
+                        administratorUsers,
+                        FileSystemRights.ReadAndExecute | FileSystemRights.Modify | FileSystemRights.Delete,
+                        InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                        PropagationFlags.None,
+                        AccessControlType.Allow));
+
+                Directory.CreateDirectory(directoryPath, directorySecurity);
+
+                // Ensure the ACLs are set correctly if the directory already existed
+                Directory.SetAccessControl(directoryPath, directorySecurity);
+            }
+            catch (IOException e)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", e.ToString());
+                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions)}: IOException while creating/configuring directory");
+
+                error = e.Message;
+                return false;
+            }
+            catch (SystemException e)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", e.ToString());
+                tracer.RelatedError(metadata, $"{nameof(this.TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions)}: SystemException while creating/configuring directory");
+
+                error = e.Message;
+                return false;
+            }
+
+            error = null;
+            return true;
         }
 
         private class NativeFileReader

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -14,6 +14,64 @@ namespace GVFS.Platform.Windows
     {
         public bool SupportsFileMode { get; } = false;
 
+        /// <summary>
+        /// Adds a new FileSystemAccessRule granting read (and optionally modify) access for all users.
+        /// </summary>
+        /// <param name="directorySecurity">DirectorySecurity to which a FileSystemAccessRule will be added.</param>
+        /// <param name="grantUsersModifyPermissions">
+        /// True if all users should be given modify access, false if users should only be allowed read access
+        /// </param>
+        public static void AddUsersAccessRulesToDirectorySecurity(DirectorySecurity directorySecurity, bool grantUsersModifyPermissions)
+        {
+            SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            FileSystemRights rights = FileSystemRights.Read;
+            if (grantUsersModifyPermissions)
+            {
+                rights = rights | FileSystemRights.Modify;
+            }
+
+            directorySecurity.AddAccessRule(
+                new FileSystemAccessRule(
+                    allUsers,
+                    rights,
+                    InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                    PropagationFlags.None,
+                    AccessControlType.Allow));
+        }
+
+        /// <summary>
+        /// Adds a new FileSystemAccessRule granting read/exceute/modify/delete access for administrators.
+        /// </summary>
+        /// <param name="directorySecurity">DirectorySecurity to which a FileSystemAccessRule will be added.</param>
+        public static void AddAdminAccessRulesToDirectorySecurity(DirectorySecurity directorySecurity)
+        {
+            SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            directorySecurity.AddAccessRule(
+                new FileSystemAccessRule(
+                    administratorUsers,
+                    FileSystemRights.ReadAndExecute | FileSystemRights.Modify | FileSystemRights.Delete,
+                    InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                    PropagationFlags.None,
+                    AccessControlType.Allow));
+        }
+
+        /// <summary>
+        /// Removes all FileSystemAccessRules from specified DirectorySecurity
+        /// </summary>
+        /// <param name="directorySecurity">DirectorySecurity from which to remove FileSystemAccessRules</param>
+        public static void RemoveAllFileSystemAccessRulesFromDirectorySecurity(DirectorySecurity directorySecurity)
+        {
+            AuthorizationRuleCollection currentRules = directorySecurity.GetAccessRules(includeExplicit: true, includeInherited: true, targetType: typeof(NTAccount));
+            foreach (AuthorizationRule authorizationRule in currentRules)
+            {
+                FileSystemAccessRule fileSystemRule = authorizationRule as FileSystemAccessRule;
+                if (fileSystemRule != null)
+                {
+                    directorySecurity.RemoveAccessRule(fileSystemRule);
+                }
+            }
+        }
+
         public void FlushFileBuffers(string path)
         {
             NativeMethods.FlushFileBuffers(path);
@@ -71,39 +129,13 @@ namespace GVFS.Platform.Windows
                     directorySecurity = new DirectorySecurity();
                 }
 
-                // Protect the access rules from inheritance
+                // Protect the access rules from inheritance and remove any inherited rules
                 directorySecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
-                // Remove any rules already set for the directory
-                AuthorizationRuleCollection currentRules = directorySecurity.GetAccessRules(includeExplicit: true, includeInherited: true, targetType: typeof(NTAccount));
-                foreach (AuthorizationRule authorizationRule in currentRules)
-                {
-                    FileSystemAccessRule fileSystemRule = authorizationRule as FileSystemAccessRule;
-                    if (fileSystemRule != null)
-                    {
-                        directorySecurity.RemoveAccessRule(fileSystemRule);
-                    }
-                }
-
-                // All users get read access
-                SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
-                directorySecurity.AddAccessRule(
-                    new FileSystemAccessRule(
-                        allUsers,
-                        FileSystemRights.Read,
-                        InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
-                        PropagationFlags.None,
-                        AccessControlType.Allow));
-
-                // Administrators have Execute/Modify/Delete access
-                SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
-                directorySecurity.AddAccessRule(
-                    new FileSystemAccessRule(
-                        administratorUsers,
-                        FileSystemRights.ReadAndExecute | FileSystemRights.Modify | FileSystemRights.Delete,
-                        InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
-                        PropagationFlags.None,
-                        AccessControlType.Allow));
+                // Remove any existing ACLs and add new ACLs for users and admins
+                RemoveAllFileSystemAccessRulesFromDirectorySecurity(directorySecurity);
+                AddUsersAccessRulesToDirectorySecurity(directorySecurity, grantUsersModifyPermissions: false);
+                AddAdminAccessRulesToDirectorySecurity(directorySecurity);
 
                 Directory.CreateDirectory(directoryPath, directorySecurity);
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -30,6 +30,9 @@ namespace GVFS.Platform.Windows
                 rights = rights | FileSystemRights.Modify;
             }
 
+            // InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit -> ACE is inherited by child directories and files
+            // PropagationFlags.None -> Standard propagation rules, settings are applied to the directory and its children
+            // AccessControlType.Allow -> Rule is used to allow access to an object
             directorySecurity.AddAccessRule(
                 new FileSystemAccessRule(
                     allUsers,
@@ -46,6 +49,10 @@ namespace GVFS.Platform.Windows
         public static void AddAdminAccessRulesToDirectorySecurity(DirectorySecurity directorySecurity)
         {
             SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+
+            // InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit -> ACE is inherited by child directories and files
+            // PropagationFlags.None -> Standard propagation rules, settings are applied to the directory and its children
+            // AccessControlType.Allow -> Rule is used to allow access to an object
             directorySecurity.AddAccessRule(
                 new FileSystemAccessRule(
                     administratorUsers,

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -380,10 +380,10 @@ namespace GVFS.Service
             }
 
             // All users gets read access
-            this.AddReadModifyUsersRule(serviceDataRootSecurity, allowModify: false);
+            this.AddReadModifyUsersRuleToDirectorySecurity(serviceDataRootSecurity, allowModify: false);
 
             // Only administrators have Execute/Modify/Delete access
-            this.AddFullAccessAdminRule(serviceDataRootSecurity);
+            this.AddFullAccessAdminRuleToDirectorySecurity(serviceDataRootSecurity);
 
             Directory.CreateDirectory(serviceDataRootPath, serviceDataRootSecurity);
             Directory.CreateDirectory(this.serviceDataLocation, serviceDataRootSecurity);
@@ -413,10 +413,10 @@ namespace GVFS.Service
             upgradeLogsSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
             // All users gets read and modify access
-            this.AddReadModifyUsersRule(upgradeLogsSecurity, allowModify: true);
+            this.AddReadModifyUsersRuleToDirectorySecurity(upgradeLogsSecurity, allowModify: true);
 
             // Administrators have Execute/Modify/Delete access
-            this.AddFullAccessAdminRule(upgradeLogsSecurity);
+            this.AddFullAccessAdminRuleToDirectorySecurity(upgradeLogsSecurity);
 
             Directory.CreateDirectory(upgradeLogsPath, upgradeLogsSecurity);
 
@@ -424,7 +424,7 @@ namespace GVFS.Service
             Directory.SetAccessControl(upgradeLogsPath, upgradeLogsSecurity);
         }
 
-        private void AddReadModifyUsersRule(DirectorySecurity directorySecurity, bool allowModify)
+        private void AddReadModifyUsersRuleToDirectorySecurity(DirectorySecurity directorySecurity, bool allowModify)
         {
             SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
             FileSystemRights rights = FileSystemRights.Read;
@@ -442,7 +442,7 @@ namespace GVFS.Service
                     AccessControlType.Allow));
         }
 
-        private void AddFullAccessAdminRule(DirectorySecurity directorySecurity)
+        private void AddFullAccessAdminRuleToDirectorySecurity(DirectorySecurity directorySecurity)
         {
             SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
             directorySecurity.AddAccessRule(

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -379,11 +379,11 @@ namespace GVFS.Service
                 }
             }
 
-            // All users gets read access
-            this.AddReadModifyUsersRuleToDirectorySecurity(serviceDataRootSecurity, allowModify: false);
+            // All users get read access
+            this.AddUsersAccessRulesToDirectorySecurity(serviceDataRootSecurity, grantUsersModifyPermissions: false);
 
-            // Only administrators have Execute/Modify/Delete access
-            this.AddFullAccessAdminRuleToDirectorySecurity(serviceDataRootSecurity);
+            // Administrators get Execute/Modify/Delete access
+            this.AddAdminAccessRulesToDirectorySecurity(serviceDataRootSecurity);
 
             Directory.CreateDirectory(serviceDataRootPath, serviceDataRootSecurity);
             Directory.CreateDirectory(this.serviceDataLocation, serviceDataRootSecurity);
@@ -413,10 +413,10 @@ namespace GVFS.Service
             upgradeLogsSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
             // All users gets read and modify access
-            this.AddReadModifyUsersRuleToDirectorySecurity(upgradeLogsSecurity, allowModify: true);
+            this.AddUsersAccessRulesToDirectorySecurity(upgradeLogsSecurity, grantUsersModifyPermissions: true);
 
             // Administrators have Execute/Modify/Delete access
-            this.AddFullAccessAdminRuleToDirectorySecurity(upgradeLogsSecurity);
+            this.AddAdminAccessRulesToDirectorySecurity(upgradeLogsSecurity);
 
             Directory.CreateDirectory(upgradeLogsPath, upgradeLogsSecurity);
 
@@ -424,11 +424,11 @@ namespace GVFS.Service
             Directory.SetAccessControl(upgradeLogsPath, upgradeLogsSecurity);
         }
 
-        private void AddReadModifyUsersRuleToDirectorySecurity(DirectorySecurity directorySecurity, bool allowModify)
+        private void AddUsersAccessRulesToDirectorySecurity(DirectorySecurity directorySecurity, bool grantUsersModifyPermissions)
         {
             SecurityIdentifier allUsers = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
             FileSystemRights rights = FileSystemRights.Read;
-            if (allowModify)
+            if (grantUsersModifyPermissions)
             {
                 rights = rights | FileSystemRights.Modify;
             }
@@ -442,7 +442,7 @@ namespace GVFS.Service
                     AccessControlType.Allow));
         }
 
-        private void AddFullAccessAdminRuleToDirectorySecurity(DirectorySecurity directorySecurity)
+        private void AddAdminAccessRulesToDirectorySecurity(DirectorySecurity directorySecurity)
         {
             SecurityIdentifier administratorUsers = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
             directorySecurity.AddAccessRule(

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -76,7 +76,7 @@ namespace GVFS.Service
 
             if (deleteExistingDownloads)
             {
-                productUpgrader.DeleteAllInstallerDownloads();
+                productUpgrader.DeleteAllInstallerDownloads(this.tracer);
             }
         }
 
@@ -102,7 +102,7 @@ namespace GVFS.Service
                     // Already up-to-date
                     // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                     // upgraded by manually downloading and running asset installers.
-                    productUpgrader.DeleteAllInstallerDownloads();
+                    productUpgrader.DeleteAllInstallerDownloads(this.tracer);
                     errorMessage = null;
                     return true;
                 }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -107,12 +107,6 @@ namespace GVFS.Service
                     return true;
                 }
 
-                if (!productUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out detailedError))
-                {
-                    errorMessage = "Failed to create download directory. " + detailedError;
-                    return false;
-                }
-
                 if (!productUpgrader.TryDownloadNewestVersion(out detailedError))
                 {
                     errorMessage = "Failed to download product upgrade. " + detailedError;

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -106,7 +106,7 @@ namespace GVFS.Service
                     return true;
                 }
 
-                if (!ProductUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out detailedError))
+                if (!productUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out detailedError))
                 {
                     errorMessage = "Failed to create download directory. " + detailedError;
                     return false;

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -82,7 +82,7 @@ namespace GVFS.Service
 
             if (deleteExistingDownloads)
             {
-                productUpgrader.DeleteAllInstallerDownloads(this.tracer);
+                productUpgrader.DeleteAllInstallerDownloads();
             }
         }
 
@@ -108,7 +108,7 @@ namespace GVFS.Service
                     // Already up-to-date
                     // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                     // upgraded by manually downloading and running asset installers.
-                    productUpgrader.DeleteAllInstallerDownloads(this.tracer);
+                    productUpgrader.DeleteAllInstallerDownloads();
                     errorMessage = null;
                     return true;
                 }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -106,16 +106,20 @@ namespace GVFS.Service
                     return true;
                 }
 
-                if (productUpgrader.TryDownloadNewestVersion(out detailedError))
+                if (!ProductUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out detailedError))
                 {
-                    errorMessage = null;
-                    return true;
-                }
-                else
-                {
-                    errorMessage = "Could not download product upgrade. " + detailedError;
+                    errorMessage = "Failed to create download directory. " + detailedError;
                     return false;
                 }
+
+                if (!productUpgrader.TryDownloadNewestVersion(out detailedError))
+                {
+                    errorMessage = "Failed to download product upgrade. " + detailedError;
+                    return false;
+                }
+
+                errorMessage = null;
+                return true;
             }
         }
     }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -61,7 +61,13 @@ namespace GVFS.Service
             ProductUpgrader productUpgrader;
             bool deleteExistingDownloads = true;
 
-            if (ProductUpgrader.TryCreateUpgrader(out productUpgrader, this.tracer, this.fileSystem, out errorMessage))
+            if (ProductUpgrader.TryCreateUpgrader(
+                this.tracer,
+                this.fileSystem,
+                dryRun: false,
+                noVerify: false,
+                newUpgrader: out productUpgrader,
+                error: out errorMessage))
             {
                 if (prerunChecker.TryRunPreUpgradeChecks(out string _) && this.TryDownloadUpgrade(productUpgrader, out errorMessage))
                 {

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -35,7 +35,8 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             GVFSCleanup = 0x40,
             GitCleanup = 0x80,
             GitAuthenticodeCheck = 0x100,
-            GVFSAuthenticodeCheck = 0x200
+            GVFSAuthenticodeCheck = 0x200,
+            CreateDownloadDirectory = 0x400,
         }
 
         public List<string> DownloadedFiles { get; private set; }
@@ -93,6 +94,18 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             this.FakeUpgradeRelease = release;
         }
 
+        public override bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
+        {
+            if (this.failActionTypes.HasFlag(ActionType.CreateDownloadDirectory))
+            {
+                error = "Error creating download directory";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
         public override bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
         {
             if (this.failActionTypes.HasFlag(ActionType.CopyTools))
@@ -102,7 +115,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
                 return false;
             }
 
-            upgraderToolPath = @"C:\ProgramData\GVFS\GVFS.Upgrade\Tools\GVFS.Upgrader.exe";
+            upgraderToolPath = @"mock:\ProgramData\GVFS\GVFS.Upgrade\Tools\GVFS.Upgrader.exe";
             error = null;
             return true;
         }
@@ -133,7 +146,7 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
             if (validAsset)
             {
-                string fakeDownloadDirectory = @"C:\ProgramData\GVFS\GVFS.Upgrade\Downloads";
+                string fakeDownloadDirectory = @"mock:\ProgramData\GVFS\GVFS.Upgrade\Downloads";
                 asset.LocalPath = Path.Combine(fakeDownloadDirectory, asset.Name);
                 this.DownloadedFiles.Add(asset.LocalPath);
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -1,6 +1,6 @@
 ﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
-using GVFS.UnitTests.Windows.Upgrader;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,7 +16,8 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         public MockGitHubUpgrader(
             string currentVersion,
             ITracer tracer,
-            GitHubUpgraderConfig config) : base(currentVersion, tracer, config)
+            PhysicalFileSystem fileSystem,
+            GitHubUpgraderConfig config) : base(currentVersion, tracer, fileSystem, config)
         {
             this.DownloadedFiles = new List<string>();
             this.InstallerArgs = new Dictionary<string, Dictionary<string, string>>();

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -95,18 +95,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             this.FakeUpgradeRelease = release;
         }
 
-        public override bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
-        {
-            if (this.failActionTypes.HasFlag(ActionType.CreateDownloadDirectory))
-            {
-                error = "Error creating download directory";
-                return false;
-            }
-
-            error = null;
-            return true;
-        }
-
         public override bool TrySetupToolsDirectory(out string upgraderToolPath, out string error)
         {
             if (this.failActionTypes.HasFlag(ActionType.CopyTools))
@@ -117,6 +105,18 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             }
 
             upgraderToolPath = @"mock:\ProgramData\GVFS\GVFS.Upgrade\Tools\GVFS.Upgrader.exe";
+            error = null;
+            return true;
+        }
+
+        protected override bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
+        {
+            if (this.failActionTypes.HasFlag(ActionType.CreateDownloadDirectory))
+            {
+                error = "Error creating download directory";
+                return false;
+            }
+
             error = null;
             return true;
         }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
@@ -125,31 +125,6 @@ namespace GVFS.UnitTests.Upgrader
         }
 
         [TestCase]
-        public void ExecuteFailsWhenCreatingDownloadDirectoryFails()
-        {
-            this.MoqUpgrader.Setup(upgrader => upgrader.TryCreateAndConfigureDownloadDirectory(It.IsAny<ITracer>(), out It.Ref<string>.IsAny))
-                .Callback(new TryCreateAndConfigureDownloadDirectoryCallback(
-                    (ITracer tracer, out string message) =>
-                    {
-                        message = "Directory creation error.";
-                    }))
-                .Returns(false);
-
-            this.orchestrator.Execute();
-
-            this.VerifyOrchestratorInvokes(
-                upgradeAllowed: true,
-                queryNewestVersion: true,
-                downloadNewestVersion: false,
-                installNewestVersion: false,
-                cleanup: true);
-
-            this.VerifyOutput("ERROR: Directory creation error.");
-
-            this.orchestrator.ExitCode.ShouldEqual(ReturnCode.GenericError);
-        }
-
-        [TestCase]
         public void ExecuteFailsWhenDownloadFails()
         {
             this.MoqUpgrader.Setup(upgrader => upgrader.TryDownloadNewestVersion(out It.Ref<string>.IsAny))
@@ -210,7 +185,6 @@ namespace GVFS.UnitTests.Upgrader
                 .Returns(true);
 
             string message = string.Empty;
-            mockUpgrader.Setup(upgrader => upgrader.TryCreateAndConfigureDownloadDirectory(It.IsAny<ITracer>(), out It.Ref<string>.IsAny)).Returns(true);
             mockUpgrader.Setup(upgrader => upgrader.TryDownloadNewestVersion(out It.Ref<string>.IsAny)).Returns(true);
             mockUpgrader.Setup(upgrader => upgrader.TryRunInstaller(It.IsAny<InstallActionWrapper>(), out message)).Returns(true);
             mockUpgrader.Setup(upgrader => upgrader.TryCleanup(out It.Ref<string>.IsAny)).Returns(true);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorTests.cs
@@ -3,6 +3,7 @@ using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
 using GVFS.UnitTests.Windows.Mock.Upgrader;
 using GVFS.Upgrader;
 using Moq;
@@ -25,6 +26,7 @@ namespace GVFS.UnitTests.Upgrader
         private delegate void TryRunInstallerCallback(InstallActionWrapper installActionWrapper, out string error);
 
         private MockTracer Tracer { get; set; }
+        private MockFileSystem FileSystem { get; set; }
         private MockTextWriter Output { get; set; }
         private MockInstallerPrerunChecker PreRunChecker { get; set; }
         private Mock<LocalGVFSConfig> MoqLocalConfig { get; set; }
@@ -36,6 +38,7 @@ namespace GVFS.UnitTests.Upgrader
         public void Setup()
         {
             this.Tracer = new MockTracer();
+            this.FileSystem = new MockFileSystem(new MockDirectory(@"mock:\GVFS.Upgrades\Download", null, null));
             this.Output = new MockTextWriter();
             this.PreRunChecker = new MockInstallerPrerunChecker(this.Tracer);
             this.PreRunChecker.Reset();
@@ -43,6 +46,7 @@ namespace GVFS.UnitTests.Upgrader
             this.orchestrator = new UpgradeOrchestrator(
                 this.MoqUpgrader.Object,
                 this.Tracer,
+                this.FileSystem,
                 this.PreRunChecker,
                 input: null,
                 output: this.Output);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -73,6 +73,25 @@ namespace GVFS.UnitTests.Windows.Upgrader
         }
 
         [TestCase]
+        public void DownloadDirectoryCreationError()
+        {
+            this.ConfigureRunAndVerify(
+                configure: () =>
+                {
+                    this.Upgrader.SetFailOnAction(MockGitHubUpgrader.ActionType.CreateDownloadDirectory);
+                },
+                expectedReturn: ReturnCode.GenericError,
+                expectedOutput: new List<string>
+                {
+                    "Error creating download directory"
+                },
+                expectedErrors: new List<string>
+                {
+                    "Error creating download directory"
+                });
+        }
+
+        [TestCase]
         public void GVFSDownloadError()
         {
             this.ConfigureRunAndVerify(

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -20,6 +20,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.orchestrator = new UpgradeOrchestrator(
                 this.Upgrader,
                 this.Tracer,
+                this.FileSystem,
                 this.PrerunChecker,
                 input: null,
                 output: this.Output);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -70,7 +70,14 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
             string expectedError = "Invalid upgrade ring `Invalid` specified in gvfs config.";
             string errorString;
-            GitHubUpgrader.Create(this.LocalConfig, this.Tracer, this.FileSystem, dryRun: false, noVerify: false, error: out errorString).ShouldBeNull();
+            GitHubUpgrader.Create(
+                this.Tracer,
+                this.FileSystem,
+                dryRun: false,
+                noVerify: false,
+                localConfig: this.LocalConfig,
+                error: out errorString).ShouldBeNull();
+
             errorString.ShouldContain(expectedError);
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
 using GVFS.UnitTests.Windows.Mock.Upgrader;
 using NUnit.Framework;
 using System;
@@ -16,6 +17,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
         protected const string NewerThanLocalVersion = "1.1.18115.1";
 
         protected MockTracer Tracer { get; private set; }
+        protected MockFileSystem FileSystem { get; private set; }
         protected MockTextWriter Output { get; private set; }
         protected MockInstallerPrerunChecker PrerunChecker { get; private set; }
         protected MockGitHubUpgrader Upgrader { get; private set; }
@@ -24,6 +26,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
         public virtual void Setup()
         {
             this.Tracer = new MockTracer();
+            this.FileSystem = new MockFileSystem(new MockDirectory(@"mock:\GVFS.Upgrades\Download", null, null));
             this.Output = new MockTextWriter();
             this.PrerunChecker = new MockInstallerPrerunChecker(this.Tracer);
             this.LocalConfig = new MockLocalGVFSConfig();
@@ -31,6 +34,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.Upgrader = new MockGitHubUpgrader(
                 LocalGVFSVersion,
                 this.Tracer,
+                this.FileSystem,
                 new GitHubUpgrader.GitHubUpgraderConfig(this.Tracer, this.LocalConfig));
 
             this.PrerunChecker.Reset();
@@ -66,7 +70,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
 
             string expectedError = "Invalid upgrade ring `Invalid` specified in gvfs config.";
             string errorString;
-            GitHubUpgrader.Create(this.LocalConfig, this.Tracer, dryRun: false, noVerify: false, error: out errorString).ShouldBeNull();
+            GitHubUpgrader.Create(this.LocalConfig, this.Tracer, this.FileSystem, dryRun: false, noVerify: false, error: out errorString).ShouldBeNull();
             errorString.ShouldContain(expectedError);
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Common;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
+using GVFS.UnitTests.Mock.FileSystem;
 using GVFS.UnitTests.Windows.Mock.Upgrader;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -23,6 +24,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.upgradeVerb = new UpgradeVerb(
                 this.Upgrader,
                 this.Tracer,
+                this.FileSystem,
                 this.PrerunChecker,
                 this.processLauncher,
                 this.Output);

--- a/GVFS/GVFS.UnitTests/Common/InstallManifestTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/InstallManifestTests.cs
@@ -1,5 +1,4 @@
-﻿using GVFS.Common;
-using GVFS.Common.NuGetUpgrader;
+﻿using GVFS.Common.NuGetUpgrade;
 using GVFS.Tests.Should;
 using Newtonsoft.Json;
 using NUnit.Framework;

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -1,6 +1,5 @@
 using GVFS.Common;
-using GVFS.Common.FileSystem;
-using GVFS.Common.NuGetUpgrader;
+using GVFS.Common.NuGetUpgrade;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
@@ -14,7 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace GVFS.UnitTests.Common
+namespace GVFS.UnitTests.Common.NuGetUpgrade
 {
     [TestFixture]
     public class NuGetUpgraderTests

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -209,10 +209,9 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
             actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
 
-            MockPlatformFileSystem mockPlatformFileSystem = GVFSPlatform.Instance.FileSystem as MockPlatformFileSystem;
-            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
-            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
             downloadSuccessful.ShouldBeFalse();
         }
 
@@ -349,10 +348,9 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
         [TestCase]
         public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
         {
-            MockPlatformFileSystem mockPlatformFileSystem = GVFSPlatform.Instance.FileSystem as MockPlatformFileSystem;
-            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
             this.upgrader.TrySetupToolsDirectory(out string upgraderToolsPath, out string error).ShouldBeFalse();
-            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
         }
 
         private IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -347,6 +347,15 @@ namespace GVFS.UnitTests.Common
             }
         }
 
+        [TestCase]
+        public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
+        {
+            MockPlatformFileSystem mockPlatformFileSystem = GVFSPlatform.Instance.FileSystem as MockPlatformFileSystem;
+            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            this.upgrader.TrySetupToolsDirectory(out string upgraderToolsPath, out string error).ShouldBeFalse();
+            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+        }
+
         private IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)
         {
             Mock<IPackageSearchMetadata> mockPackageSearchMetaData = new Mock<IPackageSearchMetadata>();

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -191,7 +191,7 @@ namespace GVFS.UnitTests.Common
         }
 
         [TestCase]
-        public void CanDownloadNewestVersionFailsIfDirectoryIsMissing()
+        public void CanDownloadNewestVersionFailsIfDownloadDirectoryCreationFails()
         {
             Version actualNewestVersion;
             string message;
@@ -212,10 +212,11 @@ namespace GVFS.UnitTests.Common
             success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
             actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
 
-            this.mockFileSystem.DeleteDirectory(this.downloadDirectoryPath);
+            MockPlatformFileSystem mockPlatformFileSystem = GVFSPlatform.Instance.FileSystem as MockPlatformFileSystem;
+            mockPlatformFileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = false;
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
+            mockPlatformFileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = true;
             downloadSuccessful.ShouldBeFalse();
-            this.mockFileSystem.CreateDirectory(this.downloadDirectoryPath);
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -4,12 +4,14 @@ using GVFS.Common.NuGetUpgrader;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
 using Moq;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -31,33 +33,33 @@ namespace GVFS.UnitTests.Common
         private MockTracer tracer;
 
         private NuGetUpgrader.NuGetUpgraderConfig upgraderConfig;
-        private string downloadFolder;
 
         private Mock<NuGetFeed> mockNuGetFeed;
-        private Mock<PhysicalFileSystem> mockFileSystem;
+        private MockFileSystem mockFileSystem;
+
+        private string downloadDirectoryPath = @"mock:\downloadFolderTestValue";
 
         [SetUp]
         public void SetUp()
         {
             this.upgraderConfig = new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName, NuGetFeedUrlForCredentials);
-            this.downloadFolder = "downloadFolderTestValue";
 
             this.tracer = new MockTracer();
 
             this.mockNuGetFeed = new Mock<NuGetFeed>(
                 NuGetFeedUrl,
                 NuGetFeedName,
-                this.downloadFolder,
+                this.downloadDirectoryPath,
                 null,
                 this.tracer);
-            this.mockFileSystem = new Mock<PhysicalFileSystem>();
+            this.mockFileSystem = new MockFileSystem(new MockDirectory(this.downloadDirectoryPath, null, null));
 
             this.upgrader = new NuGetUpgrader(
                 CurrentVersion,
                 this.tracer,
                 false,
                 false,
-                this.mockFileSystem.Object,
+                this.mockFileSystem,
                 this.upgraderConfig,
                 this.mockNuGetFeed.Object);
         }
@@ -168,11 +170,10 @@ namespace GVFS.UnitTests.Common
                 this.GeneratePackageSeachMetadata(new Version(NewerVersion)),
             };
 
+            string testDownloadPath = Path.Combine(this.downloadDirectoryPath, "testNuget.zip");
             IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
-
-            string downloadPath = "c:\\test_download_path";
             this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
-            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(downloadPath);
+            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(testDownloadPath);
 
             bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
 
@@ -182,7 +183,7 @@ namespace GVFS.UnitTests.Common
 
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
             downloadSuccessful.ShouldBeTrue();
-            this.upgrader.DownloadedPackagePath.ShouldEqual(downloadPath);
+            this.upgrader.DownloadedPackagePath.ShouldEqual(testDownloadPath);
         }
 
         [TestCase]
@@ -241,7 +242,7 @@ namespace GVFS.UnitTests.Common
                 this.tracer,
                 false,
                 false,
-                this.mockFileSystem.Object,
+                this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object);
 
@@ -256,7 +257,7 @@ namespace GVFS.UnitTests.Common
                 this.tracer,
                 false,
                 false,
-                this.mockFileSystem.Object,
+                this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object);
 
@@ -272,7 +273,7 @@ namespace GVFS.UnitTests.Common
                 this.tracer,
                 false,
                 false,
-                this.mockFileSystem.Object,
+                this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object);
 
@@ -287,7 +288,7 @@ namespace GVFS.UnitTests.Common
                 this.tracer,
                 false,
                 false,
-                this.mockFileSystem.Object,
+                this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object);
 

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -213,9 +213,9 @@ namespace GVFS.UnitTests.Common
             actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
 
             MockPlatformFileSystem mockPlatformFileSystem = GVFSPlatform.Instance.FileSystem as MockPlatformFileSystem;
-            mockPlatformFileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
-            mockPlatformFileSystem.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            mockPlatformFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
             downloadSuccessful.ShouldBeFalse();
         }
 

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -34,6 +34,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
         /// </summary>
         public bool DeleteNonExistentFileThrowsException { get; set; }
 
+        public override void RecursiveDelete(string path)
+        {
+            this.RootDirectory.DeleteDirectory(path);
+        }
+
         public override bool FileExists(string path)
         {
             return this.RootDirectory.FindFile(path) != null;

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -39,6 +39,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
             return this.RootDirectory.FindFile(path) != null;
         }
 
+        public override bool DirectoryExists(string path)
+        {
+            return this.RootDirectory.FindDirectory(path) != null;
+        }
+
         public override void CopyFile(string sourcePath, string destinationPath, bool overwrite)
         {
             throw new NotImplementedException();

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using System;
@@ -14,11 +15,14 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
             this.RootDirectory = rootDirectory;
             this.DeleteNonExistentFileThrowsException = true;
+            this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
         }
 
         public MockDirectory RootDirectory { get; private set; }
 
         public bool DeleteFileThrowsException { get; set; }
+
+        public bool TryCreateDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
 
         /// <summary>
         /// Allow FileMoves without checking the input arguments.
@@ -160,6 +164,19 @@ namespace GVFS.UnitTests.Mock.FileSystem
         public override void CreateDirectory(string path)
         {
             this.RootDirectory.CreateDirectory(path);
+        }
+
+        public override bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        {
+            error = null;
+
+            if (this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed)
+            {
+                this.RootDirectory.CreateDirectory(directoryPath);
+                return true;
+            }
+
+            return false;
         }
 
         public override void DeleteDirectory(string path, bool recursive = false)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -8,10 +8,10 @@ namespace GVFS.UnitTests.Mock.FileSystem
     {
         public MockPlatformFileSystem()
         {
-            this.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
+        public bool TryCreateDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
 
         public bool SupportsFileMode { get; } = true;
 
@@ -57,10 +57,10 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             error = null;
-            return this.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed;
+            return this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed;
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -6,6 +6,13 @@ namespace GVFS.UnitTests.Mock.FileSystem
 {
     public class MockPlatformFileSystem : IPlatformFileSystem
     {
+        public MockPlatformFileSystem()
+        {
+            this.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed = true;
+        }
+
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
+
         public bool SupportsFileMode { get; } = true;
 
         public void FlushFileBuffers(string path)
@@ -52,7 +59,8 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
         public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
-            throw new NotSupportedException();
+            error = null;
+            return this.TryCreateAndConfigureDirectoryWithAdminOnlyModifyShouldSucceed;
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -50,7 +50,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
-        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
 using System;
 
 namespace GVFS.UnitTests.Mock.FileSystem
@@ -45,6 +46,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
         }
 
         public bool IsSocket(string fileName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool TryCreateAndConfigureDirectoryWithAdminOnlyWritePermissions(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -6,13 +6,6 @@ namespace GVFS.UnitTests.Mock.FileSystem
 {
     public class MockPlatformFileSystem : IPlatformFileSystem
     {
-        public MockPlatformFileSystem()
-        {
-            this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
-        }
-
-        public bool TryCreateDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
-
         public bool SupportsFileMode { get; } = true;
 
         public void FlushFileBuffers(string path)
@@ -59,8 +52,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
         public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
-            error = null;
-            return this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed;
+            throw new NotSupportedException();
         }
     }
 }

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -150,7 +150,7 @@ namespace GVFS.Upgrader
             if (this.upgrader == null)
             {
                 ProductUpgrader upgrader;
-                if (!ProductUpgrader.TryCreateUpgrader(out upgrader, this.tracer, this.fileSystem, out errorMessage, this.DryRun, this.NoVerify))
+                if (!ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, this.DryRun, this.NoVerify, out upgrader, out errorMessage))
                 {
                     return false;
                 }

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -321,12 +321,6 @@ namespace GVFS.Upgrader
 
             using (ITracer activity = this.tracer.StartActivity($"{nameof(this.TryDownloadUpgrade)}", EventLevel.Informational, metadata))
             {
-                if (!this.upgrader.TryCreateAndConfigureDownloadDirectory(activity, out consoleError))
-                {
-                    this.tracer.RelatedError(metadata, $"{nameof(this.upgrader.TryCreateAndConfigureDownloadDirectory)} failed. {consoleError}");
-                    return false;
-                }
-
                 if (!this.upgrader.TryDownloadNewestVersion(out consoleError))
                 {
                     this.tracer.RelatedError(metadata, $"{nameof(this.upgrader.TryDownloadNewestVersion)} failed. {consoleError}");

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -316,6 +316,12 @@ namespace GVFS.Upgrader
 
             using (ITracer activity = this.tracer.StartActivity($"{nameof(this.TryDownloadUpgrade)}", EventLevel.Informational, metadata))
             {
+                if (!ProductUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out consoleError))
+                {
+                    this.tracer.RelatedError(metadata, $"{nameof(this.upgrader.TryCreateAndConfigureDownloadDirectory)} failed. {consoleError}");
+                    return false;
+                }
+
                 if (!this.upgrader.TryDownloadNewestVersion(out consoleError))
                 {
                     this.tracer.RelatedError(metadata, $"{nameof(this.upgrader.TryDownloadNewestVersion)} failed. {consoleError}");

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -167,10 +167,9 @@ namespace GVFS.Upgrader
             Version newGVFSVersion = null;
             string error = null;
 
-            this.upgrader.DeleteAllInstallerDownloads();
-
             if (!this.upgrader.UpgradeAllowed(out error))
             {
+                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
                 this.output.WriteLine(error);
                 consoleError = null;
                 newVersion = null;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -316,7 +316,7 @@ namespace GVFS.Upgrader
 
             using (ITracer activity = this.tracer.StartActivity($"{nameof(this.TryDownloadUpgrade)}", EventLevel.Informational, metadata))
             {
-                if (!ProductUpgrader.TryCreateAndConfigureDownloadDirectory(activity, out consoleError))
+                if (!this.upgrader.TryCreateAndConfigureDownloadDirectory(activity, out consoleError))
                 {
                     this.tracer.RelatedError(metadata, $"{nameof(this.upgrader.TryCreateAndConfigureDownloadDirectory)} failed. {consoleError}");
                     return false;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -169,7 +169,7 @@ namespace GVFS.Upgrader
 
             if (!this.upgrader.UpgradeAllowed(out error))
             {
-                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
+                this.upgrader.DeleteAllInstallerDownloads();
                 this.output.WriteLine(error);
                 consoleError = null;
                 newVersion = null;

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -18,9 +18,11 @@ namespace GVFS.CommandLine
         private const string DiagnoseVerbName = "diagnose";
 
         private TextWriter diagnosticLogFileWriter;
+        private PhysicalFileSystem fileSystem;
 
         public DiagnoseVerb() : base(false)
         {
+            this.fileSystem = new PhysicalFileSystem();
         }
 
         protected override string VerbName
@@ -166,7 +168,7 @@ namespace GVFS.CommandLine
                 () =>
                 {
                     ZipFile.CreateFromDirectory(archiveFolderPath, zipFilePath);
-                    PhysicalFileSystem.RecursiveDelete(archiveFolderPath);
+                    this.fileSystem.RecursiveDelete(archiveFolderPath);
 
                     return true;
                 },

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -102,7 +102,7 @@ namespace GVFS.CommandLine
                     this.prerunChecker = new InstallerPreRunChecker(this.tracer, this.Confirmed ? GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm : GVFSConstants.UpgradeVerbMessages.GVFSUpgrade);
 
                     ProductUpgrader upgrader;
-                    if (ProductUpgrader.TryCreateUpgrader(out upgrader, this.tracer, this.fileSystem, out error, this.DryRun, this.NoVerify))
+                    if (ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, this.DryRun, this.NoVerify, out upgrader, out error))
                     {
                         this.upgrader = upgrader;
                     }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -26,13 +26,14 @@ namespace GVFS.CommandLine
         public UpgradeVerb(
             ProductUpgrader upgrader,
             ITracer tracer,
+            PhysicalFileSystem fileSystem,
             InstallerPreRunChecker prerunChecker,
             ProcessLauncher processWrapper,
             TextWriter output)
         {
             this.upgrader = upgrader;
             this.tracer = tracer;
-            this.fileSystem = new PhysicalFileSystem();
+            this.fileSystem = fileSystem;
             this.prerunChecker = prerunChecker;
             this.processLauncher = processWrapper;
             this.Output = output;
@@ -40,6 +41,7 @@ namespace GVFS.CommandLine
 
         public UpgradeVerb()
         {
+            this.fileSystem = new PhysicalFileSystem();
             this.processLauncher = new ProcessLauncher();
             this.Output = Console.Out;
         }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
@@ -17,6 +18,7 @@ namespace GVFS.CommandLine
         private const string ConfirmOption = "--confirm";
 
         private ITracer tracer;
+        private PhysicalFileSystem fileSystem;
         private ProductUpgrader upgrader;
         private InstallerPreRunChecker prerunChecker;
         private ProcessLauncher processLauncher;
@@ -30,6 +32,7 @@ namespace GVFS.CommandLine
         {
             this.upgrader = upgrader;
             this.tracer = tracer;
+            this.fileSystem = new PhysicalFileSystem();
             this.prerunChecker = prerunChecker;
             this.processLauncher = processWrapper;
             this.Output = output;
@@ -99,7 +102,7 @@ namespace GVFS.CommandLine
                     this.prerunChecker = new InstallerPreRunChecker(this.tracer, this.Confirmed ? GVFSConstants.UpgradeVerbMessages.GVFSUpgradeConfirm : GVFSConstants.UpgradeVerbMessages.GVFSUpgrade);
 
                     ProductUpgrader upgrader;
-                    if (ProductUpgrader.TryCreateUpgrader(out upgrader, this.tracer, out error, this.DryRun, this.NoVerify))
+                    if (ProductUpgrader.TryCreateUpgrader(out upgrader, this.tracer, this.fileSystem, out error, this.DryRun, this.NoVerify))
                     {
                         this.upgrader = upgrader;
                     }
@@ -136,7 +139,7 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                ProductUpgrader.DeleteAllInstallerDownloads();
+                this.upgrader.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -152,7 +155,7 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                ProductUpgrader.DeleteAllInstallerDownloads();
+                this.upgrader.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -139,7 +139,7 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
+                this.upgrader.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -155,7 +155,7 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
+                this.upgrader.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -139,7 +139,7 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                this.upgrader.DeleteAllInstallerDownloads();
+                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -155,7 +155,7 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                this.upgrader.DeleteAllInstallerDownloads();
+                this.upgrader.DeleteAllInstallerDownloads(this.tracer);
                 this.ReportInfoToConsole(message);
                 return true;
             }

--- a/GVFS/GVFS/RepairJobs/RepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/RepairJob.cs
@@ -11,12 +11,14 @@ namespace GVFS.RepairJobs
     public abstract class RepairJob
     {
         private const string BackupExtension = ".bak";
+        private PhysicalFileSystem fileSystem;
 
         public RepairJob(ITracer tracer, TextWriter output, GVFSEnlistment enlistment)
         {
             this.Tracer = tracer;
             this.Output = output;
             this.Enlistment = enlistment;
+            this.fileSystem = new PhysicalFileSystem();
         }
 
         public enum IssueType
@@ -95,7 +97,7 @@ namespace GVFS.RepairJobs
         {
             try
             {
-                PhysicalFileSystem.RecursiveDelete(filePath);
+                this.fileSystem.RecursiveDelete(filePath);
                 this.Tracer.RelatedEvent(EventLevel.Informational, "FolderDeleted", new EventMetadata { { "SourcePath", filePath } });
             }
             catch (Exception e)


### PR DESCRIPTION
Part of the work required for #717 

After doing testing with the changes in #728 I found the following issues:

- The upgrader's logs directory could not be written to by a non-elevated process
- Download and Tools directory were not having the proper ACLs explicitly set

Changes in this PR:

- Explicitly remove any ACLs previously set on the `C:\ProgramData\GVFS` directory
- Explicitly remove any ACLs previously set on the `C\ProgramData\GVFS\GVFS.Upgrade\Downloads` directory
- Allow users to modify the `GVFS.Upgrade\Logs` directory so that `gvfs upgrade` can create log files when running without elevation
- Add\Update unit tests
- Fixed an issue where running the unit tests would attempt to delete the downloads directory on the dev machine (running the unit tests)
- Renamed `GVFS.Common.NuGetUpgrader` to `GVFS.Common.NuGetUpgrade` to avoid naming conflicts with the `NuGetUpgrader` class.
- Code cleanup

*Tagging as WIP as manual testing is still in progress*