### PR TITLE
ProductUpgrader: only write newest version available

### DIFF
--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -48,6 +48,12 @@ namespace GVFS.Common
                 "Newtonsoft.Json.dll"
             };
 
+        private static readonly HashSet<string> GVFSInstallerFileNamePrefixCandidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "SetupGVFS",
+            "VFSForGit"
+        };
+
         private Version installedVersion;
         private Version newestVersion;
         private Release newestRelease;
@@ -548,15 +554,15 @@ namespace GVFS.Common
 
         private bool IsGVFSAsset(Asset asset)
         {
-            return this.AssetInstallerNameCompare(asset, ProductUpgraderInfo.PossibleGVFSInstallerNamePrefixes().ToArray());
+            return this.AssetInstallerNameCompare(asset, GVFSInstallerFileNamePrefixCandidates);
         }
 
         private bool IsGitAsset(Asset asset)
         {
-            return this.AssetInstallerNameCompare(asset, GitInstallerFileNamePrefix);
+            return this.AssetInstallerNameCompare(asset, new string[] { GitInstallerFileNamePrefix });
         }
 
-        private bool AssetInstallerNameCompare(Asset asset, params string[] expectedFileNamePrefixes)
+        private bool AssetInstallerNameCompare(Asset asset, IEnumerable<string> expectedFileNamePrefixes)
         {
             foreach (string fileNamePrefix in expectedFileNamePrefixes)
             {

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
@@ -1,0 +1,60 @@
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GVFS.Common
+{
+    public partial class ProductUpgraderInfo
+    {
+        public const string UpgradeDirectoryName = "GVFS.Upgrade";
+        public const string LogDirectory = "Logs";
+        public const string DownloadDirectory = "Downloads";
+        public const string HighestAvailableVersionFileName = "HighestAvailableVersion";
+
+        private const string RootDirectory = UpgradeDirectoryName;
+
+        public static bool IsLocalUpgradeAvailable(ITracer tracer)
+        {
+            try
+            {
+                return File.Exists(GetHighestAvailableVersionFilePath());
+            }
+            catch (Exception ex) when (
+                ex is IOException ||
+                ex is UnauthorizedAccessException ||
+                ex is NotSupportedException)
+            {
+                if (tracer != null)
+                {
+                    tracer.RelatedError(
+                        CreateEventMetadata(ex),
+                        "Exception encountered when determining if an upgrade is available.");
+                }
+            }
+
+            return false;
+        }
+
+        public static string GetHighestAvailableVersionFilePath()
+        {
+            return Path.Combine(GetUpgradesDirectoryPath(), HighestAvailableVersionFileName);
+        }
+
+        public static string GetUpgradesDirectoryPath()
+        {
+            return Paths.GetServiceDataRoot(RootDirectory);
+        }
+
+        private static EventMetadata CreateEventMetadata(Exception e)
+        {
+            EventMetadata metadata = new EventMetadata();
+            if (e != null)
+            {
+                metadata.Add("Exception", e.ToString());
+            }
+
+            return metadata;
+        }
+    }
+}

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -5,37 +5,8 @@ using System.IO;
 
 namespace GVFS.Common
 {
-    public class ProductUpgraderInfo
+    public partial class ProductUpgraderInfo
     {
-        public const string UpgradeDirectoryName = "GVFS.Upgrade";
-        public const string LogDirectory = "Logs";
-        public const string DownloadDirectory = "Downloads";
-        public const string HighestAvailableVersionFileName = "HighestAvailableVersion";
-
-        protected const string RootDirectory = UpgradeDirectoryName;
-
-        public static bool IsLocalUpgradeAvailable(ITracer tracer)
-        {
-            try
-            {
-                return File.Exists(GetHighestAvailableVersionFilePath());
-            }
-            catch (Exception ex) when (
-                ex is IOException ||
-                ex is UnauthorizedAccessException ||
-                ex is NotSupportedException)
-            {
-                if (tracer != null)
-                {
-                    tracer.RelatedError(
-                        CreateEventMetadata(ex),
-                        "Exception encountered when determining if an upgrade is available.");
-                }
-            }
-
-            return false;
-        }
-
         public static void RecordHighestAvailableVersion(Version highestAvailableVersion)
         {
             string highestAvailableVersionFile = GetHighestAvailableVersionFilePath();
@@ -56,11 +27,6 @@ namespace GVFS.Common
         public static string CurrentGVFSVersion()
         {
             return ProcessHelper.GetCurrentProcessVersion();
-        }
-
-        public static string GetUpgradesDirectoryPath()
-        {
-            return Paths.GetServiceDataRoot(RootDirectory);
         }
 
         public static string GetLogDirectoryPath()
@@ -95,11 +61,6 @@ namespace GVFS.Common
             }
         }
 
-        public static string GetHighestAvailableVersionFilePath()
-        {
-            return Path.Combine(GetUpgradesDirectoryPath(), HighestAvailableVersionFileName);
-        }
-
         private static void RecursiveDelete(string path)
         {
             if (!Directory.Exists(path))
@@ -121,17 +82,6 @@ namespace GVFS.Common
             }
 
             directory.Delete();
-        }
-
-        private static EventMetadata CreateEventMetadata(Exception e)
-        {
-            EventMetadata metadata = new EventMetadata();
-            if (e != null)
-            {
-                metadata.Add("Exception", e.ToString());
-            }
-
-            return metadata;
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -15,8 +15,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [Category(Categories.WindowsOnly)]
     public class UpgradeReminderTests : TestsWithEnlistmentPerFixture
     {
-        private const string GVFSInstallerName = "VFSForGit.1.0.18234.1.exe";
-        private const string GitInstallerName = "Git-2.17.1.gvfs.2.5.g2962052-64-bit.exe";
+        private const string HighestAvailableVersionFileName = "HighestAvailableVersion";
         private const string UpgradeRingKey = "upgrade.ring";
         private const string AlwaysUpToDateRing = "None";
 
@@ -77,15 +76,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private void CreateUpgradeInstallers()
         {
-            string gvfsInstallerPath = Path.Combine(this.upgradeDirectory, GVFSInstallerName);
-            string gitInstallerPath = Path.Combine(this.upgradeDirectory, GitInstallerName);
+            string gvfsUpgradeAvailableFilePath = Path.Combine(this.upgradeDirectory, HighestAvailableVersionFileName);
 
             this.EmptyDownloadDirectory();
 
-            this.fileSystem.CreateEmptyFile(gvfsInstallerPath);
-            this.fileSystem.CreateEmptyFile(gitInstallerPath);
-            this.fileSystem.FileExists(gvfsInstallerPath).ShouldBeTrue();
-            this.fileSystem.FileExists(gitInstallerPath).ShouldBeTrue();
+            this.fileSystem.CreateEmptyFile(gvfsUpgradeAvailableFilePath);
+            this.fileSystem.FileExists(gvfsUpgradeAvailableFilePath).ShouldBeTrue();
         }
 
         private void SetUpgradeRing(string value)

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
@@ -77,7 +77,7 @@
     <Compile Include="..\GVFS.Common\ProcessResult.cs">
       <Link>Common\ProcessResult.cs</Link>
     </Compile>
-    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.cs" Link="Common\ProductUpgraderInfo.cs" />
+    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.Shared.cs" Link="Common\ProductUpgraderInfo.Shared.cs" />
     <Compile Include="..\GVFS.Common\Tracing\EventLevel.cs">
       <Link>Common\Tracing\EventLevel.cs</Link>
     </Compile>

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Windows.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Windows.csproj
@@ -94,8 +94,8 @@
     <Compile Include="..\GVFS.Common\ProcessResult.cs">
       <Link>Common\ProcessResult.cs</Link>
     </Compile>
-    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.cs">
-      <Link>Common\ProductUpgraderInfo.cs</Link>
+    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.Shared.cs">
+      <Link>Common\ProductUpgraderInfo.Shared.cs</Link>
     </Compile>
     <Compile Include="..\GVFS.Common\Tracing\EventLevel.cs">
       <Link>Common\Tracing\EventLevel.cs</Link>

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -112,7 +112,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency && ProductUpgraderInfo.IsLocalUpgradeAvailable(GVFSHooksPlatform.GetInstallerExtension()))
+            if (randomValue <= reminderFrequency && ProductUpgraderInfo.IsLocalUpgradeAvailable(tracer: null))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
             }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -1,9 +1,8 @@
 ﻿using GVFS.Common;
-using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 
 namespace GVFS.Service
@@ -53,70 +52,107 @@ namespace GVFS.Service
             }
         }
 
+        private static EventMetadata CreateEventMetadata(Exception e)
+        {
+            EventMetadata metadata = new EventMetadata();
+            if (e != null)
+            {
+                metadata.Add("Exception", e.ToString());
+            }
+
+            return metadata;
+        }
+
         private void TimerCallback(object unusedState)
         {
             string errorMessage = null;
-            InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);
-            IProductUpgrader productUpgrader;
-            bool deleteExistingDownloads = true;
 
-            if (ProductUpgraderFactory.TryCreateUpgrader(out productUpgrader, this.tracer, out errorMessage))
+            using (ITracer activity = this.tracer.StartActivity("Checking for product upgrades.", EventLevel.Informational))
             {
-                if (prerunChecker.TryRunPreUpgradeChecks(out string _) && this.TryDownloadUpgrade(productUpgrader, out errorMessage))
+                try
                 {
-                    deleteExistingDownloads = false;
+                    // The upgrade check always goes against GitHub
+                    GitHubUpgrader productUpgrader = GitHubUpgrader.Create(
+                        this.tracer,
+                        dryRun: false,
+                        noVerify: false,
+                        error: out errorMessage);
+
+                    if (productUpgrader == null)
+                    {
+                        activity.RelatedWarning(
+                            "{0}.{1}: GitHubUpgrader.Create failed to create upgrader: {2}",
+                            nameof(ProductUpgradeTimer),
+                            nameof(this.TimerCallback),
+                            errorMessage);
+                        return;
+                    }
+
+                    InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);
+                    if (!prerunChecker.TryRunPreUpgradeChecks(out errorMessage))
+                    {
+                        activity.RelatedWarning(
+                            "{0}.{1}: PreUpgradeChecks failed with: {2}",
+                            nameof(ProductUpgradeTimer),
+                            nameof(this.TimerCallback),
+                            errorMessage);
+                        return;
+                    }
+
+                    if (!productUpgrader.UpgradeAllowed(out errorMessage))
+                    {
+                        errorMessage = errorMessage ??
+                            $"{nameof(ProductUpgradeTimer)}.{nameof(this.TimerCallback)}: Upgrade is not allowed, but no reason provided.";
+                        this.tracer.RelatedWarning(errorMessage);
+                        return;
+                    }
+
+                    if (!this.TryQueryForNewerVersion(
+                            activity,
+                            productUpgrader,
+                            out Version newerVersion,
+                            out errorMessage))
+                    {
+                        this.tracer.RelatedError(errorMessage);
+                        return;
+                    }
+
+                    ProductUpgraderInfo.RecordHighestAvailableVersion(newerVersion);
                 }
-            }
-
-            if (errorMessage != null)
-            {
-                this.tracer.RelatedError(errorMessage);
-            }
-
-            if (deleteExistingDownloads)
-            {
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                catch (Exception ex) when (
+                    ex is IOException ||
+                    ex is UnauthorizedAccessException ||
+                    ex is NotSupportedException)
+                {
+                    this.tracer.RelatedWarning(
+                        CreateEventMetadata(ex),
+                        "Exception encountered recording highest available version");
+                }
+                catch (Exception ex)
+                {
+                    this.tracer.RelatedError(
+                        CreateEventMetadata(ex),
+                        "Unhanlded exception encountered recording highest available version");
+                    Environment.Exit((int)ReturnCode.GenericError);
+                }
             }
         }
 
-        private bool TryDownloadUpgrade(IProductUpgrader productUpgrader, out string errorMessage)
+        private bool TryQueryForNewerVersion(ITracer tracer, GitHubUpgrader productUpgrader, out Version newVersion, out string errorMessage)
         {
-            using (ITracer activity = this.tracer.StartActivity("Checking for product upgrades.", EventLevel.Informational))
+            errorMessage = null;
+            tracer.RelatedInfo("Querying server for latest version...");
+
+            if (!productUpgrader.TryQueryNewestVersion(out newVersion, out string detailedError))
             {
-                Version newerVersion = null;
-                string detailedError = null;
-                if (!productUpgrader.UpgradeAllowed(out errorMessage))
-                {
-                    return false;
-                }
-
-                if (!productUpgrader.TryQueryNewestVersion(out newerVersion, out detailedError))
-                {
-                    errorMessage = "Could not fetch new version info. " + detailedError;
-                    return false;
-                }
-
-                if (newerVersion == null)
-                {
-                    // Already up-to-date
-                    // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
-                    // upgraded by manually downloading and running asset installers.
-                    ProductUpgraderInfo.DeleteAllInstallerDownloads();
-                    errorMessage = null;
-                    return true;
-                }
-
-                if (productUpgrader.TryDownloadNewestVersion(out detailedError))
-                {
-                    errorMessage = null;
-                    return true;
-                }
-                else
-                {
-                    errorMessage = "Could not download product upgrade. " + detailedError;
-                    return false;
-                }
+                errorMessage = "Could not fetch new version info. " + detailedError;
+                return false;
             }
+
+            string logMessage = newVersion == null ? "No newer versions available." : $"Newer version available: {newVersion}.";
+            tracer.RelatedInfo(logMessage);
+
+            return true;
         }
     }
 }

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
@@ -12,10 +13,12 @@ namespace GVFS.Service
         private static readonly TimeSpan TimeInterval = TimeSpan.FromDays(1);
         private JsonTracer tracer;
         private Timer timer;
+        private PhysicalFileSystem fileSystem;
 
         public ProductUpgradeTimer(JsonTracer tracer)
         {
             this.tracer = tracer;
+            this.fileSystem = new PhysicalFileSystem();
         }
 
         public void Start()
@@ -117,7 +120,10 @@ namespace GVFS.Service
                         return;
                     }
 
-                    ProductUpgraderInfo.RecordHighestAvailableVersion(newerVersion);
+                    ProductUpgraderInfo info = new ProductUpgraderInfo(
+                        this.tracer,
+                        this.fileSystem);
+                    info.RecordHighestAvailableVersion(newerVersion);
                 }
                 catch (Exception ex) when (
                     ex is IOException ||

--- a/GVFS/GVFS.UnitTests/Common/ProductUpgraderInfoTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/ProductUpgraderInfoTests.cs
@@ -1,0 +1,79 @@
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class ProductUpgraderInfoTests
+    {
+        private Mock<PhysicalFileSystem> mockFileSystem;
+        private ProductUpgraderInfo productUpgraderInfo;
+        private string upgradeDirectory;
+        private string expectedNewVersionExistsFileName = "HighestAvailableVersion";
+        private string expectedNewVersionExistsFilePath;
+        private MockTracer tracer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.upgradeDirectory = Paths.GetServiceDataRoot(ProductUpgraderInfo.UpgradeDirectoryName);
+            this.expectedNewVersionExistsFilePath = Path.Combine(this.upgradeDirectory, this.expectedNewVersionExistsFileName);
+            this.mockFileSystem = new Mock<PhysicalFileSystem>();
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.WriteAllText(this.expectedNewVersionExistsFilePath, It.IsAny<string>()));
+
+            this.tracer = new MockTracer();
+
+            this.productUpgraderInfo = new ProductUpgraderInfo(
+                this.tracer,
+                this.mockFileSystem.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.mockFileSystem = null;
+            this.productUpgraderInfo = null;
+            this.tracer = null;
+        }
+
+        [TestCase]
+        public void RecordHighestVersion()
+        {
+            this.productUpgraderInfo.RecordHighestAvailableVersion(new Version("1.0.0.0"));
+            this.mockFileSystem.Verify(fileSystem => fileSystem.WriteAllText(this.expectedNewVersionExistsFilePath, It.IsAny<string>()), Times.Once());
+        }
+
+        [TestCase]
+        public void RecordingEmptyVersionDeletesExistingHighestVersionFile()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath)).Returns(true);
+
+            this.productUpgraderInfo.RecordHighestAvailableVersion(null);
+
+            this.mockFileSystem.Verify(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath), Times.Once());
+            this.mockFileSystem.Verify(fileSystem => fileSystem.DeleteFile(this.expectedNewVersionExistsFilePath), Times.Once());
+        }
+
+        [TestCase]
+        public void RecordingEmptyVersionDoesNotDeleteNonExistingHighestVersionFile()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath)).Returns(false);
+
+            this.productUpgraderInfo.RecordHighestAvailableVersion(null);
+
+            this.mockFileSystem.Verify(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath), Times.Once());
+            this.mockFileSystem.Verify(fileSystem => fileSystem.DeleteFile(this.expectedNewVersionExistsFilePath), Times.Never());
+        }
+    }
+}

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
@@ -14,6 +15,7 @@ namespace GVFS.Upgrader
 
         private IProductUpgrader upgrader;
         private ITracer tracer;
+        private PhysicalFileSystem fileSystem;
         private InstallerPreRunChecker preRunChecker;
         private TextWriter output;
         private TextReader input;
@@ -28,6 +30,7 @@ namespace GVFS.Upgrader
         {
             this.upgrader = upgrader;
             this.tracer = tracer;
+            this.fileSystem = new PhysicalFileSystem();
             this.preRunChecker = preRunChecker;
             this.output = output;
             this.input = input;
@@ -157,7 +160,10 @@ namespace GVFS.Upgrader
 
             if (!this.upgrader.UpgradeAllowed(out error))
             {
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    this.fileSystem);
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.output.WriteLine(error);
                 consoleError = null;
                 newVersion = null;

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
@@ -136,7 +137,10 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    new PhysicalFileSystem());
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -152,7 +156,10 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    new PhysicalFileSystem());
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }


### PR DESCRIPTION
When an upgrade is available, GVFS will download the update in the
background, and git commands will periodically check for the existence
of the downloaded package in a well known directory to advertise that an
update is available.

However, this downloaded update is not used for the actual update.

This changes the logic to write out a file in a well known location
containing the version of the latest available update, and avoid
downloading the actual update.

While this change stands on its own, it will be even more applicable
with the NuGet Upgrader, which will still use GitHub releases to check
for available updates, but will download the actual update from another
location.