### PR TITLE
Mac syscall tracing: Initial updates to dtruss and some basic documentation

### DIFF
--- a/Scripts/Mac/Tracing/Docs/cddl1.txt
+++ b/Scripts/Mac/Tracing/Docs/cddl1.txt
@@ -1,0 +1,385 @@
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+
+
+      1. Definitions.
+
+            1.1. “Contributor” means each individual or entity that
+            creates or contributes to the creation of Modifications.
+
+            1.2. “Contributor Version” means the combination of the
+            Original Software, prior Modifications used by a
+            Contributor (if any), and the Modifications made by that
+            particular Contributor.
+
+            1.3. “Covered Software” means (a) the Original Software, or
+            (b) Modifications, or (c) the combination of files
+            containing Original Software with files containing
+            Modifications, in each case including portions thereof.
+
+            1.4. “Executable” means the Covered Software in any form
+            other than Source Code. 
+
+            1.5. “Initial Developer” means the individual or entity
+            that first makes Original Software available under this
+            License. 
+            
+            1.6. “Larger Work” means a work which combines Covered
+            Software or portions thereof with code not governed by the
+            terms of this License.
+
+            1.7. “License” means this document.
+
+            1.8. “Licensable” means having the right to grant, to the
+            maximum extent possible, whether at the time of the initial
+            grant or subsequently acquired, any and all of the rights
+            conveyed herein.
+            
+            1.9. “Modifications” means the Source Code and Executable
+            form of any of the following: 
+
+                  A. Any file that results from an addition to,
+                  deletion from or modification of the contents of a
+                  file containing Original Software or previous
+                  Modifications; 
+
+                  B. Any new file that contains any part of the
+                  Original Software or previous Modification; or 
+
+                  C. Any new file that is contributed or otherwise made
+                  available under the terms of this License.
+
+            1.10. “Original Software” means the Source Code and
+            Executable form of computer software code that is
+            originally released under this License. 
+
+            1.11. “Patent Claims” means any patent claim(s), now owned
+            or hereafter acquired, including without limitation,
+            method, process, and apparatus claims, in any patent
+            Licensable by grantor. 
+
+            1.12. “Source Code” means (a) the common form of computer
+            software code in which modifications are made and (b)
+            associated documentation included in or with such code.
+
+            1.13. “You” (or “Your”) means an individual or a legal
+            entity exercising rights under, and complying with all of
+            the terms of, this License. For legal entities, “You”
+            includes any entity which controls, is controlled by, or is
+            under common control with You. For purposes of this
+            definition, “control” means (a) the power, direct or
+            indirect, to cause the direction or management of such
+            entity, whether by contract or otherwise, or (b) ownership
+            of more than fifty percent (50%) of the outstanding shares
+            or beneficial ownership of such entity.
+
+      2. License Grants. 
+
+            2.1. The Initial Developer Grant.
+
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, the
+            Initial Developer hereby grants You a world-wide,
+            royalty-free, non-exclusive license: 
+
+                  (a) under intellectual property rights (other than
+                  patent or trademark) Licensable by Initial Developer,
+                  to use, reproduce, modify, display, perform,
+                  sublicense and distribute the Original Software (or
+                  portions thereof), with or without Modifications,
+                  and/or as part of a Larger Work; and 
+
+                  (b) under Patent Claims infringed by the making,
+                  using or selling of Original Software, to make, have
+                  made, use, practice, sell, and offer for sale, and/or
+                  otherwise dispose of the Original Software (or
+                  portions thereof). 
+
+                  (c) The licenses granted in Sections 2.1(a) and (b)
+                  are effective on the date Initial Developer first
+                  distributes or otherwise makes the Original Software
+                  available to a third party under the terms of this
+                  License. 
+
+                  (d) Notwithstanding Section 2.1(b) above, no patent
+                  license is granted: (1) for code that You delete from
+                  the Original Software, or (2) for infringements
+                  caused by: (i) the modification of the Original
+                  Software, or (ii) the combination of the Original
+                  Software with other software or devices. 
+
+            2.2. Contributor Grant.
+
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, each
+            Contributor hereby grants You a world-wide, royalty-free,
+            non-exclusive license:
+
+                  (a) under intellectual property rights (other than
+                  patent or trademark) Licensable by Contributor to
+                  use, reproduce, modify, display, perform, sublicense
+                  and distribute the Modifications created by such
+                  Contributor (or portions thereof), either on an
+                  unmodified basis, with other Modifications, as
+                  Covered Software and/or as part of a Larger Work; and
+                  
+
+                  (b) under Patent Claims infringed by the making,
+                  using, or selling of Modifications made by that
+                  Contributor either alone and/or in combination with
+                  its Contributor Version (or portions of such
+                  combination), to make, use, sell, offer for sale,
+                  have made, and/or otherwise dispose of: (1)
+                  Modifications made by that Contributor (or portions
+                  thereof); and (2) the combination of Modifications
+                  made by that Contributor with its Contributor Version
+                  (or portions of such combination). 
+
+                  (c) The licenses granted in Sections 2.2(a) and
+                  2.2(b) are effective on the date Contributor first
+                  distributes or otherwise makes the Modifications
+                  available to a third party. 
+
+                  (d) Notwithstanding Section 2.2(b) above, no patent
+                  license is granted: (1) for any code that Contributor
+                  has deleted from the Contributor Version; (2) for
+                  infringements caused by: (i) third party
+                  modifications of Contributor Version, or (ii) the
+                  combination of Modifications made by that Contributor
+                  with other software (except as part of the
+                  Contributor Version) or other devices; or (3) under
+                  Patent Claims infringed by Covered Software in the
+                  absence of Modifications made by that Contributor. 
+
+      3. Distribution Obligations.
+
+            3.1. Availability of Source Code.
+
+            Any Covered Software that You distribute or otherwise make
+            available in Executable form must also be made available in
+            Source Code form and that Source Code form must be
+            distributed only under the terms of this License. You must
+            include a copy of this License with every copy of the
+            Source Code form of the Covered Software You distribute or
+            otherwise make available. You must inform recipients of any
+            such Covered Software in Executable form as to how they can
+            obtain such Covered Software in Source Code form in a
+            reasonable manner on or through a medium customarily used
+            for software exchange.
+
+            3.2. Modifications.
+
+            The Modifications that You create or to which You
+            contribute are governed by the terms of this License. You
+            represent that You believe Your Modifications are Your
+            original creation(s) and/or You have sufficient rights to
+            grant the rights conveyed by this License.
+
+            3.3. Required Notices.
+
+            You must include a notice in each of Your Modifications
+            that identifies You as the Contributor of the Modification.
+            You may not remove or alter any copyright, patent or
+            trademark notices contained within the Covered Software, or
+            any notices of licensing or any descriptive text giving
+            attribution to any Contributor or the Initial Developer.
+
+            3.4. Application of Additional Terms.
+
+            You may not offer or impose any terms on any Covered
+            Software in Source Code form that alters or restricts the
+            applicable version of this License or the recipients’
+            rights hereunder. You may choose to offer, and to charge a
+            fee for, warranty, support, indemnity or liability
+            obligations to one or more recipients of Covered Software.
+            However, you may do so only on Your own behalf, and not on
+            behalf of the Initial Developer or any Contributor. You
+            must make it absolutely clear that any such warranty,
+            support, indemnity or liability obligation is offered by
+            You alone, and You hereby agree to indemnify the Initial
+            Developer and every Contributor for any liability incurred
+            by the Initial Developer or such Contributor as a result of
+            warranty, support, indemnity or liability terms You offer.
+          
+
+            3.5. Distribution of Executable Versions.
+
+            You may distribute the Executable form of the Covered
+            Software under the terms of this License or under the terms
+            of a license of Your choice, which may contain terms
+            different from this License, provided that You are in
+            compliance with the terms of this License and that the
+            license for the Executable form does not attempt to limit
+            or alter the recipient’s rights in the Source Code form
+            from the rights set forth in this License. If You
+            distribute the Covered Software in Executable form under a
+            different license, You must make it absolutely clear that
+            any terms which differ from this License are offered by You
+            alone, not by the Initial Developer or Contributor. You
+            hereby agree to indemnify the Initial Developer and every
+            Contributor for any liability incurred by the Initial
+            Developer or such Contributor as a result of any such terms
+            You offer.
+
+            3.6. Larger Works.
+
+            You may create a Larger Work by combining Covered Software
+            with other code not governed by the terms of this License
+            and distribute the Larger Work as a single product. In such
+            a case, You must make sure the requirements of this License
+            are fulfilled for the Covered Software. 
+            
+      4. Versions of the License. 
+
+            4.1. New Versions.
+
+            Sun Microsystems, Inc. is the initial license steward and
+            may publish revised and/or new versions of this License
+            from time to time. Each version will be given a
+            distinguishing version number. Except as provided in
+            Section 4.3, no one other than the license steward has the
+            right to modify this License. 
+
+            4.2. Effect of New Versions.
+
+            You may always continue to use, distribute or otherwise
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. If the Initial Developer includes a
+            notice in the Original Software prohibiting it from being
+            distributed or otherwise made available under any
+            subsequent version of the License, You must distribute and
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. Otherwise, You may also choose to
+            use, distribute or otherwise make the Covered Software
+            available under the terms of any subsequent version of the
+            License published by the license steward. 
+
+            4.3. Modified Versions.
+
+            When You are an Initial Developer and You want to create a
+            new license for Your Original Software, You may create and
+            use a modified version of this License if You: (a) rename
+            the license and remove any references to the name of the
+            license steward (except to note that the license differs
+            from this License); and (b) otherwise make it clear that
+            the license contains terms which differ from this License.
+            
+
+      5. DISCLAIMER OF WARRANTY.
+
+      COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN “AS IS”
+      BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+      INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+      SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+      PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND
+      PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY
+      COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+      INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF
+      ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF
+      WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+      ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+      DISCLAIMER. 
+
+      6. TERMINATION. 
+
+            6.1. This License and the rights granted hereunder will
+            terminate automatically if You fail to comply with terms
+            herein and fail to cure such breach within 30 days of
+            becoming aware of the breach. Provisions which, by their
+            nature, must remain in effect beyond the termination of
+            this License shall survive.
+
+            6.2. If You assert a patent infringement claim (excluding
+            declaratory judgment actions) against Initial Developer or
+            a Contributor (the Initial Developer or Contributor against
+            whom You assert such claim is referred to as “Participant”)
+            alleging that the Participant Software (meaning the
+            Contributor Version where the Participant is a Contributor
+            or the Original Software where the Participant is the
+            Initial Developer) directly or indirectly infringes any
+            patent, then any and all rights granted directly or
+            indirectly to You by such Participant, the Initial
+            Developer (if the Initial Developer is not the Participant)
+            and all Contributors under Sections 2.1 and/or 2.2 of this
+            License shall, upon 60 days notice from Participant
+            terminate prospectively and automatically at the expiration
+            of such 60 day notice period, unless if within such 60 day
+            period You withdraw Your claim with respect to the
+            Participant Software against such Participant either
+            unilaterally or pursuant to a written agreement with
+            Participant.
+
+            6.3. In the event of termination under Sections 6.1 or 6.2
+            above, all end user licenses that have been validly granted
+            by You or any distributor hereunder prior to termination
+            (excluding licenses granted to You by any distributor)
+            shall survive termination.
+
+      7. LIMITATION OF LIABILITY.
+
+      UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+      (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+      INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+      COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+      LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+      CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+      LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+      STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+      COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+      INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+      LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+      INJURY RESULTING FROM SUCH PARTY’S NEGLIGENCE TO THE EXTENT
+      APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO
+      NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+      CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+      APPLY TO YOU.
+
+      8. U.S. GOVERNMENT END USERS.
+
+      The Covered Software is a “commercial item,” as that term is
+      defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of “commercial
+      computer software” (as that term is defined at 48 C.F.R. §
+      252.227-7014(a)(1)) and “commercial computer software
+      documentation” as such terms are used in 48 C.F.R. 12.212 (Sept.
+      1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+      through 227.7202-4 (June 1995), all U.S. Government End Users
+      acquire Covered Software with only those rights set forth herein.
+      This U.S. Government Rights clause is in lieu of, and supersedes,
+      any other FAR, DFAR, or other clause or provision that addresses
+      Government rights in computer software under this License.
+
+      9. MISCELLANEOUS.
+
+      This License represents the complete agreement concerning subject
+      matter hereof. If any provision of this License is held to be
+      unenforceable, such provision shall be reformed only to the
+      extent necessary to make it enforceable. This License shall be
+      governed by the law of the jurisdiction specified in a notice
+      contained within the Original Software (except to the extent
+      applicable law, if any, provides otherwise), excluding such
+      jurisdiction’s conflict-of-law provisions. Any litigation
+      relating to this License shall be subject to the jurisdiction of
+      the courts located in the jurisdiction and venue specified in a
+      notice contained within the Original Software, with the losing
+      party responsible for costs, including, without limitation, court
+      costs and reasonable attorneys’ fees and expenses. The
+      application of the United Nations Convention on Contracts for the
+      International Sale of Goods is expressly excluded. Any law or
+      regulation which provides that the language of a contract shall
+      be construed against the drafter shall not apply to this License.
+      You agree that You alone are responsible for compliance with the
+      United States export administration regulations (and the export
+      control laws and regulation of any other countries) when You use,
+      distribute or otherwise make available any Covered Software.
+
+      10. RESPONSIBILITY FOR CLAIMS.
+
+      As between Initial Developer and the Contributors, each party is
+      responsible for claims and damages arising, directly or
+      indirectly, out of its utilization of rights under this License
+      and You agree to work with Initial Developer and Contributors to
+      distribute such responsibility on an equitable basis. Nothing
+      herein is intended or shall be deemed to constitute any admission
+      of liability.

--- a/Scripts/Mac/Tracing/Tracing.md
+++ b/Scripts/Mac/Tracing/Tracing.md
@@ -1,0 +1,78 @@
+# Tracing on macOS
+
+[DTrace](https://en.wikipedia.org/wiki/DTrace) is the main low-level tool for tracing and diagnostics on macOS.
+For diagnosing issues potentially caused by VFS for Git, tracing syscalls to track down errors has proven to be a useful technique on Windows.
+On macOS, the DTrace script `dtruss` which ships with the OS can be used for tracing system calls made by processes.
+However, it has not been updated for newer OS versions for a while, making some of its features unreliable.
+We therefore recommend using our [updated version of the script](./dtruss), and the instructions below assume you are using this version.
+
+## TL;DR: This build command is failing/misbehaving and I've been asked to collect a trace
+
+To capture a trace of the syscalls made by the failing command, run the following:
+
+    ++path-to-vfs4g-source++/Scripts/Mac/Tracing/dtruss -d -e -F -f    ++command-to-run++   2> >(tee   ++trace-filename.txt++   >&2)
+
+## General tips
+
+`dtruss` simply outputs a live list of all syscalls (or all calls to one specific syscall) made by the selected/matching process(es), including return value/errno and arguments.
+Arguments are formatted for human readability to some extent. (e.g. string arguments are typically printed as a string, not just the raw `char` pointer.)
+
+The output is written to stderr, so to save it to a file use `2> filename.txt`, or to both save it to file *and* print it to the terminal, this will work in `bash`:
+
+    sudo dtruss -p 1000    2> >(tee clang-trace.txt >&2)
+
+When starting `dtruss`, wait for the column headers to appear before starting whatever activity you're trying to trace; dtrace can take a few seconds to compile and inject the script, and events that occur before this is done will be dropped.
+This is of course not an issue if you are starting the traced command on the `dtruss` command line directly.
+The column headers will look something like this, the exact headers will depend on the command line flags passed:
+
+    	PID/THRD  RELATIVE  ELAPSD SYSCALL(args) 		 = return
+
+## Specifying processes to trace
+
+### Named processes
+
+Use `-n <processname>`, for example if there seems to be a problem with syscalls made by `clang`:
+
+    sudo ./Scripts/Mac/Tracing/dtruss -d -e -n clang
+
+Note that process names in macOS are limited to `MAXCOMLEN`, i.e. 16 characters.
+
+The `-d` and `-e` flags enable printing of time stamps (in µs, where 0 = time when `dtruss` was started) and elapsed wall time during the syscall (also µs), respectively. 
+
+### By PID
+
+Use `-p <PID>` in place of `-n`.
+
+### Tracing a command
+
+For tracing processes started from the command line, launching the command directly together with dtruss is typically the most convenient. To trace the `ls` command, simply use:
+
+    ./Scripts/Mac/Tracing/dtruss ls 
+
+Note the lack of `sudo` on this command. This was required on stock `dtruss` but meant all commands launched this way ran as the root user. Instead, the script now runs only `dtrace` itself as root via sudo, so you will still need to be an admin (`wheel` group) and type your password.
+
+### Tracing child processes
+
+Often, the thing you're trying to diagnose is a more complex mix of multiple processes; for example, building some software from source will typically kick off many different processes for the build system itself, compilers, linkers, and other tools. For tracing the activity of the whole build, it's often most convenient to trace the root build command *and all processes launched by it, recursively.*
+`dtruss` supports this via the `-f` flag, which can be combined with any of the other process selectors. For example:
+
+     ./Scripts/Mac/Tracing/dtruss -d -e -f xcodebuild
+
+This will run an `xcodebuild` in the current directory, trace that process and any other processes below it in the hierarchy and additionally output time stamps and syscall runtimes.
+
+## Changes over stock `dtruss`
+
+For reference, the following improvements have been made so far:
+
+ * When launching a command with `dtruss`, it's now possible to run the command as a non-root user. Simply run `dtruss [-options] <command>` as a non-privileged admin user; the command will run as this user, and `dtrace` itself will be run as root via `sudo` (you will likely be prompted for your password).
+ * Correct logging of `execve()` and `posix_spawn()` syscalls.
+ * Improvements to output for syscalls with buffer or string parameters. (Better handling of `NULL` pointers, large buffers, etc.)  
+ * A new `-F` option for filtering out common but typically uninteresting syscalls. At the moment, this only filters out `close()` calls returning `EBADF`. Some programs seem to call `close()` on thousands of sequential integers, most of which are not valid file descriptors.
+ * The mode for following child processes (`-f`) is much more reliable. Previously, processes created with `posix_spawn()` were typically ignored. (They were typically only detected if the parent process had previously already used `fork()`; a mix of both techniques in the same program is rare, however.) `posix_spawn()` is a very common method for creating new processes on macOS nowadays, especially as `fork()`/`execve()` is explicitly disallowed for Objective-C based apps. Following `posix_spawn()`ed processes is now directly supported and some bugs that tended to occur when following *any* child process have also been fixed.
+
+### Remaining bugs/limitations in `dtruss`
+
+ * `dtruss` no longer exits when the specified command itself exits. (This regression is a consequence of the non-privileged command launch change.)
+ * There are still some syscalls which are badly formatted in the trace output.
+ * The buffers can fill up and miss events when a lot of traced events occur. This is indicated by the message `dtrace: 6228 dynamic variable drops with non-empty dirty list` - try increasing the dynamic variable memory (e.g. `-b 100m` for 100MB - default is currently 30MB) in this case. Better still, try to narrow the focus of your tracing.
+ * Currently, you can trace either all syscalls or just one, not some subset.

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -1,0 +1,1045 @@
+#!/bin/sh
+# #!/usr/bin/sh
+#
+# dtruss - print process system call time details.
+#          Written using DTrace (Solaris 10 3/05).
+#
+# 17-Jun-2005, ver 0.80         (check for newer versions)
+#
+# USAGE: dtruss [-acdeflhoLs] [-t syscall] { -p PID | -n name | command }
+#
+#          -p PID          # examine this PID
+#          -n name         # examine this process name
+#          -t syscall      # examine this syscall only
+#          -a              # print all details
+#          -c              # print system call counts
+#          -d              # print relative timestamps (us)
+#          -e              # print elapsed times (us)
+#          -f              # follow children as they are forked
+#          -l              # force printing of pid/lwpid per line
+#          -o              # print on cpu times (us)
+#          -s              # print stack backtraces
+#          -L              # don't print pid/lwpid per line
+#          -b bufsize      # dynamic variable buf size (default is "4m")
+#  eg,
+#       dtruss df -h       # run and examine the "df -h" command
+#       dtruss -p 1871     # examine PID 1871
+#       dtruss -n tar      # examine all processes called "tar"
+#       dtruss -f test.sh  # run test.sh and follow children
+#
+# The elapsed times are interesting, to help identify syscalls that take
+#  some time to complete (during which the process may have context
+#  switched off the CPU). 
+#
+# SEE ALSO: procsystime    # DTraceToolkit
+#           dapptrace      # DTraceToolkit
+#           truss
+#
+# COPYRIGHT: Copyright (c) 2005 Brendan Gregg.
+#
+# CDDL HEADER START
+#
+#  The contents of this file are subject to the terms of the
+#  Common Development and Distribution License, Version 1.0 only
+#  (the "License").  You may not use this file except in compliance
+#  with the License.
+#
+#  You can obtain a copy of the license at Docs/cddl1.txt
+#  or http://www.opensolaris.org/os/licensing.
+#  See the License for the specific language governing permissions
+#  and limitations under the License.
+#
+# CDDL HEADER END
+#
+# Author: Brendan Gregg  [Sydney, Australia]
+#
+# TODO: Track signals, more output formatting.
+#
+# 29-Apr-2005   Brendan Gregg   Created this.
+# 09-May-2005      "      " 	Fixed evaltime (thanks Adam L.)
+# 16-May-2005	   "      "	Added -t syscall tracing.
+# 17-Jun-2005	   "      "	Added -s stack backtraces.
+#
+
+
+##############################
+# --- Process Arguments ---
+#
+
+### Default variables
+opt_pid=0; opt_name=0; pid=0; pname="."
+opt_elapsed=0; opt_cpu=0; opt_counts=0; 
+opt_relative=0; opt_printid=0; opt_follow=0
+opt_command=0; command=""; opt_buf=0; buf="4m"
+opt_trace=0; trace="."; opt_stack=0;
+opt_wait=0; wname="."; opt_has_target=0
+### Process options
+while getopts ab:cdefhln:op:st:LW: name
+do
+        case $name in
+	b)	opt_buf=1; buf=$OPTARG ;;
+        p)      opt_pid=1; pid=$OPTARG ;;
+        n)      opt_name=1; pname=$OPTARG ;;
+        W)      opt_wait=1; wname=$OPTARG ;;
+        t)      opt_trace=1; trace=$OPTARG ;;
+	a)	opt_counts=1; opt_relative=1; opt_elapsed=1; opt_follow=1
+		opt_printid=1; opt_cpu=1 ;;
+	c)	opt_counts=1 ;;
+	d)	opt_relative=1 ;;
+	e)	opt_elapsed=1 ;;
+	f)	opt_follow=1 ;;
+	l)	opt_printid=1 ;;
+	o)	opt_cpu=1 ;;
+	L)	opt_printid=-1 ;;
+	s)	opt_stack=-1 ;;
+        h|?)    cat <<-END >&2
+		USAGE: dtruss [-acdefholLs] [-t syscall] { -p PID | -n name | command | -W name }
+
+		          -p PID          # examine this PID
+		          -n name         # examine this process name
+		          -t syscall      # examine this syscall only
+		          -W name         # wait for a process matching this name
+		          -a              # print all details
+		          -c              # print syscall counts
+		          -d              # print relative times (us)
+		          -e              # print elapsed times (us)
+		          -f              # follow children
+		          -l              # force printing pid/lwpid
+		          -o              # print on cpu times
+		          -s              # print stack backtraces
+		          -L              # don't print pid/lwpid
+		          -b bufsize      # dynamic variable buf size
+		   eg,
+		       dtruss df -h       # run and examine "df -h"
+		       dtruss -p 1871     # examine PID 1871
+		       dtruss -n tar      # examine all processes called "tar"
+		       dtruss -f test.sh  # run test.sh and follow children
+		END
+		exit 1
+        esac
+done
+shift `expr $OPTIND - 1`
+
+### Option logic
+if [ $opt_pid -eq 0 -a $opt_name -eq 0 -a $opt_wait -eq 0 ]; then
+	opt_has_target=1
+	opt_command=1
+	if [ "$*" = "" ]; then
+		$0 -h
+		exit
+	fi
+	command="$*"	# yes, I meant $*!
+fi
+if [ $opt_wait -eq 1 ]; then
+	opt_has_target=1
+fi
+if [ $opt_follow -eq 1 -o $opt_name -eq 1 ]; then
+	if [ $opt_printid -ne -1 ]; then
+		opt_printid=1
+	else
+		opt_printid=0
+	fi
+fi
+
+### Option translation
+## if [ "$trace" = "exec" ]; then trace="exece"; fi
+if [ "$trace" = "exec" ]; then trace="execve"; fi
+
+
+#################################
+# --- Main Program, DTrace ---
+#
+
+### Define D Script
+dtrace='
+ #pragma D option quiet
+ 
+ /*
+  * Command line arguments
+  */
+ inline int OPT_has_target   = '$opt_has_target';
+ inline int OPT_follow    = '$opt_follow';
+ inline int OPT_printid   = '$opt_printid';
+ inline int OPT_relative  = '$opt_relative';
+ inline int OPT_elapsed   = '$opt_elapsed';
+ inline int OPT_cpu       = '$opt_cpu';
+ inline int OPT_counts    = '$opt_counts';
+ inline int OPT_pid       = '$opt_pid';
+ inline int OPT_name      = '$opt_name';
+ inline int OPT_trace     = '$opt_trace';
+ inline int OPT_stack     = '$opt_stack';
+ inline int PID           = '$pid';
+ inline string NAME       = "'"$pname"'";
+ inline string TRACE      = "'$trace'";
+
+ dtrace:::BEGIN 
+ {
+	/* print header */
+	/* OPT_printid  ? printf("%-8s  ","PID/LWP") : 1; */
+	OPT_printid  ? printf("\t%-8s  ","PID/THRD") : 1;
+	OPT_relative ? printf("%8s ","RELATIVE") : 1;
+	OPT_elapsed  ? printf("%7s ","ELAPSD") : 1;
+	OPT_cpu      ? printf("%6s ","CPU") : 1;
+	printf("SYSCALL(args) \t\t = return\n");
+
+	/* Apple: Names of top-level sysctl MIBs */
+	sysctl_first[0] = "CTL_UNSPEC";
+	sysctl_first[1] = "CTL_KERN";
+	sysctl_first[2] = "CTL_VM";
+	sysctl_first[3] = "CTL_VFS";
+	sysctl_first[4] = "CTL_NET";
+	sysctl_first[5] = "CTL_DEBUG";
+	sysctl_first[6] = "CTL_HW";
+	sysctl_first[7] = "CTL_MACHDEP";
+	sysctl_first[9] = "CTL_MAXID";
+
+	/* globals */
+	trackedpid[pid] = 0;
+	self->child = 0;
+	this->type = 0;
+ }
+
+ /*
+  * Save syscall entry info
+  */
+
+ /* MacOS X: notice first appearance of child from fork. Its parent
+    fires syscall::*fork:return in the ususal way (see below) */
+ syscall:::entry
+ /OPT_follow && trackedpid[ppid] == -1 && 0 == self->child/
+ {
+	/* set as child */
+	self->child = 1;
+
+	/* print output */
+	self->code = errno == 0 ? "" : "Err#";
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d:  ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d:  ",0) : 1;
+	OPT_cpu      ? printf("%6d ",0) : 1;
+	printf("%s()\t\t = %d %s%d\n","fork",
+	    0,self->code,(int)errno);
+ }
+
+ /* MacOS X: notice first appearance of child and parent from vfork */
+ syscall:::entry
+ /OPT_follow && trackedpid[ppid] > 0 && 0 == self->child/
+ {
+	/* set as child */
+	this->vforking_tid = trackedpid[ppid];
+	self->child = (this->vforking_tid == tid) ? 0 : 1;
+
+	/* print output */
+	self->code = errno == 0 ? "" : "Err#";
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",(this->vforking_tid == tid) ? ppid : pid,tid) : 1;
+	OPT_relative ? printf("%8d:  ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d:  ",0) : 1;
+	OPT_cpu      ? printf("%6d ",0) : 1;
+	printf("%s()\t\t = %d %s%d\n","vfork",
+	    (this->vforking_tid == tid) ? pid : 0,self->code,(int)errno);
+ }
+ 
+ syscall:::entry
+ /(OPT_has_target && pid == $target) ||
+  (OPT_pid && pid == PID) ||
+  (OPT_name && NAME == strstr(NAME, execname)) ||
+  (OPT_name && execname == strstr(execname, NAME)) ||
+  (self->child)/
+ {
+	/* set start details */
+	self->start = timestamp;
+	self->vstart = vtimestamp;
+	self->arg0 = arg0;
+	self->arg1 = arg1;
+	self->arg2 = arg2;
+
+	/* count occurances */
+	OPT_counts == 1 ? @Counts[probefunc] = count() : 1;
+ }
+
+/* 4, 5 and 6 arguments */
+ syscall::select:entry,
+ syscall::mmap:entry,
+ syscall::pwrite:entry,
+ syscall::pread:entry,
+ syscall::openat:entry,
+ syscall::unlinkat:entry,
+ syscall::getattrlistat:entry,
+ syscall::readlinkat:entry,
+ syscall::linkat:entry,
+ syscall::fchownat:entry,
+ syscall::renameat:entry,
+ syscall::sysctl:entry,
+ syscall::sysctlbyname:entry,
+ syscall::faccessat:entry,
+ syscall::kdebug_trace64:entry
+ /(OPT_has_target && pid == $target) ||
+  (OPT_pid && pid == PID) ||
+  (OPT_name && NAME == strstr(NAME, execname)) ||
+  (OPT_name && execname == strstr(execname, NAME)) ||
+  (self->child)/
+ {
+	self->arg3 = arg3;
+	self->arg4 = arg4;
+	self->arg5 = arg5;
+ }
+
+ /*
+  * Follow children
+  */
+ syscall::fork:entry
+ /OPT_follow && self->start/
+ {
+	/* track this parent process */
+	trackedpid[pid] = -1;
+ }
+ 
+ syscall::vfork:entry
+ /OPT_follow && self->start/
+ {
+	/* track this parent process */
+	trackedpid[pid] = tid;
+ }
+ 
+ /* syscall::rexit:entry */
+ syscall::exit:entry
+ {
+	/* forget child */
+	self->child = 0;
+	trackedpid[pid] = 0;
+ }
+
+ /*
+  * Check for syscall tracing
+  */
+ syscall:::entry
+ /OPT_trace && probefunc != TRACE/
+ {
+	/* drop info */
+	self->start = 0;
+	self->vstart = 0;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+	self->arg5 = 0;
+ }
+
+ /*
+  * Print return data
+  */
+
+ /*
+  * NOTE:
+  *  The following code is written in an intentionally repetetive way.
+  *  The first versions had no code redundancies, but performed badly during
+  *  benchmarking. The priority here is speed, not cleverness. I know there
+  *  are many obvious shortcuts to this code, Ive tried them. This style has
+  *  shown in benchmarks to be the fastest (fewest probes, fewest actions).
+  */
+
+ /* print 3 args, return as hex */
+ syscall::sigprocmask:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, 0x%X, 0x%X)\t\t = 0x%X %s%d\n",probefunc,
+	    (int)self->arg0,self->arg1,self->arg2,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 3 args, arg0 as a string */
+ syscall::execve:return,
+ syscall::stat:return, 
+ syscall::stat64:return, 
+ syscall::lstat:return, 
+ syscall::lstat64:return, 
+ syscall::access:return,
+ syscall::mkdir:return,
+ syscall::chdir:return,
+ syscall::chroot:return,
+ syscall::getattrlist:return, /* XXX 5 arguments */
+ syscall::chown:return,
+ syscall::lchown:return,
+ syscall::chflags:return,
+ syscall::readlink:return,
+ syscall::utimes:return,
+ syscall::pathconf:return,
+ syscall::truncate:return,
+ syscall::getxattr:return,
+ syscall::setxattr:return,
+ syscall::removexattr:return,
+ syscall::unlink:return,
+ syscall::open:return,
+ syscall::open_nocancel:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(\"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
+	    copyinstr(self->arg0),self->arg1,self->arg2,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 3 args, arg1 as a string, for read/write variant */
+ syscall::write:return,
+ syscall::write_nocancel:return,
+ syscall::read:return,
+ syscall::read_nocancel:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    arg0 == -1 ? "" : stringof(copyin(self->arg1,arg0)),self->arg2,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 3 args, arg1 as a string */
+ syscall::mkdirat:return,
+ syscall::unlinkat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    copyinstr(self->arg1),self->arg2,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 3 args, arg0 and arg2 as strings */
+ syscall::symlinkat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(\"%S\", 0x%X, \"%S\")\t\t = %d %s%d\n",probefunc,
+	    copyinstr(self->arg0), self->arg1, copyinstr(self->arg2), (int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+
+ /* print 2 args, arg0 and arg1 as strings */
+ syscall::rename:return,
+ syscall::symlink:return,
+ syscall::link:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(\"%S\", \"%S\")\t\t = %d %s%d\n",probefunc,
+	    copyinstr(self->arg0), copyinstr(self->arg1),
+	    (int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 0 arg output */
+ syscall::*fork:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s()\t\t = %d %s%d\n",probefunc,
+	    (int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 1 arg output */
+ syscall::close:return,
+ syscall::close_nocancel:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    (int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print 2 arg output */
+ syscall::utimes:return,
+ syscall::munmap:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    self->arg1,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print pread/pwrite with 4 arguments */
+ syscall::pread*:return,
+ syscall::pwrite*:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    stringof(copyin(self->arg1,self->arg2)),self->arg2,self->arg3,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+ }
+
+ /* print 4 args, arg1 as string */
+ syscall::openat:return,
+ syscall::faccessat:return,
+ syscall::fchmodat:return,
+ syscall::readlinkat:return,
+ syscall::fstatat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
+	    self->arg0, copyinstr(self->arg1),self->arg2,self->arg3,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+ }
+
+ /* print 4 args, arg1 and arg3 as strings */
+ syscall::renameat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, \"%S\")\t\t = %d %s%d\n",probefunc,
+		self->arg0, copyinstr(self->arg1), self->arg2, copyinstr(self->arg3), (int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+ }
+
+ /* Apple: print the arguments passed to sysctl */
+ syscall::sysctl:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	mib = copyin(self->arg0, self->arg1 * sizeof(int));
+	mib1 = *(int *)mib;
+	mib2 = *((int *)mib + 1);
+
+	printf("%s(", probefunc);
+
+	printf("[%s, ", (self->arg1 > 0) ? ((*(int *)mib > 0 && *(int *)mib < 9) ? sysctl_first[mib1] : "unknown") : 0);
+
+	printf("%d, %d, %d, %d, %d] (%d), ",
+	    (self->arg1 > 1) ? *((int *)mib + 1) : 0,
+	    (self->arg1 > 2) ? *((int *)mib + 2) : 0,
+	    (self->arg1 > 3) ? *((int *)mib + 3) : 0,
+	    (self->arg1 > 4) ? *((int *)mib + 4) : 0,
+	    (self->arg1 > 5) ? *((int *)mib + 5) : 0,
+	    self->arg1);
+
+	printf("0x%X, 0x%X, 0x%X, 0x%X)\t\t = %d %s%d\n",
+	    self->arg2, self->arg3, self->arg4, self->arg5,
+		(int)arg0, self->code, (int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+	self->arg5 = 0;
+ }
+
+ /* Apple: print the string provided to sysctlbyname */
+ syscall::sysctlbyname:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(%s, 0x%X, 0x%X, 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
+	    copyinstr(self->arg0),
+	    self->arg1,self->arg2,self->arg3,self->arg4,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+ }
+
+ /* print 5 arguments */
+ syscall::kdebug_trace64:return,
+ syscall::select:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, 0x%X, 0x%X, 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    self->arg1,self->arg2,self->arg3,self->arg4,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+ }
+
+ /* print 5 args, arg1 as string */
+ syscall::fchownat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
+		self->arg0, copyinstr(self->arg1), self->arg2, self->arg3, self->arg4,
+		(int)arg0,self->code,(int)errno);
+
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+ }
+ /* print 5 args, arg1 and arg3 as strings */
+ syscall::linkat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, \"%S\", 0x%X)\t\t = %d %s%d\n",probefunc,
+		self->arg0, copyinstr(self->arg1), self->arg2, self->arg3 ? copyinstr(self->arg3) : "", self->arg4,
+		(int)arg0,self->code,(int)errno);
+
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+ }
+
+ /* getattrlistat has 6 arguments */
+ syscall::getattrlistat:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, \"%S\", 0x%X, 0x%X, 0x%X, 0x%X)\t\t = 0x%X %s%d\n",probefunc,self->arg0,
+		copyinstr(self->arg1),self->arg2,self->arg3,self->arg4,self->arg5, arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+	self->arg5 = 0;
+ }
+
+ /* kill has 2 args that should be shown as decimal*/
+ syscall::kill:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(%d, %d)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    self->arg1,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+ }
+
+ /* mmap has 6 arguments */
+ syscall::mmap:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, 0x%X, 0x%X, 0x%X, 0x%X, 0x%X)\t\t = 0x%X %s%d\n",probefunc,self->arg0,
+	    self->arg1,self->arg2,self->arg3,self->arg4,self->arg5, arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+	self->arg5 = 0;
+ }
+
+ /* print 3 arg output - default */
+ syscall:::return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+ 
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+ 
+	/* print main data */
+	printf("%s(0x%X, 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    self->arg1,self->arg2,(int)arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* print counts */
+ dtrace:::END
+ {
+	OPT_counts == 1 ? printf("\n%-32s %16s\n","CALL","COUNT") : 1;
+	OPT_counts == 1 ? printa("%-32s %@16d\n",@Counts) : 1;
+ }
+'
+
+### Run DTrace
+#if [ $opt_command -eq 1 ]; then
+#	/usr/sbin/dtrace -x dynvarsize=$buf -x evaltime=postinit -n "$dtrace" \
+#	    -c "$command" >&2
+#else
+#	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" >&2
+#fi
+
+### Run DTrace (Mac OS X)
+# Redirect the output to stderr so that it doesn't mingle with
+# data going to the target's stdout
+if [ $opt_wait -eq 1 ]; then
+	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" \
+	    -W "$wname" >&2
+elif [ $opt_command -eq 1 ]; then
+	/usr/sbin/dtrace -x dynvarsize=$buf -x evaltime=preinit -Z -n "$dtrace" \
+	    -c "$command" >&2
+
+else
+	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" >&2
+fi

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -303,6 +303,21 @@ dtrace='
 	self->arg5 = arg5;
  }
 
+ syscall::execve:entry
+ /(OPT_has_target && pid == $target) ||
+  (OPT_pid && pid == PID) ||
+  (OPT_name && NAME == strstr(NAME, execname)) ||
+  (OPT_name && execname == strstr(execname, NAME)) ||
+  (self->child)/
+ {
+	// Save the PID as this is reported incorrectly in the :return probe
+	self->execve_self_pid = pid;
+	/* Copy the executable path from user space now, as the process will have an
+	 * entirely new address space when execve() returns. */
+	self->arg0_str = arg0 ? copyinstr(arg0) : "";
+}
+
+
  /*
   * Follow children
   */
@@ -388,7 +403,6 @@ dtrace='
  }
 
  /* print 3 args, arg0 as a string */
- syscall::execve:return,
  syscall::stat:return, 
  syscall::stat64:return, 
  syscall::lstat:return, 
@@ -436,6 +450,38 @@ dtrace='
 	self->arg0 = 0;
 	self->arg1 = 0;
 	self->arg2 = 0;
+ }
+
+ /* print 3 args, arg0 as a string, already copied (due to pid weirdness) */
+ syscall::execve:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	/* For some reason execve:return always reports pid = 0, so print stored value */
+	OPT_printid  ? printf("%5d/0x%x:  ", self->execve_self_pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(\"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
+	    self->arg0_str,self->arg1,self->arg2,(int)arg0,
+	    self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg0_str = 0;
+	self->execve_self_pid = 0;
  }
 
  /* print 3 args, arg1 as a string, for read/write variant */

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -70,7 +70,7 @@
 opt_pid=0; opt_name=0; pid=0; pname="."
 opt_elapsed=0; opt_cpu=0; opt_counts=0; 
 opt_relative=0; opt_printid=0; opt_follow=0
-opt_command=0; command=""; opt_buf=0; buf="4m"
+opt_command=0; command=""; opt_buf=0; buf="30m"
 opt_trace=0; trace="."; opt_stack=0;
 opt_wait=0; wname="."; opt_has_target=0
 opt_filter=0
@@ -206,10 +206,12 @@ dtrace='
 	 * -1 = tracing this process
 	 * >0 = thread ID (tid) during vfork call */
 	trackedpid[pid] = 0;
-	/* child: effectively a boolean, set to 1 once a thread has been identified
-	 * as part of a traced process due to its descendence from a traced process. */
+	/* child: set to PID once a thread has been identified as part of a traced
+	 * process due to its descendence from a traced process. Threads get recycled
+	 * by other processes, so storing the PID here catches that case. */
 	self->child = 0;
-	this->type = 0;
+
+	self->follow_in_spawn_call = 0;
  }
 
  dtrace:::BEGIN
@@ -224,23 +226,33 @@ dtrace='
   * Save syscall entry info
   */
 
- /* MacOS X: notice first appearance of child from fork. Its parent
-    fires syscall::*fork:return in the ususal way (see below) */
+
+ /* Threads seem to be recycled on macOS, including thread-local DTrace
+  * variables; check for mismatch between self->child and pid to detect and
+  * reset the variables. */
  syscall:::entry
- /OPT_follow && trackedpid[ppid] == -1 && 0 == self->child/
+ /OPT_follow && (self->child != 0) && (self->child != pid)/
+ {
+	/* Clean up recycled threads */
+	self->child = 0;
+	self->start = (uint64_t)0;
+	self->vstart = (uint64_t)0;
+	self->arg0 = (uint64_t)0;
+	self->arg1 = (uint64_t)0;
+	self->arg2 = (uint64_t)0;
+	self->arg3 = (uint64_t)0;
+	self->arg4 = (uint64_t)0;
+	self->arg5 = (uint64_t)0;
+ }
+
+ /* MacOS X: notice first appearance of child process´s thread from fork or
+  * posix_spawn. Checking the own process for presence in the trackedpid table
+  * also catches new threads in child processes whose parent process has died. */
+ syscall:::entry
+ /OPT_follow && 0 == self->child && (trackedpid[ppid] == -1 || trackedpid[pid] == -1)/
  {
 	/* set as child */
-	self->child = 1;
-
-	/* print output */
-	self->code = errno == 0 ? "" : "Err#";
-	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
-	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
-	OPT_relative ? printf("%8d:  ",vtimestamp/1000) : 1;
-	OPT_elapsed  ? printf("%7d:  ",0) : 1;
-	OPT_cpu      ? printf("%6d ",0) : 1;
-	printf("%s()\t\t = %d %s%d\n","fork",
-	    0,self->code,(int)errno);
+	self->child = pid;
  }
 
  /* MacOS X: notice first appearance of child and parent from vfork */
@@ -249,7 +261,7 @@ dtrace='
  {
 	/* set as child */
 	this->vforking_tid = trackedpid[ppid];
-	self->child = (this->vforking_tid == tid) ? 0 : 1;
+	self->child = (this->vforking_tid == tid) ? 0 : pid;
 
 	/* print output */
 	self->code = errno == 0 ? "" : "Err#";
@@ -261,13 +273,34 @@ dtrace='
 	printf("%s()\t\t = %d %s%d\n","vfork",
 	    (this->vforking_tid == tid) ? pid : 0,self->code,(int)errno);
  }
- 
+
+ /* Alternative detection of recycled threads: start time stamp is still set,
+  * although no tracking criteria are met. Again, reset thread-local variables. */
+ syscall:::entry
+ /self->start &&
+  !((OPT_has_target && pid == $target) ||
+    (OPT_pid && pid == PID) ||
+    (OPT_name && NAME == strstr(NAME, execname)) ||
+    (OPT_name && execname == strstr(execname, NAME)) ||
+    (self->child == pid))/
+ {
+	self->child = 0;
+	self->start = (uint64_t)0;
+	self->vstart = (uint64_t)0;
+	self->arg0 = (uint64_t)0;
+	self->arg1 = (uint64_t)0;
+	self->arg2 = (uint64_t)0;
+	self->arg3 = (uint64_t)0;
+	self->arg4 = (uint64_t)0;
+	self->arg5 = (uint64_t)0;
+ }
+
  syscall:::entry
  /(OPT_has_target && pid == $target) ||
   (OPT_pid && pid == PID) ||
   (OPT_name && NAME == strstr(NAME, execname)) ||
   (OPT_name && execname == strstr(execname, NAME)) ||
-  (self->child)/
+  (self->child == pid)/
  {
 	/* set start details */
 	self->start = timestamp;
@@ -300,7 +333,7 @@ dtrace='
   (OPT_pid && pid == PID) ||
   (OPT_name && NAME == strstr(NAME, execname)) ||
   (OPT_name && execname == strstr(execname, NAME)) ||
-  (self->child)/
+  (self->child == pid)/
  {
 	self->arg3 = arg3;
 	self->arg4 = arg4;
@@ -312,7 +345,7 @@ dtrace='
   (OPT_pid && pid == PID) ||
   (OPT_name && NAME == strstr(NAME, execname)) ||
   (OPT_name && execname == strstr(execname, NAME)) ||
-  (self->child)/
+  (self->child == pid)/
  {
 	/* Save the executable path as it often seems to be unavailable on return */
 	self->arg1_str = (arg1 != 0 ? copyinstr(arg1) : "");
@@ -326,7 +359,7 @@ dtrace='
   (OPT_pid && pid == PID) ||
   (OPT_name && NAME == strstr(NAME, execname)) ||
   (OPT_name && execname == strstr(execname, NAME)) ||
-  (self->child)/
+  (self->child == pid)/
  {
 	// Save the PID as this is reported incorrectly in the :return probe
 	self->execve_self_pid = pid;
@@ -355,11 +388,53 @@ dtrace='
  
  /* syscall::rexit:entry */
  syscall::exit:entry
+ /(self->child != 0)/
  {
 	/* forget child */
 	self->child = 0;
 	trackedpid[pid] = 0;
  }
+
+ proc::proc_exit:exited
+ /tracepid[args[0]->pr_pid] != 0/
+ {
+	/* Clears exited processes from the table in case the PID gets recycled */
+	self->child = 0;
+	tracepid[args[0]->pr_pid] = 0;
+ }
+
+ /* Follow posix_spawn()ed child processes */
+
+ proc:mach_kernel:posix_spawn:create
+ /OPT_follow &&
+  ((OPT_has_target && pid == $target) ||
+   (OPT_pid && pid == PID) ||
+   (OPT_name && NAME == strstr(NAME, execname)) ||
+   (OPT_name && execname == strstr(execname, NAME)) ||
+   (self->child == pid))/
+ {
+	trackedpid[pid] = -1;
+	self->follow_posix_spawn_child_pid = args[0]->pr_pid;
+	self->follow_in_spawn_call = 1;
+ }
+
+ proc::posix_spawn:spawn-success
+ /self->follow_in_spawn_call/
+ {
+	trackedpid[self->follow_posix_spawn_child_pid] = -1;
+
+	self->follow_posix_spawn_child_pid = 0;
+	self->follow_in_spawn_call = 0;
+ }
+
+ // If the posix_spawn() call failed, reset our state, ready for the next such call.
+proc::posix_spawn:*-failure
+/self->follow_in_spawn_call/
+{
+	self->follow_posix_spawn_child_pid = 0;
+	self->follow_in_spawn_call = 0;
+}
+
 
  /*
   * Check for syscall tracing
@@ -370,12 +445,12 @@ dtrace='
 	/* drop info */
 	self->start = 0;
 	self->vstart = 0;
-	self->arg0 = 0;
-	self->arg1 = 0;
-	self->arg2 = 0;
-	self->arg3 = 0;
-	self->arg4 = 0;
-	self->arg5 = 0;
+	self->arg0 = (uint64_t)0;
+	self->arg1 = (uint64_t)0;
+	self->arg2 = (uint64_t)0;
+	self->arg3 = (uint64_t)0;
+	self->arg4 = (uint64_t)0;
+	self->arg5 = (uint64_t)0;
  }
 
  /*

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -303,6 +303,20 @@ dtrace='
 	self->arg5 = arg5;
  }
 
+ syscall::posix_spawn:entry
+ /(OPT_has_target && pid == $target) ||
+  (OPT_pid && pid == PID) ||
+  (OPT_name && NAME == strstr(NAME, execname)) ||
+  (OPT_name && execname == strstr(execname, NAME)) ||
+  (self->child)/
+ {
+	/* Save the executable path as it often seems to be unavailable on return */
+	self->arg1_str = (arg1 != 0 ? copyinstr(arg1) : "");
+	self->arg3 = arg3;
+	self->arg4 = arg4;
+	self->arg5 = arg5;
+ }
+
  syscall::execve:entry
  /(OPT_has_target && pid == $target) ||
   (OPT_pid && pid == PID) ||
@@ -1048,6 +1062,44 @@ dtrace='
 	self->arg4 = 0;
 	self->arg5 = 0;
  }
+
+ /* posix_spawn has 6 arguments, most of them too complicated to print here,
+  * but PID and path are the most useful for tracing anyway. */
+ syscall::posix_spawn:return
+ /self->start/
+ {
+	/* calculate elapsed time */
+	this->elapsed = timestamp - self->start;
+	self->start = 0;
+	this->cpu = vtimestamp - self->vstart;
+	self->vstart = 0;
+	self->code = errno == 0 ? "" : "Err#";
+
+	/* print optional fields */
+	/* OPT_printid  ? printf("%5d/%d:  ",pid,tid) : 1; */
+	OPT_printid  ? printf("%5d/0x%x:  ",pid,tid) : 1;
+	OPT_relative ? printf("%8d ",vtimestamp/1000) : 1;
+	OPT_elapsed  ? printf("%7d ",this->elapsed/1000) : 1;
+	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
+
+	/* print main data */
+	printf("%s(0x%X -> PID %d, \"%S\" (0x%X), 0x%X, 0x%X, 0x%X, 0x%X)\t\t = 0x%X %s%d\n", probefunc,
+		self->arg0, ((self->arg0 != 0) ? *(pid_t*)copyin(self->arg0, sizeof(pid_t)) : -1),
+	  self->arg1_str, self->arg1,
+	  self->arg2,
+	  self->arg3,self->arg4,self->arg5, arg0,self->code,(int)errno);
+	OPT_stack ? ustack()    : 1;
+	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+	self->arg3 = 0;
+	self->arg4 = 0;
+	self->arg5 = 0;
+	self->arg1_str = 0;
+ }
+
+
 
  /* print 3 arg output - default */
  syscall:::return

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -73,8 +73,9 @@ opt_relative=0; opt_printid=0; opt_follow=0
 opt_command=0; command=""; opt_buf=0; buf="4m"
 opt_trace=0; trace="."; opt_stack=0;
 opt_wait=0; wname="."; opt_has_target=0
+opt_filter=0
 ### Process options
-while getopts ab:cdefhln:op:st:LW: name
+while getopts ab:cdefhln:op:st:LFW: name
 do
         case $name in
 	b)	opt_buf=1; buf=$OPTARG ;;
@@ -92,8 +93,9 @@ do
 	o)	opt_cpu=1 ;;
 	L)	opt_printid=-1 ;;
 	s)	opt_stack=-1 ;;
+	F)	opt_filter=1 ;;
         h|?)    cat <<-END >&2
-		USAGE: dtruss [-acdefholLs] [-t syscall] { -p PID | -n name | command | -W name }
+		USAGE: dtruss [-acdefholLFs] [-t syscall] { -p PID | -n name | command | -W name }
 
 		          -p PID          # examine this PID
 		          -n name         # examine this process name
@@ -108,6 +110,7 @@ do
 		          -o              # print on cpu times
 		          -s              # print stack backtraces
 		          -L              # don't print pid/lwpid
+		          -F              # filter out common & noisy syscalls
 		          -b bufsize      # dynamic variable buf size
 		   eg,
 		       dtruss df -h       # run and examine "df -h"
@@ -169,6 +172,7 @@ dtrace='
  inline int OPT_name      = '$opt_name';
  inline int OPT_trace     = '$opt_trace';
  inline int OPT_stack     = '$opt_stack';
+ inline int OPT_filtercommon = '$opt_filter';
  inline int PID_OPT       = '$pid';
  inline string NAME       = "'"$pname"'";
  inline string TRACE      = "'$trace'";
@@ -644,6 +648,23 @@ dtrace='
 	    (int)arg0,self->code,(int)errno);
 	OPT_stack ? ustack()    : 1;
 	OPT_stack ? trace("\n") : 1;
+	self->arg0 = 0;
+	self->arg1 = 0;
+	self->arg2 = 0;
+ }
+
+ /* Some processes seem to close a huge number of file descriptors they
+  * never opened as a precautionary measure, which floods the trace, so
+  * hide EBADF. */
+ syscall::close:return,
+ syscall::close_nocancel:return
+ /self->start &&
+  (OPT_filtercommon && arg0 == -1 && errno == 9)/
+ {
+	self->start = 0;
+	self->vstart = 0;
+
+	OPT_counts == 1 ? @CloseBadFDCounts[pid] = count() : 1;
 	self->arg0 = 0;
 	self->arg1 = 0;
 	self->arg2 = 0;
@@ -1134,6 +1155,9 @@ dtrace='
  {
 	OPT_counts == 1 ? printf("\n%-32s %16s\n","CALL","COUNT") : 1;
 	OPT_counts == 1 ? printa("%-32s %@16d\n",@Counts) : 1;
+
+	(OPT_counts == 1 && OPT_filtercommon == 1) ? printf("\n%-7s %16s\n","PID","EBADF CLOSE() COUNT") : 1;
+	(OPT_counts == 1 && OPT_filtercommon == 1) ? printa("%7d %@16d\n", @CloseBadFDCounts) : 1;
  }
 '
 

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -457,7 +457,7 @@ dtrace='
  
 	/* print main data */
 	printf("%s(\"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,
-	    copyinstr(self->arg0),self->arg1,self->arg2,(int)arg0,
+	    self->arg0 ? copyinstr(self->arg0) : "[NULL]",self->arg1,self->arg2,(int)arg0,
 	    self->code,(int)errno);
 	OPT_stack ? ustack()    : 1;
 	OPT_stack ? trace("\n") : 1;
@@ -520,8 +520,8 @@ dtrace='
 	OPT_cpu      ? printf("%6d ",this->cpu/1000) : 1;
  
 	/* print main data */
-	printf("%s(0x%X, \"%S\", 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
-	    arg0 == -1 ? "" : stringof(copyin(self->arg1,arg0)),self->arg2,(int)arg0,
+	printf("%s(0x%X, \"%S\" (0x%X), 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
+	    (arg0 == -1 || self->arg1 == 0) ? "" : stringof(copyin(self->arg1, arg0 < 1024 ? arg0 : 1024)), self->arg1, self->arg2,(int)arg0,
 	    self->code,(int)errno);
 	OPT_stack ? ustack()    : 1;
 	OPT_stack ? trace("\n") : 1;
@@ -728,7 +728,7 @@ dtrace='
  
 	/* print main data */
 	printf("%s(0x%X, \"%S\", 0x%X, 0x%X)\t\t = %d %s%d\n",probefunc,self->arg0,
-	    stringof(copyin(self->arg1,self->arg2)),self->arg2,self->arg3,(int)arg0,self->code,(int)errno);
+	    stringof(copyin(self->arg1,self->arg2 < 1024 ? self->arg2 : 1024)),self->arg2,self->arg3,(int)arg0,self->code,(int)errno);
 	OPT_stack ? ustack()    : 1;
 	OPT_stack ? trace("\n") : 1;
 	self->arg0 = 0;

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -122,7 +122,7 @@ shift `expr $OPTIND - 1`
 
 ### Option logic
 if [ $opt_pid -eq 0 -a $opt_name -eq 0 -a $opt_wait -eq 0 ]; then
-	opt_has_target=1
+	opt_pid=1
 	opt_command=1
 	if [ "$*" = "" ]; then
 		$0 -h
@@ -158,6 +158,7 @@ dtrace='
   * Command line arguments
   */
  inline int OPT_has_target   = '$opt_has_target';
+ inline int OPT_command   = '$opt_command';
  inline int OPT_follow    = '$opt_follow';
  inline int OPT_printid   = '$opt_printid';
  inline int OPT_relative  = '$opt_relative';
@@ -168,12 +169,13 @@ dtrace='
  inline int OPT_name      = '$opt_name';
  inline int OPT_trace     = '$opt_trace';
  inline int OPT_stack     = '$opt_stack';
- inline int PID           = '$pid';
+ inline int PID_OPT       = '$pid';
  inline string NAME       = "'"$pname"'";
  inline string TRACE      = "'$trace'";
 
  dtrace:::BEGIN 
  {
+	PID = PID_OPT;
 	/* print header */
 	/* OPT_printid  ? printf("%-8s  ","PID/LWP") : 1; */
 	OPT_printid  ? printf("\t%-8s  ","PID/THRD") : 1;
@@ -194,10 +196,25 @@ dtrace='
 	sysctl_first[9] = "CTL_MAXID";
 
 	/* globals */
+	/* variables for following child processes.
+	 * trackedpid is indexed by PID; values:
+	 * 0 = not tracing this process
+	 * -1 = tracing this process
+	 * >0 = thread ID (tid) during vfork call */
 	trackedpid[pid] = 0;
+	/* child: effectively a boolean, set to 1 once a thread has been identified
+	 * as part of a traced process due to its descendence from a traced process. */
 	self->child = 0;
 	this->type = 0;
  }
+
+ dtrace:::BEGIN
+ /OPT_command && $1 > 0/
+ {
+	PID = $1;
+	system("/bin/kill -CONT %d", $1);
+ }
+
 
  /*
   * Save syscall entry info
@@ -1037,8 +1054,20 @@ if [ $opt_wait -eq 1 ]; then
 	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" \
 	    -W "$wname" >&2
 elif [ $opt_command -eq 1 ]; then
-	/usr/sbin/dtrace -x dynvarsize=$buf -x evaltime=preinit -Z -n "$dtrace" \
-	    -c "$command" >&2
+	# Getting dtrace to run the command means it'll run as root, so instead:
+	#
+	# Create a subshell and get it to send SIGSTOP to itself, suspending the process.
+	# When it wakes back up, it will exec the command, so the command will
+	# take over the subshell's process & PID
+	(:; bash -c 'kill -STOP $PPID' ; exec $command ) &
+	# Remember the subshell's PID
+	command_pid=$!
+	echo Process for running command "$command" with PID $command_pid started and suspended. Launching dtrace, which will resume it:
+	# Launch dtruss via sudo and pass the subshell's PID in. We've already enabled
+	# OPT_command, so on startup, dtrace will resume the PID we passed in.
+	# Note that we need -w as resuming processes is considered "destructive".
+	/usr/bin/sudo /usr/sbin/dtrace -w -x dynvarsize=$buf -x evaltime=preinit -Z -n "$dtrace" \
+	    "$command_pid" >&2
 
 else
 	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" >&2

--- a/Scripts/Mac/Tracing/dtruss
+++ b/Scripts/Mac/Tracing/dtruss
@@ -1149,7 +1149,7 @@ dtrace='
 # Redirect the output to stderr so that it doesn't mingle with
 # data going to the target's stdout
 if [ $opt_wait -eq 1 ]; then
-	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" \
+	/usr/sbin/dtrace -w -x defaultargs -x dynvarsize=$buf -n "$dtrace" \
 	    -W "$wname" >&2
 elif [ $opt_command -eq 1 ]; then
 	# Getting dtrace to run the command means it'll run as root, so instead:
@@ -1165,8 +1165,8 @@ elif [ $opt_command -eq 1 ]; then
 	# OPT_command, so on startup, dtrace will resume the PID we passed in.
 	# Note that we need -w as resuming processes is considered "destructive".
 	/usr/bin/sudo /usr/sbin/dtrace -w -x dynvarsize=$buf -x evaltime=preinit -Z -n "$dtrace" \
-	    "$command_pid" >&2
+	    "$command_pid" >&2 || kill $command_pid
 
 else
-	/usr/sbin/dtrace -x dynvarsize=$buf -n "$dtrace" >&2
+	/usr/sbin/dtrace -x defaultargs -w -x dynvarsize=$buf -n "$dtrace" >&2
 fi

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,0 +1,397 @@
+microsoft-VFSForGit
+
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
+
+
+1.     dtruss from Apple's dtrace distribution version 284.200.15 (https://opensource.apple.com/source/dtrace/dtrace-284.200.15/DTTk/)
+
+
+dtrace NOTICES AND INFORMATION BEGIN HERE
+=========================================
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+
+
+      1. Definitions.
+
+            1.1. “Contributor” means each individual or entity that
+            creates or contributes to the creation of Modifications.
+
+            1.2. “Contributor Version” means the combination of the
+            Original Software, prior Modifications used by a
+            Contributor (if any), and the Modifications made by that
+            particular Contributor.
+
+            1.3. “Covered Software” means (a) the Original Software, or
+            (b) Modifications, or (c) the combination of files
+            containing Original Software with files containing
+            Modifications, in each case including portions thereof.
+
+            1.4. “Executable” means the Covered Software in any form
+            other than Source Code. 
+
+            1.5. “Initial Developer” means the individual or entity
+            that first makes Original Software available under this
+            License. 
+            
+            1.6. “Larger Work” means a work which combines Covered
+            Software or portions thereof with code not governed by the
+            terms of this License.
+
+            1.7. “License” means this document.
+
+            1.8. “Licensable” means having the right to grant, to the
+            maximum extent possible, whether at the time of the initial
+            grant or subsequently acquired, any and all of the rights
+            conveyed herein.
+            
+            1.9. “Modifications” means the Source Code and Executable
+            form of any of the following: 
+
+                  A. Any file that results from an addition to,
+                  deletion from or modification of the contents of a
+                  file containing Original Software or previous
+                  Modifications; 
+
+                  B. Any new file that contains any part of the
+                  Original Software or previous Modification; or 
+
+                  C. Any new file that is contributed or otherwise made
+                  available under the terms of this License.
+
+            1.10. “Original Software” means the Source Code and
+            Executable form of computer software code that is
+            originally released under this License. 
+
+            1.11. “Patent Claims” means any patent claim(s), now owned
+            or hereafter acquired, including without limitation,
+            method, process, and apparatus claims, in any patent
+            Licensable by grantor. 
+
+            1.12. “Source Code” means (a) the common form of computer
+            software code in which modifications are made and (b)
+            associated documentation included in or with such code.
+
+            1.13. “You” (or “Your”) means an individual or a legal
+            entity exercising rights under, and complying with all of
+            the terms of, this License. For legal entities, “You”
+            includes any entity which controls, is controlled by, or is
+            under common control with You. For purposes of this
+            definition, “control” means (a) the power, direct or
+            indirect, to cause the direction or management of such
+            entity, whether by contract or otherwise, or (b) ownership
+            of more than fifty percent (50%) of the outstanding shares
+            or beneficial ownership of such entity.
+
+      2. License Grants. 
+
+            2.1. The Initial Developer Grant.
+
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, the
+            Initial Developer hereby grants You a world-wide,
+            royalty-free, non-exclusive license: 
+
+                  (a) under intellectual property rights (other than
+                  patent or trademark) Licensable by Initial Developer,
+                  to use, reproduce, modify, display, perform,
+                  sublicense and distribute the Original Software (or
+                  portions thereof), with or without Modifications,
+                  and/or as part of a Larger Work; and 
+
+                  (b) under Patent Claims infringed by the making,
+                  using or selling of Original Software, to make, have
+                  made, use, practice, sell, and offer for sale, and/or
+                  otherwise dispose of the Original Software (or
+                  portions thereof). 
+
+                  (c) The licenses granted in Sections 2.1(a) and (b)
+                  are effective on the date Initial Developer first
+                  distributes or otherwise makes the Original Software
+                  available to a third party under the terms of this
+                  License. 
+
+                  (d) Notwithstanding Section 2.1(b) above, no patent
+                  license is granted: (1) for code that You delete from
+                  the Original Software, or (2) for infringements
+                  caused by: (i) the modification of the Original
+                  Software, or (ii) the combination of the Original
+                  Software with other software or devices. 
+
+            2.2. Contributor Grant.
+
+            Conditioned upon Your compliance with Section 3.1 below and
+            subject to third party intellectual property claims, each
+            Contributor hereby grants You a world-wide, royalty-free,
+            non-exclusive license:
+
+                  (a) under intellectual property rights (other than
+                  patent or trademark) Licensable by Contributor to
+                  use, reproduce, modify, display, perform, sublicense
+                  and distribute the Modifications created by such
+                  Contributor (or portions thereof), either on an
+                  unmodified basis, with other Modifications, as
+                  Covered Software and/or as part of a Larger Work; and
+                  
+
+                  (b) under Patent Claims infringed by the making,
+                  using, or selling of Modifications made by that
+                  Contributor either alone and/or in combination with
+                  its Contributor Version (or portions of such
+                  combination), to make, use, sell, offer for sale,
+                  have made, and/or otherwise dispose of: (1)
+                  Modifications made by that Contributor (or portions
+                  thereof); and (2) the combination of Modifications
+                  made by that Contributor with its Contributor Version
+                  (or portions of such combination). 
+
+                  (c) The licenses granted in Sections 2.2(a) and
+                  2.2(b) are effective on the date Contributor first
+                  distributes or otherwise makes the Modifications
+                  available to a third party. 
+
+                  (d) Notwithstanding Section 2.2(b) above, no patent
+                  license is granted: (1) for any code that Contributor
+                  has deleted from the Contributor Version; (2) for
+                  infringements caused by: (i) third party
+                  modifications of Contributor Version, or (ii) the
+                  combination of Modifications made by that Contributor
+                  with other software (except as part of the
+                  Contributor Version) or other devices; or (3) under
+                  Patent Claims infringed by Covered Software in the
+                  absence of Modifications made by that Contributor. 
+
+      3. Distribution Obligations.
+
+            3.1. Availability of Source Code.
+
+            Any Covered Software that You distribute or otherwise make
+            available in Executable form must also be made available in
+            Source Code form and that Source Code form must be
+            distributed only under the terms of this License. You must
+            include a copy of this License with every copy of the
+            Source Code form of the Covered Software You distribute or
+            otherwise make available. You must inform recipients of any
+            such Covered Software in Executable form as to how they can
+            obtain such Covered Software in Source Code form in a
+            reasonable manner on or through a medium customarily used
+            for software exchange.
+
+            3.2. Modifications.
+
+            The Modifications that You create or to which You
+            contribute are governed by the terms of this License. You
+            represent that You believe Your Modifications are Your
+            original creation(s) and/or You have sufficient rights to
+            grant the rights conveyed by this License.
+
+            3.3. Required Notices.
+
+            You must include a notice in each of Your Modifications
+            that identifies You as the Contributor of the Modification.
+            You may not remove or alter any copyright, patent or
+            trademark notices contained within the Covered Software, or
+            any notices of licensing or any descriptive text giving
+            attribution to any Contributor or the Initial Developer.
+
+            3.4. Application of Additional Terms.
+
+            You may not offer or impose any terms on any Covered
+            Software in Source Code form that alters or restricts the
+            applicable version of this License or the recipients’
+            rights hereunder. You may choose to offer, and to charge a
+            fee for, warranty, support, indemnity or liability
+            obligations to one or more recipients of Covered Software.
+            However, you may do so only on Your own behalf, and not on
+            behalf of the Initial Developer or any Contributor. You
+            must make it absolutely clear that any such warranty,
+            support, indemnity or liability obligation is offered by
+            You alone, and You hereby agree to indemnify the Initial
+            Developer and every Contributor for any liability incurred
+            by the Initial Developer or such Contributor as a result of
+            warranty, support, indemnity or liability terms You offer.
+          
+
+            3.5. Distribution of Executable Versions.
+
+            You may distribute the Executable form of the Covered
+            Software under the terms of this License or under the terms
+            of a license of Your choice, which may contain terms
+            different from this License, provided that You are in
+            compliance with the terms of this License and that the
+            license for the Executable form does not attempt to limit
+            or alter the recipient’s rights in the Source Code form
+            from the rights set forth in this License. If You
+            distribute the Covered Software in Executable form under a
+            different license, You must make it absolutely clear that
+            any terms which differ from this License are offered by You
+            alone, not by the Initial Developer or Contributor. You
+            hereby agree to indemnify the Initial Developer and every
+            Contributor for any liability incurred by the Initial
+            Developer or such Contributor as a result of any such terms
+            You offer.
+
+            3.6. Larger Works.
+
+            You may create a Larger Work by combining Covered Software
+            with other code not governed by the terms of this License
+            and distribute the Larger Work as a single product. In such
+            a case, You must make sure the requirements of this License
+            are fulfilled for the Covered Software. 
+            
+      4. Versions of the License. 
+
+            4.1. New Versions.
+
+            Sun Microsystems, Inc. is the initial license steward and
+            may publish revised and/or new versions of this License
+            from time to time. Each version will be given a
+            distinguishing version number. Except as provided in
+            Section 4.3, no one other than the license steward has the
+            right to modify this License. 
+
+            4.2. Effect of New Versions.
+
+            You may always continue to use, distribute or otherwise
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. If the Initial Developer includes a
+            notice in the Original Software prohibiting it from being
+            distributed or otherwise made available under any
+            subsequent version of the License, You must distribute and
+            make the Covered Software available under the terms of the
+            version of the License under which You originally received
+            the Covered Software. Otherwise, You may also choose to
+            use, distribute or otherwise make the Covered Software
+            available under the terms of any subsequent version of the
+            License published by the license steward. 
+
+            4.3. Modified Versions.
+
+            When You are an Initial Developer and You want to create a
+            new license for Your Original Software, You may create and
+            use a modified version of this License if You: (a) rename
+            the license and remove any references to the name of the
+            license steward (except to note that the license differs
+            from this License); and (b) otherwise make it clear that
+            the license contains terms which differ from this License.
+            
+
+      5. DISCLAIMER OF WARRANTY.
+
+      COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN “AS IS”
+      BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+      INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+      SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+      PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND
+      PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY
+      COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+      INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF
+      ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF
+      WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+      ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+      DISCLAIMER. 
+
+      6. TERMINATION. 
+
+            6.1. This License and the rights granted hereunder will
+            terminate automatically if You fail to comply with terms
+            herein and fail to cure such breach within 30 days of
+            becoming aware of the breach. Provisions which, by their
+            nature, must remain in effect beyond the termination of
+            this License shall survive.
+
+            6.2. If You assert a patent infringement claim (excluding
+            declaratory judgment actions) against Initial Developer or
+            a Contributor (the Initial Developer or Contributor against
+            whom You assert such claim is referred to as “Participant”)
+            alleging that the Participant Software (meaning the
+            Contributor Version where the Participant is a Contributor
+            or the Original Software where the Participant is the
+            Initial Developer) directly or indirectly infringes any
+            patent, then any and all rights granted directly or
+            indirectly to You by such Participant, the Initial
+            Developer (if the Initial Developer is not the Participant)
+            and all Contributors under Sections 2.1 and/or 2.2 of this
+            License shall, upon 60 days notice from Participant
+            terminate prospectively and automatically at the expiration
+            of such 60 day notice period, unless if within such 60 day
+            period You withdraw Your claim with respect to the
+            Participant Software against such Participant either
+            unilaterally or pursuant to a written agreement with
+            Participant.
+
+            6.3. In the event of termination under Sections 6.1 or 6.2
+            above, all end user licenses that have been validly granted
+            by You or any distributor hereunder prior to termination
+            (excluding licenses granted to You by any distributor)
+            shall survive termination.
+
+      7. LIMITATION OF LIABILITY.
+
+      UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+      (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+      INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+      COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+      LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+      CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+      LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+      STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+      COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+      INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+      LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+      INJURY RESULTING FROM SUCH PARTY’S NEGLIGENCE TO THE EXTENT
+      APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO
+      NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+      CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+      APPLY TO YOU.
+
+      8. U.S. GOVERNMENT END USERS.
+
+      The Covered Software is a “commercial item,” as that term is
+      defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of “commercial
+      computer software” (as that term is defined at 48 C.F.R. §
+      252.227-7014(a)(1)) and “commercial computer software
+      documentation” as such terms are used in 48 C.F.R. 12.212 (Sept.
+      1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+      through 227.7202-4 (June 1995), all U.S. Government End Users
+      acquire Covered Software with only those rights set forth herein.
+      This U.S. Government Rights clause is in lieu of, and supersedes,
+      any other FAR, DFAR, or other clause or provision that addresses
+      Government rights in computer software under this License.
+
+      9. MISCELLANEOUS.
+
+      This License represents the complete agreement concerning subject
+      matter hereof. If any provision of this License is held to be
+      unenforceable, such provision shall be reformed only to the
+      extent necessary to make it enforceable. This License shall be
+      governed by the law of the jurisdiction specified in a notice
+      contained within the Original Software (except to the extent
+      applicable law, if any, provides otherwise), excluding such
+      jurisdiction’s conflict-of-law provisions. Any litigation
+      relating to this License shall be subject to the jurisdiction of
+      the courts located in the jurisdiction and venue specified in a
+      notice contained within the Original Software, with the losing
+      party responsible for costs, including, without limitation, court
+      costs and reasonable attorneys’ fees and expenses. The
+      application of the United Nations Convention on Contracts for the
+      International Sale of Goods is expressly excluded. Any law or
+      regulation which provides that the language of a contract shall
+      be construed against the drafter shall not apply to this License.
+      You agree that You alone are responsible for compliance with the
+      United States export administration regulations (and the export
+      control laws and regulation of any other countries) when You use,
+      distribute or otherwise make available any Covered Software.
+
+      10. RESPONSIBILITY FOR CLAIMS.
+
+      As between Initial Developer and the Contributors, each party is
+      responsible for claims and damages arising, directly or
+      indirectly, out of its utilization of rights under this License
+      and You agree to work with Initial Developer and Contributors to
+      distribute such responsibility on an equitable basis. Nothing
+      herein is intended or shall be deemed to constitute any admission
+      of liability.


### PR DESCRIPTION
This is a first pass at tackling issue #563. At a bare minimum, it should allow us to collect a syscall trace of e.g. a failing build on the affected machine, which we can manually pick through to find out what's going through.

Stock `dtruss` wasn't really up to that job due to lack of special handling for many quirks of (modern versions of?) macOS. So the majority of this PR is bugfixing and adding features in `dtruss`.

 * When launching a command with dtruss, it's now possible to run the command as a non-root user.
 * Correct logging of execve() and posix_spawn() syscalls.
 * Improvements to output for syscalls with buffer or string parameters. (Better handling of NULL pointers, large buffers, etc.)
 * A new -F option for filtering out common but typically uninteresting syscalls. At the moment, this only filters out close() calls returning EBADF. Some programs seem to call close() on thousands of sequential integers, most of which are not valid file descriptors.
 * The mode for following child processes (-f) is much more reliable. There were so many bugs in the previous implementation of this it effectively didn't work at all most of the time.
 * I've added a short readme-style document for getting started with *using* `dtruss`.

The changes are largely contained and explained in individual commits as usual; I realise none of you have probably seen DTrace scripts before but it should be fairly readable to anyone familiar with C. Knowing about some of its oddities will make understanding easier:
 * There's no control flow apart from the `/ … /` conditional block at the start of each probe action, and the `?:` conditional operator. No if/else, no loops.
 * Variables are implicitly strongly typed based on the first assignment that occurs in the source code.
 * `self->foo` variables are thread-local, `this->bar` variables are local to action blocks.
 * Pointers can be in kernel or user space depending on context. User space pointers must be dereferenced with `copyin`/`copyinstr`.
Feel free to ask questions if you're curious about anything in particular. The macOS `dtrace` man page is a reference you might want to consult too. (`man 1 dtrace`)

Probably more important than reviewing the intricacies of the script's code: actually trying out the script to see what limitations and bugs still need to be fixed.

Not yet done:
 1. Limiting the tracing scope to file I/O syscalls only. For some programs this means we generate a lot of noise that's probably not useful for VFS4G diagnostics; plus it increases the likelihood of a trace buffer overflow.
 2. A trace is just a long list of barely human readable raw data. You have to keep track of which process is which by its PID yourself, likewise for file descriptors and such. There's no filtering beyond `grep` and friends, etc.
 3. There's no way to provide multiple PIDs or process names to watch; you can only trace one syscall or all of them. This might not be necessary in practice if follow-mode works well enough, and if we create predefined, hardcoded groups of syscalls such as the file I/O one.

Especially for item 2, I'd welcome discussion in #563 about what shape the post-processing might take.