### PR TITLE
Use package feed URL to query for credentials

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -121,9 +121,15 @@ namespace GVFS.Common.NuGetUpgrader
                 return false;
             }
 
+            string authUrl;
+            if (!TryCreateAzDevOrgUrlFromPackageFeedUrl(upgraderConfig.FeedUrl, out authUrl, out error))
+            {
+                return false;
+            }
+
             if (!TryGetPersonalAccessToken(
                     GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath(),
-                    upgraderConfig.FeedUrlForCredentials,
+                    authUrl,
                     tracer,
                     out string token,
                     out string getPatError))

--- a/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrader/NuGetUpgrader.cs
@@ -163,13 +163,13 @@ namespace GVFS.Common.NuGetUpgrader
             if (!urlMatch.Success)
             {
                 azureDevOpsUrl = null;
-                error = $"Input URL {packageFeedUrl} did not match expected format for an Azure Devops Package Feed URL";
+                error = $"Input URL {packageFeedUrl} did not match expected format for an Azure DevOps Package Feed URL";
                 return false;
             }
 
             string org = urlMatch.Groups["org"].Value;
 
-            azureDevOpsUrl = urlMatch.Result($"https://dev.azure.com/{org}");
+            azureDevOpsUrl = urlMatch.Result($"https://{org}.visualstudio.com");
             error = null;
 
             return true;
@@ -207,11 +207,6 @@ namespace GVFS.Common.NuGetUpgrader
             else if (string.IsNullOrEmpty(this.nuGetUpgraderConfig.PackageFeedName))
             {
                 message = "NuGet package feed has not been configured";
-                return false;
-            }
-            else if (string.IsNullOrEmpty(this.nuGetUpgraderConfig.FeedUrlForCredentials))
-            {
-                message = "URL to lookup credentials has not been configured";
                 return false;
             }
 
@@ -479,18 +474,15 @@ namespace GVFS.Common.NuGetUpgrader
                 ITracer tracer,
                 LocalGVFSConfig localGVFSConfig,
                 string feedUrl,
-                string packageFeedName,
-                string feedUrlForCredentials)
+                string packageFeedName)
                 : this(tracer, localGVFSConfig)
             {
                 this.FeedUrl = feedUrl;
                 this.PackageFeedName = packageFeedName;
-                this.FeedUrlForCredentials = feedUrlForCredentials;
             }
 
             public string FeedUrl { get; private set; }
             public string PackageFeedName { get; private set; }
-            public string FeedUrlForCredentials { get; private set; }
 
             /// <summary>
             /// Check if the NuGetUpgrader is ready for use. A
@@ -500,13 +492,12 @@ namespace GVFS.Common.NuGetUpgrader
             public bool IsReady(out string error)
             {
                 if (string.IsNullOrEmpty(this.FeedUrl) ||
-                    string.IsNullOrEmpty(this.PackageFeedName) ||
-                    string.IsNullOrEmpty(this.FeedUrlForCredentials))
+                    string.IsNullOrEmpty(this.PackageFeedName))
                 {
                     error = string.Join(
                         Environment.NewLine,
                         "One or more required settings for NuGetUpgrader are missing.",
-                        $"Use `gvfs config [{GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedCredentialUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName}] <value>` to set the config.");
+                        $"Use `gvfs config [{GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName}] <value>` to set the config.");
                     return false;
                 }
 
@@ -520,13 +511,12 @@ namespace GVFS.Common.NuGetUpgrader
             public bool IsConfigured(out string error)
             {
                 if (string.IsNullOrEmpty(this.FeedUrl) &&
-                    string.IsNullOrEmpty(this.PackageFeedName) &&
-                    string.IsNullOrEmpty(this.FeedUrlForCredentials))
+                    string.IsNullOrEmpty(this.PackageFeedName))
                 {
                     error = string.Join(
                         Environment.NewLine,
                         "NuGet upgrade server is not configured.",
-                        $"Use `gvfs config [{GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedCredentialUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName}] <value>` to set the config.");
+                        $"Use `gvfs config [ {GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName}] <value>` to set the config.");
                     return false;
                 }
 
@@ -547,14 +537,6 @@ namespace GVFS.Common.NuGetUpgrader
                 }
 
                 this.FeedUrl = configValue;
-
-                if (!this.localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeFeedCredentialUrl, out configValue, out error))
-                {
-                    this.tracer.RelatedError(error);
-                    return false;
-                }
-
-                this.FeedUrlForCredentials = configValue;
 
                 if (!this.localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName, out configValue, out error))
                 {

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -305,6 +305,31 @@ namespace GVFS.UnitTests.Common
             NuGetUpgrader.ReplaceArgTokens(sourceStringWithTokens, "unique_id").ShouldEqual(expectedProcessedString, "expected tokens have not been replaced");
         }
 
+        [TestCase("https://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://dev.azure.com/test-pat")]
+        [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://dev.azure.com/test-pat")]
+        [TestCase("https://dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
+        [TestCase("http://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
+        public void CanConstructAzureDevOpsUrlFromPackageFeedUrl(string packageFeedUrl, string expectedAzureDevOpsUrl)
+        {
+            bool success = NuGetUpgrader.TryCreateAzDevOrgUrlFromPackageFeedUrl(
+                packageFeedUrl,
+                out string azureDevOpsUrl,
+                out string error);
+
+            if (expectedAzureDevOpsUrl != null)
+            {
+                success.ShouldBeTrue();
+                azureDevOpsUrl.ShouldEqual(expectedAzureDevOpsUrl);
+                error.ShouldBeNull();
+            }
+            else
+            {
+                success.ShouldBeFalse();
+                azureDevOpsUrl.ShouldBeNull();
+                error.ShouldNotBeNull();
+            }
+        }
+
         private IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)
         {
             Mock<IPackageSearchMetadata> mockPackageSearchMetaData = new Mock<IPackageSearchMetadata>();

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgraderTests.cs
@@ -11,7 +11,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace GVFS.UnitTests.Common
 {
@@ -24,7 +23,6 @@ namespace GVFS.UnitTests.Common
         private const string NewerVersion2 = "1.7.1185.0";
 
         private const string NuGetFeedUrl = "feedUrlValue";
-        private const string NuGetFeedUrlForCredentials = "feedUrlForCredentialsValue";
         private const string NuGetFeedName = "feedNameValue";
 
         private NuGetUpgrader upgrader;
@@ -39,7 +37,7 @@ namespace GVFS.UnitTests.Common
         [SetUp]
         public void SetUp()
         {
-            this.upgraderConfig = new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName, NuGetFeedUrlForCredentials);
+            this.upgraderConfig = new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName);
             this.downloadFolder = "downloadFolderTestValue";
 
             this.tracer = new MockTracer();
@@ -232,9 +230,9 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void TestUpgradeAllowed()
         {
-            // Properly Configured NuGet config FeedUrlForCredentials
+            // Properly Configured NuGet config
             NuGetUpgrader.NuGetUpgraderConfig nuGetUpgraderConfig =
-                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName, NuGetFeedUrlForCredentials);
+                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName);
 
             NuGetUpgrader nuGetUpgrader = new NuGetUpgrader(
                 CurrentVersion,
@@ -249,7 +247,7 @@ namespace GVFS.UnitTests.Common
 
             // Empty FeedURL
             nuGetUpgraderConfig =
-                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, string.Empty, NuGetFeedName, NuGetFeedUrlForCredentials);
+                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, string.Empty, NuGetFeedName);
 
              nuGetUpgrader = new NuGetUpgrader(
                 CurrentVersion,
@@ -264,7 +262,7 @@ namespace GVFS.UnitTests.Common
 
             // Empty packageFeedName
             nuGetUpgraderConfig =
-                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, string.Empty, NuGetFeedUrlForCredentials);
+                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, string.Empty);
 
             // Empty packageFeedName
             nuGetUpgrader = new NuGetUpgrader(
@@ -277,21 +275,6 @@ namespace GVFS.UnitTests.Common
                 this.mockNuGetFeed.Object);
 
             nuGetUpgrader.UpgradeAllowed(out string _).ShouldBeFalse("Upgrade without FeedName configured should not be allowed.");
-
-            // Empty FeedUrlForCredentials
-            nuGetUpgraderConfig =
-                new NuGetUpgrader.NuGetUpgraderConfig(this.tracer, null, NuGetFeedUrl, NuGetFeedName, string.Empty);
-
-            nuGetUpgrader = new NuGetUpgrader(
-                CurrentVersion,
-                this.tracer,
-                false,
-                false,
-                this.mockFileSystem.Object,
-                nuGetUpgraderConfig,
-                this.mockNuGetFeed.Object);
-
-            nuGetUpgrader.UpgradeAllowed(out string _).ShouldBeFalse("Upgrade without FeedUrlForCredentials configured should not be allowed.");
         }
 
         [TestCase]
@@ -305,8 +288,8 @@ namespace GVFS.UnitTests.Common
             NuGetUpgrader.ReplaceArgTokens(sourceStringWithTokens, "unique_id").ShouldEqual(expectedProcessedString, "expected tokens have not been replaced");
         }
 
-        [TestCase("https://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://dev.azure.com/test-pat")]
-        [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://dev.azure.com/test-pat")]
+        [TestCase("https://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
+        [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
         [TestCase("https://dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
         [TestCase("http://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
         public void CanConstructAzureDevOpsUrlFromPackageFeedUrl(string packageFeedUrl, string expectedAzureDevOpsUrl)


### PR DESCRIPTION
Instead of explicitly providing the URL used to query Git Credential Helper for credentials, transform the URL used for the packaging feed to construct the URL to query Git Credential Helper with.