### PR TITLE
Read upgrade ring config from feedurl

### DIFF
--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -529,29 +529,65 @@ namespace GVFS.Common
                 this.UpgradeRing = RingType.NoConfig;
 
                 string ringConfig = null;
-                if (this.LocalConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error))
-                {
-                    RingType ringType;
-                    if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) &&
-                        Enum.IsDefined(typeof(RingType), ringType) &&
-                        ringType != RingType.Invalid)
-                    {
-                        this.UpgradeRing = ringType;
-                    }
-                    else
-                    {
-                        if (!string.IsNullOrEmpty(ringConfig))
-                        {
-                            this.UpgradeRing = RingType.Invalid;
-                        }
-                    }
+                string upgradeFeedUrl = null;
+                string loadError = "Could not read GVFS Config." + Environment.NewLine + GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
 
-                    return true;
+                // There are couple config settings that contain info about Upgrade rings.
+                // upgrade.ring and upgrade.feedURL. upgrade.feedURL will override upgrade.ring
+                // config. If upgrade.feedURL is set, but does not contain valid ring info then
+                // upgrade ring would be set to NoConfig and auto upgrade checks will fail.
+                if (!this.LocalConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl, out upgradeFeedUrl, out error))
+                {
+                    error = loadError;
+                    return false;
                 }
 
-                error = "Could not read GVFS Config." + Environment.NewLine;
-                error += GVFSConstants.UpgradeVerbMessages.SetUpgradeRingCommand;
-                return false;
+                // If upgradeFeedUrl is available then use it for the ring config, if not use regular
+                // upgrade.ring.
+                if (!string.IsNullOrEmpty(upgradeFeedUrl))
+                {
+                    this.UpgradeRing = RingType.None;
+
+                    string[] expectedRings = new string[] { RingType.Slow.ToString(), RingType.Fast.ToString() };
+                    foreach (string ring in expectedRings)
+                    {
+                        string ringSubstring = $"@{ring}/";
+                        if (upgradeFeedUrl.IndexOf(ringSubstring, StringComparison.OrdinalIgnoreCase) != -1)
+                        {
+                            ringConfig = ring;
+                            break;
+                        }
+                    }
+                }
+                else if (!this.LocalConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out ringConfig, out error))
+                {
+                    error = loadError;
+                    return false;
+                }
+
+                this.ParseUpgradeRing(ringConfig);
+                return true;
+            }
+
+            public void ParseUpgradeRing(string ringConfig)
+            {
+                if (string.IsNullOrEmpty(ringConfig))
+                {
+                    this.UpgradeRing = RingType.None;
+                    return;
+                }
+
+                RingType ringType;
+                if (Enum.TryParse(ringConfig, ignoreCase: true, result: out ringType) &&
+                    Enum.IsDefined(typeof(RingType), ringType) &&
+                    ringType != RingType.Invalid)
+                {
+                    this.UpgradeRing = ringType;
+                }
+                else
+                {
+                    this.UpgradeRing = RingType.Invalid;
+                }
             }
 
             public bool ConfigError()

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockLocalGVFSConfig.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockLocalGVFSConfig.cs
@@ -27,7 +27,8 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
         {
             error = null;
 
-            return this.Settings.TryGetValue(name, out value);
+            this.Settings.TryGetValue(name, out value);
+            return true;
         }
 
         public override bool TrySetConfig(

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/ProductUpgraderTests.cs
@@ -80,6 +80,75 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 expectedUpgradeVersion:UpgradeTests.NewerThanLocalVersion);
         }
 
+        [TestCase]
+        public void RingInNugetFeedURLOverridesUpgradeRing()
+        {
+            // Pretend there is an upgrade available in Fast ring. Set upgrade.ring
+            // to fast and verify that Upgrader returns the new version.
+            Version newVersion;
+            string error;
+            this.SetUpgradeRing(GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast.ToString());
+
+            // Replace pretend upgrade Release set by UpgradeTests.Setup() method
+            this.Upgrader.PretendNewReleaseAvailableAtRemote(UpgradeTests.NewerThanLocalVersion, GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast);
+
+            this.Upgrader.TryQueryNewestVersion(out newVersion, out error).ShouldBeTrue();
+            newVersion.ShouldNotBeNull();
+            newVersion.ToString().ShouldEqual(UpgradeTests.NewerThanLocalVersion);
+
+            // Now add upgrade.feedurl with Slow ring info. The Slow ring in upgrade.feedurl should
+            // override the Fast that is set already (in the steps above) in upgrade.ring. Since
+            // there is no upgrade available in Slow, Verify that Upgrader returns Null upgrade
+            // this time.
+            string feedUrlWithSlowRing = "https://foo.bar.visualstudio.com/helloworld/_packaging/GVFS@Slow/nuget/v3/index.json";
+            this.LocalConfig.TrySetConfig("upgrade.feedurl", feedUrlWithSlowRing, out error);
+            this.Upgrader.Config.TryLoad(out error).ShouldBeTrue();
+
+            this.Upgrader.TryQueryNewestVersion(out newVersion, out error).ShouldBeTrue();
+            newVersion.ShouldBeNull();
+            error.ShouldContain("Great news");
+        }
+
+        [TestCase]
+        public void FastUpgradeRingAndNoRingInNugetFeedURLReturnsNoUpgrade()
+        {
+            // Pretend there is an upgrade available in Fast ring. Set upgrade.ring
+            // to fast and verify that Upgrader returns the new version.
+            Version newVersion;
+            string error;
+            this.SetUpgradeRing(GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast.ToString());
+
+            // Replace pretend upgrade Release set by UpgradeTests.Setup() method
+            this.Upgrader.PretendNewReleaseAvailableAtRemote(UpgradeTests.NewerThanLocalVersion, GitHubUpgrader.GitHubUpgraderConfig.RingType.Fast);
+
+            this.Upgrader.TryQueryNewestVersion(out newVersion, out error).ShouldBeTrue();
+            newVersion.ShouldNotBeNull();
+
+            // Now add upgrade.feedurl with no ring info. The presence of upgrade.feedurl config
+            // should force upgrader to reset its ring to the one specified in upgrade.feedurl.
+            // But since there is no ring specified in upgrade.feedurl, upgrader should have no valid
+            // ring now. Verify that Upgrader returns Null upgrade this time.
+            string feedUrlWithNoRing = "https://foo.bar.visualstudio.com/helloworld/GVFS/nuget/v3/index.json";
+            this.LocalConfig.TrySetConfig("upgrade.feedurl", feedUrlWithNoRing, out error);
+            this.Upgrader.Config.TryLoad(out error).ShouldBeTrue();
+
+            this.Upgrader.TryQueryNewestVersion(out newVersion, out error).ShouldBeTrue();
+            newVersion.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void NoRingInNugetFeedURLReturnsNullUpgrade()
+        {
+            string error;
+            string feedUrlWithNoRing = "https://foo.bar.visualstudio.com/helloworld/_packaging/GVFS/nuget/v3/index.json";
+            this.LocalConfig.TrySetConfig("upgrade.feedurl", feedUrlWithNoRing, out error);
+            this.Upgrader.Config.TryLoad(out error).ShouldBeTrue();
+
+            Version newVersion;
+            this.Upgrader.TryQueryNewestVersion(out newVersion, out error).ShouldBeTrue();
+            newVersion.ShouldBeNull();
+        }
+
         public override void NoneLocalRing()
         {
             throw new NotSupportedException();


### PR DESCRIPTION
This PR helps avoid user needing to specify upgrade ring info in two separate config settings (upgrade.ring and upgrade.feedurl).

Upgrade feedurl already contains upgrade ring specification as a substring. Github upgrader now attempts to parse feedurl and read the ring info specified. If a known ring info (Slow or Fast) is not found, then it would fallback on using the old upgrade.ring gvfs config.

Example: A feedurl in production might look like this "https://1essharedassets.pkgs.visualstudio.com/_packaging/GVFS@Fast/nuget/v3/index.json". The url contains the substring "@Fast/" meaning "Fast" ring has to be used for upgrade checks. 