### PR TITLE
Configure installer to install PrjFSKextLogDaemon

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -36,10 +36,12 @@ fi
 
 STAGINGDIR=$BUILDOUTPUTDIR"Staging"
 VFSFORGITDESTINATION="usr/local/vfsforgit"
+DAEMONPLISTDESTINATION="Library/LaunchDaemons"
 LIBRARYEXTENSIONSDESTINATION="Library/Extensions"
 INSTALLERPACKAGENAME="VFSForGit.$PACKAGEVERSION"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
 UNINSTALLERPATH="${SOURCEDIRECTORY}/uninstall_vfsforgit.sh"
+SCRIPTSPATH="${SOURCEDIRECTORY}/scripts"
 
 function CheckBuildIsAvailable()
 {
@@ -65,6 +67,9 @@ function CreateInstallerRoot()
     
     mkdirBin="mkdir -p \"${STAGINGDIR}/$LIBRARYEXTENSIONSDESTINATION\""
     eval $mkdirBin || exit 1
+    
+    mkdirBin="mkdir -p \"${STAGINGDIR}/$DAEMONPLISTDESTINATION\""
+    eval $mkdirBin || exit 1
 }
 
 function CopyBinariesToInstall()
@@ -84,10 +89,16 @@ function CopyBinariesToInstall()
     copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/prjfs-log \"${STAGINGDIR}/${VFSFORGITDESTINATION}/.\""
     eval $copyPrjFS || exit 1
     
+    copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/PrjFSKextLogDaemon \"${STAGINGDIR}/${VFSFORGITDESTINATION}/.\""
+    eval $copyPrjFS || exit 1
+    
     copyUnInstaller="cp -f \"${UNINSTALLERPATH}\" \"${STAGINGDIR}/${VFSFORGITDESTINATION}/.\""
     eval $copyUnInstaller || exit 1
     
     copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/PrjFSKext.kext \"${STAGINGDIR}/${LIBRARYEXTENSIONSDESTINATION}/.\""
+    eval $copyPrjFS || exit 1
+    
+    copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist \"${STAGINGDIR}/${DAEMONPLISTDESTINATION}/.\""
     eval $copyPrjFS || exit 1
     
     currentDirectory=`pwd`
@@ -99,7 +110,7 @@ function CopyBinariesToInstall()
 
 function CreateInstaller()
 {
-    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --root \"${STAGINGDIR}\" \"${BUILDOUTPUTDIR}\"$INSTALLERPACKAGENAME.pkg"
+    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --scripts \"${SCRIPTSPATH}\" --root \"${STAGINGDIR}\" \"${BUILDOUTPUTDIR}\"$INSTALLERPACKAGENAME.pkg"
     eval $pkgBuildCommand || exit 1
 }
 

--- a/GVFS/GVFS.Installer.Mac/scripts/postinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/postinstall
@@ -1,0 +1,4 @@
+#!/bin/bash
+loadCmd="sudo launchctl load -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
+echo "Loading PrjFSKextLogDaemon: '$loadCmd'..."
+eval $loadCmd || exit 1

--- a/GVFS/GVFS.Installer.Mac/scripts/preinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/preinstall
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -f /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist ]; then
+    unloadCmd="sudo launchctl unload -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
+    echo "Unloading PrjFSKextLogDaemon: '$unloadCmd'..."
+    eval $unloadCmd || exit 1
+fi

--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -3,6 +3,8 @@
 KEXTFILENAME="PrjFSKext.kext"
 VFSFORDIRECTORY="/usr/local/vfsforgit"
 PRJFSKEXTDIRECTORY="/Library/Extensions"
+LAUNCHDAEMONDIRECTORY="/Library/LaunchDaemons"
+LOGDAEMONLAUNCHDFILENAME="org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
 GVFSCOMMANDPATH="/usr/local/bin/gvfs"
 UNINSTALLERCOMMANDPATH="/usr/local/bin/uninstall_vfsforgit.sh"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
@@ -28,6 +30,15 @@ function UnInstallVFSForGit()
     
     if [ -d "${PRJFSKEXTDIRECTORY}/$KEXTFILENAME" ]; then
         rmCmd="sudo /bin/rm -Rf ${PRJFSKEXTDIRECTORY}/$KEXTFILENAME"
+        echo "$rmCmd..."
+        eval $rmCmd || exit 1
+    fi
+    
+    if [ -f "${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME" ]; then
+        unloadCmd="sudo launchctl unload -w ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
+        echo "$unloadCmd..."
+        eval $unloadCmd || exit 1
+        rmCmd="sudo /bin/rm -Rf ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
         echo "$rmCmd..."
         eval $rmCmd || exit 1
     fi

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -119,13 +119,13 @@
 		};
 		4A08256621E77B7F00E21AFD /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /Library/LaunchDaemons;
-			dstSubfolderSpec = 0;
+			buildActionMask = 12;
+			dstPath = "";
+			dstSubfolderSpec = 16;
 			files = (
 				4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */,
 			);
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 

--- a/ProjFS.Mac/PrjFSKextLogDaemon/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist
@@ -5,7 +5,7 @@
 	<key>Label</key>
 	<string>org.vfsforgit.prjfs.PrjFSKextLogDaemon</string>
 	<key>Program</key>
-	<string>/usr/local/libexec/PrjFSKextLogDaemon</string>
+	<string>/usr/local/vfsforgit/PrjFSKextLogDaemon</string>
 	<key>KeepAlive</key>
 	<true/>
 	<key>RunAtLoad</key>


### PR DESCRIPTION
Fixes #638 

This commit installs the logging daemon as part of our installer.
Update the plist with the install location and modify the xcodeproj
to have the Daemon copied into the BuildOutput directory.

Modify the Installer project to have the plist and daemon in the
structure that becomes part of the installer. Add a postinstall script
to register the daemon with launchd.

Update uninstaller to handle these new additions.