### PR TITLE
Call git-credential approve on successful credential usage

### DIFF
--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -147,7 +147,7 @@ namespace GVFS.Common.Http
                     string contentType = GetSingleHeaderOrEmpty(response.Content.Headers, "Content-Type");
                     responseMetadata.Add("ContentType", contentType);
 
-                    this.authentication.ConfirmCredentialsWorked(authString);
+                    this.authentication.ApproveCredentials(this.Tracer, authString);
                     Stream responseStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 
                     gitEndPointResponseData = new GitEndPointResponseData(
@@ -172,7 +172,7 @@ namespace GVFS.Common.Http
                     }
                     else if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Redirect)
                     {
-                        this.authentication.Revoke(authString);
+                        this.authentication.RejectCredentials(this.Tracer, authString);
                         if (!this.authentication.IsBackingOff)
                         {
                             errorMessage = string.Format("Server returned error code {0} ({1}). Your PAT may be expired and we are asking for a new one. Original error message from server: {2}", statusInt, response.StatusCode, errorMessage);

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Git;
+using System.Linq;
+using GVFS.Common.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
@@ -33,15 +34,17 @@ namespace GVFS.UnitTests.Git
 
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
 
-            dut.Revoke(authString);
-            dut.IsBackingOff.ShouldEqual(false, "Should not backoff after credentials initially revoked");
+            dut.RejectCredentials(tracer, authString);
+            dut.IsBackingOff.ShouldEqual(false, "Should not backoff after credentials initially rejected");
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
 
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to retry getting credential on iteration");
             dut.IsBackingOff.ShouldEqual(false, "Should not backoff after successfully getting credentials");
 
-            dut.Revoke(authString);
-            dut.IsBackingOff.ShouldEqual(true, "Should continue to backoff after revoking credentials");
+            dut.RejectCredentials(tracer, authString);
+            dut.IsBackingOff.ShouldEqual(true, "Should continue to backoff after rejecting credentials");
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(false, "TryGetCredential should not succeed during backoff");
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(2);
         }
 
         [TestCase]
@@ -59,10 +62,12 @@ namespace GVFS.UnitTests.Git
             for (int i = 0; i < 5; ++i)
             {
                 dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get credential on iteration " + i + ": " + error);
-                dut.Revoke(authString);
+                dut.RejectCredentials(tracer, authString);
                 dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to retry getting credential on iteration " + i + ": " + error);
-                dut.ConfirmCredentialsWorked(authString);
+                dut.ApproveCredentials(tracer, authString);
                 dut.IsBackingOff.ShouldEqual(false, "Should reset backoff after successfully refreshing credentials");
+                gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(i+1, $"Should have {i+1} credentials rejection");
+                gitProcess.CredentialApprovals["mock://repoUrl"].Count.ShouldEqual(i+1, $"Should have {i+1} credential approvals");
             }
         }
 
@@ -79,16 +84,18 @@ namespace GVFS.UnitTests.Git
             string error;
 
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
-            dut.Revoke(authString);
+            dut.RejectCredentials(tracer, authString);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
 
             gitProcess.ShouldFail = true;
 
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(false, "Succeeded despite GitProcess returning failure");
             dut.IsBackingOff.ShouldEqual(true, "Should continue to backoff if failed to get credentials");
 
-            dut.Revoke(authString);
+            dut.RejectCredentials(tracer, authString);
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(false, "TryGetCredential should not succeed during backoff");
             dut.IsBackingOff.ShouldEqual(true, "Should continue to backoff if failed to get credentials");
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
         }
 
         [TestCase]
@@ -108,8 +115,10 @@ namespace GVFS.UnitTests.Git
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true);
 
             // Simulate a 401 error on two threads
-            dut.Revoke(authString);
-            dut.Revoke(authString);
+            dut.RejectCredentials(tracer, authString);
+            dut.RejectCredentials(tracer, authString);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialRejections["mock://repoUrl"][0].BasicAuthString.ShouldEqual(authString);
 
             // Both threads should still be able to get a PAT for retry purposes
             dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "The second thread caused back off when it shouldn't");
@@ -126,7 +135,9 @@ namespace GVFS.UnitTests.Git
             dut.TryInitializeAndRequireAuth(tracer, out _);
 
             string thread1Auth;
+            string thread1AuthRetry;
             string thread2Auth;
+            string thread2AuthRetry;
             string error;
 
             // Populate an initial PAT on two threads
@@ -134,16 +145,20 @@ namespace GVFS.UnitTests.Git
             dut.TryGetCredentials(tracer, out thread2Auth, out error).ShouldEqual(true);
 
             // Simulate a 401 error on one threads
-            dut.Revoke(thread1Auth);
+            dut.RejectCredentials(tracer, thread1Auth);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialRejections["mock://repoUrl"][0].BasicAuthString.ShouldEqual(thread1Auth);
 
             // That thread then retries
-            dut.TryGetCredentials(tracer, out thread1Auth, out error).ShouldEqual(true);
+            dut.TryGetCredentials(tracer, out thread1AuthRetry, out error).ShouldEqual(true);
 
             // The second thread fails with the old PAT
-            dut.Revoke(thread2Auth);
+            dut.RejectCredentials(tracer, thread2Auth);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1, "Should not have rejected a second time");
+            gitProcess.CredentialRejections["mock://repoUrl"][0].BasicAuthString.ShouldEqual(thread1Auth, "Should only have rejected thread1's initial credential");
 
             // The second thread should be able to get a PAT
-            dut.TryGetCredentials(tracer, out thread2Auth, out error).ShouldEqual(true, error);
+            dut.TryGetCredentials(tracer, out thread2AuthRetry, out error).ShouldEqual(true, error);
         }
 
         [TestCase]
@@ -164,18 +179,69 @@ namespace GVFS.UnitTests.Git
             dut.TryGetCredentials(tracer, out thread2Auth, out error).ShouldEqual(true);
 
             // Simulate a 401 error on one threads
-            dut.Revoke(thread1Auth);
+            dut.RejectCredentials(tracer, thread1Auth);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialRejections["mock://repoUrl"][0].BasicAuthString.ShouldEqual(thread1Auth);
 
             // That thread then retries and succeeds
             dut.TryGetCredentials(tracer, out thread1Auth, out error).ShouldEqual(true);
-            dut.ConfirmCredentialsWorked(thread1Auth);
+            dut.ApproveCredentials(tracer, thread1Auth);
+            gitProcess.CredentialApprovals["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialApprovals["mock://repoUrl"][0].BasicAuthString.ShouldEqual(thread1Auth);
 
             // If the second thread fails with the old PAT, it shouldn't stomp the new PAT
-            dut.Revoke(thread2Auth);
+            dut.RejectCredentials(tracer, thread2Auth);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1);
 
             // The second thread should be able to get a PAT
             dut.TryGetCredentials(tracer, out thread2Auth, out error).ShouldEqual(true);
             thread2Auth.ShouldEqual(thread1Auth, "The second thread stomp the first threads good auth string");
+        }
+
+        [TestCase]
+        public void DontDoubleStoreExistingCredential()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.TryInitializeAndRequireAuth(tracer, out _);
+
+            string authString;
+            dut.TryGetCredentials(tracer, out authString, out _).ShouldBeTrue();
+            dut.ApproveCredentials(tracer, authString);
+            dut.ApproveCredentials(tracer, authString);
+            dut.ApproveCredentials(tracer, authString);
+            dut.ApproveCredentials(tracer, authString);
+            dut.ApproveCredentials(tracer, authString);
+
+            gitProcess.CredentialApprovals["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialRejections.Count.ShouldEqual(0);
+            gitProcess.StoredCredentials.Count.ShouldEqual(1);
+            gitProcess.StoredCredentials.Single().Key.ShouldEqual("mock://repoUrl");
+        }
+
+        [TestCase]
+        public void DontStoreDifferentCredentialFromCachedValue()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.TryInitializeAndRequireAuth(tracer, out _);
+
+            // Get and store an initial value that will be cached
+            string authString;
+            dut.TryGetCredentials(tracer, out authString, out _).ShouldBeTrue();
+            dut.ApproveCredentials(tracer, authString);
+
+            // Try and store a different value from the one that is cached
+            dut.ApproveCredentials(tracer, "different value");
+
+            gitProcess.CredentialApprovals["mock://repoUrl"].Count.ShouldEqual(1);
+            gitProcess.CredentialRejections.Count.ShouldEqual(0);
+            gitProcess.StoredCredentials.Count.ShouldEqual(1);
+            gitProcess.StoredCredentials.Single().Key.ShouldEqual("mock://repoUrl");
         }
 
         private MockGitProcess GetGitProcess()
@@ -193,16 +259,25 @@ namespace GVFS.UnitTests.Git
                 gitProcess.SetExpectedCommandResult("config --get-urlmatch http mock://repoUrl", () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
             }
 
-            int revocations = 0;
+            int approvals = 0;
+            int rejections = 0;
             gitProcess.SetExpectedCommandResult(
                 "-c credential.useHttpPath=true credential fill",
-                () => new GitProcess.Result("username=username\r\npassword=password" + revocations + "\r\n", string.Empty, GitProcess.Result.SuccessCode));
+                () => new GitProcess.Result("username=username\r\npassword=password" + rejections + "\r\n", string.Empty, GitProcess.Result.SuccessCode));
+
+            gitProcess.SetExpectedCommandResult(
+                "credential approve",
+                () =>
+                {
+                    approvals++;
+                    return new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode);
+                });
 
             gitProcess.SetExpectedCommandResult(
                 "credential reject",
                 () =>
                 {
-                    revocations++;
+                    rejections++;
                     return new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode);
                 });
             return gitProcess;

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -1,11 +1,10 @@
-﻿using GVFS.Common.FileSystem;
-using GVFS.Common.Git;
+﻿using GVFS.Common.Git;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
-using GVFS.UnitTests.Mock.FileSystem;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace GVFS.UnitTests.Mock.Git
 {
@@ -17,15 +16,61 @@ namespace GVFS.UnitTests.Mock.Git
             : base(new MockGVFSEnlistment())
         {
             this.CommandsRun = new List<string>();
+            this.StoredCredentials = new Dictionary<string, Credential>(StringComparer.OrdinalIgnoreCase);
+            this.CredentialApprovals = new Dictionary<string, List<Credential>>();
+            this.CredentialRejections = new Dictionary<string, List<Credential>>();
         }
 
         public List<string> CommandsRun { get; }
         public bool ShouldFail { get; set; }
+        public Dictionary<string, Credential> StoredCredentials { get; }
+        public Dictionary<string, List<Credential>> CredentialApprovals { get; }
+        public Dictionary<string, List<Credential>> CredentialRejections { get; }
 
         public void SetExpectedCommandResult(string command, Func<Result> result, bool matchPrefix = false)
         {
             CommandInfo commandInfo = new CommandInfo(command, result, matchPrefix);
             this.expectedCommandInfos.Add(commandInfo);
+        }
+
+        public override void ApproveCredentials(string repoUrl, string username, string password)
+        {
+            Credential credential = new Credential(username, password);
+
+            // Record the approval request for this credential
+            List<Credential> acceptedCredentials;
+            if (!this.CredentialApprovals.TryGetValue(repoUrl, out acceptedCredentials))
+            {
+                acceptedCredentials = new List<Credential>();
+                this.CredentialApprovals[repoUrl] = acceptedCredentials;
+            }
+
+            acceptedCredentials.Add(credential);
+
+            // Store the credential
+            this.StoredCredentials[repoUrl] = credential;
+
+            base.ApproveCredentials(repoUrl, username, password);
+        }
+
+        public override void RejectCredentials(string repoUrl, string username, string password)
+        {
+            Credential credential = new Credential(username, password);
+
+            // Record the rejection request for this credential
+            List<Credential> rejectedCredentials;
+            if (!this.CredentialRejections.TryGetValue(repoUrl, out rejectedCredentials))
+            {
+                rejectedCredentials = new List<Credential>();
+                this.CredentialRejections[repoUrl] = rejectedCredentials;
+            }
+
+            rejectedCredentials.Add(credential);
+
+            // Erase the credential
+            this.StoredCredentials.Remove(repoUrl);
+
+            base.RejectCredentials(repoUrl, username, password);
         }
 
         protected override Result InvokeGitImpl(
@@ -62,6 +107,23 @@ namespace GVFS.UnitTests.Mock.Git
             matchedCommand.ShouldNotBeNull("Unexpected command: " + command);
 
             return matchedCommand.Result();
+        }
+
+        public class Credential
+        {
+            public Credential(string username, string password)
+            {
+                this.Username = username;
+                this.Password = password;
+            }
+
+            public string Username { get; }
+            public string Password { get; }
+
+            public string BasicAuthString
+            {
+                get => Convert.ToBase64String(Encoding.ASCII.GetBytes(this.Username + ":" + this.Password));
+            }
         }
 
         private class CommandInfo


### PR DESCRIPTION
After we have successfully used a generated credential we should inform Git that the credential is valid and should be stored, by calling `git credential approve`.

We make an effort to not call `approve` (which calls `gcm store`) if we've already called it once before for the currently cached credential to prevent a `store` per successfully auth'd network request.

Fixes #745 