### PR TITLE
Merge master into releases/mac_ea

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.FileSystem
         bool EnumerationExpandsDirectories { get; }
         string LogsFolderPath { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
-        string FlushLogs();
+        bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
         bool IsGVFSUpgradeSupported();

--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Common.Tracing;
 using System;
+using System.IO;
 
 namespace GVFS.Common.FileSystem
 {
@@ -10,7 +11,7 @@ namespace GVFS.Common.FileSystem
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         bool TryFlushLogs(out string errors);
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
-        bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error);
+        bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error);
         bool IsGVFSUpgradeSupported();
     }
 }

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common.FileSystem;
+﻿﻿using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
@@ -137,20 +137,17 @@ namespace GVFS.Common
                 bool supportsGVFSService = true,
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool supportsKernelLogs = true,
                 bool requiresDeprecatedGitHooksLoader = false)
             {
                 this.SupportsGVFSService = supportsGVFSService;
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
-                this.SupportsKernelLogs = supportsKernelLogs;
                 this.RequiresDeprecatedGitHooksLoader = requiresDeprecatedGitHooksLoader;
             }
 
             public bool SupportsGVFSService { get; }
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
-            public bool SupportsKernelLogs { get; }
             public bool RequiresDeprecatedGitHooksLoader { get; }
         }
     }

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -48,6 +48,12 @@ namespace GVFS.Common
                 "Newtonsoft.Json.dll"
             };
 
+        private static readonly HashSet<string> GVFSInstallerFileNamePrefixCandidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "SetupGVFS",
+            "VFSForGit"
+        };
+
         private Version installedVersion;
         private Version newestVersion;
         private Release newestRelease;
@@ -548,15 +554,15 @@ namespace GVFS.Common
 
         private bool IsGVFSAsset(Asset asset)
         {
-            return this.AssetInstallerNameCompare(asset, ProductUpgraderInfo.PossibleGVFSInstallerNamePrefixes().ToArray());
+            return this.AssetInstallerNameCompare(asset, GVFSInstallerFileNamePrefixCandidates);
         }
 
         private bool IsGitAsset(Asset asset)
         {
-            return this.AssetInstallerNameCompare(asset, GitInstallerFileNamePrefix);
+            return this.AssetInstallerNameCompare(asset, new string[] { GitInstallerFileNamePrefix });
         }
 
-        private bool AssetInstallerNameCompare(Asset asset, params string[] expectedFileNamePrefixes)
+        private bool AssetInstallerNameCompare(Asset asset, IEnumerable<string> expectedFileNamePrefixes)
         {
             foreach (string fileNamePrefix in expectedFileNamePrefixes)
             {

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
@@ -1,0 +1,60 @@
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GVFS.Common
+{
+    public partial class ProductUpgraderInfo
+    {
+        public const string UpgradeDirectoryName = "GVFS.Upgrade";
+        public const string LogDirectory = "Logs";
+        public const string DownloadDirectory = "Downloads";
+        public const string HighestAvailableVersionFileName = "HighestAvailableVersion";
+
+        private const string RootDirectory = UpgradeDirectoryName;
+
+        public static bool IsLocalUpgradeAvailable(ITracer tracer)
+        {
+            try
+            {
+                return File.Exists(GetHighestAvailableVersionFilePath());
+            }
+            catch (Exception ex) when (
+                ex is IOException ||
+                ex is UnauthorizedAccessException ||
+                ex is NotSupportedException)
+            {
+                if (tracer != null)
+                {
+                    tracer.RelatedError(
+                        CreateEventMetadata(ex),
+                        "Exception encountered when determining if an upgrade is available.");
+                }
+            }
+
+            return false;
+        }
+
+        public static string GetHighestAvailableVersionFilePath()
+        {
+            return Path.Combine(GetUpgradesDirectoryPath(), HighestAvailableVersionFileName);
+        }
+
+        public static string GetUpgradesDirectoryPath()
+        {
+            return Paths.GetServiceDataRoot(RootDirectory);
+        }
+
+        private static EventMetadata CreateEventMetadata(Exception e)
+        {
+            EventMetadata metadata = new EventMetadata();
+            if (e != null)
+            {
+                metadata.Add("Exception", e.ToString());
+            }
+
+            return metadata;
+        }
+    }
+}

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -1,3 +1,4 @@
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
@@ -5,49 +6,20 @@ using System.IO;
 
 namespace GVFS.Common
 {
-    public class ProductUpgraderInfo
+    public partial class ProductUpgraderInfo
     {
-        public const string UpgradeDirectoryName = "GVFS.Upgrade";
-        public const string LogDirectory = "Logs";
-        public const string DownloadDirectory = "Downloads";
+        private ITracer tracer;
+        private PhysicalFileSystem fileSystem;
 
-        protected const string RootDirectory = UpgradeDirectoryName;
-
-        private static readonly HashSet<string> GVFSInstallerFileNamePrefixCandidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        public ProductUpgraderInfo(ITracer tracer, PhysicalFileSystem fileSystem)
         {
-            "SetupGVFS",
-            "VFSForGit"
-        };
-
-        public static bool IsLocalUpgradeAvailable(string installerExtension)
-        {
-            string downloadDirectory = GetAssetDownloadsPath();
-            if (Directory.Exists(downloadDirectory))
-            {
-                foreach (string file in Directory.EnumerateFiles(downloadDirectory, "*", SearchOption.TopDirectoryOnly))
-                {
-                    string[] components = Path.GetFileName(file).Split('.');
-                    int length = components.Length;
-                    if (length >= 2 &&
-                        GVFSInstallerFileNamePrefixCandidates.Contains(components[0]) &&
-                        installerExtension.Equals(components[length - 1], StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
+            this.tracer = tracer;
+            this.fileSystem = fileSystem;
         }
 
-        public static IEnumerable<string> PossibleGVFSInstallerNamePrefixes()
+        public static string CurrentGVFSVersion()
         {
-            return GVFSInstallerFileNamePrefixCandidates;
-        }
-
-        public static string GetUpgradesDirectoryPath()
-        {
-            return Paths.GetServiceDataRoot(RootDirectory);
+            return ProcessHelper.GetCurrentProcessVersion();
         }
 
         public static string GetLogDirectoryPath()
@@ -67,42 +39,36 @@ namespace GVFS.Common
         /// This can include old installers which were downloaded, but user never installed
         /// using gvfs upgrade and GVFS is now up to date already.
         /// </summary>
-        public static void DeleteAllInstallerDownloads(ITracer tracer = null)
+        public void DeleteAllInstallerDownloads()
         {
             try
             {
-                RecursiveDelete(ProductUpgraderInfo.GetAssetDownloadsPath());
+                PhysicalFileSystem.RecursiveDelete(ProductUpgraderInfo.GetAssetDownloadsPath());
             }
             catch (Exception ex)
             {
-                if (tracer != null)
+                if (this.tracer != null)
                 {
-                    tracer.RelatedError($"{nameof(DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
+                    this.tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
                 }
             }
         }
 
-        private static void RecursiveDelete(string path)
+        public void RecordHighestAvailableVersion(Version highestAvailableVersion)
         {
-            if (!Directory.Exists(path))
+            string highestAvailableVersionFile = GetHighestAvailableVersionFilePath();
+
+            if (highestAvailableVersion == null)
             {
-                return;
+                if (this.fileSystem.FileExists(highestAvailableVersionFile))
+                {
+                    this.fileSystem.DeleteFile(highestAvailableVersionFile);
+                }
             }
-
-            DirectoryInfo directory = new DirectoryInfo(path);
-
-            foreach (FileInfo file in directory.GetFiles())
+            else
             {
-                file.Attributes = FileAttributes.Normal;
-                file.Delete();
+                this.fileSystem.WriteAllText(highestAvailableVersionFile, highestAvailableVersion.ToString());
             }
-
-            foreach (DirectoryInfo subDirectory in directory.GetDirectories())
-            {
-                RecursiveDelete(subDirectory.FullName);
-            }
-
-            directory.Delete();
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -15,8 +15,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [Category(Categories.WindowsOnly)]
     public class UpgradeReminderTests : TestsWithEnlistmentPerFixture
     {
-        private const string GVFSInstallerName = "VFSForGit.1.0.18234.1.exe";
-        private const string GitInstallerName = "Git-2.17.1.gvfs.2.5.g2962052-64-bit.exe";
+        private const string HighestAvailableVersionFileName = "HighestAvailableVersion";
         private const string UpgradeRingKey = "upgrade.ring";
         private const string AlwaysUpToDateRing = "None";
 
@@ -77,15 +76,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private void CreateUpgradeInstallers()
         {
-            string gvfsInstallerPath = Path.Combine(this.upgradeDirectory, GVFSInstallerName);
-            string gitInstallerPath = Path.Combine(this.upgradeDirectory, GitInstallerName);
+            string gvfsUpgradeAvailableFilePath = Path.Combine(this.upgradeDirectory, HighestAvailableVersionFileName);
 
             this.EmptyDownloadDirectory();
 
-            this.fileSystem.CreateEmptyFile(gvfsInstallerPath);
-            this.fileSystem.CreateEmptyFile(gitInstallerPath);
-            this.fileSystem.FileExists(gvfsInstallerPath).ShouldBeTrue();
-            this.fileSystem.FileExists(gitInstallerPath).ShouldBeTrue();
+            this.fileSystem.CreateEmptyFile(gvfsUpgradeAvailableFilePath);
+            this.fileSystem.FileExists(gvfsUpgradeAvailableFilePath).ShouldBeTrue();
         }
 
         private void SetUpgradeRing(string value)

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
@@ -77,7 +77,7 @@
     <Compile Include="..\GVFS.Common\ProcessResult.cs">
       <Link>Common\ProcessResult.cs</Link>
     </Compile>
-    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.cs" Link="Common\ProductUpgraderInfo.cs" />
+    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.Shared.cs" Link="Common\ProductUpgraderInfo.Shared.cs" />
     <Compile Include="..\GVFS.Common\Tracing\EventLevel.cs">
       <Link>Common\Tracing\EventLevel.cs</Link>
     </Compile>

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Windows.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Windows.csproj
@@ -94,8 +94,8 @@
     <Compile Include="..\GVFS.Common\ProcessResult.cs">
       <Link>Common\ProcessResult.cs</Link>
     </Compile>
-    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.cs">
-      <Link>Common\ProductUpgraderInfo.cs</Link>
+    <Compile Include="..\GVFS.Common\ProductUpgraderInfo.Shared.cs">
+      <Link>Common\ProductUpgraderInfo.Shared.cs</Link>
     </Compile>
     <Compile Include="..\GVFS.Common\Tracing\EventLevel.cs">
       <Link>Common\Tracing\EventLevel.cs</Link>

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -112,7 +112,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency && ProductUpgraderInfo.IsLocalUpgradeAvailable(GVFSHooksPlatform.GetInstallerExtension()))
+            if (randomValue <= reminderFrequency && ProductUpgraderInfo.IsLocalUpgradeAvailable(tracer: null))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
             }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -18,8 +18,7 @@ namespace GVFS.Platform.Mac
                 underConstruction: new UnderConstructionFlags(
                     supportsGVFSService: false,
                     supportsGVFSUpgrade: false,
-                    supportsGVFSConfig: false,
-                    supportsKernelLogs: false))
+                    supportsGVFSConfig: false))
         {
         }
 

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -14,7 +14,13 @@ namespace GVFS.Platform.Mac
 
         public bool EnumerationExpandsDirectories { get; } = true;
 
-        public string LogsFolderPath => throw new NotImplementedException();
+        public string LogsFolderPath
+        {
+            get
+            {
+                return Path.Combine(System.IO.Path.GetTempPath(), "PrjFSKext");
+            }
+        }
 
         public bool IsGVFSUpgradeSupported()
         {
@@ -42,9 +48,14 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
-        public string FlushLogs()
+        public bool TryFlushLogs(out string error)
         {
-            throw new NotImplementedException();
+            Directory.CreateDirectory(this.LogsFolderPath);
+            ProcessResult logShowOutput = ProcessHelper.Run("log", args: "show --predicate \"subsystem contains \'org.vfsforgit\'\" --info", redirectOutput: true);
+            File.WriteAllText(Path.Combine(this.LogsFolderPath, "PrjFSKext.log"), logShowOutput.Output);
+            error = string.Empty;
+
+            return true;
         }
 
         public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -320,7 +320,7 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        public string FlushLogs()
+        public bool TryFlushLogs(out string error)
         {
             StringBuilder sb = new StringBuilder();
             try
@@ -330,14 +330,19 @@ namespace GVFS.Platform.Windows
                 if (result != 0)
                 {
                     sb.AppendFormat($"Failed to flush {ProjFSFilter.ServiceName} log buffers {result}");
+                    error = sb.ToString();
+                    return false;
                 }
             }
             catch (Exception e)
             {
                 sb.AppendFormat($"Failed to flush {ProjFSFilter.ServiceName} log buffers, exception: {e.ToString()}");
+                error = sb.ToString();
+                return false;
             }
 
-            return sb.ToString();
+            error = sb.ToString();
+            return true;
         }
 
         public bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception)

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -377,7 +377,7 @@ namespace GVFS.Platform.Windows
 
         // TODO 1050199: Once the service is an optional component, GVFS should only attempt to attach
         // the filter via the service if the service is present\enabled
-        public bool IsReady(JsonTracer tracer, string enlistmentRoot, out string error)
+        public bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error)
         {
             error = string.Empty;
             return

--- a/GVFS/GVFS.UnitTests/Common/ProductUpgraderInfoTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/ProductUpgraderInfoTests.cs
@@ -1,0 +1,79 @@
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class ProductUpgraderInfoTests
+    {
+        private Mock<PhysicalFileSystem> mockFileSystem;
+        private ProductUpgraderInfo productUpgraderInfo;
+        private string upgradeDirectory;
+        private string expectedNewVersionExistsFileName = "HighestAvailableVersion";
+        private string expectedNewVersionExistsFilePath;
+        private MockTracer tracer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.upgradeDirectory = Paths.GetServiceDataRoot(ProductUpgraderInfo.UpgradeDirectoryName);
+            this.expectedNewVersionExistsFilePath = Path.Combine(this.upgradeDirectory, this.expectedNewVersionExistsFileName);
+            this.mockFileSystem = new Mock<PhysicalFileSystem>();
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.WriteAllText(this.expectedNewVersionExistsFilePath, It.IsAny<string>()));
+
+            this.tracer = new MockTracer();
+
+            this.productUpgraderInfo = new ProductUpgraderInfo(
+                this.tracer,
+                this.mockFileSystem.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.mockFileSystem = null;
+            this.productUpgraderInfo = null;
+            this.tracer = null;
+        }
+
+        [TestCase]
+        public void RecordHighestVersion()
+        {
+            this.productUpgraderInfo.RecordHighestAvailableVersion(new Version("1.0.0.0"));
+            this.mockFileSystem.Verify(fileSystem => fileSystem.WriteAllText(this.expectedNewVersionExistsFilePath, It.IsAny<string>()), Times.Once());
+        }
+
+        [TestCase]
+        public void RecordingEmptyVersionDeletesExistingHighestVersionFile()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath)).Returns(true);
+
+            this.productUpgraderInfo.RecordHighestAvailableVersion(null);
+
+            this.mockFileSystem.Verify(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath), Times.Once());
+            this.mockFileSystem.Verify(fileSystem => fileSystem.DeleteFile(this.expectedNewVersionExistsFilePath), Times.Once());
+        }
+
+        [TestCase]
+        public void RecordingEmptyVersionDoesNotDeleteNonExistingHighestVersionFile()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath)).Returns(false);
+
+            this.productUpgraderInfo.RecordHighestAvailableVersion(null);
+
+            this.mockFileSystem.Verify(fileSystem => fileSystem.FileExists(this.expectedNewVersionExistsFilePath), Times.Once());
+            this.mockFileSystem.Verify(fileSystem => fileSystem.DeleteFile(this.expectedNewVersionExistsFilePath), Times.Never());
+        }
+    }
+}

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
@@ -14,6 +15,7 @@ namespace GVFS.Upgrader
 
         private IProductUpgrader upgrader;
         private ITracer tracer;
+        private PhysicalFileSystem fileSystem;
         private InstallerPreRunChecker preRunChecker;
         private TextWriter output;
         private TextReader input;
@@ -28,6 +30,7 @@ namespace GVFS.Upgrader
         {
             this.upgrader = upgrader;
             this.tracer = tracer;
+            this.fileSystem = new PhysicalFileSystem();
             this.preRunChecker = preRunChecker;
             this.output = output;
             this.input = input;
@@ -157,7 +160,10 @@ namespace GVFS.Upgrader
 
             if (!this.upgrader.UpgradeAllowed(out error))
             {
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    this.fileSystem);
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.output.WriteLine(error);
                 consoleError = null;
                 newVersion = null;

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -88,11 +88,10 @@ namespace GVFS.CommandLine
                         // .gvfs
                         this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSConstants.DotGVFS.Root, copySubFolders: false);
 
-                        if (GVFSPlatform.Instance.UnderConstruction.SupportsKernelLogs)
+                        // driver
+                        if (this.FlushKernelDriverLogs())
                         {
-                            // driver
-                            this.FlushKernelDriverLogs();
-                            string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
+                             string kernelLogsFolderPath = GVFSPlatform.Instance.KernelDriver.LogsFolderPath;
 
                             // This copy sometimes fails because the OS has an exclusive lock on the etl files. The error is not actionable
                             // for the user so we don't write the error message to stdout, just to our own log file.
@@ -473,10 +472,12 @@ namespace GVFS.CommandLine
             }
         }
 
-        private void FlushKernelDriverLogs()
+        private bool FlushKernelDriverLogs()
         {
-            string errors = GVFSPlatform.Instance.KernelDriver.FlushLogs();
+            string errors;
+            bool flushSuccess = GVFSPlatform.Instance.KernelDriver.TryFlushLogs(out errors);
             this.diagnosticLogFileWriter.WriteLine(errors);
+            return flushSuccess;
         }
 
         private void PrintDiskSpaceInfo(string localCacheRoot, string enlistmentRootParameter)

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -115,7 +115,7 @@ namespace GVFS.CommandLine
                         { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
                     });
 
-                if (!GVFSPlatform.Instance.KernelDriver.IsReady(tracer, enlistment.EnlistmentRoot, out errorMessage))
+                if (!GVFSPlatform.Instance.KernelDriver.IsReady(tracer, enlistment.EnlistmentRoot, this.Output, out errorMessage))
                 {
                     if (GVFSPlatform.Instance.UnderConstruction.SupportsGVFSService)
                     {

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Upgrader;
 using System;
@@ -136,7 +137,10 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    new PhysicalFileSystem());
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -152,7 +156,10 @@ namespace GVFS.CommandLine
             {
                 // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
                 // upgraded by manually downloading and running asset installers.
-                ProductUpgraderInfo.DeleteAllInstallerDownloads();
+                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                    this.tracer,
+                    new PhysicalFileSystem());
+                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.ReportInfoToConsole(message);
                 return true;
             }

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -253,7 +253,10 @@ PrjFS_Result PrjFS_ConvertDirectoryToVirtualizationRoot(
     _In_    const char*                             virtualizationRootFullPath)
 {
 #ifdef DEBUG
-    cout << "PrjFS_ConvertDirectoryToVirtualizationRoot(" << virtualizationRootFullPath << ")" << endl;
+    cout
+        << "PrjFS_ConvertDirectoryToVirtualizationRoot("
+        << virtualizationRootFullPath
+        << ")" << endl;
 #endif
     
     if (nullptr == virtualizationRootFullPath)
@@ -286,7 +289,10 @@ PrjFS_Result PrjFS_WritePlaceholderDirectory(
     _In_    const char*                             relativePath)
 {
 #ifdef DEBUG
-    cout << "PrjFS_WritePlaceholderDirectory(" << relativePath << ")" << endl;
+    cout
+        << "PrjFS_WritePlaceholderDirectory("
+        << relativePath
+        << ")" << endl;
 #endif
     
     if (nullptr == relativePath)
@@ -708,7 +714,12 @@ static void HandleKernelRequest(void* messageMemory, uint32_t messageSize)
 static PrjFS_Result HandleEnumerateDirectoryRequest(const MessageHeader* request, const char* relativePath)
 {
 #ifdef DEBUG
-    cout << "PrjFSLib.HandleEnumerateDirectoryRequest: " << relativePath << endl;
+    cout
+        << "PrjFSLib.HandleEnumerateDirectoryRequest: "
+        << relativePath
+        << " Process name: " << request->procname
+        << " Pid: " << request->pid
+        << endl;
 #endif
     
     char fullPath[PrjFSMaxPath];
@@ -754,7 +765,12 @@ CleanupAndReturn:
 static PrjFS_Result HandleRecursivelyEnumerateDirectoryRequest(const MessageHeader* request, const char* relativePath)
 {
 #ifdef DEBUG
-    cout << "PrjFSLib.HandleRecursivelyEnumerateDirectoryRequest: " << relativePath << endl;
+    cout
+        << "PrjFSLib.HandleRecursivelyEnumerateDirectoryRequest: "
+        << relativePath
+        << " Process name: " << request->procname
+        << " Pid: " << request->pid
+        << endl;
 #endif
     
     DIR* directory = nullptr;
@@ -809,7 +825,12 @@ CleanupAndReturn:
 static PrjFS_Result HandleHydrateFileRequest(const MessageHeader* request, const char* relativePath)
 {
 #ifdef DEBUG
-    cout << "PrjFSLib.HandleHydrateFileRequest: " << relativePath << endl;
+    cout
+        << "PrjFSLib.HandleHydrateFileRequest: "
+        << relativePath
+        << " Process name: " << request->procname
+        << " Pid: " << request->pid
+        << endl;
 #endif
     
     char fullPath[PrjFSMaxPath];
@@ -907,7 +928,10 @@ static PrjFS_Result HandleNewFileInRootNotification(
 {
 #ifdef DEBUG
     cout
-        << "HandleNewFileInRootNotification: " << relativePath
+        << "HandleNewFileInRootNotification: "
+        << relativePath
+        << " Process name: " << request->procname
+        << " Pid: " << request->pid
         << " notificationType: " << NotificationTypeToString(notificationType)
         << " isDirectory: " << isDirectory << endl;
 #endif
@@ -939,7 +963,10 @@ static PrjFS_Result HandleFileNotification(
 {
 #ifdef DEBUG
     cout
-        << "PrjFSLib.HandleFileNotification: " << relativePath
+        << "PrjFSLib.HandleFileNotification: "
+        << relativePath
+        << " Process name: " << request->procname
+        << " Pid: " << request->pid
         << " notificationType: " << NotificationTypeToString(notificationType)
         << " isDirectory: " << isDirectory << endl;
 #endif


### PR DESCRIPTION
We want to pick up #712 for our release to early adopters.

Contains
#726 - Add additional debug logging to ProjFSLib
#686 - Teach `GVFS diagnose` to parse log daemon data from the `log show` command
#712 - Try loading the kext if not loaded on mount time
#736 - Teach product updater to only write the newest version available