### PR TITLE
List blocking processes with pid

### DIFF
--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -76,7 +76,7 @@ namespace GVFS.Upgrader
                 // actually quits.
                 this.tracer.RelatedInfo("Checking if GVFS or dependent processes are running.");
                 int retryCount = 10;
-                HashSet<string> processList = null;
+                List<string> processList = null;
                 while (retryCount > 0)
                 {
                     if (!this.IsBlockingProcessRunning(out processList))
@@ -126,11 +126,11 @@ namespace GVFS.Upgrader
             return GVFSEnlistment.IsUnattended(this.tracer);
         }
 
-        protected virtual bool IsBlockingProcessRunning(out HashSet<string> processes)
+        protected virtual bool IsBlockingProcessRunning(out List<string> processes)
         {
             int currentProcessId = Process.GetCurrentProcess().Id;
             Process[] allProcesses = Process.GetProcesses();
-            HashSet<string> matchingNames = new HashSet<string>();
+            List<string> matchingNames = new List<string>();
 
             foreach (Process process in allProcesses)
             {
@@ -139,7 +139,7 @@ namespace GVFS.Upgrader
                     continue;
                 }
 
-                matchingNames.Add(process.ProcessName);
+                matchingNames.Add(process.ProcessName + " pid:" + process.Id);
             }
 
             processes = matchingNames;

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -72,9 +72,9 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             return this.FakedResultOfCheck(FailOnCheckType.UnattendedMode);
         }
 
-        protected override bool IsBlockingProcessRunning(out HashSet<string> processes)
+        protected override bool IsBlockingProcessRunning(out List<string> processes)
         {
-            processes = new HashSet<string>();
+            processes = new List<string>();
 
             bool isRunning = this.FakedResultOfCheck(FailOnCheckType.BlockingProcessesRunning);
             if (isRunning)


### PR DESCRIPTION
This does a very small change to give both process and pid when the gvfs installer cannot run.
This will allow users to better see the git processes causing issues.
If we feel necessary we could go a step further and list the full command line, but that isn't on `Process `so we'd have to call lower level  windows/linux specific commands so I'm punting unless we fine we need it.

This
```
ERROR: Blocking processes are running.
Run `gvfs upgrade --confirm` again after quitting these processes - git
```
Becomes
```
ERROR: Blocking processes are running.
Run `gvfs upgrade --confirm` again after quitting these processes - git pid:9116, git pid:16396
```

Ideally we'd want to kill background processes when we unmount.  
Speaking with @dscho that unfortunately is non-trival.
What we have in code today sends process.Kill (Terminate) to the running git process.  
This isn't sufficient however, since git may have spawned other processes.

**Here are some options:**
1. Walk the processes tree calling Kill.  This is the easiest and also a cross-platform solution.  The issue here could be that we leave .lock files interfering with future runs causing user frustration.  
This would be something to double check with @derrickstolee , but @dscho believes we'll almost certainly have this issue.

2. Create a Windows and Unix specific solution
- On Windows
  - Ensure VFS / Git have the same bit version 
  - Enumerate the process tree filtering by original pid as (possibly transitive) parent, then send all of them a remote thread with ExitProcess()
- On Linux/Mac
  - kill(2)

3. Leverage Git For Windows for the Windows specific solution
- On Windows
  - Expose an existing git feature for killing [here](https://github.com/git-for-windows/git/blob/master/compat/win32/exit-process.h)

_For now I think it's best to see how big of an issue this is before planning reaction work._
#704