### PR TITLE
Bug bash fixes [into milestones/M147]

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -245,7 +245,7 @@ namespace GVFS.Common.NuGetUpgrade
 
                 if (newVersion != null)
                 {
-                    this.tracer.RelatedInfo($"{nameof(this.TryQueryNewestVersion)} - new version available: installedVersion: {this.installedVersion}, highestVersionAvailable: {highestVersionAvailable}");
+                    this.tracer.RelatedInfo($"{nameof(this.TryQueryNewestVersion)} - new version available: installedVersion: {this.installedVersion}, highestVersionAvailable: {newVersion}");
                     message = $"New version {highestVersionAvailable.Identity.Version} is available.";
                     return true;
                 }


### PR DESCRIPTION
Merge of #753 into the release candidate branch

PR for bug bash fixes, a second PR into the release branch will be created once it's available.

### Commit 1

Fixed an issue where "highestVersionAvailable:" was not being properly logged.

*Example*

[2019-02-07 14:40:33 -08:00] Information {"Message":"TryQueryNewestVersion - new version available: installedVersion: 0.2.173.2, **highestVersionAvailable: NuGet.Protocol.PackageSearchMetadataRegistration"**}

*With Fix*

[2019-02-07 15:16:10 -08:00] Information {"Message":"TryQueryNewestVersion - new version available: installedVersion: 0.2.173.2, **highestVersionAvailable: 0.3.0.20"**}

### Commit 2

Fixed an issue where running `gvfs upgrade` with `--confirm` or `--dry-run` resulted in 2 to 3 `gvfs_productupgrade_process` log files being created.

The cause of the issue was that `UpgradeOrchestrator()` is apparently called multiple times by `CommandLine`'s parser, and each invocation was creating a new tracer (and corresponding log file).  The fix was to use the same approach as `InProcessMountVerb` which creates the tracer in its `Execute()` method.
