### PR TITLE
Log ring when querying for upgrades on the background timer [M147 port]

### DIFF
--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -179,7 +179,7 @@ namespace GVFS.Service
         private bool TryQueryForNewerVersion(ITracer tracer, GitHubUpgrader productUpgrader, out Version newVersion, out string errorMessage)
         {
             errorMessage = null;
-            tracer.RelatedInfo("Querying server for latest version...");
+            tracer.RelatedInfo($"Querying server for latest version in ring {productUpgrader.Config.UpgradeRing}...");
 
             if (!productUpgrader.TryQueryNewestVersion(out newVersion, out string detailedError))
             {


### PR DESCRIPTION
Old behavior:
```
[2019-02-08 10:05:32 -08:00] Information {"Message":"Querying server for latest version..."} 
[2019-02-08 10:05:32 -08:00] Information {"Message":"No newer versions available."} 
```

New behavior:
```
[2019-02-08 20:35:51 -05:00] Information {"Message":"Querying server for latest version in ring Fast..."}
[2019-02-08 20:35:51 -05:00] Information {"Message":"Newer version available: 1.0.18297.1."}
```