### PR TITLE
Better feedback and fixes for Upgrade Scenario

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -58,6 +58,9 @@ namespace GVFS.Common
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly);
 
         public abstract bool IsConsoleOutputRedirectedToFile();
+
+        public abstract bool TryKillProcessTree(int processId, out int exitCode, out string error);
+
         public abstract bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage);
 
         public abstract bool IsGitStatusCacheSupported();

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -126,7 +126,7 @@ namespace GVFS.Common.Git
             return true;
         }
 
-        public bool TryKillRunningProcess()
+        public bool WaitForRunningGitProcess()
         {
             this.stopping = true;
 
@@ -138,7 +138,7 @@ namespace GVFS.Common.Git
 
                     if (process != null)
                     {
-                        process.Kill();
+                        process.WaitForExit();
                     }
 
                     return true;

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -74,11 +74,9 @@ namespace GVFS.Upgrader
             return true;
         }
 
-        public virtual bool NoBlockingProcessCheck(out string consoleError)
+        public virtual bool IsInstallationBlockedByRunningProcess(out string consoleError)
         {
             consoleError = null;
-
-            this.tracer.RelatedInfo("Checking for running git processes.");
 
             // While checking for blocking processes like GVFS.Mount immediately after un-mounting,
             // then sometimes GVFS.Mount shows up as running. But if the check is done after waiting
@@ -87,7 +85,7 @@ namespace GVFS.Upgrader
             // actually quits.
             this.tracer.RelatedInfo("Checking if GVFS or dependent processes are running.");
             int retryCount = 10;
-            List<string> processList = null;
+            HashSet<string> processList = null;
             while (retryCount > 0)
             {
                 if (!this.IsBlockingProcessRunning(out processList))
@@ -105,7 +103,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     "Blocking processes are running.",
                     $"Run {this.CommandToRerun} again after quitting these processes - " + string.Join(", ", processList.ToArray()));
-                this.tracer.RelatedError($"{nameof(this.TryUnmountAllGVFSRepos)}: {consoleError}");
+                this.tracer.RelatedError($"{nameof(this.IsInstallationBlockedByRunningProcess)}: {consoleError}");
                 return false;
             }
 
@@ -134,11 +132,11 @@ namespace GVFS.Upgrader
             return GVFSEnlistment.IsUnattended(this.tracer);
         }
 
-        protected virtual bool IsBlockingProcessRunning(out List<string> processes)
+        protected virtual bool IsBlockingProcessRunning(out HashSet<string> processes)
         {
             int currentProcessId = Process.GetCurrentProcess().Id;
             Process[] allProcesses = Process.GetProcesses();
-            List<string> matchingNames = new List<string>();
+            HashSet<string> matchingNames = new HashSet<string>();
 
             foreach (Process process in allProcesses)
             {

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -58,7 +58,6 @@ namespace GVFS.Upgrader
         public virtual bool TryUnmountAllGVFSRepos(out string consoleError)
         {
             consoleError = null;
-
             this.tracer.RelatedInfo("Unmounting any mounted GVFS repositories.");
 
             using (ITracer activity = this.tracer.StartActivity(nameof(this.TryUnmountAllGVFSRepos), EventLevel.Informational))
@@ -69,36 +68,45 @@ namespace GVFS.Upgrader
                     return false;
                 }
 
-                // While checking for blocking processes like GVFS.Mount immediately after un-mounting,
-                // then sometimes GVFS.Mount shows up as running. But if the check is done after waiting
-                // for some time, then eventually GVFS.Mount goes away. The retry loop below is to help
-                // account for this delay between the time un-mount call returns and when GVFS.Mount
-                // actually quits.
-                this.tracer.RelatedInfo("Checking if GVFS or dependent processes are running.");
-                int retryCount = 10;
-                HashSet<string> processList = null;
-                while (retryCount > 0)
-                {
-                    if (!this.IsBlockingProcessRunning(out processList))
-                    {
-                        break;
-                    }
-
-                    Thread.Sleep(TimeSpan.FromMilliseconds(250));
-                    retryCount--;
-                }
-
-                if (processList.Count > 0)
-                {
-                    consoleError = string.Join(
-                        Environment.NewLine,
-                        "Blocking processes are running.",
-                        $"Run {this.CommandToRerun} again after quitting these processes - " + string.Join(", ", processList.ToArray()));
-                    this.tracer.RelatedError($"{nameof(this.TryUnmountAllGVFSRepos)}: {consoleError}");
-                    return false;
-                }
-
                 activity.RelatedInfo("Successfully unmounted repositories.");
+            }
+
+            return true;
+        }
+
+        public virtual bool NoBlockingProcessCheck(out string consoleError)
+        {
+            consoleError = null;
+
+            this.tracer.RelatedInfo("Checking for running git processes.");
+
+            // While checking for blocking processes like GVFS.Mount immediately after un-mounting,
+            // then sometimes GVFS.Mount shows up as running. But if the check is done after waiting
+            // for some time, then eventually GVFS.Mount goes away. The retry loop below is to help
+            // account for this delay between the time un-mount call returns and when GVFS.Mount
+            // actually quits.
+            this.tracer.RelatedInfo("Checking if GVFS or dependent processes are running.");
+            int retryCount = 10;
+            List<string> processList = null;
+            while (retryCount > 0)
+            {
+                if (!this.IsBlockingProcessRunning(out processList))
+                {
+                    break;
+                }
+
+                Thread.Sleep(TimeSpan.FromMilliseconds(250));
+                retryCount--;
+            }
+
+            if (processList.Count > 0)
+            {
+                consoleError = string.Join(
+                    Environment.NewLine,
+                    "Blocking processes are running.",
+                    $"Run {this.CommandToRerun} again after quitting these processes - " + string.Join(", ", processList.ToArray()));
+                this.tracer.RelatedError($"{nameof(this.TryUnmountAllGVFSRepos)}: {consoleError}");
+                return false;
             }
 
             return true;
@@ -126,11 +134,11 @@ namespace GVFS.Upgrader
             return GVFSEnlistment.IsUnattended(this.tracer);
         }
 
-        protected virtual bool IsBlockingProcessRunning(out HashSet<string> processes)
+        protected virtual bool IsBlockingProcessRunning(out List<string> processes)
         {
             int currentProcessId = Process.GetCurrentProcess().Id;
             Process[] allProcesses = Process.GetProcesses();
-            HashSet<string> matchingNames = new HashSet<string>();
+            List<string> matchingNames = new List<string>();
 
             foreach (Process process in allProcesses)
             {
@@ -139,7 +147,7 @@ namespace GVFS.Upgrader
                     continue;
                 }
 
-                matchingNames.Add(process.ProcessName);
+                matchingNames.Add(process.ProcessName + " pid:" + process.Id);
             }
 
             processes = matchingNames;

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -79,18 +79,18 @@ namespace GVFS.Common.Maintenance
 
                 if (process != null)
                 {
-                    if (process.TryKillRunningProcess())
+                    if (process.WaitForRunningGitProcess())
                     {
                         this.Context.Tracer.RelatedEvent(
                             EventLevel.Informational,
-                            this.Area + ": killed background Git process during " + nameof(this.Stop),
+                            this.Area + ": waited for background Git process during " + nameof(this.Stop),
                             metadata: null);
                     }
                     else
                     {
                         this.Context.Tracer.RelatedEvent(
                             EventLevel.Informational,
-                            this.Area + ": failed to kill background Git process during " + nameof(this.Stop),
+                            this.Area + ": failed to wait for background Git process during " + nameof(this.Stop),
                             metadata: null);
                     }
                 }

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -79,18 +79,28 @@ namespace GVFS.Common.Maintenance
 
                 if (process != null)
                 {
-                    if (process.WaitForRunningGitProcess())
+                    if (process.TryKillRunningProcess(out string processName, out int exitCode, out string error))
                     {
                         this.Context.Tracer.RelatedEvent(
                             EventLevel.Informational,
-                            this.Area + ": waited for background Git process during " + nameof(this.Stop),
+                            string.Format(
+                                "{0}: killed background process {1} during {2}",
+                                this.Area,
+                                processName,
+                                nameof(this.Stop)),
                             metadata: null);
                     }
                     else
                     {
                         this.Context.Tracer.RelatedEvent(
                             EventLevel.Informational,
-                            this.Area + ": failed to wait for background Git process during " + nameof(this.Stop),
+                            string.Format(
+                                "{0}: failed to kill background process {1} during {2}. ExitCode:{3} Error:{4}",
+                                this.Area,
+                                processName,
+                                nameof(this.Stop),
+                                exitCode,
+                                error),
                             metadata: null);
                     }
                 }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -159,5 +159,13 @@ namespace GVFS.Platform.Mac
         {
             return new MacFileBasedLock(fileSystem, tracer, lockPath);
         }
+
+        public override bool TryKillProcessTree(int processId, out int exitCode, out string error)
+        {
+            ProcessResult result = ProcessHelper.Run("pkill", $"-P {processId}");
+            error = result.Errors;
+            exitCode = result.ExitCode;
+            return result.ExitCode == 0;
+        }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -332,6 +332,14 @@ namespace GVFS.Platform.Windows
             return WindowsPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
         }
 
+        public override bool TryKillProcessTree(int processId, out int exitCode, out string error)
+        {
+            ProcessResult result = ProcessHelper.Run("taskkill", $"/pid {processId} /f /t");
+            error = result.Errors;
+            exitCode = result.ExitCode;
+            return result.ExitCode == 0;
+        }
+
         private static object GetValueFromRegistry(RegistryHive registryHive, string key, string valueName, RegistryView view)
         {
             RegistryKey localKey = RegistryKey.OpenBaseKey(registryHive, view);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -72,9 +72,9 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             return this.FakedResultOfCheck(FailOnCheckType.UnattendedMode);
         }
 
-        protected override bool IsBlockingProcessRunning(out HashSet<string> processes)
+        protected override bool IsBlockingProcessRunning(out List<string> processes)
         {
-            processes = new HashSet<string>();
+            processes = new List<string>();
 
             bool isRunning = this.FakedResultOfCheck(FailOnCheckType.BlockingProcessesRunning);
             if (isRunning)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockInstallerPreRunChecker.cs
@@ -72,9 +72,9 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             return this.FakedResultOfCheck(FailOnCheckType.UnattendedMode);
         }
 
-        protected override bool IsBlockingProcessRunning(out List<string> processes)
+        protected override bool IsBlockingProcessRunning(out HashSet<string> processes)
         {
-            processes = new List<string>();
+            processes = new HashSet<string>();
 
             bool isRunning = this.FakedResultOfCheck(FailOnCheckType.BlockingProcessesRunning);
             if (isRunning)

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -12,7 +12,7 @@ namespace GVFS.UnitTests.Git
         public void TryKillRunningProcess_NeverRan()
         {
             GitProcess process = new GitProcess(new MockGVFSEnlistment());
-            process.TryKillRunningProcess().ShouldBeTrue();
+            process.WaitForRunningGitProcess().ShouldBeTrue();
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -12,7 +12,11 @@ namespace GVFS.UnitTests.Git
         public void TryKillRunningProcess_NeverRan()
         {
             GitProcess process = new GitProcess(new MockGVFSEnlistment());
-            process.WaitForRunningGitProcess().ShouldBeTrue();
+            process.TryKillRunningProcess(out string processName, out int exitCode, out string error).ShouldBeTrue();
+
+            processName.ShouldBeNull();
+            exitCode.ShouldEqual(-1);
+            error.ShouldBeNull();
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -122,5 +122,12 @@ namespace GVFS.UnitTests.Mock.Common
         {
             return new MockFileBasedLock(fileSystem, tracer, lockPath);
         }
+
+        public override bool TryKillProcessTree(int processId, out int exitCode, out string error)
+        {
+            error = null;
+            exitCode = 0;
+            return true;
+        }
     }
 }

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -219,6 +219,27 @@ namespace GVFS.Upgrader
                 return false;
             }
 
+            if (!this.LaunchInsideSpinner(
+                () =>
+                {
+                    // if (!this.preRunChecker.TryUnmountAllGVFSRepos(out error))
+
+                    if (!this.preRunChecker.NoBlockingProcessCheck(out error))
+                    {
+                        return false;
+                    }
+
+                    this.mount = true;
+
+                    return true;
+                },
+                "Checking for running git processes."))
+            {
+                newVersion = null;
+                consoleError = error;
+                return false;
+            }
+
             if (!this.upgrader.TryRunInstaller(this.LaunchInsideSpinner, out consoleError))
             {
                 newVersion = null;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -222,18 +222,14 @@ namespace GVFS.Upgrader
             if (!this.LaunchInsideSpinner(
                 () =>
                 {
-                    // if (!this.preRunChecker.TryUnmountAllGVFSRepos(out error))
-
-                    if (!this.preRunChecker.NoBlockingProcessCheck(out error))
+                    if (!this.preRunChecker.IsInstallationBlockedByRunningProcess(out error))
                     {
                         return false;
                     }
 
-                    this.mount = true;
-
                     return true;
                 },
-                "Checking for running git processes."))
+                "Checking for blocking processes."))
             {
                 newVersion = null;
                 consoleError = error;


### PR DESCRIPTION
This is a continuation of PR #752 , which was accidentally closed and can't be reopened.  Resolves #704

1. We kill the entire tree for background jobs.  

I used taskkill on windows and kill on mac.  I did try using the native libraries but in addition to being messier it didn't take out the entire tree.  If anyone is interested the branch with that approach is [here](https://github.com/jeschu1/VFSForGit/tree/upgrade_fail_native).

2. When running upgrade we do a seperate check to see if any git processes are running.  At this point the only clashers would be ones external to gvfs.

This
```
Downloading...Succeeded
Unmounting repositories...Failed
Mounting repositories...Succeeded

ERROR: Blocking processes are running.
Run `gvfs upgrade --confirm` again after quitting these processes - git
```
Becomes
```
Downloading...Succeeded
Unmounting repositories...Succeeded
Checking for running git processes....Failed
Mounting repositories...Succeeded

ERROR: Blocking processes are running.
Run `gvfs upgrade --confirm` again after quitting these processes - git pid:18360, git pid:46588`
```

Testing on Mac is still in progress...