### PR TITLE
[merge to master] Log GVFS.Service ACL exceptions, and fix upgrade log directory ACL issue

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -124,6 +124,16 @@ namespace GVFS.Common
             string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
             string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ToolsDirectory);
 
+            Exception deleteDirectoryException;
+            if (this.fileSystem.DirectoryExists(toolsDirectoryPath) &&
+                !this.fileSystem.TryDeleteDirectory(toolsDirectoryPath, out deleteDirectoryException))
+            {
+                upgraderToolPath = null;
+                error = $"Failed to delete {toolsDirectoryPath} - {deleteDirectoryException.Message}";
+                this.TraceException(deleteDirectoryException, nameof(this.TrySetupToolsDirectory), $"Error deleting {toolsDirectoryPath}.");
+                return false;
+            }
+
             if (!this.fileSystem.TryCreateDirectoryWithAdminOnlyModify(
                     this.tracer,
                     toolsDirectoryPath,

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
+    [NonParallelizable]
     [Category(Categories.FullSuiteOnly)]
     public class DiagnoseTests : TestsWithEnlistmentPerFixture
     {

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -509,7 +509,7 @@ namespace GVFS.Service
             // Protect the access rules from inheritance and remove any inherited rules
             upgradeLogsSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
 
-            // Add new ACLs for users and admins.  Users will be granted write permissions.S
+            // Add new ACLs for users and admins.  Users will be granted write permissions.
             WindowsFileSystem.AddUsersAccessRulesToDirectorySecurity(upgradeLogsSecurity, grantUsersModifyPermissions: true);
             WindowsFileSystem.AddAdminAccessRulesToDirectorySecurity(upgradeLogsSecurity);
             return upgradeLogsSecurity;

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -374,10 +374,17 @@ namespace GVFS.Service
             DirectorySecurity serviceDataRootSecurity;
             if (Directory.Exists(serviceDataRootPath))
             {
+                this.tracer.RelatedInfo(
+                    $"{nameof(this.CreateAndConfigureProgramDataDirectories)}: {serviceDataRootPath} exists, setting ACLs.");
+
                 serviceDataRootSecurity = Directory.GetAccessControl(serviceDataRootPath);
             }
             else
             {
+                // Warning because CreateServiceLogsDirectory should have created this directory already if it didn't exist
+                this.tracer.RelatedWarning(
+                    $"{nameof(this.CreateAndConfigureProgramDataDirectories)}: {serviceDataRootPath} does not exist, creating directory.");
+
                 serviceDataRootSecurity = new DirectorySecurity();
             }
 
@@ -406,10 +413,12 @@ namespace GVFS.Service
             DirectorySecurity upgradeLogsSecurity;
             if (Directory.Exists(upgradeLogsPath))
             {
+                this.tracer.RelatedInfo("Setting ACLs on existing upgrade log directory");
                 upgradeLogsSecurity = Directory.GetAccessControl(upgradeLogsPath);
             }
             else
             {
+                this.tracer.RelatedInfo("Creating new upgrade log directory");
                 upgradeLogsSecurity = new DirectorySecurity();
             }
 
@@ -423,8 +432,73 @@ namespace GVFS.Service
 
             Directory.CreateDirectory(upgradeLogsPath, upgradeLogsSecurity);
 
-            // Ensure the ACLs are set correct on any files or directories that were already created (e.g. after upgrading VFS4G)
-            Directory.SetAccessControl(upgradeLogsPath, upgradeLogsSecurity);
+            try
+            {
+                // Ensure the ACLs are set correct on any files or directories that were already created (e.g. after upgrading VFS4G)
+                Directory.SetAccessControl(upgradeLogsPath, upgradeLogsSecurity);
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                // This can happen when the Logs directory was created by a non-elevated user running 'gvfs upgrade'
+
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", e.ToString());
+                metadata.Add(
+                    TracingConstants.MessageKey.InfoMessage,
+                    $"{nameof(this.CreateAndConfigureUpgradeLogDirectory)}: UnauthorizedAccessException when setting log dir ACLs");
+                this.tracer.RelatedEvent(EventLevel.Informational, "LogDirACL_UnauthorizedAccessException", metadata);
+
+                this.MigrateUpgradeLogsToDirectoryWithFreshACLs();
+            }
+        }
+
+        private void MigrateUpgradeLogsToDirectoryWithFreshACLs()
+        {
+            string upgradeLogsPath = ProductUpgraderInfo.GetLogDirectoryPath();
+            string tempUpgradeLogsPath = Path.Combine(
+                Path.GetDirectoryName(upgradeLogsPath),
+                ProductUpgraderInfo.LogDirectory + "_" + Guid.NewGuid().ToString("N"));
+
+            this.tracer.RelatedInfo($"Renaming '{upgradeLogsPath}' to '{tempUpgradeLogsPath}'");
+            Directory.Move(upgradeLogsPath, tempUpgradeLogsPath);
+
+            this.tracer.RelatedInfo($"Creating new '{upgradeLogsPath}' directory with appropriate ACLs");
+            DirectorySecurity upgradeLogsSecurity = new DirectorySecurity();
+
+            // Protect the access rules from inheritance and remove any inherited rules
+            // (any manually added ACLs are left in place)
+            upgradeLogsSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+            // Add ACLs for users and admins
+            WindowsFileSystem.AddUsersAccessRulesToDirectorySecurity(upgradeLogsSecurity, grantUsersModifyPermissions: true);
+            WindowsFileSystem.AddAdminAccessRulesToDirectorySecurity(upgradeLogsSecurity);
+            Directory.CreateDirectory(upgradeLogsPath, upgradeLogsSecurity);
+
+            try
+            {
+                DirectoryInfo tempDirectoryInfo = new DirectoryInfo(tempUpgradeLogsPath);
+                FileInfo[] existingLogFileInfos = tempDirectoryInfo.GetFiles("*", SearchOption.TopDirectoryOnly);
+
+                this.tracer.RelatedInfo($"Moving {existingLogFileInfos.Length} log files from '{tempUpgradeLogsPath}' to '{upgradeLogsPath}'");
+                foreach (FileInfo logFileInfo in existingLogFileInfos)
+                {
+                    File.Move(logFileInfo.FullName, Path.Combine(upgradeLogsPath, logFileInfo.Name));
+                }
+
+                PhysicalFileSystem fileSystem = new PhysicalFileSystem();
+                fileSystem.DeleteDirectory(tempUpgradeLogsPath, recursive: true);
+            }
+            catch (Exception e)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", e.ToString());
+                metadata.Add(nameof(tempUpgradeLogsPath), tempUpgradeLogsPath);
+                metadata.Add(nameof(upgradeLogsPath), upgradeLogsPath);
+
+                this.tracer.RelatedWarning(
+                    metadata,
+                    $"{nameof(this.MigrateUpgradeLogsToDirectoryWithFreshACLs)}: Caught exception migrating log files");
+            }
         }
     }
 }


### PR DESCRIPTION
This is the same branch as #776, but targeted to master

---

Fixes #767 and fixes #768

This PR has three commits:

1. Create a tracer before adjusting ACLs so that exceptions (and progress) can be logged
2. Always delete any existing Tools directory before creating a new one
3. There was an issue that if a user previously ran `gvfs upgrade`, `C:\ProgramData\GVFS\GVFS.Upgrade\Logs` would be created with that user as the owner.  Then later, upon upgrading to this version, `Logs` would inherit more restrictive ACLs from its parent directory that would not allow non-elevated `gvfs mount` processes to create new log files.  Attempts to adjust the ACLs on `C:\ProgramData\GVFS\GVFS.Upgrade\Logs` directly by GVFS.Service would fail because `Administrators` was not the owner.  To address this, if GVFS.Service is unable to adjust the ACLs it will create a new `Logs` directory and migrate over any existing log files.