### PR TITLE
Update VFS4G for upcoming changes to the ProjFS managed API

### DIFF
--- a/GVFS/GVFS.Build/ProjFS.props
+++ b/GVFS/GVFS.Build/ProjFS.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjFSPackage>GVFS.ProjFS.2018.823.1</ProjFSPackage>
+    <ProjFSPackage>GVFS.ProjFS.2019.211.1-pr</ProjFSPackage>
   </PropertyGroup>
 </Project>

--- a/GVFS/GVFS.Platform.Windows/packages.config
+++ b/GVFS/GVFS.Platform.Windows/packages.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GVFS.ProjFS" version="2018.823.1" targetFramework="net461" />
+  <package id="GVFS.ProjFS" version="2019.211.1-pr" targetFramework="net461" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.Database.Collections.Generic" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.Database.Isam" version="1.9.4" targetFramework="net461" />

--- a/GVFS/GVFS.UnitTests.Windows/packages.config
+++ b/GVFS/GVFS.UnitTests.Windows/packages.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
-  <package id="GVFS.ProjFS" version="2018.823.1" targetFramework="net461" />
+  <package id="GVFS.ProjFS" version="2019.211.1-pr" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.0.0" targetFramework="net461" />
   <package id="Moq" version="4.10.1" targetFramework="net461" />


### PR DESCRIPTION
DO NOT MERGE: This PR was generated to provide the latest updates to the managed API.

This PR contains the updated managed library. As such it is expected that the Windows tests will fail since they won't even be able to build.

@wilbaker here is the final version of the managed API.  Aside from the namespace change from `Microsoft.Windows.PrjFSLib` to `Microsoft.Windows.ProjFS` I think the only other API change is a data type fix on one of the parameters to `IRequiredCallbacks.GetFileDataCallback`.