### PR TITLE
Update git to include trace2 v7 and process walk fix.

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190104.4</GitPackageVersion>
+    <GitPackageVersion>2.20190212.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
Update git to:

  178619c5d0 ("Merge pull request #117 from jeffhostetler/gvfs-trace2-next-fixup", 2019-02-11)

Includes trace2 V7 and associated fixes.

(cherry picked from commit c08fc060259c124afece0e540be2f8b7f896a6c0)