### PR TITLE
Rephrase ProjFS error messaging

### DIFF
--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -190,7 +190,7 @@ namespace GVFS.Upgrader
             {
                 consoleError = string.Join(
                     Environment.NewLine,
-                    $"{GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is not supported because you have previously installed an out of band ProjFS driver.",
+                    $"{GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature.",
                     "Check your team's documentation for how to upgrade.");
                 return false;
             }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -142,12 +142,12 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 expectedReturn: ReturnCode.GenericError,
                 expectedOutput: new List<string>
                 {
-                    "ERROR: `gvfs upgrade` is not supported because you have previously installed an out of band ProjFS driver.",
+                    "ERROR: `gvfs upgrade` is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature.",
                     "Check your team's documentation for how to upgrade."
                 },
                 expectedErrors: new List<string>
                 {
-                    "`gvfs upgrade` is not supported because you have previously installed an out of band ProjFS driver."
+                    "`gvfs upgrade` is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature."
                 });
         }
 


### PR DESCRIPTION
On Windows RS1/Server ProjFS is not inboxed. On those PCs the current upgrade pre-check error messaging is confusing. Updated the messaging.

Issue #769. Cherry picking a82ade35ad839b66c9ce873148dca454574db69a.