### PR TITLE
Listen to VNODE_WRITE to trigger modified files

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -46,7 +46,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
         }
 
-        [Ignore("This test exposes a bug we don't yet have a fix for")]
         [TestCase]
         public void WriteWithoutClose()
         {

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
@@ -29,6 +29,7 @@ enum PrjFSPerfCounter : int32_t
         PrjFSPerfCounter_VnodeOp_EnumerateDirectory,
         PrjFSPerfCounter_VnodeOp_RecursivelyEnumerateDirectory,
         PrjFSPerfCounter_VnodeOp_HydrateFile,
+        PrjFSPerfCounter_VnodeOp_FileModified,
     
     PrjFSPerfCounter_FileOp,
         PrjFSPerfCounter_FileOp_ShouldHandle,
@@ -40,7 +41,6 @@ enum PrjFSPerfCounter : int32_t
                 PrjFSPerfCounter_FileOp_ShouldHandle_OriginatedByProvider,
         PrjFSPerfCounter_FileOp_Renamed,
         PrjFSPerfCounter_FileOp_HardLinkCreated,
-        PrjFSPerfCounter_FileOp_FileModified,
         PrjFSPerfCounter_FileOp_FileCreated,
 
     PrjFSPerfCounter_Count,

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -52,6 +52,7 @@ static const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
     [PrjFSPerfCounter_VnodeOp_EnumerateDirectory]                           = " |--RaiseEnumerateDirectoryEvent",
     [PrjFSPerfCounter_VnodeOp_RecursivelyEnumerateDirectory]                = " |--RaiseRecursivelyEnumerateEvent",
     [PrjFSPerfCounter_VnodeOp_HydrateFile]                                  = " |--RaiseHydrateFileEvent",
+    [PrjFSPerfCounter_VnodeOp_FileModified]                                 = " |--RaiseFileModifiedEvent",
     [PrjFSPerfCounter_FileOp]                                               = "HandleFileOpOperation",
     [PrjFSPerfCounter_FileOp_ShouldHandle]                                  = " |--ShouldHandleFileOpEvent",
     [PrjFSPerfCounter_FileOp_ShouldHandle_FindVirtualizationRoot]           = " |  |--FindVirtualizationRoot",
@@ -62,7 +63,6 @@ static const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
     [PrjFSPerfCounter_FileOp_ShouldHandle_OriginatedByProvider]             = " |     |--OriginatedByProvider",
     [PrjFSPerfCounter_FileOp_Renamed]                                       = " |--RaiseRenamedEvent",
     [PrjFSPerfCounter_FileOp_HardLinkCreated]                               = " |--RaiseHardLinkCreatedEvent",
-    [PrjFSPerfCounter_FileOp_FileModified]                                  = " |--RaiseFileModifiedEvent",
     [PrjFSPerfCounter_FileOp_FileCreated]                                   = " |--RaiseFileCreatedEvent",
 };
 


### PR DESCRIPTION
Moved the modified file trigger from KAUTH_FILEOP_CLOSE/KAUTH_FILEOP_CLOSE_MODIFIED to KAUTH_VNODE_WRITE_DATA.

This means whenever authorization to write is requested we'll trigger a modified event.
In testing this doesn't seem excessive, different IDEs act differently
- TextEdit requests authorization once on open (1 event)
- Sublime/VSCode requests authorization for each save (event per save)
- VS/XCode take the approach of renaming temp files and deleting (not affected by change)

This solves the issue where a file may be written to and the descriptor isn't closed by the process.

Address half of #209