### PR TITLE
Linux: remove unneeded virtualization root setup from API

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -12,10 +12,8 @@ namespace MirrorProvider.Linux
 
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
-            Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(directory);
-
-            error = result.ToString();
-            return result == Result.Success;
+            error = null;
+            return true;
         }
 
         public override bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -22,10 +22,6 @@ namespace PrjFSLib.Linux.Interop
         public static extern void StopVirtualizationInstance(
             IntPtr mountHandle);
 
-        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_ConvertDirectoryToVirtualizationRoot")]
-        public static extern Result ConvertDirectoryToVirtualizationRoot(
-            string virtualizationRootFullPath);
-
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderDirectory")]
         public static extern Result WritePlaceholderDirectory(
             IntPtr mountHandle,

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Result.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Result.cs
@@ -20,9 +20,8 @@
         EAccessDenied                       = 0x20000010,
         EInvalidHandle                      = 0x20000020,
         EIOError                            = 0x20000040,
-        ENotAVirtualizationRoot             = 0x20000080,
-        EVirtualizationRootAlreadyExists    = 0x20000100,
         EDirectoryNotEmpty                  = 0x20000200,
+        EVirtualizationInvalidOperation     = 0x20000400,
 
         ENotYetImplemented                  = 0xFFFFFFFF,
     }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -22,11 +22,6 @@ namespace PrjFSLib.Linux
         public virtual NotifyFileRenamedEvent OnFileRenamed { get; set; }
         public virtual NotifyHardLinkCreatedEvent OnHardLinkCreated { get; set; }
 
-        public static Result ConvertDirectoryToVirtualizationRoot(string fullPath)
-        {
-            return Interop.PrjFSLib.ConvertDirectoryToVirtualizationRoot(fullPath);
-        }
-
         public virtual Result StartVirtualizationInstance(
             string storageRootFullPath,
             string virtualizationRootFullPath,


### PR DESCRIPTION
We expect any Linux implementation to virtualize using a dedicated mounted filesystem, so we do not need to flag directories within the global file hierarchy as being virtualized.  Therefore we can remove the `ConvertDirectoryToVirtualizationRoot()` function from the Linux API, and just return true from any caller (e.g., in MirrorProvider).

We can also remove the pair of associated error code which pertain to the setup of a virtualization root.