### PR TITLE
Mac: Add PreConvertToFull when Write Access is requested

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -243,10 +243,12 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.CreateFileWithoutClose(controlFile);
         }
 
-        protected void OpenFileAndWriteWithoutClose(string path, string contents)
+        protected void ReadFileAndWriteWithoutClose(string path, string contents)
         {
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
+            this.FileSystem.ReadAllText(virtualFile);
+            this.FileSystem.ReadAllText(controlFile);
             this.FileSystem.OpenFileAndWriteWithoutClose(virtualFile, contents);
             this.FileSystem.OpenFileAndWriteWithoutClose(controlFile, contents);
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -46,12 +46,11 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
         }
 
-        [Ignore("This test exposes a bug we don't yet have a fix for")]
         [TestCase]
         public void WriteWithoutClose()
         {
             string srcPath = @"Readme.md";
-            this.OpenFileAndWriteWithoutClose(srcPath, "More Stuff");
+            this.ReadFileAndWriteWithoutClose(srcPath, "More Stuff");
             this.ValidateGitCommand("status");
         }
 

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -218,6 +218,7 @@ namespace GVFS.Platform.Mac
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
             this.virtualizationInstance.OnHardLinkCreated = this.OnHardLinkCreated;
+            this.virtualizationInstance.OnFilePreConvertToFull = this.NotifyFilePreConvertToFull;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -437,23 +438,17 @@ namespace GVFS.Platform.Mac
                 {
                     this.OnDotGitFileOrFolderChanged(relativePath);
                 }
-                else
-                {
-                    // TODO(Mac): As a temporary work around (until we have a ConvertToFull type notification) treat every modification
-                    // as the first write to the file
-                    bool isFolder;
-                    string fileName;
-                    bool isPathProjected = this.FileSystemCallbacks.GitIndexProjection.IsPathProjected(relativePath, out fileName, out isFolder);
-                    if (isPathProjected)
-                    {
-                        this.FileSystemCallbacks.OnFileConvertedToFull(relativePath);
-                    }
-                }
             }
             catch (Exception e)
             {
                 this.LogUnhandledExceptionAndExit(nameof(this.OnFileModified), this.CreateEventMetadata(relativePath, e));
             }
+        }
+
+        private Result NotifyFilePreConvertToFull(string relativePath)
+        {
+            this.OnFilePreConvertToFull(relativePath);
+            return Result.Success;
         }
 
         private Result OnPreDelete(string relativePath, bool isDirectory)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1264,21 +1264,7 @@ namespace GVFS.Platform.Windows
 
         private HResult NotifyFilePreConvertToFullHandler(string virtualPath)
         {
-            try
-            {
-                bool isFolder;
-                string fileName;
-                bool isPathProjected = this.FileSystemCallbacks.GitIndexProjection.IsPathProjected(virtualPath, out fileName, out isFolder);
-                if (isPathProjected)
-                {
-                    this.FileSystemCallbacks.OnFileConvertedToFull(virtualPath);
-                }
-            }
-            catch (Exception e)
-            {
-                this.LogUnhandledExceptionAndExit(nameof(this.NotifyFilePreConvertToFullHandler), this.CreateEventMetadata(virtualPath, e));
-            }
-
+            this.OnFilePreConvertToFull(virtualPath);
             return HResult.Ok;
         }
 

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -277,6 +277,24 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
+        protected void OnFilePreConvertToFull(string relativePath)
+        {
+            try
+            {
+                bool isFolder;
+                string fileName;
+                bool isPathProjected = this.FileSystemCallbacks.GitIndexProjection.IsPathProjected(relativePath, out fileName, out isFolder);
+                if (isPathProjected)
+                {
+                    this.FileSystemCallbacks.OnFileConvertedToFull(relativePath);
+                }
+            }
+            catch (Exception e)
+            {
+                this.LogUnhandledExceptionAndExit(nameof(this.OnFilePreConvertToFull), this.CreateEventMetadata(relativePath, e));
+            }
+        }
+
         protected EventMetadata CreateEventMetadata(
             Guid enumerationId,
             string relativePath = null,

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -27,6 +27,7 @@ namespace MirrorProvider.Mac
             this.virtualizationInstance.OnNewFileCreated = this.OnNewFileCreated;
             this.virtualizationInstance.OnFileRenamed = this.OnFileRenamed;
             this.virtualizationInstance.OnHardLinkCreated = this.OnHardLinkCreated;
+            this.virtualizationInstance.OnFilePreConvertToFull = this.OnFilePreConvertToFull;
 
             Result result = this.virtualizationInstance.StartVirtualizationInstance(
                 enlistment.SrcRoot,
@@ -199,6 +200,12 @@ namespace MirrorProvider.Mac
         private void OnHardLinkCreated(string relativeNewLinkPath)
         {
             Console.WriteLine($"OnHardLinkCreated: {relativeNewLinkPath}");
+        }
+
+        private Result OnFilePreConvertToFull(string relativePath)
+        {
+            Console.WriteLine($"OnFilePreConvertToFull: {relativePath}");
+            return Result.Success;
         }
 
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -39,6 +39,7 @@ namespace MirrorProvider.Windows
             this.virtualizationInstance.OnNotifyFileHandleClosedFileModifiedOrDeleted = this.OnFileModifiedOrDeleted;
             this.virtualizationInstance.OnNotifyFileRenamed = this.OnFileRenamed;
             this.virtualizationInstance.OnNotifyHardlinkCreated = this.OnHardlinkCreated;
+            this.virtualizationInstance.OnNotifyFilePreConvertToFull = this.OnFilePreConvertToFull;
 
             uint threadCount = (uint)Environment.ProcessorCount * 2;
 
@@ -334,6 +335,12 @@ namespace MirrorProvider.Windows
             string relativeNewLinkFilePath)
         {
             Console.WriteLine($"OnHardlinkCreated, relativeExistingFilePath: {relativeExistingFilePath}, relativeNewLinkFilePath: {relativeNewLinkFilePath}");
+        }
+
+        private HResult OnFilePreConvertToFull(string relativePath)
+        {
+            Console.WriteLine($"OnFilePreConvertToFullHandler: {relativePath}");
+            return HResult.Ok;
         }
 
         // TODO: Add this to the ProjFS API

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -21,6 +21,7 @@ typedef enum
     MessageType_KtoU_NotifyFileRenamed,
     MessageType_KtoU_NotifyDirectoryRenamed,
     MessageType_KtoU_NotifyFileHardLinkCreated,
+    MessageType_KtoU_NotifyFilePreConvertToFull,
     
     // Responses
     MessageType_Response_Success,

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
@@ -29,6 +29,7 @@ enum PrjFSPerfCounter : int32_t
         PrjFSPerfCounter_VnodeOp_EnumerateDirectory,
         PrjFSPerfCounter_VnodeOp_RecursivelyEnumerateDirectory,
         PrjFSPerfCounter_VnodeOp_HydrateFile,
+        PrjFSPerfCounter_VnodeOp_PreConvertToFull,
     
     PrjFSPerfCounter_FileOp,
         PrjFSPerfCounter_FileOp_ShouldHandle,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -15,6 +15,7 @@ namespace PrjFSLib.Mac
         public virtual GetFileStreamCallback OnGetFileStream { get; set; }
 
         public virtual NotifyFileModified OnFileModified { get; set; }
+        public virtual NotifyFilePreConvertToFullEvent OnFilePreConvertToFull { get; set; }
         public virtual NotifyPreDeleteEvent OnPreDelete { get; set; }
         public virtual NotifyNewFileCreatedEvent OnNewFileCreated { get; set; }
         public virtual NotifyFileRenamedEvent OnFileRenamed { get; set; }
@@ -204,6 +205,9 @@ namespace PrjFSLib.Mac
                 case NotificationType.HardLinkCreated:
                     this.OnHardLinkCreated(relativePath);
                     return Result.Success;
+
+                case NotificationType.PreConvertToFull:
+                    return this.OnFilePreConvertToFull(relativePath);
             }
 
             return Result.ENotYetImplemented;

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -52,6 +52,7 @@ static constexpr const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
     [PrjFSPerfCounter_VnodeOp_EnumerateDirectory]                           = " |--RaiseEnumerateDirectoryEvent",
     [PrjFSPerfCounter_VnodeOp_RecursivelyEnumerateDirectory]                = " |--RaiseRecursivelyEnumerateEvent",
     [PrjFSPerfCounter_VnodeOp_HydrateFile]                                  = " |--RaiseHydrateFileEvent",
+    [PrjFSPerfCounter_VnodeOp_PreConvertToFull]                             = " |--RaisePreConvertToFull",
     [PrjFSPerfCounter_FileOp]                                               = "HandleFileOpOperation",
     [PrjFSPerfCounter_FileOp_ShouldHandle]                                  = " |--ShouldHandleFileOpEvent",
     [PrjFSPerfCounter_FileOp_ShouldHandle_FindVirtualizationRoot]           = " |  |--FindVirtualizationRoot",


### PR DESCRIPTION
Add PreConvertToFull Event when Write Access is requested
- This will mark the file as D in placeholders.dat and insert into modifiedPaths.dat
- This cleans up the existing ModifiedFile event which was also being used as the initial switch from placeholders.dat

Addresses #209