### PR TITLE
GetInsertionIndex should include the entry's name when it throws an InvalidOperationException

### DIFF
--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
@@ -132,7 +132,7 @@ namespace GVFS.Virtualization.Projection
                     insertionIndex = this.GetSortedEntriesIndexOfName(name);
                     if (insertionIndex >= 0)
                     {
-                        throw new InvalidOperationException("All entries should be unique");
+                        throw new InvalidOperationException($"All entries should be unique, non-unique entry: {name.GetString()}");
                     }
 
                     // When the name is not found the returned value is the bitwise complement of


### PR DESCRIPTION
While on support I found that this error did not include any information about the entry that VFS4G determined was non-unique:

```
[2/15/2019 12:13:36 PM] Error {"Area":"GitIndexProjection",
"Exception":"System.InvalidOperationException: All entries should be unique
   at GVFS.Virtualization.Projection.GitIndexProjection.SortedFolderEntries.GetInsertionIndex(LazyUTF8String name)
   at GVFS.Virtualization.Projection.GitIndexProjection.AddItemFromIndexEntry(GitIndexEntry indexEntry)
   at GVFS.Virtualization.Projection.GitIndexProjection.GitIndexParser.AddToProjection(GitIndexEntry data)
   at GVFS.Virtualization.Projection.GitIndexProjection.GitIndexParser.ParseIndex(ITracer tracer, Stream indexStream, Func`2 entryAction)
   at GVFS.Virtualization.Projection.GitIndexProjection.GitIndexParser.RebuildProjection(ITracer tracer, Stream indexStream)
   at GVFS.Virtualization.Projection.GitIndexProjection.BuildProjection()
   at GVFS.Virtualization.Projection.GitIndexProjection.ParseIndexThreadMain()",
"ErrorMessage":"ParseIndexThreadMain caught unhandled exception, exiting process"}
```

With the changes in this PR, the item's name will be included in the exception message:

```
"Exception":"System.InvalidOperationException: All entries should be unique, non-unique entry: Params.cpp
```

Although the full path is not included, having the file name helps when tracking down which entries in the index might be causing an issue.