### PR TITLE
WIP/RFC Mac kext: Prototype implementation of RAII based vnode iocount

### DIFF
--- a/ProjFS.Mac/PrjFSKext/Memory.hpp
+++ b/ProjFS.Mac/PrjFSKext/Memory.hpp
@@ -9,6 +9,11 @@ kern_return_t Memory_Cleanup();
 void* Memory_Alloc(uint32_t size);
 void Memory_Free(void* buffer, uint32_t size);
 
+inline void* operator new(size_t size, void* memory)
+{
+    return memory;
+}
+
 template <typename T>
 T* Memory_AllocArray(uint32_t arrayLength)
 {
@@ -18,12 +23,23 @@ T* Memory_AllocArray(uint32_t arrayLength)
         return nullptr;
     }
     
-    return static_cast<T*>(Memory_Alloc(static_cast<uint32_t>(allocBytes)));
+    T* array = static_cast<T*>(Memory_Alloc(static_cast<uint32_t>(allocBytes)));
+    for (uint32_t i = 0; i < arrayLength; ++i)
+    {
+        new(&array[i]) T();
+    }
+    
+    return array;
 }
 
 template <typename T>
 void Memory_FreeArray(T* array, uint32_t arrayLength)
 {
+    for (uint32_t i = 0; i < arrayLength; ++i)
+    {
+        array[i].~T();
+    }
+    
     size_t arrayBytes = arrayLength * sizeof(T);
     assert(arrayBytes <= UINT32_MAX);
     Memory_Free(array, static_cast<uint32_t>(arrayBytes));

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -320,6 +320,7 @@ static VirtualizationRootHandle FindRootAtVnode_Locked(vnode_t vnode, uint32_t v
         
         if (FsidsAreEqual(rootEntry.rootFsid, fileId.fsid) && rootEntry.rootInode == fileId.inode)
         {
+            assert(rootEntry.providerUserClient == nullptr);
             // root vnode must be stale, update it
             rootEntry.rootVNode = vnode;
             rootEntry.rootVNodeVid = vid;

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
@@ -5,6 +5,7 @@
 #include "public/PrjFSPerfCounter.h"
 #include "PerformanceTracing.hpp"
 #include "kernel-header-wrappers/vnode.h"
+#include "VnodeUtilities.hpp"
 
 typedef int16_t VirtualizationRootHandle;
 
@@ -41,7 +42,13 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootHandle);
 struct Message;
 errno_t ActiveProvider_SendMessage(VirtualizationRootHandle rootHandle, const Message message);
 bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode_t _Nonnull vnode);
+inline bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(const VnodeIORef& vnodeRef);
 bool VirtualizationRoot_IsOnline(VirtualizationRootHandle rootHandle);
 bool VirtualizationRoot_PIDMatchesProvider(VirtualizationRootHandle rootHandle, pid_t pid);
 bool VirtualizationRoot_IsValidRootHandle(VirtualizationRootHandle rootHandle);
 const char* _Nonnull VirtualizationRoot_GetRootRelativePath(VirtualizationRootHandle rootHandle, const char* _Nonnull path);
+
+inline bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(const VnodeIORef& vnodeRef)
+{
+    return VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnodeRef.Get());
+}

--- a/ProjFS.Mac/PrjFSKext/VnodeUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeUtilities.hpp
@@ -2,7 +2,10 @@
 
 #include <sys/kernel_types.h>
 #include <sys/_types/_fsid_t.h>
+#include <kern/assert.h>
+#include "kernel-header-wrappers/vnode.h"
 #include "public/FsidInode.h"
+#include "KextLog.hpp"
 
 struct SizeOrError
 {
@@ -12,3 +15,184 @@ struct SizeOrError
 
 SizeOrError Vnode_ReadXattr(vnode_t _Nonnull vnode, const char* _Nonnull xattrName, void* _Nullable buffer, size_t bufferSize);
 FsidInode Vnode_GetFsidAndInode(vnode_t _Nonnull vnode, vfs_context_t _Nonnull context);
+
+template <typename T> struct remove_reference
+{
+    typedef T type;
+};
+template <typename T> struct remove_reference<T&>
+{
+    typedef T type;
+};
+template <typename T> struct remove_reference<T&&>
+{
+    typedef T type;
+};
+
+template <class T>
+    constexpr typename remove_reference<T>::type&& move(T&& t) noexcept
+{
+    return static_cast<typename remove_reference<T>::type&&>(t);
+}
+
+class VnodeIORef
+{
+    _Nullable vnode_t vnode;
+    
+public:
+    // Transfers ownership if not nullptr
+    explicit VnodeIORef(_Nullable vnode_t&& ref);
+    explicit VnodeIORef(_Nullable vnode_t& ref);
+    VnodeIORef();
+    VnodeIORef(VnodeIORef&& rval);
+    VnodeIORef(const VnodeIORef& rhs);
+    VnodeIORef& operator=(const VnodeIORef& rhs);
+    VnodeIORef& operator=(VnodeIORef&& rhs);
+    ~VnodeIORef();
+    
+    _Nullable vnode_t Get() const;
+    bool IsNull() const;
+    void Transfer(_Nullable vnode_t& newVnode);
+    void Reset();
+    void SetAndRetain(_Nullable vnode_t newVnode);
+};
+
+inline bool vnode_isdir(const VnodeIORef& vnodeRef)
+{
+    return vnode_isdir(vnodeRef.Get());
+}
+
+inline uint32_t vnode_vid(const VnodeIORef& vnodeRef)
+{
+    return vnode_vid(vnodeRef.Get());
+}
+
+template <typename... args>
+    void KextLog_PrintfVnodePathAndProperties(KextLog_Level loglevel, const VnodeIORef& vnode, const char* _Nonnull fmt, args... a)
+{
+    KextLog_PrintfVnodePathAndProperties(loglevel, vnode.Get(), fmt, a...);
+}
+
+template <typename... args>
+    void KextLog_PrintfVnodeProperties(KextLog_Level loglevel, const VnodeIORef& vnode, const char* _Nonnull fmt, args... a)
+{
+    KextLog_PrintfVnodeProperties(loglevel, vnode.Get(), fmt, a...);
+}
+
+inline VnodeIORef::VnodeIORef(_Nullable vnode_t&& ref) :
+    vnode(ref)
+{
+}
+
+inline VnodeIORef::VnodeIORef(_Nullable vnode_t& ref) :
+    vnode(ref)
+{
+    ref = NULLVP;
+}
+
+inline VnodeIORef::VnodeIORef() :
+    vnode(NULLVP)
+{
+}
+
+inline VnodeIORef::VnodeIORef(VnodeIORef&& rval) :
+    vnode(rval.vnode)
+{
+    rval.vnode = NULLVP;
+}
+
+inline VnodeIORef::VnodeIORef(const VnodeIORef& rhs) :
+    vnode(rhs.vnode)
+{
+    errno_t error = vnode_get(rhs.vnode);
+    assert(error == 0); // rhs should already hold an iocount reference, so vnode_get should always succeed
+    (void)error;
+}
+
+inline VnodeIORef& VnodeIORef::operator=(const VnodeIORef& rhs)
+{
+    vnode_t newVnode = rhs.vnode;
+    if (this->vnode == newVnode)
+    {
+        return *this;
+    }
+    
+    if (this->vnode != NULLVP)
+    {
+        vnode_put(this->vnode);
+    }
+    
+    this->vnode = newVnode;
+    if (newVnode != NULLVP)
+    {
+        errno_t error = vnode_get(newVnode);
+        assert(error == 0); // rhs should already hold an iocount reference, so vnode_get should always succeed
+        (void)error;
+    }
+    
+    return *this;
+}
+
+inline VnodeIORef& VnodeIORef::operator=(VnodeIORef&& rhs)
+{
+    if (this->vnode != NULLVP)
+    {
+        vnode_put(this->vnode);
+    }
+
+    this->vnode = rhs.vnode;
+    rhs.vnode = NULLVP;
+    return *this;
+}
+
+inline VnodeIORef::~VnodeIORef()
+{
+    this->Reset();
+}
+
+inline _Nullable vnode_t VnodeIORef::Get() const
+{
+    return this->vnode;
+}
+
+inline bool VnodeIORef::IsNull() const
+{
+    return this->vnode == nullptr;
+}
+
+inline void VnodeIORef::Transfer(_Nullable vnode_t& newVnode)
+{
+    if (this->vnode != NULLVP)
+    {
+        vnode_put(this->vnode);
+    }
+    
+    this->vnode = newVnode;
+    newVnode = NULLVP;
+}
+
+inline void VnodeIORef::Reset()
+{
+    if (this->vnode != NULLVP)
+    {
+        vnode_put(this->vnode);
+        this->vnode = NULLVP;
+    }
+}
+
+inline void VnodeIORef::SetAndRetain(_Nullable vnode_t newVnode)
+{
+    if (this->vnode == newVnode)
+    {
+        return;
+    }
+    
+    if (newVnode != nullptr)
+    {
+        errno_t error = vnode_get(newVnode);
+        assert(error == 0); // rhs should already hold an iocount reference, so vnode_get should always succeed
+        (void)error;
+    }
+    
+    this->vnode = newVnode;
+}


### PR DESCRIPTION
This is a prototype implementation of a RAII-based vnode refcounting implementation in response to #797 (and as has previously been suggested in https://github.com/Microsoft/VFSForGit/pull/643#discussion_r245077013 for example).

* The first commit is an extra assertion which should definitely be included in my opinion, as it checks one of the invariants associated with retaining root vnodes or not.
* The second commit is a RAII wrapper for maintaining the correct iocount on vnode pointers. I find the code inflation caused by it somewhat off-putting, so I'm unsure whether this is the way forward. I actually haven't found the bug underlying #797 and so don't know if this change will fix it.

Note that there are some changes in PR #500 which definitely improve correctness and also clarity of the reference counting code when inserting new virtualisation roots. Again, I'm not sure they'll fix #797 as I don't know what's causing it.