### PR TITLE
Linux: use stat to get filemode

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using Mono.Unix.Native;
 
 namespace MirrorProvider.Linux
 {
@@ -103,14 +104,16 @@ namespace MirrorProvider.Linux
                     }
                     else
                     {
-                        // The MirrorProvider marks every file as executable (mode 755), but this is just a shortcut to avoid the pain of
-                        // having to p/invoke to determine if the original file is exectuable or not.
-                        // A real provider will have to get this information from its data source. For example, GVFS gets this info
-                        // out of the git index along with all the other info for projecting files.
-                        UInt16 fileMode = Convert.ToUInt16("755", 8);
+                        string childRelativePath = Path.Combine(relativePath, child.Name);
+                        int statResult = Syscall.lstat(this.GetFullPathInMirror(childRelativePath), out Stat stat);
+                        if (statResult == -1)
+                        {
+                            return Result.EIOError;
+                        }
+                        ushort fileMode = (ushort)(stat.st_mode & FilePermissions.ALLPERMS);
 
                         Result result = this.virtualizationInstance.WritePlaceholderFile(
-                            Path.Combine(relativePath, child.Name),
+                            childRelativePath,
                             providerId: ToVersionIdByteArray(1),
                             contentId: ToVersionIdByteArray(0),
                             fileSize: (ulong)child.Size,
@@ -162,7 +165,7 @@ namespace MirrorProvider.Linux
                             (uint)bytesToCopy);
                         if (result != Result.Success)
                         {
-                        Console.WriteLine($"WriteFileContents failed: {result}");
+                            Console.WriteLine($"WriteFileContents failed: {result}");
                             return false;
                         }
 

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -40,4 +40,7 @@
     <None Include="$(BuildOutputDir)\ProjFS.Linux\Native\Build\Products\$(Configuration)\libprojfs.so" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   -->
+  <ItemGroup>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Create placeholders with the correct permissions. It's "just" the mirror provider, but it was bugging me enough that I wanted to fix it.

/cc @chrisd8088 fyi