### PR TITLE
Linux: add mountHandle to WriteSymLink call

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/PrjFSLib.cs
@@ -40,6 +40,7 @@ namespace PrjFSLib.Linux.Interop
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WriteSymLink")]
         public static extern Result WriteSymLink(
+            IntPtr mountHandle,
             string relativePath,
             string symLinkTarget);
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -121,7 +121,10 @@ namespace PrjFSLib.Linux
             string relativePath,
             string symLinkTarget)
         {
-            return Interop.PrjFSLib.WriteSymLink(relativePath, symLinkTarget);
+            return Interop.PrjFSLib.WriteSymLink(
+                this.mountHandle,
+                relativePath,
+                symLinkTarget);
         }
 
         public virtual Result UpdatePlaceholderIfNeeded(


### PR DESCRIPTION
Implementing this call on the `libprojfs` side and I need this!