### PR TITLE
Set feed url based on upgrade ring during installer [M147]

### DIFF
--- a/GVFS/GVFS.Installer.Windows/Setup.iss
+++ b/GVFS/GVFS.Installer.Windows/Setup.iss
@@ -651,7 +651,7 @@ var
   ResultCode: integer;
   ResultString: ansiString;
 begin
-  Result := false
+  Result := False
   if ExecWithResult('gvfs.exe', Format('config %s', [ConfigKey]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
     ResultString := AnsiLowercase(Trim(ResultString));
     Log(Format('IsConfigured(%s): value is %s', [ConfigKey, ResultString]));
@@ -664,14 +664,14 @@ var
   ResultCode: integer;
   ResultString: ansiString;
 begin
-  if IsConfigured(ConfigKey) = false then begin
+  if IsConfigured(ConfigKey) = False then begin
     if ExecWithResult('gvfs.exe', Format('config %s %s', [ConfigKey, ConfigValue]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
-      Log(Format('SetNuGetFeedIfNecessary: Set %s to %s', [ConfigKey, ConfigValue]));
+      Log(Format('SetIfNotConfigured: Set %s to %s', [ConfigKey, ConfigValue]));
     end else begin
-      Log(Format('SetNuGetFeedIfNecessary: Failed to set %s with %s', [ConfigKey, SysErrorMessage(ResultCode)]));
+      Log(Format('SetIfNotConfigured: Failed to set %s with %s', [ConfigKey, SysErrorMessage(ResultCode)]));
     end;
   end else begin
-    Log(Format('%s is configured, not overwriting', [ConfigKey]));
+    Log(Format('SetIfNotConfigured: %s is configured, not overwriting', [ConfigKey]));
   end;
 end;
 

--- a/GVFS/GVFS.Installer.Windows/Setup.iss
+++ b/GVFS/GVFS.Installer.Windows/Setup.iss
@@ -669,7 +669,7 @@ begin
     Log('Failed to set upgrade.feedurl with ' + SysErrorMessage(ResultCode));
   end;
 
-  if ExecWithResult('gvfs.exe', Format('config upgrade.feedpackagename %s', [FeedPackageName]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) = false then begin
+  if ExecWithResult('gvfs.exe', Format('config upgrade.feedpackagename %s', [FeedPackageName]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
     Log('Set upgrade.feedpackagename to ' + FeedPackageName)
   end else begin
     Log('Failed to set upgrade.feedpackagename with ' + SysErrorMessage(ResultCode));

--- a/GVFS/GVFS.Installer.Windows/Setup.iss
+++ b/GVFS/GVFS.Installer.Windows/Setup.iss
@@ -628,17 +628,21 @@ begin
   if ExecWithResult('gvfs.exe', 'config upgrade.ring', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
     if ResultCode = 0 then begin
       ResultString := AnsiLowercase(Trim(ResultString));
-      Log('upgrade.ring is ' + ResultString);
+      Log('GetConfiguredUpgradeRing: upgrade.ring is ' + ResultString);
       if CompareText(ResultString, 'none') = 0 then begin
         Result := urNone;
       end else if CompareText(ResultString, 'fast') = 0 then begin
         Result := urFast;
       end else if CompareText(ResultString, 'slow') = 0 then begin
         Result := urSlow;
+      end else begin
+        Log('GetConfiguredUpgradeRing: Unknown upgrade ring: ' + ResultString);
       end;
+    end else begin
+      Log('GetConfiguredUpgradeRing: Call to gvfs config upgrade.ring failed with ' + SysErrorMessage(ResultCode));
     end;
   end else begin
-    Log('Call gvfs config upgrade.ring failed with ' + SysErrorMessage(ResultCode));
+    Log('GetConfiguredUpgradeRing: Call to gvfs config upgrade.ring failed with ' + SysErrorMessage(ResultCode));
   end;
 end;
 
@@ -657,22 +661,22 @@ begin
   end else if (ConfiguredRing = urSlow) or (ConfiguredRing = urNone) then begin
     RingName := 'Slow';
   end else begin
-    Log('No upgrade ring configured. Not configuring NuGet feed.')
+    Log('SetNuGetFeedIfNecessary: No upgrade ring configured. Not configuring NuGet feed.')
     exit;
   end;
 
   TargetFeed := Format('https://pkgs.dev.azure.com/microsoft/_packaging/VFSForGit-%s/nuget/v3/index.json', [RingName]);
   FeedPackageName := 'Microsoft.VfsForGitEnvironment';
   if ExecWithResult('gvfs.exe', Format('config upgrade.feedurl %s', [TargetFeed]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
-    Log('Set upgrade.feedurl to ' + TargetFeed);
+    Log('SetNuGetFeedIfNecessary: Set upgrade.feedurl to ' + TargetFeed);
   end else begin
-    Log('Failed to set upgrade.feedurl with ' + SysErrorMessage(ResultCode));
+    Log('SetNuGetFeedIfNecessary: Failed to set upgrade.feedurl with ' + SysErrorMessage(ResultCode));
   end;
 
   if ExecWithResult('gvfs.exe', Format('config upgrade.feedpackagename %s', [FeedPackageName]), '', SW_HIDE, ewWaitUntilTerminated, ResultCode, ResultString) then begin
-    Log('Set upgrade.feedpackagename to ' + FeedPackageName)
+    Log('SetNuGetFeedIfNecessary: Set upgrade.feedpackagename to ' + FeedPackageName)
   end else begin
-    Log('Failed to set upgrade.feedpackagename with ' + SysErrorMessage(ResultCode));
+    Log('SetNuGetFeedIfNecessary: Failed to set upgrade.feedpackagename with ' + SysErrorMessage(ResultCode));
   end;
 end;
 


### PR DESCRIPTION
When upgrading internal installations of VFSForGit (as determined by the explicit presence of upgrade.ring), configure a NuGet feed URL.

### Scenarios:
#### No GVFS installation
```
2019-02-19 15:33:11.910   GetConfiguredUpgradeRing: Call to gvfs config upgrade.ring failed with Incorrect function
2019-02-19 15:33:11.910   SetNuGetFeedIfNecessary: No upgrade ring configured. Not configuring NuGet feed.
```
#### No configured ring
```
2019-02-19 15:38:13.163   GetConfiguredUpgradeRing: upgrade.ring is 
2019-02-19 15:38:13.163   GetConfiguredUpgradeRing: Unknown upgrade ring: 
2019-02-19 15:38:13.163   SetNuGetFeedIfNecessary: No upgrade ring configured. Not configuring NuGet feed.
```
#### Bogus ring
```
2019-02-19 15:30:05.764   GetConfiguredUpgradeRing: upgrade.ring is bogus
2019-02-19 15:30:05.764   GetConfiguredUpgradeRing: Unknown upgrade ring: bogus
2019-02-19 15:30:05.764   SetNuGetFeedIfNecessary: No upgrade ring configured. Not configuring NuGet feed.
```
#### Slow ring
```
2019-02-19 15:35:08.156   GetConfiguredUpgradeRing: upgrade.ring is slow
2019-02-19 15:35:08.463   SetNuGetFeedIfNecessary: Set upgrade.feedurl to https://pkgs.dev.azure.com/microsoft/_packaging/VFSForGit-Slow/nuget/v3/index.json
2019-02-19 15:35:08.833   SetNuGetFeedIfNecessary: Set upgrade.feedpackagename to Microsoft.VfsForGitEnvironment
```