### PR TITLE
Mac Kext: Extra virtualization root vnode assertions & logging

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KextLog.cpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.cpp
@@ -122,3 +122,10 @@ void KextLog_Printf(KextLog_Level loglevel, const char* fmt, ...)
         Memory_Free(messagePtr, messageSize);
     }
 }
+
+const void* KextLog_Unslide(const void* pointer)
+{
+    vm_offset_t outPointer = 0;
+    vm_kernel_unslide_or_perm_external(reinterpret_cast<vm_offset_t>(pointer), &outPointer);
+    return reinterpret_cast<const void*>(outPointer);
+}

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -8,6 +8,9 @@
 #include "kernel-header-wrappers/mount.h"
 #include <os/log.h>
 
+// Redeclared as printf-like to get format string warnings on assertf()
+extern "C" void panic(const char* fmt, ...) __printflike(1, 2);
+
 bool KextLog_Init();
 void KextLog_Cleanup();
 

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -21,6 +21,9 @@ void KextLog_Cleanup();
 bool KextLog_RegisterUserClient(PrjFSLogUserClient* userClient);
 void KextLog_DeregisterUserClient(PrjFSLogUserClient* userClient);
 void KextLog_Printf(KextLog_Level loglevel, const char* fmt, ...)  __printflike(2,3);
+// Prepares a kernel pointer for printing to user space without revealing the
+// genuine kernel-space address, which would be a security issue.
+const void* KextLog_Unslide(const void* pointer);
 
 
 // Helper macros/function for logging with file paths. Note that the path must

--- a/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -118,7 +118,7 @@ void PrjFSProviderUserClient::cleanupProviderRegistration()
     this->virtualizationRootHandle = RootHandle_None;
     if (RootHandle_None != root)
     {
-        ActiveProvider_Disconnect(root);
+        ActiveProvider_Disconnect(root, this);
     }
 }
 

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -470,7 +470,7 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
     return VirtualizationRootResult { err, rootIndex };
 }
 
-void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex)
+void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex, PrjFSProviderUserClient* _Nonnull userClient)
 {
     assert(rootIndex >= 0);
     RWLock_AcquireExclusive(s_virtualizationRootsLock);
@@ -479,6 +479,8 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex)
 
         VirtualizationRoot* root = &s_virtualizationRoots[rootIndex];
         assert(nullptr != root->providerUserClient);
+        assertf(userClient == root->providerUserClient, "ActiveProvider_Disconnect: disconnecting provider IOUC %p for root index %d (%s), but expecting IOUC %p",
+            KextLog_Unslide(userClient), rootIndex, root->path, KextLog_Unslide(root->providerUserClient));
         
         assert(NULLVP != root->rootVNode);
         vnode_put(root->rootVNode);

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
@@ -36,7 +36,7 @@ struct VirtualizationRootResult
     VirtualizationRootHandle root;
 };
 VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProviderUserClient* _Nonnull userClient, pid_t clientPID, const char* _Nonnull virtualizationRootPath);
-void ActiveProvider_Disconnect(VirtualizationRootHandle rootHandle);
+void ActiveProvider_Disconnect(VirtualizationRootHandle rootHandle, PrjFSProviderUserClient* _Nonnull userClient);
 
 struct Message;
 errno_t ActiveProvider_SendMessage(VirtualizationRootHandle rootHandle, const Message message);


### PR DESCRIPTION
I am slightly mystified by issue #797, and as yet do not know what is causing it. If it turns up again, it would be useful to have a log of the events that led up to it, or to catch a violation of the invariants as soon as possible.

The `rootVNode` in each `VirtualizationRoot` should hold an iocount while an active provider is connected, and should be allowed to be recycled (no iocount) when there is no provider connected. To that end, the iocount is reduced via `vnode_put()` in `ActiveProvider_Disconnect()`. The panic was caused by the fact that the iocount was already 0 when the user terminated the provider. I can only see 4 possible causes for this:

 1. When registering the provider in the first place, we did not retain an iocount on the root vnode. (In `VirtualizationRoot_RegisterProviderForPath`, the iocount is incremented by the `vnode_lookup` call, and in the code path where the provider is successfully registered, we arrange for `vnode_put()` *not* to be called. Upon close inspection of the code, I can't see a case where this is violated, but I guess it's possible.)
 2. For some reason, between provider registration and disconnection, `rootVNode` is reassigned to another vnode which does not have an iocount, so when we call `vnode_put()` on disconnecting, we're decrementing the iocount on the wrong vnode, so it goes bang. (The only times `rootVNode` is changed are during provider registration, disconnecting, and in `FindRootAtVnode_Locked()` if the vnode is recycled. Recycling should never happen for roots with an active provider, however, thanks to the nonzero iocount.)
 3. Some other, unrelated code makes an unmatched `vnode_put()` call to the `rootVNode`. (If this was routinely happening, the chances of hitting the iocount assertion in the kernel would surely be much higher for that unrelated code, as all our other functions that call `vnode_put()` run *much* more frequently than `ActiveProvider_Disconnect()`.)
 4. The array of virtualisation roots is getting corrupted somehow; the only place I can think of that happening is when inserting a new root, and for some reason the existing root is being overwritten.

I'm struggling to come up with scenarios where any of these 3 could actually happen. The closest I've got is finding that the recycled vnode refresh code in `FindRootAtVnode_Locked()` (see item 2 above) suffers from a race condition when it is called with only a shared lock, as happens (frequently) in `FindOrDetectRootAtVnode()`. However:

 * I'm struggling to come up with a case where that race condition would actually cause any problems, it seems to me that the worst that can happen is that the `rootVNode` is refreshed to the same new vnode by both racing threads.
 * The vnode of a root with an active provider shouldn't be recycled in the first place.

So, to try and narrow down where the problem is coming from, I've made the following changes:

* Added some more asserts that might catch programming errors in this area, and possibly the root cause of #797 too. Specifically, I'm trying to catch any cases where the vnode of a root with an active provider is recycled, or there is some mismatch between the vnodes.
* Adds verbose logging of changes to virtualisation root table entries: insertions, provider registration/disconnect, and stale root vnode updates.