### PR TITLE
Update RunFunctionalTests to not load kext when testing installed gvfs

### DIFF
--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -10,5 +10,9 @@ fi
 sudo mkdir /GVFS.FT
 sudo chown $USER /GVFS.FT
 
-$VFS_SRCDIR/ProjFS.Mac/Scripts/LoadPrjFSKext.sh $CONFIGURATION
+if [ "$2" != "--test-gvfs-on-path" ]; then
+  echo "Calling LoadPrjFSKext.sh as --test-gvfs-on-path not set..."
+  $VFS_SRCDIR/ProjFS.Mac/Scripts/LoadPrjFSKext.sh $CONFIGURATION
+fi
+
 $VFS_PUBLISHDIR/GVFS.FunctionalTests --full-suite $2


### PR DESCRIPTION
We've recently made the infrastructure change to call the RunFunctionalTests.sh
script with '--test-gvfs-on-path' to ensure that we're testing the product
as it is installed on customer machines.

When we're testing in that scenario, we shouldn't call the developer convenience
script as it will load the locally built kext rather than the installed kext.