### PR TITLE
Provide a more actionable "unsupported features" message for Server 2016 users

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -316,7 +316,7 @@ namespace GVFS.Platform.Windows
                 return true;
             }
 
-            error = "File system does not support features required by GVFS. Confirm that Windows version is at or beyond that required by GVFS";
+            error = "File system does not support features required by VFS for Git. Confirm that Windows version is at or beyond that required by VFS for Git. A one-time reboot is required on Windows Server 2016 after installing VFS for Git.";
             return false;
         }
 


### PR DESCRIPTION
Windows Server 2016 requires a one-time reboot after installing VFS for Git to enable required features. Let's provide a better error message to help our users.