### PR TITLE
[upgrade] Reconsider PhysicalFileSystem.DeleteDirectory

### DIFF
--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -188,7 +188,7 @@ namespace FastFetch
                         {
                             if (Directory.Exists(treeOp.TargetPath))
                             {
-                                this.fileSystem.RecursiveDelete(treeOp.TargetPath);
+                                this.fileSystem.DeleteDirectory(treeOp.TargetPath);
                             }
                         }
                         catch (Exception ex)

--- a/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
@@ -123,7 +123,7 @@ namespace GVFS.DiskLayoutUpgrades
             try
             {
                 PhysicalFileSystem fileSystem = new PhysicalFileSystem();
-                fileSystem.RecursiveDelete(folderName);
+                fileSystem.DeleteDirectory(folderName);
             }
             catch (Exception e)
             {

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common.FileSystem
     {
         public const int DefaultStreamBufferSize = 8192;
 
-        public virtual void RecursiveDelete(string path)
+        public virtual void DeleteDirectory(string path, bool recursive = true)
         {
             if (!Directory.Exists(path))
             {
@@ -21,15 +21,18 @@ namespace GVFS.Common.FileSystem
 
             DirectoryInfo directory = new DirectoryInfo(path);
 
-            foreach (FileInfo file in directory.GetFiles())
+            if (recursive)
             {
-                file.Attributes = FileAttributes.Normal;
-                file.Delete();
-            }
+                foreach (FileInfo file in directory.GetFiles())
+                {
+                    file.Attributes = FileAttributes.Normal;
+                    file.Delete();
+                }
 
-            foreach (DirectoryInfo subDirectory in directory.GetDirectories())
-            {
-                this.RecursiveDelete(subDirectory.FullName);
+                foreach (DirectoryInfo subDirectory in directory.GetDirectories())
+                {
+                    this.DeleteDirectory(subDirectory.FullName);
+                }
             }
 
             directory.Delete();
@@ -124,11 +127,6 @@ namespace GVFS.Common.FileSystem
         public virtual bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
         {
             return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(tracer, directoryPath, out error);
-        }
-
-        public virtual void DeleteDirectory(string path, bool recursive = false)
-        {
-            this.RecursiveDelete(path);
         }
 
         public virtual bool IsSymLink(string path)

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -38,7 +38,7 @@ namespace GVFS.Common
         {
             try
             {
-                this.fileSystem.RecursiveDelete(GetAssetDownloadsPath());
+                this.fileSystem.DeleteDirectory(GetAssetDownloadsPath());
             }
             catch (Exception ex)
             {

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -38,8 +38,13 @@ namespace GVFS.UnitTests.Mock.FileSystem
         /// </summary>
         public bool DeleteNonExistentFileThrowsException { get; set; }
 
-        public override void RecursiveDelete(string path)
+        public override void DeleteDirectory(string path, bool recursive = true)
         {
+            if (!recursive)
+            {
+                throw new NotImplementedException();
+            }
+
             this.RootDirectory.DeleteDirectory(path);
         }
 
@@ -213,14 +218,6 @@ namespace GVFS.UnitTests.Mock.FileSystem
             }
 
             return false;
-        }
-
-        public override void DeleteDirectory(string path, bool recursive = false)
-        {
-            MockDirectory directory = this.RootDirectory.FindDirectory(path);
-            directory.ShouldNotBeNull();
-
-            this.RootDirectory.DeleteDirectory(path);
         }
 
         public override IEnumerable<DirectoryItemInfo> ItemsInDirectory(string path)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
@@ -48,7 +48,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
         }
 
-        public override void DeleteDirectory(string path, bool recursive = false)
+        public override void DeleteDirectory(string path, bool recursive = true)
         {
             throw new InvalidOperationException("DeleteDirectory has not been implemented.");
         }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -167,7 +167,7 @@ namespace GVFS.CommandLine
                 () =>
                 {
                     ZipFile.CreateFromDirectory(archiveFolderPath, zipFilePath);
-                    this.fileSystem.RecursiveDelete(archiveFolderPath);
+                    this.fileSystem.DeleteDirectory(archiveFolderPath);
 
                     return true;
                 },

--- a/GVFS/GVFS/RepairJobs/RepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/RepairJob.cs
@@ -97,7 +97,7 @@ namespace GVFS.RepairJobs
         {
             try
             {
-                this.fileSystem.RecursiveDelete(filePath);
+                this.fileSystem.DeleteDirectory(filePath);
                 this.Tracer.RelatedEvent(EventLevel.Informational, "FolderDeleted", new EventMetadata { { "SourcePath", filePath } });
             }
             catch (Exception e)


### PR DESCRIPTION
PhysicalFileSystem.DeleteDirectory is a single line wrapper around for PhysicalFileSystem.RecursiveDelete. Removing redundant DeleteDirectory.

Fixes #758