### PR TITLE
[upgrade] Perform Upgrade Check after PrjFlt is enabled

### DIFF
--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -27,7 +27,7 @@ namespace GVFS.Service
                 string error;
                 if (!EnableAndAttachProjFSHandler.TryEnablePrjFlt(this.tracer, out error))
                 {
-                    this.tracer.RelatedError($"{nameof(this.Mount)}: Unable to start the GVFS.exe process: {error}");
+                    this.tracer.RelatedError($"{nameof(this.Mount)}: Could not enable PrjFlt: {error}");
                 }
             }
 

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -45,7 +45,6 @@ namespace GVFS.Service
 
                 this.repoRegistry = new RepoRegistry(this.tracer, new PhysicalFileSystem(), this.serviceDataLocation);
                 this.repoRegistry.Upgrade();
-                this.productUpgradeTimer.Start();
                 string pipeName = this.serviceName + ".Pipe";
                 this.tracer.RelatedInfo("Starting pipe server with name: " + pipeName);
 
@@ -55,12 +54,20 @@ namespace GVFS.Service
 
                     using (ITracer activity = this.tracer.StartActivity("EnsurePrjFltHealthy", EventLevel.Informational))
                     {
+                        // Make a best-effort to enable PrjFlt. Continue even if it fails.
+                        // This will be tried again when user attempts to mount an enlistment.
                         string error;
                         EnableAndAttachProjFSHandler.TryEnablePrjFlt(activity, out error);
                     }
 
                     this.serviceStopped.WaitOne();
                 }
+
+                // Start product upgrade timer only after attempting to enable prjflt.
+                // On Windows server (where PrjFlt is not inboxed) this helps avoid
+                // a race between TryEnablePrjFlt() and installer pre-check which is
+                // performed by UpgradeTimer in parallel.
+                this.productUpgradeTimer.Start();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
On Windows server PCs, PrjFlt is not inboxed. In this scenario UpgradeCheck used to run in parallel with the Service code to enable PrjFlt. If UpgradeCheck wins, then installer pre-check detects PrjFlt is not enabled. Upgrade check would fail. In this PR, Upgrade check is scheduled to happen only after PrjFlt is enabled.

Fixes #774