### PR TITLE
Mac kext: Fix for race conditions in virtualization root lookup & provider client cleanup

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -114,12 +114,16 @@ IOReturn PrjFSProviderUserClient::clientClose()
 
 void PrjFSProviderUserClient::cleanupProviderRegistration()
 {
-    VirtualizationRootHandle root = this->virtualizationRootHandle;
-    this->virtualizationRootHandle = RootHandle_None;
-    if (RootHandle_None != root)
+    Mutex_Acquire(this->dataQueueWriterMutex);
     {
-        ActiveProvider_Disconnect(root, this);
+        VirtualizationRootHandle root = this->virtualizationRootHandle;
+        this->virtualizationRootHandle = RootHandle_None;
+        if (RootHandle_None != root)
+        {
+            ActiveProvider_Disconnect(root, this);
+        }
     }
+    Mutex_Release(this->dataQueueWriterMutex);
 }
 
 // Called when user process requests memory-mapping of kernel data


### PR DESCRIPTION
The function `FindRootAtVnode_Locked()` is called while holding a shared lock from `FindOrDetectRootAtVnode()`. However, very rarely, when a root's vnode is recycled and the new one is encountered, `FindRootAtVnode_Locked()` will refresh the registered vnode in the virtualization root. When only the shared lock is held, this could potentially cause a race between 2 or more threads. In theory, all threads involved should reach the same conclusion and update to the same vnode, so there should not be any actual data corruption.

This change fixes the race by not refreshing the vnode in `FindRootAtVnode_Locked()\ and instead performing the refresh in a new helper function which is only called when the lock is held exclusively.

**Update:** The second commit fixes the possible race condition [pointed out by @wilbaker ](https://github.com/Microsoft/VFSForGit/pull/819#issuecomment-466213421).

**Reviewer note:** I found this while trying to work out what was causing #797. ~~I *think* this race condition shouldn't be able to cause that bug, or indeed cause any other kind of malfunction because all threads would converge on the same result. Nevertheless, I'd appreciate a few extra sets of eyes & brains on analysing this race. I'm reluctant to merge this fix as long as we haven't worked out #797, but given that I might be wrong about this race being benign, perhaps someone can spot how it might have caused #797 after all, so I'm posting it now.~~

**Update:** Given that the cause for #797 is understood and a fix (#856) has been implemented, I think we should fix the discovered race conditions as well, even if they most probably are not causing any problems.