### PR TITLE
Mac: Matches up KextLog levels with os_log levels

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -883,7 +883,7 @@ static bool TryGetVirtualizationRoot(
     }
     else if (RootHandle_None == *root)
     {
-        KextLog_FileNote(vnode, "No virtualization root found for file with set flag.");
+        KextLog_File(vnode, "No virtualization root found for file with set flag.");
         perfTracer->IncrementCount(PrjFSPerfCounter_VnodeOp_GetVirtualizationRoot_NoRootFound);
     
         *kauthResult = KAUTH_RESULT_DEFER;

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -16,7 +16,7 @@ void KextLog_Cleanup();
 
 #define KextLog_Error(format, ...) KextLog_Printf(KEXTLOG_ERROR, format, ##__VA_ARGS__)
 #define KextLog_Info(format, ...) KextLog_Printf(KEXTLOG_INFO, format, ##__VA_ARGS__)
-#define KextLog_Note(format, ...) KextLog_Printf(KEXTLOG_NOTE, format, ##__VA_ARGS__)
+#define KextLog(format, ...) KextLog_Printf(KEXTLOG_DEFAULT, format, ##__VA_ARGS__)
 
 bool KextLog_RegisterUserClient(PrjFSLogUserClient* userClient);
 void KextLog_DeregisterUserClient(PrjFSLogUserClient* userClient);
@@ -53,7 +53,7 @@ template <typename... args>
 // The %s at the end of the format string for the vnode path is implicit.
 #define KextLog_FileError(vnode, format, ...) ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_ERROR, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
 #define KextLog_FileInfo(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_INFO, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
-#define KextLog_FileNote(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_NOTE, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
+#define KextLog_File(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_DEFAULT, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
 
 
 // See comments for KextLogFile_Printf() above for rationale.
@@ -112,7 +112,7 @@ template <typename... args>
     do { \
         if (VDIR == vnodeType) \
         { \
-            KextLog_FileNote( \
+            KextLog_File( \
                 vnode, \
                 message ". Proc name: %s. Directory vnode action: %s%s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
                 procname, \
@@ -132,7 +132,7 @@ template <typename... args>
         } \
         else \
         { \
-            KextLog_FileNote( \
+            KextLog_File( \
                 vnode, \
                 message ". Proc name: %s. File vnode action: %s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
                 procname, \

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -328,7 +328,7 @@ static VirtualizationRootHandle FindRootAtVnode_Locked(vnode_t vnode, uint32_t v
             assertf(rootEntry.providerUserClient == nullptr, "Finding root vnode based on FSID/inode equality but not vnode identity (recycled vnode) should only happen if no provider is active. Root index %d, provider PID %d, IOUC %p path '%s'",
                 i, rootEntry.providerPid, rootEntry.providerUserClient, rootEntry.path);
             // root vnode must be stale, update it
-            KextLog_FileNote(vnode, "FindRootAtVnode_Locked: virtualization root %d (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u has gone stale, refreshing to %p:%u",
+            KextLog_File(vnode, "FindRootAtVnode_Locked: virtualization root %d (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u has gone stale, refreshing to %p:%u",
                 i, rootEntry.path, rootEntry.rootFsid.val[0], rootEntry.rootFsid.val[1], rootEntry.rootInode, KextLog_Unslide(rootEntry.rootVNode), rootEntry.rootVNodeVid, KextLog_Unslide(vnode), vid);
             rootEntry.rootVNode = vnode;
             rootEntry.rootVNodeVid = vid;
@@ -356,7 +356,7 @@ static VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUse
 
         root->rootVNode = vnode;
         root->rootVNodeVid = vid;
-        KextLog_FileNote(vnode, "InsertVirtualizationRoot_Locked: virtualization root inserted at index %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u, user client PID %d, IOUC %p.",
+        KextLog_File(vnode, "InsertVirtualizationRoot_Locked: virtualization root inserted at index %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u, user client PID %d, IOUC %p.",
             rootIndex, path, persistentIds.fsid.val[0], persistentIds.fsid.val[1], persistentIds.inode, KextLog_Unslide(vnode), vid, clientPID, KextLog_Unslide(userClient));
         
         root->rootFsid = persistentIds.fsid;
@@ -428,7 +428,7 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                             assert(root.rootVNode == virtualizationRootVNode);
                             root.providerUserClient = userClient;
                             root.providerPid = clientPID;
-                            KextLog_FileNote(virtualizationRootVNode, "VirtualizationRoot_RegisterProviderForPath: registered provider (PID %d, IOUC %p) for virtualization root %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u.",
+                            KextLog_File(virtualizationRootVNode, "VirtualizationRoot_RegisterProviderForPath: registered provider (PID %d, IOUC %p) for virtualization root %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u.",
                                 clientPID, KextLog_Unslide(userClient), rootIndex, root.path, root.rootFsid.val[0], root.rootFsid.val[1], root.rootInode, KextLog_Unslide(virtualizationRootVNode), rootVid);
                             virtualizationRootVNode = NULLVP; // transfer ownership
                         }
@@ -442,7 +442,7 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                         
                             virtualizationRootVNode = NULLVP; // prevent vnode_put later; active provider should hold vnode reference
                         
-                            KextLog_Note("VirtualizationRoot_RegisterProviderForPath: new root not found in offline roots, inserted as new root with index %d. path '%s'", rootIndex, virtualizationRootCanonicalPath);
+                            KextLog("VirtualizationRoot_RegisterProviderForPath: new root not found in offline roots, inserted as new root with index %d. path '%s'", rootIndex, virtualizationRootCanonicalPath);
                         }
                         else
                         {
@@ -491,7 +491,7 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex, PrjFSProvider
         
         assert(NULLVP != root->rootVNode);
         
-        KextLog_FileNote(root->rootVNode, "ActiveProvider_Disconnect: disconnecting provider (PID %d, IOUC %p) for virtualization root %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u.",
+        KextLog_File(root->rootVNode, "ActiveProvider_Disconnect: disconnecting provider (PID %d, IOUC %p) for virtualization root %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u.",
             root->providerPid, KextLog_Unslide(root->providerUserClient), rootIndex, root->path, root->rootFsid.val[0], root->rootFsid.val[1], root->rootInode, KextLog_Unslide(root->rootVNode), root->rootVNodeVid);
 
         

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
@@ -24,11 +24,12 @@ enum PrjFSLogUserClientPortType
     LogPortType_MessageQueue,
 };
 
+// Log message levels, these correspond to their os_log counterparts
 enum KextLog_Level : uint32_t
 {
-    KEXTLOG_ERROR = 0,
-    KEXTLOG_INFO = 1,
-    KEXTLOG_NOTE,
+    KEXTLOG_ERROR = 0,   // For important failures, always gets logged and causes INFO messages to be committed too.
+    KEXTLOG_DEFAULT = 2, // Run-of-the-mill messages that shouldn't be too frequent as they always are logged to disk.
+    KEXTLOG_INFO = 1,    // Verbose logging that might help with diagnosing problems; these don't usually get logged to disk, except when an ERROR is loggod.
 };
 
 struct KextLog_MessageHeader

--- a/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
@@ -82,7 +82,7 @@ static os_log_type_t KextLogLevelAsOSLogType(KextLog_Level level)
     {
     case KEXTLOG_INFO:
         return OS_LOG_TYPE_INFO;
-    case KEXTLOG_NOTE:
+    case KEXTLOG_DEFAULT:
         return OS_LOG_TYPE_DEFAULT;
     case KEXTLOG_ERROR:
     default:

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -145,8 +145,8 @@ static const char* KextLogLevelAsString(KextLog_Level level)
         return "Error";
     case KEXTLOG_INFO:
         return "Info";
-    case KEXTLOG_NOTE:
-        return "Note";
+    case KEXTLOG_DEFAULT:
+        return "Default";
     default:
         return "Unknown";
     }


### PR DESCRIPTION
The existing levels in the KextLog mechanism have repeatedly [caused confusion](https://github.com/Microsoft/VFSForGit/pull/805#discussion_r258728471) with regard to their relative importance and whether or not they hit the on-disk system log.

 * The "Note" level has been replaced with "Default" to match its os_log counterpart. The corresponding macros have been renamed to KextLog() and KextLog_File(), so "Default" need not be spelled out explicitly.
 * Comments have been added to the log level enum definition to explain the syslog policy.