### PR TITLE
Return result code when process is stopping  [M147]

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -752,6 +752,7 @@ namespace GVFS.Common.Git
         {
             public const int SuccessCode = 0;
             public const int GenericFailureCode = 1;
+            public const int ExitDueToShutDownCode = 2;
 
             public Result(string stdout, string stderr, int exitCode)
             {
@@ -771,7 +772,7 @@ namespace GVFS.Common.Git
 
             public bool ExitCodeIsFailure
             {
-                get { return !this.ExitCodeIsSuccess; }
+                get { return !this.ExitCodeIsSuccess && this.ExitCode != ExitDueToShutDownCode; }
             }
 
             public bool StderrContainsErrors()

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -120,11 +120,12 @@ namespace GVFS.Common.Maintenance
             {
                 if (this.Stopping)
                 {
+                    string message = this.Area + "Not launching Git process because the mount is stopping";
                     this.Context.Tracer.RelatedWarning(
                         metadata: null,
-                        message: this.Area + ": Not launching Git process because the mount is stopping",
+                        message: message,
                         keywords: Keywords.Telemetry);
-                    return null;
+                    return new GitProcess.Result(message, string.Empty, GitProcess.Result.ExitDueToShutDownCode);
                 }
 
                 GitProcess.Result result = work.Invoke(this.GitProcess);


### PR DESCRIPTION
Return result code instead of null, fixing a null reference

There will be a further change (not needed for this release) to better log / audit return codes consistently across maintenance jobs.