### PR TITLE
Improved MaintanceStep Handling

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -127,7 +127,7 @@ namespace GVFS.Common.Maintenance
                         metadata: null,
                         message: $"{this.Area}: Not launching Git process {gitCommand} because the mount is stopping",
                         keywords: Keywords.Telemetry);
-                    return null;
+                    throw new StoppingException();
                 }
 
                 GitProcess.Result result = work.Invoke(this.MaintenanceGitProcess);
@@ -234,7 +234,18 @@ namespace GVFS.Common.Maintenance
                 this.MaintenanceGitProcess = this.Context.Enlistment.CreateGitProcess();
             }
 
-            this.PerformMaintenance();
+            try
+            {
+                this.PerformMaintenance();
+            }
+            catch (StoppingException)
+            {
+                // Part of shutdown, skipped commands have already been logged
+            }
+        }
+
+        protected class StoppingException : Exception
+        {
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
@@ -3,6 +3,7 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Maintenance;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.FileSystem;
 using NUnit.Framework;
@@ -26,6 +27,7 @@ namespace GVFS.UnitTests.Maintenance
         }
 
         [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
         public void GitMaintenanceStepSkipsGitActionAfterStop()
         {
             this.TestSetup();
@@ -39,6 +41,7 @@ namespace GVFS.UnitTests.Maintenance
         }
 
         [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
         public void GitMaintenanceStepSkipsRunGitCommandAfterStop()
         {
             this.TestSetup();


### PR DESCRIPTION
This change is different than the one on shipped, to better address the issue

- Stop MaintenceStep Process during shutdown
  - We throw an exception when we flip to Stopping.  I've tried to update the code to make the process more obvious.  We use an exception so we don't have put if checks everywhere.  There is a single place where we need to catch.
  - Thread.Abort is another option to using Stopping.  However Thread.Abort is quite a hammer, so we're gracefully trying to terminate.  I'm calling that out as something we may decide to change our mind on in the future.  
