### PR TITLE
[releases/shipped] Enhance git command logging

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -22,7 +22,7 @@ namespace GVFS.Common.Maintenance
         protected virtual TimeSpan TimeBetweenRuns { get; }
         protected virtual string LastRunTimeFilePath { get; set; }
         protected GVFSContext Context { get; }
-        protected GitProcess GitProcess { get; private set; }
+        protected GitProcess MaintenanceGitProcess { get; private set; }
         protected bool Stopping { get; private set; }
         protected bool RequireObjectCacheLock { get; }
         protected GitProcessChecker GitProcessChecker { get; }
@@ -75,7 +75,7 @@ namespace GVFS.Common.Maintenance
             {
                 this.Stopping = true;
 
-                GitProcess process = this.GitProcess;
+                GitProcess process = this.MaintenanceGitProcess;
 
                 if (process != null)
                 {
@@ -114,13 +114,16 @@ namespace GVFS.Common.Maintenance
         /// </summary>
         protected abstract void PerformMaintenance();
 
-        protected GitProcess.Result RunGitCommand(Func<GitProcess, GitProcess.Result> work)
+        protected GitProcess.Result RunGitCommand(Func<GitProcess, GitProcess.Result> work, string gitCommand)
         {
-            using (ITracer activity = this.Context.Tracer.StartActivity("RunGitCommand", EventLevel.Informational, Keywords.Telemetry, metadata: this.CreateEventMetadata()))
+            EventMetadata metadata = this.CreateEventMetadata();
+            metadata.Add("gitCommand", gitCommand);
+
+            using (ITracer activity = this.Context.Tracer.StartActivity("RunGitCommand", EventLevel.Informational, Keywords.Telemetry, metadata))
             {
                 if (this.Stopping)
                 {
-                    string message = this.Area + "Not launching Git process because the mount is stopping";
+                    string message = $"{this.Area}: Not launching Git process {gitCommand} because the mount is stopping";
                     this.Context.Tracer.RelatedWarning(
                         metadata: null,
                         message: message,
@@ -128,13 +131,20 @@ namespace GVFS.Common.Maintenance
                     return new GitProcess.Result(message, string.Empty, GitProcess.Result.ExitDueToShutDownCode);
                 }
 
-                GitProcess.Result result = work.Invoke(this.GitProcess);
+                GitProcess.Result result = work.Invoke(this.MaintenanceGitProcess);
 
                 if (!this.Stopping && result?.ExitCodeIsFailure == true)
                 {
+                    string errorMessage = result?.Errors == null ? string.Empty : result.Errors;
+                    if (errorMessage.Length > 1000)
+                    {
+                        // For large error messages, we show the first and last 500 chars
+                        errorMessage = $"beginning: {errorMessage.Substring(0, 500)} ending: {errorMessage.Substring(errorMessage.Length - 500)}";
+                    }
+
                     this.Context.Tracer.RelatedWarning(
                         metadata: null,
-                        message: this.Area + ": Git process failed with errors:" + result.Errors,
+                         message: $"{this.Area}: Git process {gitCommand} failed with errors: {errorMessage}",
                         keywords: Keywords.Telemetry);
                     return result;
                 }
@@ -189,29 +199,25 @@ namespace GVFS.Common.Maintenance
             }
         }
 
-        protected void LogErrorAndRewriteMultiPackIndex(ITracer activity, GitProcess.Result result)
+        protected void LogErrorAndRewriteMultiPackIndex(ITracer activity)
         {
             EventMetadata errorMetadata = this.CreateEventMetadata();
-            errorMetadata["MultiPackIndexVerifyOutput"] = result.Output;
-            errorMetadata["MultiPackIndexVerifyErrors"] = result.Errors;
             string multiPackIndexPath = Path.Combine(this.Context.Enlistment.GitPackRoot, "multi-pack-index");
             errorMetadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(multiPackIndexPath);
 
-            GitProcess.Result rewriteResult = this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+            GitProcess.Result rewriteResult = this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
             errorMetadata["RewriteResultExitCode"] = rewriteResult.ExitCode;
 
             activity.RelatedError(errorMetadata, "multi-pack-index is corrupt after write. Deleting and rewriting.");
         }
 
-        protected void LogErrorAndRewriteCommitGraph(ITracer activity, GitProcess.Result result, List<string> packs)
+        protected void LogErrorAndRewriteCommitGraph(ITracer activity, List<string> packs)
         {
             EventMetadata errorMetadata = this.CreateEventMetadata();
-            errorMetadata["CommitGraphVerifyOutput"] = result.Output;
-            errorMetadata["CommitGraphVerifyErrors"] = result.Errors;
             string commitGraphPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graph");
             errorMetadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(commitGraphPath);
 
-            GitProcess.Result rewriteResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, packs));
+            GitProcess.Result rewriteResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, packs), nameof(GitProcess.WriteCommitGraph));
             errorMetadata["RewriteResultExitCode"] = rewriteResult.ExitCode;
 
             activity.RelatedError(errorMetadata, "commit-graph is corrupt after write. Deleting and rewriting.");
@@ -226,7 +232,7 @@ namespace GVFS.Common.Maintenance
                     return;
                 }
 
-                this.GitProcess = this.Context.Enlistment.CreateGitProcess();
+                this.MaintenanceGitProcess = this.Context.Enlistment.CreateGitProcess();
             }
 
             this.PerformMaintenance();

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -118,7 +118,8 @@ namespace GVFS.Common.Maintenance
                 (process) => process.PackObjects(
                     "from-loose",
                     this.Context.Enlistment.GitObjectsRoot,
-                    (StreamWriter writer) => objectsAddedToPack = this.WriteLooseObjectIds(writer)));
+                    (StreamWriter writer) => objectsAddedToPack = this.WriteLooseObjectIds(writer)),
+                nameof(GitProcess.PackObjects));
 
             return objectsAddedToPack;
         }
@@ -147,7 +148,7 @@ namespace GVFS.Common.Maintenance
                     }
 
                     int beforeLooseObjectsCount = this.CountLooseObjects();
-                    GitProcess.Result result = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot));
+                    GitProcess.Result result = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.PrunePacked));
                     int afterLooseObjectsCount = this.CountLooseObjects();
 
                     int objectsAddedToPack = this.CreateLooseObjectsPackFile();

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -138,23 +138,23 @@ namespace GVFS.Common.Maintenance
                     return;
                 }
 
-                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.MultiPackIndexExpire));
                 List<string> staleIdxFiles = this.CleanStaleIdxFiles(out int numDeletionBlocked);
                 this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
 
-                GitProcess.Result verifyAfterExpire = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyAfterExpire = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyAfterExpire.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyAfterExpire);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
 
-                GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize));
+                GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize), nameof(GitProcess.MultiPackIndexRepack));
                 this.GetPackFilesInfo(out int afterCount, out long afterSize, out hasKeep);
 
-                GitProcess.Result verifyAfterRepack = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyAfterRepack = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyAfterRepack.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyAfterRepack);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
 
                 EventMetadata metadata = new EventMetadata();
@@ -166,11 +166,7 @@ namespace GVFS.Common.Maintenance
                 metadata.Add(nameof(expireSize), expireSize);
                 metadata.Add(nameof(afterCount), afterCount);
                 metadata.Add(nameof(afterSize), afterSize);
-                metadata.Add("ExpireOutput", expireResult.Output);
-                metadata.Add("ExpireErrors", expireResult.Errors);
                 metadata.Add("VerifyAfterExpireExitCode", verifyAfterExpire.ExitCode);
-                metadata.Add("RepackOutput", repackResult.Output);
-                metadata.Add("RepackErrors", repackResult.Errors);
                 metadata.Add("VerifyAfterRepackExitCode", verifyAfterRepack.ExitCode);
                 metadata.Add("NumStaleIdxFiles", staleIdxFiles.Count);
                 metadata.Add("NumIdxDeletionsBlocked", numDeletionBlocked);

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -26,12 +26,12 @@ namespace GVFS.Common.Maintenance
                 string multiPackIndexLockPath = Path.Combine(this.Context.Enlistment.GitPackRoot, MultiPackIndexLock);
                 this.Context.FileSystem.TryDeleteFile(multiPackIndexLockPath);
 
-                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
 
-                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyResult);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
             }
 
@@ -46,13 +46,13 @@ namespace GVFS.Common.Maintenance
                 string commitGraphLockPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", CommitGraphLock);
                 this.Context.FileSystem.TryDeleteFile(commitGraphLockPath);
 
-                this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes));
+                this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
 
-                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyCommitGraph));
 
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteCommitGraph(activity, verifyResult, this.packIndexes);
+                    this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
                 }
             }
         }

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -89,11 +89,13 @@ namespace GVFS.Common.Maintenance
                 return;
             }
 
-            this.RunGitCommand(process =>
-            {
-                this.TryPrefetchCommitsAndTrees(out error, process);
-                return null;
-            });
+            this.RunGitCommand(
+                process =>
+                {
+                    this.TryPrefetchCommitsAndTrees(out error, process);
+                    return null;
+                },
+                nameof(this.TryPrefetchCommitsAndTrees));
 
             if (!string.IsNullOrEmpty(error))
             {
@@ -162,7 +164,7 @@ namespace GVFS.Common.Maintenance
                     metadata.Add("pack", packPath);
                     metadata.Add("idxPath", idxPath);
                     metadata.Add("timestamp", timestamp);
-                    GitProcess.Result indexResult = this.RunGitCommand(process => this.GitObjects.IndexPackFile(packPath, process));
+                    GitProcess.Result indexResult = this.RunGitCommand(process => this.GitObjects.IndexPackFile(packPath, process), nameof(this.GitObjects.IndexPackFile));
 
                     if (this.Stopping)
                     {
@@ -174,7 +176,6 @@ namespace GVFS.Common.Maintenance
                     {
                         firstBadPack = i;
 
-                        metadata.Add("Errors", indexResult.Errors);
                         this.Context.Tracer.RelatedWarning(metadata, $"{nameof(this.TryGetMaxGoodPrefetchTimestamp)}: Found pack file that's missing idx file, and failed to regenerate idx");
                         break;
                     }

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
@@ -72,11 +72,13 @@ namespace GVFS.UnitTests.Maintenance
 
             protected override void PerformMaintenance()
             {
-                this.RunGitCommand(process =>
-                {
-                    this.SawWorkInvoked = true;
-                    return null;
-                });
+                this.RunGitCommand(
+                    process =>
+                    {
+                        this.SawWorkInvoked = true;
+                        return null;
+                    },
+                    nameof(this.SawWorkInvoked));
             }
         }
 
@@ -94,11 +96,13 @@ namespace GVFS.UnitTests.Maintenance
             protected override void PerformMaintenance()
             {
                 this.Stop();
-                this.RunGitCommand(process =>
-                {
-                    this.SawWorkInvoked = true;
-                    return null;
-                });
+                this.RunGitCommand(
+                    process =>
+                    {
+                        this.SawWorkInvoked = true;
+                        return null;
+                    },
+                    nameof(this.SawWorkInvoked));
             }
         }
     }


### PR DESCRIPTION
- Limit error message output to 1000 chars
- Include name of GitCommand
- Remove Output logging from commands.  This can be looked up in Trace2.