### PR TITLE
[cherry-pick to master] Use a new log directory for upgrade logs to avoid ACL issues

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -13,6 +13,7 @@ namespace GVFS.Common.FileSystem
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
-        bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error);
+        bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error);
+        bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error);
     }
 }

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -124,9 +124,14 @@ namespace GVFS.Common.FileSystem
             Directory.CreateDirectory(path);
         }
 
-        public virtual bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public virtual bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
         {
-            return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminOnlyModify(tracer, directoryPath, out error);
+            return GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(directoryPath, out error);
+        }
+
+        public virtual bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error)
+        {
+            return GVFSPlatform.Instance.FileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissions(tracer, directoryPath, out error);
         }
 
         public virtual bool IsSymLink(string path)

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -136,7 +136,7 @@ namespace GVFS.Common
                 return false;
             }
 
-            if (!this.fileSystem.TryCreateDirectoryWithAdminOnlyModify(
+            if (!this.fileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissions(
                     this.tracer,
                     toolsDirectoryPath,
                     out error))
@@ -207,7 +207,7 @@ namespace GVFS.Common
 
         protected virtual bool TryCreateAndConfigureDownloadDirectory(ITracer tracer, out string error)
         {
-            return this.fileSystem.TryCreateDirectoryWithAdminOnlyModify(
+            return this.fileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissions(
                 tracer,
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 out error);

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.Shared.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common
     public partial class ProductUpgraderInfo
     {
         public const string UpgradeDirectoryName = "GVFS.Upgrade";
-        public const string LogDirectory = "Logs";
+        public const string LogDirectory = "UpgraderLogs";
         public const string DownloadDirectory = "Downloads";
         public const string HighestAvailableVersionFileName = "HighestAvailableVersion";
 

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -57,7 +57,12 @@ namespace GVFS.Platform.Mac
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
-        public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -122,7 +122,35 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
-        public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
+        {
+            try
+            {
+                DirectorySecurity directorySecurity = new DirectorySecurity();
+
+                // Protect the access rules from inheritance and remove any inherited rules
+                directorySecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+                // Add new ACLs for users and admins.  Users will be granted write permissions.
+                AddUsersAccessRulesToDirectorySecurity(directorySecurity, grantUsersModifyPermissions: true);
+                AddAdminAccessRulesToDirectorySecurity(directorySecurity);
+
+                Directory.CreateDirectory(directoryPath, directorySecurity);
+            }
+            catch (Exception e) when (e is IOException ||
+                                      e is UnauthorizedAccessException ||
+                                      e is PathTooLongException ||
+                                      e is DirectoryNotFoundException)
+            {
+                error = $"Exception while creating directory `{directoryPath}`: {e.Message}";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        public bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error)
         {
             try
             {
@@ -153,7 +181,7 @@ namespace GVFS.Platform.Windows
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("Exception", e.ToString());
-                tracer.RelatedError(metadata, $"{nameof(this.TryCreateDirectoryWithAdminOnlyModify)}: Exception while creating/configuring directory");
+                tracer.RelatedError(metadata, $"{nameof(this.TryCreateOrUpdateDirectoryToAdminModifyPermissions)}: Exception while creating/configuring directory");
 
                 error = e.Message;
                 return false;

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -216,9 +216,9 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
             actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
 
-            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
             bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
-            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
             downloadSuccessful.ShouldBeFalse();
         }
 
@@ -357,9 +357,9 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
         [TestCase]
         public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
         {
-            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = false;
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
             this.upgrader.TrySetupToolsDirectory(out string upgraderToolsPath, out string error).ShouldBeFalse();
-            this.mockFileSystem.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -15,14 +15,14 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
             this.RootDirectory = rootDirectory;
             this.DeleteNonExistentFileThrowsException = true;
-            this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed = true;
+            this.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
         }
 
         public MockDirectory RootDirectory { get; private set; }
 
         public bool DeleteFileThrowsException { get; set; }
 
-        public bool TryCreateDirectoryWithAdminOnlyModifyShouldSucceed { get; set; }
+        public bool TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed { get; set; }
 
         /// <summary>
         /// Allow FileMoves without checking the input arguments.
@@ -197,14 +197,19 @@ namespace GVFS.UnitTests.Mock.FileSystem
             this.RootDirectory.CreateDirectory(path);
         }
 
-        public override bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public override bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error)
         {
             error = null;
 
-            if (this.TryCreateDirectoryWithAdminOnlyModifyShouldSucceed)
+            if (this.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed)
             {
-                // TryCreateDirectoryWithAdminOnlyModify is typically called for paths in C:\ProgramData\GVFS, it's called
-                // for one of those paths remap the paths to be inside the mock: root
+                // TryCreateOrUpdateDirectoryToAdminModifyPermissions is typically called for paths in C:\ProgramData\GVFS,
+                // if it's called for one of those paths remap the paths to be inside the mock: root
                 string mockDirectoryPath = directoryPath;
                 string gvfsProgramData = @"C:\ProgramData\GVFS";
                 if (directoryPath.StartsWith(gvfsProgramData, StringComparison.OrdinalIgnoreCase))

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -50,7 +50,12 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
-        public bool TryCreateDirectoryWithAdminOnlyModify(ITracer tracer, string directoryPath, out string error)
+        public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -16,6 +16,7 @@ namespace GVFS.CommandLine
     public class DiagnoseVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string DiagnoseVerbName = "diagnose";
+        private const string DeprecatedUpgradeLogsDirectory = "Logs";
 
         private TextWriter diagnosticLogFileWriter;
         private PhysicalFileSystem fileSystem;
@@ -135,9 +136,17 @@ namespace GVFS.CommandLine
                             this.CopyAllFiles(
                                 ProductUpgraderInfo.GetUpgradesDirectoryPath(),
                                 archiveFolderPath,
+                                DeprecatedUpgradeLogsDirectory,
+                                copySubFolders: true,
+                                targetFolderName: Path.Combine(ProductUpgraderInfo.UpgradeDirectoryName, DeprecatedUpgradeLogsDirectory));
+
+                            this.CopyAllFiles(
+                                ProductUpgraderInfo.GetUpgradesDirectoryPath(),
+                                archiveFolderPath,
                                 ProductUpgraderInfo.LogDirectory,
                                 copySubFolders: true,
-                                targetFolderName: ProductUpgraderInfo.UpgradeDirectoryName);
+                                targetFolderName: Path.Combine(ProductUpgraderInfo.UpgradeDirectoryName, ProductUpgraderInfo.LogDirectory));
+
                             this.LogDirectoryEnumeration(
                                 ProductUpgraderInfo.GetUpgradesDirectoryPath(),
                                 Path.Combine(archiveFolderPath, ProductUpgraderInfo.UpgradeDirectoryName),


### PR DESCRIPTION
Cherry-pick of the changes in #840 to master

------------

Fixes #837 

This address the issue in #837 by switching to a new directory for upgrader logs.  GVFS.Service will create the directory if it does not exist (with the proper ACLs) and prevent the directory from inheriting ACLs (when GVFS.Service updates them on C:\ProgramData\GVFS).

Additionally, `gvfs upgrade` will use the correct ACLs when creating the logs directory if for some reason the service has not already created it.

Note: There is no automatic healing if someone manually adjusts the ACLs on the directory.