### PR TITLE
UpgradeVerb: tweak message logged after checking for update

### DIFF
--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -307,9 +307,14 @@ namespace GVFS.CommandLine
                     return false;
                 }
 
+                string currentVersion = ProcessHelper.GetCurrentProcessVersion();
                 latestVersion = version;
 
-                activity.RelatedInfo($"Successfully checked server for GVFS upgrades. New version available {latestVersion}");
+                string message = latestVersion == null ?
+                    $"Successfully checked for VFSForGit upgrades. Local version ({currentVersion}) is up-to-date." :
+                    $"Successfully checked for VFSForGit upgrades. A new version is available: {latestVersion}, local version is: {currentVersion}.";
+
+                activity.RelatedInfo(message);
             }
 
             return true;


### PR DESCRIPTION
Fixes #834 

Message when no new update is available:
```
[2019-02-26 10:17:51 -05:00] Information {"Message":"Successfully checked for VFSForGit upgrades. Local version (0.2.173.2) is up-to-date."}
```

Message when update is available:
```
[2019-02-26 10:17:06 -05:00] Information {"Message":"Successfully checked for VFSForGit upgrades. A new version is available: 1.0.19052.2, local version is: 0.2.173.2."}
```