### PR TITLE
Upgrader cleanup tweaks

### DIFF
--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -226,38 +226,6 @@ namespace GVFS.Common
             return true;
         }
 
-        public override bool TryCleanup(out string error)
-        {
-            error = string.Empty;
-            if (this.newestRelease == null)
-            {
-                return true;
-            }
-
-            foreach (Asset asset in this.newestRelease.Assets)
-            {
-                Exception exception;
-                if (!this.TryDeleteDownloadedAsset(asset, out exception))
-                {
-                    error += $"Could not delete {asset.LocalPath}. {exception.ToString()}." + Environment.NewLine;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(error))
-            {
-                error.TrimEnd(Environment.NewLine.ToCharArray());
-                return false;
-            }
-
-            error = null;
-            return true;
-        }
-
-        protected virtual bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
-        {
-            return this.fileSystem.TryDeleteFile(asset.LocalPath, out exception);
-        }
-
         protected virtual bool TryDownloadAsset(Asset asset, out string errorMessage)
         {
             errorMessage = null;

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -320,6 +320,11 @@ namespace GVFS.Common.NuGetUpgrade
 
         public override bool TryCleanup(out string error)
         {
+            if (!base.TryCleanup(out error))
+            {
+                return false;
+            }
+
             return this.TryRecursivelyDeleteInstallerDirectory(out error);
         }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -186,7 +186,11 @@ namespace GVFS.Common
             }
         }
 
-        public abstract bool TryCleanup(out string error);
+        public virtual bool TryCleanup(out string error)
+        {
+            ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(this.tracer, this.fileSystem);
+            return productUpgraderInfo.TryDeleteAllInstallerDownloads(out error);
+        }
 
         public void TraceException(Exception exception, string method, string message)
         {

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -36,16 +36,27 @@ namespace GVFS.Common
 
         public void DeleteAllInstallerDownloads()
         {
-            try
-            {
-                this.fileSystem.DeleteDirectory(GetAssetDownloadsPath());
-            }
-            catch (Exception ex)
+            if (!this.TryDeleteAllInstallerDownloads(out string error))
             {
                 if (this.tracer != null)
                 {
-                    this.tracer.RelatedError($"{nameof(this.DeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.ToString()}");
+                    this.tracer.RelatedWarning(error);
                 }
+            }
+        }
+
+        public bool TryDeleteAllInstallerDownloads(out string error)
+        {
+            try
+            {
+                this.fileSystem.DeleteDirectory(GetAssetDownloadsPath());
+                error = null;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = $"{nameof(this.TryDeleteAllInstallerDownloads)}: Could not remove directory: {ProductUpgraderInfo.GetAssetDownloadsPath()}.{ex.Message}";
+                return false;
             }
         }
 

--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -65,5 +65,20 @@ namespace GVFS.Common
                 this.fileSystem.WriteAllText(highestAvailableVersionFile, highestAvailableVersion.ToString());
             }
         }
+
+        public void RecordHighestAvailableVersionSafe(Version highestAvailableVersion)
+        {
+            try
+            {
+                this.RecordHighestAvailableVersion(highestAvailableVersion);
+            }
+            catch (Exception ex) when (
+                    ex is IOException ||
+                    ex is UnauthorizedAccessException ||
+                    ex is NotSupportedException)
+            {
+                this.tracer.RelatedWarning($"{nameof(this.RecordHighestAvailableVersionSafe)}: Failed to record highest available version available.");
+            }
+        }
     }
 }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockGitHubUpgrader.cs
@@ -33,8 +33,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
             GVFSDownload = 0x8,
             GitInstall = 0x10,
             GVFSInstall = 0x20,
-            GVFSCleanup = 0x40,
-            GitCleanup = 0x80,
             GitAuthenticodeCheck = 0x100,
             GVFSAuthenticodeCheck = 0x200,
             CreateDownloadDirectory = 0x400,
@@ -157,37 +155,6 @@ namespace GVFS.UnitTests.Windows.Mock.Upgrader
 
             errorMessage = "Cannot download unknown asset.";
             return false;
-        }
-
-        protected override bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
-        {
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                if (this.failActionTypes.HasFlag(ActionType.GVFSCleanup))
-                {
-                    exception = new Exception("Error deleting downloaded GVFS installer.");
-                    return false;
-                }
-
-                exception = null;
-                return true;
-            }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                if (this.failActionTypes.HasFlag(ActionType.GitCleanup))
-                {
-                    exception = new Exception("Error deleting downloaded Git installer.");
-                    return false;
-                }
-
-                exception = null;
-                return true;
-            }
-            else
-            {
-                exception = new Exception("Unknown asset.");
-                return false;
-            }
         }
 
         protected override bool TryFetchReleases(out List<Release> releases, out string errorMessage)

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -240,7 +240,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             this.ConfigureRunAndVerify(
                 configure: () =>
                 {
-                    this.Upgrader.SetFailOnAction(MockGitHubUpgrader.ActionType.GVFSCleanup);
+                    this.FileSystem.DeleteDirectoryExceptionToThrow = new System.Exception("Error deleting downloaded GVFS installer.");
                 },
                 expectedReturn: ReturnCode.Success,
                 expectedOutput: new List<string>
@@ -249,24 +249,6 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 expectedErrors: new List<string>
                 {
                     "Error deleting downloaded GVFS installer."
-                });
-        }
-
-        [TestCase]
-        public void GitCleanupError()
-        {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.Upgrader.SetFailOnAction(MockGitHubUpgrader.ActionType.GitCleanup);
-                },
-                expectedReturn: ReturnCode.Success,
-                expectedOutput: new List<string>
-                {
-                },
-                expectedErrors: new List<string>
-                {
-                    "Error deleting downloaded Git installer."
                 });
         }
 

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -90,7 +90,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public override bool IsElevated()
         {
-            throw new NotSupportedException();
+            return false;
         }
 
         public override bool IsProcessActive(int processId)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -22,6 +22,8 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
         public bool DeleteFileThrowsException { get; set; }
 
+        public Exception DeleteDirectoryExceptionToThrow { get; set; }
+
         public bool TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed { get; set; }
 
         /// <summary>
@@ -43,6 +45,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
             if (!recursive)
             {
                 throw new NotImplementedException();
+            }
+
+            if (this.DeleteDirectoryExceptionToThrow != null)
+            {
+                throw this.DeleteDirectoryExceptionToThrow;
             }
 
             this.RootDirectory.DeleteDirectory(path);

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -205,10 +205,6 @@ namespace GVFS.Upgrader
 
             if (!this.upgrader.UpgradeAllowed(out error))
             {
-                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
-                    this.tracer,
-                    this.fileSystem);
-                productUpgraderInfo.DeleteAllInstallerDownloads();
                 this.output.WriteLine(error);
                 consoleError = null;
                 newVersion = null;

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -154,11 +154,14 @@ namespace GVFS.CommandLine
 
             if (!this.upgrader.UpgradeAllowed(out message))
             {
-                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
-                    this.tracer,
-                    this.fileSystem);
-                productUpgraderInfo.DeleteAllInstallerDownloads();
-                productUpgraderInfo.RecordHighestAvailableVersion(highestAvailableVersion: null);
+                if (GVFSPlatform.Instance.IsElevated())
+                {
+                    ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                        this.tracer,
+                        this.fileSystem);
+                    productUpgraderInfo.RecordHighestAvailableVersionSafe(highestAvailableVersion: null);
+                }
+
                 this.ReportInfoToConsole(message);
                 return true;
             }
@@ -172,12 +175,14 @@ namespace GVFS.CommandLine
 
             if (newestVersion == null)
             {
-                // Make sure there a no asset installers remaining in the Downloads directory. This can happen if user
-                // upgraded by manually downloading and running asset installers.
-                ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
-                    this.tracer,
-                    this.fileSystem);
-                productUpgraderInfo.DeleteAllInstallerDownloads();
+                if (GVFSPlatform.Instance.IsElevated())
+                {
+                    ProductUpgraderInfo productUpgraderInfo = new ProductUpgraderInfo(
+                        this.tracer,
+                        this.fileSystem);
+                    productUpgraderInfo.RecordHighestAvailableVersionSafe(highestAvailableVersion: null);
+                }
+
                 this.ReportInfoToConsole(message);
                 return true;
             }


### PR DESCRIPTION
Streamline when upgrade cleans up old downloads

Previously, the upgrade notification logic checked for previous downloads of the upgrade packages in order to drive whether to notify the user about whether an upgrade is available. There were cases where the user updated outside of the upgrader logic, where the downloaded upgrade packages where not cleaned up, resulting in spurious upgrade notifications.

Since then, we have changed the logic to look at a sentinel file to indicate whether an upgrade is available, and stopped downloading packages in the background.

The NuGet upgrader did not clean up the downloaded packages, only the extracted packages.

This change:
1) UpgradeVerb and UpgradeOrchestrator no longer opportunistically deletes the download folder containing upgrade packages
2) UpgradVerb deletes the upgrade available sentinel file if run elevated
3) Upgrader deletes the download folder after running

### Questions:
Q1) Do we want to always delete the downloaded packages after upgrade runs (if upgrade fails for some reason, it might be useful to have the package around for diagnostic purposes)

A) We can look at this as a future improvement

Q2) Do we need to be more proactive when running `GVFS upgrade` to remove the sentinel file if not update is available? One issue is that this file can only be modified by a process with elevated permissions.

A) We will delete the sentinel file if run as an admin. We can look at improving this more in the future based on feedback.

Fixes #833 