### PR TITLE
[cherry-pick to master] Enhance git command logging

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -118,7 +118,8 @@ namespace GVFS.Common.Maintenance
                 (process) => process.PackObjects(
                     "from-loose",
                     this.Context.Enlistment.GitObjectsRoot,
-                    (StreamWriter writer) => objectsAddedToPack = this.WriteLooseObjectIds(writer)));
+                    (StreamWriter writer) => objectsAddedToPack = this.WriteLooseObjectIds(writer)),
+                nameof(GitProcess.PackObjects));
 
             return objectsAddedToPack;
         }
@@ -147,7 +148,7 @@ namespace GVFS.Common.Maintenance
                     }
 
                     int beforeLooseObjectsCount = this.CountLooseObjects();
-                    GitProcess.Result result = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot));
+                    GitProcess.Result result = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.PrunePacked));
                     int afterLooseObjectsCount = this.CountLooseObjects();
 
                     int objectsAddedToPack = this.CreateLooseObjectsPackFile();

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -150,23 +150,23 @@ namespace GVFS.Common.Maintenance
                     return;
                 }
 
-                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.MultiPackIndexExpire));
                 List<string> staleIdxFiles = this.CleanStaleIdxFiles(out int numDeletionBlocked);
                 this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
 
-                GitProcess.Result verifyAfterExpire = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyAfterExpire = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyAfterExpire.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyAfterExpire);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
 
-                GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize));
+                GitProcess.Result repackResult = this.RunGitCommand((process) => process.MultiPackIndexRepack(this.Context.Enlistment.GitObjectsRoot, this.batchSize), nameof(GitProcess.MultiPackIndexRepack));
                 this.GetPackFilesInfo(out int afterCount, out long afterSize, out hasKeep);
 
-                GitProcess.Result verifyAfterRepack = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyAfterRepack = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyAfterRepack.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyAfterRepack);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
 
                 EventMetadata metadata = new EventMetadata();
@@ -178,11 +178,7 @@ namespace GVFS.Common.Maintenance
                 metadata.Add(nameof(expireSize), expireSize);
                 metadata.Add(nameof(afterCount), afterCount);
                 metadata.Add(nameof(afterSize), afterSize);
-                metadata.Add("ExpireOutput", expireResult.Output);
-                metadata.Add("ExpireErrors", expireResult.Errors);
                 metadata.Add("VerifyAfterExpireExitCode", verifyAfterExpire.ExitCode);
-                metadata.Add("RepackOutput", repackResult.Output);
-                metadata.Add("RepackErrors", repackResult.Errors);
                 metadata.Add("VerifyAfterRepackExitCode", verifyAfterRepack.ExitCode);
                 metadata.Add("NumStaleIdxFiles", staleIdxFiles.Count);
                 metadata.Add("NumIdxDeletionsBlocked", numDeletionBlocked);

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -26,12 +26,12 @@ namespace GVFS.Common.Maintenance
                 string multiPackIndexLockPath = Path.Combine(this.Context.Enlistment.GitPackRoot, MultiPackIndexLock);
                 this.Context.FileSystem.TryDeleteFile(multiPackIndexLockPath);
 
-                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
 
-                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteMultiPackIndex(activity, verifyResult);
+                    this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
             }
 
@@ -46,13 +46,13 @@ namespace GVFS.Common.Maintenance
                 string commitGraphLockPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", CommitGraphLock);
                 this.Context.FileSystem.TryDeleteFile(commitGraphLockPath);
 
-                this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes));
+                this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
 
-                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot));
+                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyCommitGraph));
 
                 if (verifyResult.ExitCodeIsFailure)
                 {
-                    this.LogErrorAndRewriteCommitGraph(activity, verifyResult, this.packIndexes);
+                    this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
                 }
             }
         }

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -89,11 +89,13 @@ namespace GVFS.Common.Maintenance
                 return;
             }
 
-            this.RunGitCommand(process =>
-            {
-                this.TryPrefetchCommitsAndTrees(out error, process);
-                return null;
-            });
+            this.RunGitCommand(
+                process =>
+                {
+                    this.TryPrefetchCommitsAndTrees(out error, process);
+                    return null;
+                },
+                nameof(this.TryPrefetchCommitsAndTrees));
 
             if (!string.IsNullOrEmpty(error))
             {
@@ -162,7 +164,7 @@ namespace GVFS.Common.Maintenance
                     metadata.Add("pack", packPath);
                     metadata.Add("idxPath", idxPath);
                     metadata.Add("timestamp", timestamp);
-                    GitProcess.Result indexResult = this.RunGitCommand(process => this.GitObjects.IndexPackFile(packPath, process));
+                    GitProcess.Result indexResult = this.RunGitCommand(process => this.GitObjects.IndexPackFile(packPath, process), nameof(this.GitObjects.IndexPackFile));
 
                     if (this.Stopping)
                     {
@@ -174,7 +176,6 @@ namespace GVFS.Common.Maintenance
                     {
                         firstBadPack = i;
 
-                        metadata.Add("Errors", indexResult.Errors);
                         this.Context.Tracer.RelatedWarning(metadata, $"{nameof(this.TryGetMaxGoodPrefetchTimestamp)}: Found pack file that's missing idx file, and failed to regenerate idx");
                         break;
                     }

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
@@ -72,11 +72,13 @@ namespace GVFS.UnitTests.Maintenance
 
             protected override void PerformMaintenance()
             {
-                this.RunGitCommand(process =>
-                {
-                    this.SawWorkInvoked = true;
-                    return null;
-                });
+                this.RunGitCommand(
+                    process =>
+                    {
+                        this.SawWorkInvoked = true;
+                        return null;
+                    },
+                    nameof(this.SawWorkInvoked));
             }
         }
 
@@ -94,11 +96,13 @@ namespace GVFS.UnitTests.Maintenance
             protected override void PerformMaintenance()
             {
                 this.Stop();
-                this.RunGitCommand(process =>
-                {
-                    this.SawWorkInvoked = true;
-                    return null;
-                });
+                this.RunGitCommand(
+                    process =>
+                    {
+                        this.SawWorkInvoked = true;
+                        return null;
+                    },
+                    nameof(this.SawWorkInvoked));
             }
         }
     }


### PR DESCRIPTION
- Limit error message output to 1000 chars
- Include name of GitCommand
- Remove Output logging from commands. This can be looked up in Trace2.

resolves #832