### PR TITLE
[upgrade] Background upgrade check fix

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -84,7 +84,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private bool ServiceLogContainsUpgradeMessaging()
         {
-            string upgradeTimerMessage = "Checking for product upgrades. (Start)";
+            // This test checks for the upgrade timer start message in the Service log
+            // file. GVFS.Service should schedule the timer as it starts.
+            string expectedTimerMessage = "Checking for product upgrades. (Start)";
             string serviceLogFolder = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                 "GVFS",
@@ -102,7 +104,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                     string nextLine = null;
                     while ((nextLine = fileStream.ReadLine()) != null)
                     {
-                        if (nextLine.Contains(upgradeTimerMessage))
+                        if (nextLine.Contains(expectedTimerMessage))
                         {
                             return true;
                         }

--- a/GVFS/GVFS.Service/GvfsService.cs
+++ b/GVFS/GVFS.Service/GvfsService.cs
@@ -60,14 +60,14 @@ namespace GVFS.Service
                         EnableAndAttachProjFSHandler.TryEnablePrjFlt(activity, out error);
                     }
 
+                    // Start product upgrade timer only after attempting to enable prjflt.
+                    // On Windows server (where PrjFlt is not inboxed) this helps avoid
+                    // a race between TryEnablePrjFlt() and installer pre-check which is
+                    // performed by UpgradeTimer in parallel.
+                    this.productUpgradeTimer.Start();
+
                     this.serviceStopped.WaitOne();
                 }
-
-                // Start product upgrade timer only after attempting to enable prjflt.
-                // On Windows server (where PrjFlt is not inboxed) this helps avoid
-                // a race between TryEnablePrjFlt() and installer pre-check which is
-                // performed by UpgradeTimer in parallel.
-                this.productUpgradeTimer.Start();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Service was not checking for upgrades in the background. `UpgradeTimer.Start()` was incorrectly placed after `service.WaitOne()`. Meaning the timer was getting scheduled just when the Service is about to stop. Fixed and manually tested and verified that timer is getting scheduled correctly on Service launch. Added FT to verify Upgrader get scheduled on Service start.