### PR TITLE
Mac kext: Fix for vnode_put() panic bug, tighter invariant assertion & improved root search logic.

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -873,7 +873,7 @@ static bool TryGetVirtualizationRoot(
         PrjFSPerfCounter_VnodeOp_FindRoot,
         PrjFSPerfCounter_VnodeOp_FindRoot_Iteration,
         vnode,
-        *vnodeFsidInode);
+        context);
 
     if (RootHandle_ProviderTemporaryDirectory == *root)
     {
@@ -947,13 +947,12 @@ static bool ShouldHandleFileOpEvent(
     {
         PerfSample findRootSample(perfTracer, PrjFSPerfCounter_FileOp_ShouldHandle_FindVirtualizationRoot);
         
-        *vnodeFsidInode = Vnode_GetFsidAndInode(vnode, context);
         *root = VirtualizationRoot_FindForVnode(
             perfTracer,
             PrjFSPerfCounter_FileOp_FindRoot,
             PrjFSPerfCounter_FileOp_FindRoot_Iteration,
             vnode,
-            *vnodeFsidInode);
+            context);
         
         if (!VirtualizationRoot_IsValidRootHandle(*root))
         {
@@ -973,7 +972,9 @@ static bool ShouldHandleFileOpEvent(
             return false;
         }
     }
-    
+
+    *vnodeFsidInode = Vnode_GetFsidAndInode(vnode, context);
+
     return true;
 }
 

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -316,7 +316,10 @@ static VirtualizationRootHandle FindRootAtVnode_Locked(vnode_t vnode, uint32_t v
         
         if (rootEntry.rootVNode == vnode && rootEntry.rootVNodeVid == vid)
         {
-            assert(fileId.fsid.val[0] == rootEntry.rootFsid.val[0]);
+            assertf(
+                FsidsAreEqual(fileId.fsid, rootEntry.rootFsid) && fileId.inode == rootEntry.rootInode,
+                "FindRootAtVnode_Locked: matching root vnode/vid but not fsid/inode? vnode %p:%u. rootEntry fsid 0x%x:%x, inode 0x%llx, searching for fsid 0x%x:%x, inode 0x%llx",
+                KextLog_Unslide(vnode), vid, rootEntry.rootFsid.val[0], rootEntry.rootFsid.val[1], rootEntry.rootInode, fileId.fsid.val[0], fileId.fsid.val[1], fileId.inode);
             return i;
         }
         else if (rootEntry.rootVNode == vnode)

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -151,7 +151,7 @@ VirtualizationRootHandle VirtualizationRoot_FindForVnode(
     PrjFSPerfCounter functionCounter,
     PrjFSPerfCounter innerLoopCounter,
     vnode_t _Nonnull vnode,
-    const FsidInode& vnodeFsidInode)
+    vfs_context_t context)
 {
     PerfSample findForVnodeSample(perfTracer, functionCounter);
     
@@ -167,6 +167,8 @@ VirtualizationRootHandle VirtualizationRoot_FindForVnode(
     while (RootHandle_None == rootHandle && NULLVP != vnode && !vnode_isvroot(vnode))
     {
         PerfSample iterationSample(perfTracer, innerLoopCounter);
+
+        FsidInode vnodeFsidInode = Vnode_GetFsidAndInode(vnode, context);
 
         rootHandle = FindOrDetectRootAtVnode(vnode, vnodeFsidInode);
         

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
@@ -28,7 +28,7 @@ VirtualizationRootHandle VirtualizationRoot_FindForVnode(
     PrjFSPerfCounter functionCounter,
     PrjFSPerfCounter innerLoopCounter,
     vnode_t _Nonnull vnode,
-    const FsidInode& vnodeFsidInode);
+    vfs_context_t _Nonnull context);
 
 struct VirtualizationRootResult
 {


### PR DESCRIPTION
The first commit in this series fixes #797, the second one strengthens one of the related `assert()`s and the third further cleans up the function that contained the bug.

 1. I explained the nature & cause of the bug [in this comment](https://github.com/Microsoft/VFSForGit/issues/797#issuecomment-467618364) so I won't repeat that here. The fix is of course to use the inode of each directory level to try to match a virtualisation root as we walk up the hierarchy.
 2. In addition to the new asserts I added in PR #805, this tightens up a much older assert in a way that would have caught this bug in action. If the vnode/vid pair matches a root vnode/vid pair, their fsid/inode must also match, or something has gone badly wrong.
 3. There has so far been no proper error handling for the `vnode_get()` call in `VirtualizationRoot_FindForVnode()`. I don't think that call *can* fail in that situation, but just in case, I've now changed the logic such that the iocount remains correct. In cases where the incoming vnode is not a directory however, it actually makes more sense to start the search with the parent directory, so we can call `vnode_getparent()` in that case instead.

I am planning to write some unit tests for `VirtualizationRoot_FindForVnode()` that would have caught this bug. However, these will depend on the substantial upgrades to the unit testing infrastructure I added in PR #839, and as that PR is still some way away from being merged, I won't delay the fix until then.