### PR TITLE
GitStatusCache: logging tweaks

### DIFF
--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -539,6 +539,10 @@ namespace GVFS.Mount
             {
                 this.tracer.RelatedInfo("Git status cache enabled. Backoff time: {0}ms", this.gitStatusCacheConfig.BackoffTime.TotalMilliseconds);
             }
+            else
+            {
+                this.tracer.RelatedInfo("Git status cache is not enabled");
+            }
 
             this.fileSystemCallbacks = this.CreateOrReportAndExit(() => new FileSystemCallbacks(this.context, this.gitObjects, RepoMetadata.Instance, virtualizer, gitStatusCache), "Failed to create src folder callback listener");
             this.maintenanceScheduler = this.CreateOrReportAndExit(() => new GitMaintenanceScheduler(this.context, this.gitObjects), "Failed to start maintenance scheduler");


### PR DESCRIPTION
This includes the following logging tweaks:

1) Log when status cache is not enabled.
This makes it more explicit whether the cache is enabled or not.

```
[2019-02-27 10:30:43 -05:00] Information {"Message":"Git status cache is not enabled"}
```


2) Reduce the number of trace statements generated by the status cache
The current logging is a bit verbose, and at this point has not been used for diagnostics. This change reduces the number of lines we trace, but adds a bit more information to the final trace statement after a background status command is run.

```
[2019-02-27 10:27:51 -05:00] Information {"Message":"GitStatusCache.RebuildStatusCacheIfNeeded: Done generating status. Cache state: Clean. Status scan time: 24.69s."}
[2019-02-27 10:28:37 -05:00] Information {"Message":"GitStatusCache.RebuildStatusCacheIfNeeded: Done generating status. Cache state: Clean. Status scan time: 2.17s. Status scan was delayed for: 6.01s."}
```

Fixes #206 