### PR TITLE
GitStatusCache: handle errors creating directory

### DIFF
--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -337,7 +337,21 @@ namespace GVFS.Common
         /// </summary>
         private bool TryRebuildStatusCache()
         {
-            this.context.FileSystem.CreateDirectory(this.context.Enlistment.GitStatusCacheFolder);
+            try
+            {
+                this.context.FileSystem.CreateDirectory(this.context.Enlistment.GitStatusCacheFolder);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Area", EtwArea);
+                metadata.Add("Exception", ex.ToString());
+
+                this.context.Tracer.RelatedWarning(
+                    metadata,
+                    string.Format("GitStatusCache is unable to create git status cache folder at {0}.", this.context.Enlistment.GitStatusCacheFolder));
+                return false;
+            }
 
             // The status cache is regenerated on mount. This means that even if the write to temp file
             // and rename operation doesn't complete (due to a system crash), and there is a torn write,

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -21,6 +21,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         public MockDirectory RootDirectory { get; private set; }
 
         public bool DeleteFileThrowsException { get; set; }
+        public Exception ExceptionThrownByCreateDirectory { get; set; }
 
         public bool TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed { get; set; }
 
@@ -194,6 +195,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
 
         public override void CreateDirectory(string path)
         {
+            if (this.ExceptionThrownByCreateDirectory != null)
+            {
+                throw this.ExceptionThrownByCreateDirectory;
+            }
+
             this.RootDirectory.CreateDirectory(path);
         }
 


### PR DESCRIPTION
An error creating the status cache directory should not bring down the mount process

Fixes: #489 