### PR TITLE
[upgrade] No telemetry for non-elevated upgrade

### DIFF
--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -198,7 +198,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     $"{GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature.",
                     "Check your team's documentation for how to upgrade.");
-                this.tracer.RelatedError($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
+                this.tracer.RelatedWarning(metadata: null, message:$"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}", keywords: Keywords.Telemetry);
                 return false;
             }
 

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -31,7 +31,7 @@ namespace GVFS.Upgrader
                 if (this.IsUnattended())
                 {
                     consoleError = $"{GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is not supported in unattended mode";
-                    this.tracer.RelatedError($"{nameof(this.TryRunPreUpgradeChecks)}: {consoleError}");
+                    this.tracer.RelatedWarning($"{nameof(this.TryRunPreUpgradeChecks)}: {consoleError}");
                     return false;
                 }
 
@@ -102,7 +102,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     "Blocking processes are running.",
                     $"Run {this.CommandToRerun} again after quitting these processes - " + string.Join(", ", processList.ToArray()));
-                this.tracer.RelatedError($"{nameof(this.IsInstallationBlockedByRunningProcess)}: {consoleError}");
+                this.tracer.RelatedWarning($"{nameof(this.IsInstallationBlockedByRunningProcess)}: {consoleError}");
                 return false;
             }
 
@@ -209,7 +209,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     "GVFS Service is not running.",
                     adviceText);
-                this.tracer.RelatedError($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
+                this.tracer.RelatedWarning($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
                 return false;
             }
 

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -37,7 +37,6 @@ namespace GVFS.Upgrader
 
                 if (!this.IsGVFSUpgradeAllowed(out consoleError))
                 {
-                    this.tracer.RelatedError($"{nameof(this.TryRunPreUpgradeChecks)}: {consoleError}");
                     return false;
                 }
 
@@ -189,6 +188,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     "The installer needs to be run from an elevated command prompt.",
                     adviceText);
+                this.tracer.RelatedWarning($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
                 return false;
             }
 
@@ -198,6 +198,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     $"{GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature.",
                     "Check your team's documentation for how to upgrade.");
+                this.tracer.RelatedError($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
                 return false;
             }
 
@@ -208,6 +209,7 @@ namespace GVFS.Upgrader
                     Environment.NewLine,
                     "GVFS Service is not running.",
                     adviceText);
+                this.tracer.RelatedError($"{nameof(this.IsGVFSUpgradeAllowed)}: Upgrade is not installable. {consoleError}");
                 return false;
             }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -67,7 +67,8 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "ERROR: Blocking processes are running.",
                     $"Run `gvfs upgrade --confirm` again after quitting these processes - GVFS.Mount, git"
                 },
-                expectedErrors: new List<string>
+                expectedErrors: null,
+                expectedWarnings: new List<string>
                 {
                     $"Run `gvfs upgrade --confirm` again after quitting these processes - GVFS.Mount, git"
                 });

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeTests.cs
@@ -109,7 +109,8 @@ namespace GVFS.UnitTests.Windows.Upgrader
             Action configure,
             ReturnCode expectedReturn,
             List<string> expectedOutput,
-            List<string> expectedErrors)
+            List<string> expectedErrors,
+            List<string> expectedWarnings = null)
         {
             configure();
 
@@ -127,6 +128,13 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 this.Tracer.RelatedErrorEvents.ShouldContain(
                     expectedErrors,
                     (error, expectedError) => { return error.Contains(expectedError); });
+            }
+
+            if (expectedWarnings != null)
+            {
+                this.Tracer.RelatedWarningEvents.ShouldContain(
+                    expectedWarnings,
+                    (warning, expectedWarning) => { return warning.Contains(expectedWarning); });
             }
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -167,7 +167,8 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "GVFS Service is not running.",
                     "Run `sc start GVFS.Service` and run `gvfs upgrade --confirm` again from an elevated command prompt."
                 },
-                expectedErrors: new List<string>
+                expectedErrors: null,
+                expectedWarnings: new List<string>
                 {
                     "GVFS Service is not running."
                 });
@@ -189,11 +190,11 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "The installer needs to be run from an elevated command prompt.",
                     "Run `gvfs upgrade --confirm` again from an elevated command prompt."
                 },
-                expectedErrors: null);
-
-            this.Tracer.RelatedWarningEvents.ShouldContain(
-                    new List<string> { "The installer needs to be run from an elevated command prompt." },
-                    (error, expectedError) => { return error.Contains(expectedError); });
+                expectedErrors: null,
+                expectedWarnings: new List<string>
+                {
+                    "The installer needs to be run from an elevated command prompt."
+                });
         }
 
         [TestCase]
@@ -210,7 +211,8 @@ namespace GVFS.UnitTests.Windows.Upgrader
                 {
                     "`gvfs upgrade` is not supported in unattended mode"
                 },
-                expectedErrors: new List<string>
+                expectedErrors: null,
+                expectedWarnings: new List<string>
                 {
                     "`gvfs upgrade` is not supported in unattended mode"
                 });

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -145,7 +145,8 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "ERROR: `gvfs upgrade` is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature.",
                     "Check your team's documentation for how to upgrade."
                 },
-                expectedErrors: new List<string>
+                expectedErrors: null,
+                expectedWarnings: new List<string>
                 {
                     "`gvfs upgrade` is only supported after the \"Windows Projected File System\" optional feature has been enabled by a manual installation of VFS for Git, and only on versions of Windows that support this feature."
                 });

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/UpgradeVerbTests.cs
@@ -189,10 +189,11 @@ namespace GVFS.UnitTests.Windows.Upgrader
                     "The installer needs to be run from an elevated command prompt.",
                     "Run `gvfs upgrade --confirm` again from an elevated command prompt."
                 },
-                expectedErrors: new List<string>
-                {
-                    "The installer needs to be run from an elevated command prompt."
-                });
+                expectedErrors: null);
+
+            this.Tracer.RelatedWarningEvents.ShouldContain(
+                    new List<string> { "The installer needs to be run from an elevated command prompt." },
+                    (error, expectedError) => { return error.Contains(expectedError); });
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -69,6 +69,10 @@ namespace GVFS.UnitTests.Mock.Common
                 metadata[TracingConstants.MessageKey.WarningMessage] = message;
                 this.RelatedWarningEvents.Add(JsonConvert.SerializeObject(metadata));
             }
+            else if (message != null)
+            {
+                this.RelatedWarning(message);
+            }
         }
 
         public void RelatedWarning(EventMetadata metadata, string message, Keywords keyword)

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -148,7 +148,6 @@ namespace GVFS.CommandLine
             {
                 this.ReportInfoToConsole($"Cannot upgrade GVFS on this machine.");
                 this.Output.WriteLine(errorOutputFormat, cannotInstallReason);
-                this.tracer.RelatedError($"{nameof(this.TryRunProductUpgrade)}: Upgrade is not installable. {cannotInstallReason}");
                 return false;
             }
 


### PR DESCRIPTION
When user runs `gvfs upgrade --confirm` from a non-elevated command prompt, VFS4Git displays error on Console and triggers a Telemetry error event. This PR removes the telemetry (no other change). Rather than generating pre-check telemetry errors generally at the higher `UpgradeVerb` level, `InstallerPrerunChecker` now decides whether to log Warning or Error events depending on specific pre-check failures.

Updated events.
1. Unattended mode - Log error locally. No reporting to server.
2. Non-elevated upgrade - Log error locally. No reporting to server.
3. PrjFlt not inboxed & enabled - Report to server.
4. Service not running - Log warming. Report warning to server.
5. Installer blocked by running processes - Log error locally.

Fixes #831