### PR TITLE
Upgrade: handle not finding git installation

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -119,6 +119,13 @@ namespace GVFS.Common.NuGetUpgrade
                 return false;
             }
 
+            string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+            if (string.IsNullOrEmpty(GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath()))
+            {
+                error = $"NuGetUpgrader: Unable to locate git installation. Ensure git is installed and try again.";
+                return false;
+            }
+
             string authUrl;
             if (!TryCreateAzDevOrgUrlFromPackageFeedUrl(upgraderConfig.FeedUrl, out authUrl, out error))
             {
@@ -126,7 +133,7 @@ namespace GVFS.Common.NuGetUpgrade
             }
 
             if (!TryGetPersonalAccessToken(
-                    GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath(),
+                    gitBinPath,
                     authUrl,
                     tracer,
                     out string token,

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -79,6 +79,13 @@ namespace GVFS.Platform.Windows
         {
             string gitBinRoot = this.GitInstallation.GetInstalledGitBinPath();
 
+            // If we do not have a git binary, then we cannot check if we should set up telemetry
+            // We also cannot log this, as we are setting up tracer.
+            if (string.IsNullOrEmpty(gitBinRoot))
+            {
+                yield break;
+            }
+
             ETWTelemetryEventListener etwListener = ETWTelemetryEventListener.CreateIfEnabled(gitBinRoot, providerName, enlistmentId, mountId);
             if (etwListener != null)
             {


### PR DESCRIPTION
Fixes an issue where the upgrader would crash if it was unable to find the local git installation. With this change, we will handle this scenario better.

Previously, the tracer would throw an exception if it was unable to find the git installation. This change:

1) The tracer will handle this by assuming it is not configured to report telemetry

2) The NuGet Upgrader includes a check to make sure it can find the git installation, as it is required for acquiring credentials.

When running the NuGet upgrader with this change, but in an environment where it can't find the git installation, it will report the following error:

```
>gvfs upgrade
ERROR: NuGetUpgrader: Unable to locate git installation. Ensure git is installed and try again.
```

Fixes #864