### PR TITLE
Upgrade: run upgrader in system diretory

### DIFF
--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -380,6 +380,7 @@ namespace GVFS.CommandLine
                 this.Process.StartInfo = new ProcessStartInfo(path)
                 {
                     UseShellExecute = true,
+                    WorkingDirectory = Environment.SystemDirectory,
                     WindowStyle = ProcessWindowStyle.Normal,
                     Arguments = args
                 };


### PR DESCRIPTION
Run the upgrade tool from the system directory to avoid potential
interactions with the local directory. This could happen if the
installer attempts to run a batch script, which might pick environment
from the local location (e.g. if it runs a git command, it might try and
run the locally configured git hooks).

(cherry picked from commit 714867872d55d7d3a6a9fcb2a7d47763c0dd234b)