### PR TITLE
NuGetUpgrader: test actual gitbin variable

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -120,7 +120,7 @@ namespace GVFS.Common.NuGetUpgrade
             }
 
             string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            if (string.IsNullOrEmpty(GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath()))
+            if (string.IsNullOrEmpty(gitBinPath))
             {
                 error = $"NuGetUpgrader: Unable to locate git installation. Ensure git is installed and try again.";
                 return false;


### PR DESCRIPTION
Quick fix to #867 - I wasn't testing the actual variable that I stored the git installation path into. I did correct this in the port into the releases/shipped branch in #869 