### PR TITLE
Linux/Mac: remove unused NotificationMapping class

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationMapping.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationMapping.cs
@@ -1,8 +1,0 @@
-﻿namespace PrjFSLib.Linux
-{
-    public class NotificationMapping
-    {
-        public NotificationType NotificationMask { get; set; }
-        public string NotificationRelativeRoot { get; set; }
-    }
-}

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationMapping.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationMapping.cs
@@ -1,8 +1,0 @@
-﻿namespace PrjFSLib.Mac
-{
-    public class NotificationMapping
-    {
-        public NotificationType NotificationMask { get; set; }
-        public string NotificationRelativeRoot { get; set; }
-    }
-}

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -57,13 +57,6 @@ typedef enum
 
 } PrjFS_NotificationType;
 
-typedef struct
-{
-    _In_    PrjFS_NotificationType                  NotificationBitMask;
-    _In_    const char*                             NotificationRelativeRoot;
-
-} PrjFS_NotificationMapping;
-
 extern "C" PrjFS_Result PrjFS_StartVirtualizationInstance(
     _In_    const char*                             virtualizationRootFullPath,
     _In_    PrjFS_Callbacks                         callbacks,


### PR DESCRIPTION
The `NotificationMapping` class is used only on Windows to fill out the [`PRJ_NOTIFICATION_MAPPING` structure](https://docs.microsoft.com/en-us/windows/desktop/api/projectedfslib/ns-projectedfslib-prj_notification_mapping) supported by the PrjFlt filter driver.

This allows the Windows implementation to defer filtering of file operation notifications to the filter driver so that, for example, the [`NotifyPreDeleteHandler`](https://github.com/Microsoft/VFSForGit/blob/master/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs#L1241) can assume it will only be called for events on the Git index file.

By contrast, the macOS and Linux ProjFS implementations do not support this functionality in the lower-level libraries, and instead filter events by file path in the handlers, e.g., by checking for the Git index file path in the [`OnPreDelete`](https://github.com/Microsoft/VFSForGit/blob/master/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs#L495) handler.

Therefore we can remove their respective versions of this class.

(As a future possibility, the Linux libprojfs library could support such functionality, in a manner akin to -- or by actually using -- the [inotify(7)](http://man7.org/linux/man-pages/man7/inotify.7.html) interface. If we choose to pursue that option, we can re-introduce a dedicated Linux class or structure to represent the paths and event masks which is more aligned with the underlying Linux APIs.)

/cc @jrbriggs @kivikakk