### PR TITLE
[upgrade] Test reliability

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -108,6 +108,21 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
+        public string ReadConfig(string key)
+        {
+            return this.CallGVFS($"config {key}", failOnError: true).TrimEnd('\r', '\n');
+        }
+
+        public void WriteConfig(string key, string value)
+        {
+            this.CallGVFS($"config {key} {value}", failOnError: true);
+        }
+
+        public void DeleteConfig(string key)
+        {
+            this.CallGVFS($"config --delete {key}", failOnError: true);
+        }
+
         private string CallGVFS(string args, bool failOnError = false, string trace = null, string standardInput = null, string internalParameter = null)
         {
             ProcessStartInfo processInfo = null;


### PR DESCRIPTION
The issue is that when gvfs upgrade verb uses Nuget server for upgrades when Nuget config is available. The failing test sets the upgrade ring to "None". Then creates dummy upgrade marker file (C:\ProgramData\GVFS\GVFS.Upgrade\highestAvailableVersion). Then launches upgrade verb. Since the upgrade ring is None, the test expects upgrade verb to delete the marker file. This used to work. But now, upgrade verb will use Nuget upgrader when Nuget config is availble. Nuget upgrader ignores upgrade ring and checks for upgrade. It will not delete the marker file, if it finds one. Updated the test to delete Nuget config before running.

Fixes #852