### PR TITLE
Adding Distribution.xml & installation-check

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -18,7 +18,7 @@ if [ -z $PACKAGEVERSION ]; then
   exit 1
 fi
 
-BUILDOUTPUTDIR=$4
+BUILDOUTPUTDIR=${4%/}
 if [ -z $BUILDOUTPUTDIR ]; then
   echo "Error: Build output directory not specified"
   exit 1
@@ -34,7 +34,8 @@ if [ -z $VFS_PUBLISHDIR ]; then
   exit 1
 fi
 
-STAGINGDIR=$BUILDOUTPUTDIR"Staging"
+STAGINGDIR="${BUILDOUTPUTDIR}/Staging"
+PACKAGESTAGINGDIR="${BUILDOUTPUTDIR}/Packages"
 VFSFORGITDESTINATION="usr/local/vfsforgit"
 DAEMONPLISTDESTINATION="Library/LaunchDaemons"
 LIBRARYEXTENSIONSDESTINATION="Library/Extensions"
@@ -42,6 +43,7 @@ INSTALLERPACKAGENAME="VFSForGit.$PACKAGEVERSION"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
 UNINSTALLERPATH="${SOURCEDIRECTORY}/uninstall_vfsforgit.sh"
 SCRIPTSPATH="${SOURCEDIRECTORY}/scripts"
+DIST_FILE_NAME="Distribution.updated.xml"
 
 function CheckBuildIsAvailable()
 {
@@ -61,6 +63,9 @@ function CreateInstallerRoot()
 {
     mkdirVfsForGit="mkdir -p \"${STAGINGDIR}/$VFSFORGITDESTINATION\""
     eval $mkdirVfsForGit || exit 1
+    
+    mkdirPkgStaging="mkdir -p \"${PACKAGESTAGINGDIR}\""
+    eval $mkdirPkgStaging || exit 1
 
     mkdirBin="mkdir -p \"${STAGINGDIR}/usr/local/bin\""
     eval $mkdirBin || exit 1
@@ -98,7 +103,7 @@ function CopyBinariesToInstall()
     copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/PrjFSKext.kext \"${STAGINGDIR}/${LIBRARYEXTENSIONSDESTINATION}/.\""
     eval $copyPrjFS || exit 1
     
-    copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION\"/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist \"${STAGINGDIR}/${DAEMONPLISTDESTINATION}/.\""
+    copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist\" \"${STAGINGDIR}/${DAEMONPLISTDESTINATION}/.\""
     eval $copyPrjFS || exit 1
     
     currentDirectory=`pwd`
@@ -108,19 +113,59 @@ function CopyBinariesToInstall()
     cd $currentDirectory
 }
 
-function CreateInstaller()
+function CreateVFSForGitInstaller()
 {
-    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --scripts \"${SCRIPTSPATH}\" --root \"${STAGINGDIR}\" \"${BUILDOUTPUTDIR}\"$INSTALLERPACKAGENAME.pkg"
+    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --scripts \"${SCRIPTSPATH}\" --root \"${STAGINGDIR}\" \"${PACKAGESTAGINGDIR}/$INSTALLERPACKAGENAME.pkg\""
     eval $pkgBuildCommand || exit 1
 }
 
-function CreateMetaInstaller()
+function UpdateDistributionFile()
+{
+    VFSFORGIT_PKG_VERSION=$PACKAGEVERSION
+    VFSFORGIT_PKG_NAME="$INSTALLERPACKAGENAME.pkg"
+    GIT_PKG_NAME=$1
+    GIT_PKG_VERSION=$2
+        
+    /usr/bin/sed -e "s|VFSFORGIT_VERSION_PLACHOLDER|$VFSFORGIT_PKG_VERSION|g" "$SCRIPTSPATH/Distribution.xml" > "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    /usr/bin/sed -i.bak "s|VFSFORGIT_PKG_NAME_PLACEHOLDER|$VFSFORGIT_PKG_NAME|g" "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    
+    if [ ! -z "$GIT_PKG_NAME" ] && [ ! -z "$GIT_PKG_VERSION" ]; then
+        GIT_CHOICE_OUTLINE_ELEMENT_TEXT="<line choice=\"com.git.pkg\"/>"
+        GIT_CHOICE_ID_ELEMENT_TEXT="<choice id=\"com.git.pkg\" visible=\"false\"> <pkg-ref id=\"com.git.pkg\"/> </choice>"
+        GIT_PKG_REF_ELEMENT_TEXT="<pkg-ref id=\"com.git.pkg\" version=\"$GIT_PKG_VERSION\" onConclusion=\"none\">$GIT_PKG_NAME</pkg-ref>"
+    else
+        GIT_CHOICE_OUTLINE_ELEMENT_TEXT=""
+        GIT_CHOICE_ID_ELEMENT_TEXT=""
+        GIT_PKG_REF_ELEMENT_TEXT=""
+    fi
+    
+    /usr/bin/sed -i.bak "s|GIT_CHOICE_OUTLINE_PLACEHOLDER|$GIT_CHOICE_OUTLINE_ELEMENT_TEXT|g" "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    /usr/bin/sed -i.bak "s|GIT_CHOICE_ID_PLACEHOLDER|$GIT_CHOICE_ID_ELEMENT_TEXT|g" "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    /usr/bin/sed -i.bak "s|GIT_PKG_REF_PLACEHOLDER|$GIT_PKG_REF_ELEMENT_TEXT|g" "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    
+    /bin/rm -f "${BUILDOUTPUTDIR}/$DIST_FILE_NAME.bak"
+}
+
+function CreateVFSForGitDistribution()
+{
+    # Update distribution file(removes Git info from template.)
+    UpdateDistributionFile "" ""
+    
+    buildVFSForGitDistCmd="/usr/bin/productbuild --distribution \"${BUILDOUTPUTDIR}/Distribution.updated.xml\" --package-path \"$PACKAGESTAGINGDIR\" \"${BUILDOUTPUTDIR}/$INSTALLERPACKAGENAME.pkg\""
+    echo $buildVFSForGitDistCmd
+    eval $buildVFSForGitDistCmd || exit 1
+    
+    /bin/rm -f "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+}
+
+function CreateMetaDistribution()
 {
     GITVERSION="$($VFS_SCRIPTDIR/GetGitVersionNumber.sh)"
     GITDMGPATH="$(find $VFS_PACKAGESDIR/gitformac.gvfs.installer/$GITVERSION -type f -name *.dmg)" || exit 1
     GITDMGNAME="${GITDMGPATH##*/}"
     GITINSTALLERNAME="${GITDMGNAME%.dmg}"
     GITVERSIONSTRING=`echo $GITINSTALLERNAME | cut -d"-" -f2`
+    GITPKGNAME="$GITINSTALLERNAME.pkg"
     
     if [[ -z "$GITVERSION" || -z "$GITVERSIONSTRING" ]]; then
         echo "Error creating metapackage: could not determine Git package version."
@@ -144,11 +189,17 @@ function CreateMetaInstaller()
         exit 1
     fi
     
-    METAPACKAGENAME="$INSTALLERPACKAGENAME-Git.$GITVERSION.pkg"
+    copyGitPkgCmd="/bin/cp -Rf \"${GITINSTALLERPATH}\" \"${PACKAGESTAGINGDIR}/.\""
+    eval $copyGitPkgCmd
+
+    UpdateDistributionFile "$GITPKGNAME" "$GITVERSIONSTRING"
     
-    buildMetapkgCmd="/usr/bin/productbuild --package \"$GITINSTALLERPATH\" --package \"${BUILDOUTPUTDIR}\"$INSTALLERPACKAGENAME.pkg \"${BUILDOUTPUTDIR}\"$METAPACKAGENAME"
+    METAPACKAGENAME="$INSTALLERPACKAGENAME-Git.$GITVERSION.pkg"
+    buildMetapkgCmd="/usr/bin/productbuild --distribution \"${BUILDOUTPUTDIR}/Distribution.updated.xml\" --package-path \"$PACKAGESTAGINGDIR\" \"${BUILDOUTPUTDIR}/$METAPACKAGENAME\""
     echo $buildMetapkgCmd
     eval $buildMetapkgCmd || exit 1
+    
+    /bin/rm -f "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
     
     unmountCmd="/usr/bin/hdiutil detach \"$MOUNTEDVOLUME\""
     echo "$unmountCmd"
@@ -161,8 +212,9 @@ function Run()
     CreateInstallerRoot
     CopyBinariesToInstall
     SetPermissions
-    CreateInstaller
-    CreateMetaInstaller
+    CreateVFSForGitInstaller
+    CreateVFSForGitDistribution
+    CreateMetaDistribution
 }
 
 Run

--- a/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
+++ b/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <pkg-ref id="com.vfsforgit.pkg"/>
+    <pkg-ref id="com.git.pkg"/>
+    <options customize="never" allow-external-scripts="true"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.vfsforgit.pkg"/>
+            GIT_CHOICE_OUTLINE_PLACEHOLDER
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.vfsforgit.pkg" visible="false">
+        <pkg-ref id="com.vfsforgit.pkg"/>
+    </choice>
+    <pkg-ref id="com.vfsforgit.pkg" version="VFSFORGIT_VERSION_PLACHOLDER" onConclusion="none">VFSFORGIT_PKG_NAME_PLACEHOLDER</pkg-ref>
+    GIT_CHOICE_ID_PLACEHOLDER
+    GIT_PKG_REF_PLACEHOLDER
+    <installation-check script="InstallationCheck()"/>
+    <script>
+        function InstallationCheck(prefix) 
+        {
+            var blockingProcesses = GetBlockingProcesses();
+            if (blockingProcesses.length > 0)
+            {
+                my.result.message = "Quit these processes and try again - " + blockingProcesses.join(", ") + ".";
+                my.result.type = 'Fatal';
+                return false;
+            }
+            
+            return true;
+        }
+        
+        function GetBlockingProcesses()
+        {
+            var watchList = [ "gvfs", "GVFS.Mount", "git", "gitk", "Wish" ];
+            var blockingProcesses = new Array();
+            for (var process of watchList)
+            {
+                var isRunningCmd = "ps -Ac -o command | grep -w '" + process + "'";
+                var status = system.run("/bin/bash", "-c", isRunningCmd);
+                if (status == 0) 
+                {
+                    blockingProcesses.push(process);
+                }
+            }
+            
+            return blockingProcesses;
+        }
+    </script>
+</installer-gui-script>

--- a/GVFS/GVFS.Installer.Mac/scripts/preinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/preinstall
@@ -4,3 +4,21 @@ if [ -f /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist ]; t
     echo "Unloading PrjFSKextLogDaemon: '$unloadCmd'..."
     eval $unloadCmd || exit 1
 fi
+
+KEXTBUNDLEID="org.vfsforgit.PrjFSKext"
+isKextLoadedCmd="/usr/sbin/kextstat -l -b $KEXTBUNDLEID | wc -l"
+isKextLoaded=$(eval $isKextLoadedCmd)
+if [ "$isKextLoaded" -gt 0 ]; then
+	unloadCmd="/sbin/kextunload -b $KEXTBUNDLEID"
+    echo $unloadCmd
+    eval $unloadCmd || exit 1
+fi
+
+LEGACYKEXTBUNDLEID="io.gvfs.PrjFSKext"
+isKextLoadedCmd="/usr/sbin/kextstat -l -b $LEGACYKEXTBUNDLEID | wc -l"
+isKextLoaded=$(eval $isKextLoadedCmd)
+if [ "$isKextLoaded" -gt 0 ]; then
+	unloadCmd="/sbin/kextunload -b $LEGACYKEXTBUNDLEID"
+    echo $unloadCmd
+    eval $unloadCmd || exit 1
+fi


### PR DESCRIPTION
On the Mac, the GVFS standalone installer and the combined GVFS & Git meta installer, would check if any GVFS of git processes are running. If they are running, then installer would display error messaging and will not continue.

1. Added [Distribution XML](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html) for both GVFS standalone and combined meta installers.
2. Updated `GVFS.Installer.Mac::CreateInstaller` script to create distributions for both GVFS Standalone and combined meta installers.
3. Created a new `Packages` staging directory where component packages are kept. (The distributable installers is kept in the same location as before.)
4. Updated `preflight` installer script to automatically unload `PrjFlt.kext` if it is loaded at install time.
5. Installation pre-check will block on these processes - `"gvfs", "gvfs.mount", "git", "gitk", "wish"`