### PR TITLE
Mac PrjFS: Adds static verification for perf counter name initialization

### DIFF
--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -26,7 +26,7 @@ static uint64_t nanosecondsFromAbsoluteTime(uint64_t machAbsoluteTime)
     return static_cast<__uint128_t>(machAbsoluteTime) * s_machTimebase.numer / s_machTimebase.denom;
 }
 
-static const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
+static constexpr const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
 {
     [PrjFSPerfCounter_VnodeOp]                                              = "HandleVnodeOperation",
     [PrjFSPerfCounter_VnodeOp_GetPath]                                      = " |--GetPath",
@@ -65,6 +65,19 @@ static const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
     [PrjFSPerfCounter_FileOp_FileModified]                                  = " |--RaiseFileModifiedEvent",
     [PrjFSPerfCounter_FileOp_FileCreated]                                   = " |--RaiseFileCreatedEvent",
 };
+
+template <typename T, size_t N>
+    constexpr bool AllArrayElementsInitialized(T (&array)[N], size_t fromIndex = 0)
+{
+    return
+        fromIndex >= N
+        ? true
+        : (array[fromIndex] != T()
+           && AllArrayElementsInitialized(array, fromIndex + 1));
+}
+
+static_assert(AllArrayElementsInitialized(PerfCounterNames), "There must be an initialization of PerfCounterNames elements corresponding to each PrjFSPerfCounter enum value");
+
 
 static double FindSuitablPrefixedUnitFromNS(double nanoSeconds, const char*& outUnit)
 {


### PR DESCRIPTION
This adds a `static_assert` and helper function to facilitate compile-time checking that the `PerfCounterNames` array has got **initialised** elements corresponding to each enum values. This should catch the easy mistake of adding enum values but forgetting to amend the array.

In true C++ fashion, the templated helper function is a bit weird, but thanks to `constexpr` it's nowhere near as weird as template metaprogramming from days of yore.

Bonus points: I think I managed to counteract my muscle memory and spell "initialised" ~~incorrectly~~ the US English way throughout the patch.