### PR TITLE
Upgrader: reacquire credentials on auth failure

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -222,7 +222,7 @@ namespace GVFS.Common.NuGetUpgrade
         {
             try
             {
-                IList<IPackageSearchMetadata> queryResults = this.nuGetFeed.QueryFeedAsync(this.nuGetUpgraderConfig.PackageFeedName).GetAwaiter().GetResult();
+                IList<IPackageSearchMetadata> queryResults = this.QueryFeed(firstAttempt: true);
 
                 // Find the package with the highest version
                 IPackageSearchMetadata highestVersionAvailable = null;
@@ -455,10 +455,40 @@ namespace GVFS.Common.NuGetUpgrade
             }
         }
 
+        protected static EventMetadata CreateEventMetadata(Exception e = null)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("Area", nameof(NuGetFeed));
+            if (e != null)
+            {
+                metadata.Add("Exception", e.ToString());
+            }
+
+            return metadata;
+        }
+
         private static bool TryGetPersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer, out string token, out string error)
         {
             GitProcess gitProcess = new GitProcess(gitBinaryPath, null, null);
             return gitProcess.TryGetCredentials(tracer, credentialUrl, out string username, out token, out error);
+        }
+
+        private static void ErasePersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer)
+        {
+            GitProcess gitProcess = new GitProcess(gitBinaryPath, null, null);
+            gitProcess.RejectCredentials(credentialUrl);
+        }
+
+        private static bool TryReacquirePersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer, out string token, out string error)
+        {
+            ErasePersonalAccessToken(gitBinaryPath, credentialUrl, tracer);
+
+            if (!TryGetPersonalAccessToken(gitBinaryPath, credentialUrl, tracer, out token, out error))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static string replacementToken(string tokenString)
@@ -490,6 +520,91 @@ namespace GVFS.Common.NuGetUpgrade
             }
 
             return true;
+        }
+
+        private IList<IPackageSearchMetadata> QueryFeed(bool firstAttempt)
+        {
+            try
+            {
+                return this.nuGetFeed.QueryFeedAsync(this.nuGetUpgraderConfig.PackageFeedName).GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (firstAttempt &&
+                                       this.IsAuthRelatedException(ex))
+            {
+                // If we fail to query the feed due to an authorization error, then it is possible we have stale
+                // credentials, or credentials without the correct scope. Re-aquire fresh credentials and try again.
+                EventMetadata data = CreateEventMetadata(ex);
+                this.tracer.RelatedWarning(data, "Failed to query feed due to unauthorized error. Re-acquiring new credentials and trying again.");
+
+                if (!this.TryRefreshCredentials(out string error))
+                {
+                    // If we were unable to re-acquire credentials, throw a new exception indicating that we tried to handle this, but were unable to.
+                    throw new Exception($"Failed to query the feed for upgrade packages due to: {ex.Message}, and was not able to re-acquire new credentials due to: {error}", ex);
+                }
+
+                // Now that we have re-acquired credentials, try again - but with the retry flag set to false.
+                return this.QueryFeed(firstAttempt: false);
+            }
+            catch (Exception ex)
+            {
+                EventMetadata data = CreateEventMetadata(ex);
+                string message = $"Error encountered when querying NuGet feed. Is first attempt: {firstAttempt}.";
+                this.tracer.RelatedWarning(data, message);
+                throw new Exception($"Failed to query the NuGet package feed due to error: {ex.Message}", ex);
+            }
+        }
+
+        private bool IsAuthRelatedException(Exception ex)
+        {
+            // In observation, we have seen either an HttpRequestException directly, or
+            // a FatalProtocolException wrapping an HttpRequestException when we are not able
+            // to auth against the NuGet feed.
+            System.Net.Http.HttpRequestException httpRequestException = null;
+            if (ex is System.Net.Http.HttpRequestException)
+            {
+                httpRequestException = ex as System.Net.Http.HttpRequestException;
+            }
+            else if (ex is FatalProtocolException &&
+                ex.InnerException is System.Net.Http.HttpRequestException)
+            {
+                httpRequestException = ex.InnerException as System.Net.Http.HttpRequestException;
+            }
+
+            if (httpRequestException != null &&
+                (httpRequestException.Message.Contains("401") || httpRequestException.Message.Contains("403")))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryRefreshCredentials(out string error)
+        {
+            try
+            {
+                string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+
+                string authUrl;
+                if (!TryCreateAzDevOrgUrlFromPackageFeedUrl(this.nuGetUpgraderConfig.FeedUrl, out authUrl, out error))
+                {
+                    return false;
+                }
+
+                if (!NuGetUpgrader.TryReacquirePersonalAccessToken(gitBinPath, authUrl, this.tracer, out string token, out error))
+                {
+                    return false;
+                }
+
+                this.nuGetFeed.SetCredentials(token);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                this.TraceException(ex, nameof(this.TryRefreshCredentials), "Failed to refresh credentials.");
+                return false;
+            }
         }
 
         public class NuGetUpgraderConfig


### PR DESCRIPTION
The NuGet upgrader can get stale credentials. When the credentials fail (due to a 401 response), we want to clear the credentials in the credential manager and re-acquire fresh credentials.

This change will be ported to the current release, so I would like to keep it structured in a way that is amenable to porting.