### PR TITLE
[upgrade] Upgrade Functional Test failure fix

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -18,6 +18,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     {
         private const string HighestAvailableVersionFileName = "HighestAvailableVersion";
         private const string UpgradeRingKey = "upgrade.ring";
+        private const string NugetFeedURLKey = "upgrade.feedurl";
+        private const string NugetFeedPackageNameKey = "upgrade.feedpackagename";
         private const string AlwaysUpToDateRing = "None";
 
         private string upgradeDownloadsDirectory;
@@ -94,22 +96,33 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ReadNugetConfig(out string feedUrl, out string feedName)
         {
             GVFSProcess gvfs = new GVFSProcess(GVFSTestConfig.PathToGVFS, enlistmentRoot: null, localCacheRoot: null);
-            feedUrl = gvfs.ReadConfig("upgrade.feedurl");
-            feedName = gvfs.ReadConfig("upgrade.feedpackagename");
+
+            // failOnError is set to false because gvfs config read can exit with
+            // GenericError when the key-value is not available in config file. That
+            // is normal.
+            feedUrl = gvfs.ReadConfig(NugetFeedURLKey, failOnError: false);
+            feedName = gvfs.ReadConfig(NugetFeedPackageNameKey, failOnError: false);
         }
 
         private void DeleteNugetConfig()
         {
             GVFSProcess gvfs = new GVFSProcess(GVFSTestConfig.PathToGVFS, enlistmentRoot: null, localCacheRoot: null);
-            gvfs.DeleteConfig("upgrade.feedurl");
-            gvfs.DeleteConfig("upgrade.feedpackagename");
+            gvfs.DeleteConfig(NugetFeedURLKey);
+            gvfs.DeleteConfig(NugetFeedPackageNameKey);
         }
 
         private void WriteNugetConfig(string feedUrl, string feedName)
         {
             GVFSProcess gvfs = new GVFSProcess(GVFSTestConfig.PathToGVFS, enlistmentRoot: null, localCacheRoot: null);
-            gvfs.WriteConfig("upgrade.feedurl", feedUrl);
-            gvfs.WriteConfig("upgrade.feedpackagename", feedName);
+            if (!string.IsNullOrEmpty(feedUrl))
+            {
+                gvfs.WriteConfig(NugetFeedURLKey, feedUrl);
+            }
+
+            if (!string.IsNullOrEmpty(feedName))
+            {
+                gvfs.WriteConfig(NugetFeedPackageNameKey, feedName);
+            }
         }
 
         private bool ServiceLogContainsUpgradeMessaging()

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -108,9 +108,9 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("service " + argument, failOnError: true);
         }
 
-        public string ReadConfig(string key)
+        public string ReadConfig(string key, bool failOnError)
         {
-            return this.CallGVFS($"config {key}", failOnError: true).TrimEnd('\r', '\n');
+            return this.CallGVFS($"config {key}", failOnError).TrimEnd('\r', '\n');
         }
 
         public void WriteConfig(string key, string value)


### PR DESCRIPTION
When Nuget settings (`upgrade.feedurl` & `upgrade.feedpackagename`) are not available in `gvfs config`, then an attempt to read (or write) those missing values will cause `gvfs config read/write` to exit with error code `3`. `UpgradeReminder` FT tries to 1. read existing nuget config, 2. delete it, 3. execute tests and then 4. restore previously read Nuget config. The failure used to happen in step 1. while attempting to read a config key which is not available in `gvfs config` file.

Fixes #852