### PR TITLE
[master] Use a thread-safe collection for the failed listeners in JsonTracer

### DIFF
--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -373,12 +373,7 @@ namespace GVFS.Common.Tracing
             if (this.failedListeners.TryRemove(recoveredListener, out _))
             {
                 TraceEventMessage message = CreateListenerRecoveryMessage(recoveredListener);
-
-                // Only log that the listener has recovered to the other good listeners
-                foreach (EventListener listener in this.listeners.Except(this.failedListeners.Keys))
-                {
-                    listener.TryRecordMessage(message, out _);
-                }
+                this.LogMessageToNonFailedListeners(message);
             }
         }
 
@@ -391,8 +386,11 @@ namespace GVFS.Common.Tracing
             }
 
             TraceEventMessage message = CreateListenerFailureMessage(failedListener, errorMessage);
+            this.LogMessageToNonFailedListeners(message);
+        }
 
-            // Only log the failure to listeners that have not failed themselves
+        private void LogMessageToNonFailedListeners(TraceEventMessage message)
+        {
             foreach (EventListener listener in this.listeners.Except(this.failedListeners.Keys))
             {
                 // To prevent infinitely recursive failures, we won't try and log that we failed to log that a listener failed :)


### PR DESCRIPTION
Port of #901 to master (fix for #893).

Includes the addition of a helper method for logging to non-failed listeners as suggested in https://github.com/Microsoft/VFSForGit/pull/901#discussion_r263905788