### PR TITLE
Mac kext: Unit tests for VirtualizationRoot_FindForVnode

### DIFF
--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -35,7 +35,7 @@ static void RefreshRootVnodeIfNecessary_Locked(VirtualizationRootHandle rootHand
 static VirtualizationRootHandle FindOrDetectRootAtVnode(vnode_t vnode, const FsidInode& vnodeFsidInode);
 
 static VirtualizationRootHandle FindUnusedIndex_Locked();
-static VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
+KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
 
 ActiveProviderProperties VirtualizationRoot_GetActiveProvider(VirtualizationRootHandle rootHandle)
 {
@@ -377,7 +377,7 @@ static void RefreshRootVnodeIfNecessary_Locked(VirtualizationRootHandle rootHand
 }
 
 // Returns negative value if it failed, or inserted index on success
-static VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path)
+KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path)
 {
     VirtualizationRootHandle rootIndex = FindUnusedIndexOrGrow_Locked();
     

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
@@ -8,3 +8,6 @@
 
 extern uint16_t s_maxVirtualizationRoots;
 extern VirtualizationRoot* s_virtualizationRoots;
+
+KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
+

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -43,7 +43,7 @@ using std::shared_ptr;
 
 - (void)testShouldIgnoreVnodeType {
     shared_ptr<mount> testMount = mount::Create("hfs", fsid_t{}, 0);
-    shared_ptr<vnode> testVnode = vnode::Create(testMount, "/foo");
+    shared_ptr<vnode> testVnode = testMount->CreateVnode("/foo");
     XCTAssertTrue(ShouldIgnoreVnodeType(VNON, testVnode.get()));
     XCTAssertTrue(ShouldIgnoreVnodeType(VBLK, testVnode.get()));
     XCTAssertTrue(ShouldIgnoreVnodeType(VCHR, testVnode.get()));

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -111,7 +111,7 @@ shared_ptr<vnode> vnode::Create(const shared_ptr<mount>& mount, const char* path
     shared_ptr<vnode> result(new vnode(mount));
     s_allVnodes.insert(make_pair(result.get(), weak_ptr<vnode>(result)));
     result->weakSelfPointer = result;
-    result->SetPath(path);
+    result->SetAndRegisterPath(path);
     result->type = vnodeType;
     return result;
 }
@@ -138,7 +138,7 @@ void vnode::SetGetPathError(errno_t error)
     this->getPathError = error;
 }
 
-void vnode::SetPath(const string& path)
+void vnode::SetAndRegisterPath(const string& path)
 {
     s_vnodesByPath.erase(this->path);
 

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -142,13 +142,6 @@ shared_ptr<vnode> vnode::Create(const shared_ptr<mount>& mount, const char* path
     return result;
 }
 
-shared_ptr<vnode> vnode::Create(const shared_ptr<mount>& mount, const char* path, vtype vnodeType, uint64_t inode)
-{
-    shared_ptr<vnode> result = Create(mount, path, vnodeType);
-    result->inode = inode;
-    return result;
-}
-
 void vnode::StartRecycling()
 {
     s_vnodesByPath.erase(this->path);

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -38,6 +38,15 @@ vnode::vnode(const shared_ptr<mount>& mount) :
 {
 }
 
+vnode::vnode(const std::shared_ptr<mount>& mount, VnodeCreationProperties properties) :
+    mountPoint(mount),
+    name(nullptr),
+    inode(properties.inode == UINT64_MAX ? mount->nextInode++ : properties.inode),
+    type(properties.type),
+    parent(properties.parent)
+{
+}
+
 vnode::~vnode()
 {
     assert(this->ioCount == 0);
@@ -107,6 +116,20 @@ shared_ptr<vnode> mount::CreateVnodeTree(const string& path, vtype vnodeType)
     }
     
     return fileVnode;
+}
+
+std::shared_ptr<vnode> mount::CreateVnode(std::string path, VnodeCreationProperties properties)
+{
+    uint64_t inode = properties.inode;
+    if (inode == UINT64_MAX)
+    {
+        inode = this->nextInode++;
+    }
+    shared_ptr<vnode> newVnode(new vnode(this->weakSelfPointer.lock(), properties));
+    s_allVnodes.insert(make_pair(newVnode.get(), weak_ptr<vnode>(newVnode)));
+    newVnode->weakSelfPointer = newVnode;
+    newVnode->SetAndRegisterPath(path);
+    return newVnode;
 }
 
 shared_ptr<vnode> vnode::Create(const shared_ptr<mount>& mount, const char* path, vtype vnodeType)

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -18,10 +18,12 @@ static WeakVnodeMap s_allVnodes;
 shared_ptr<mount> mount::Create(const char* fileSystemTypeName, fsid_t fsid, uint64_t initialInode)
 {
     shared_ptr<mount> result(new mount{});
+    result->weakSelfPointer = result;
     assert(strlen(fileSystemTypeName) + 1 < sizeof(result->statfs.f_fstypename));
     result->statfs.f_fsid = fsid;
     result->nextInode = initialInode;
     strlcpy(result->statfs.f_fstypename, fileSystemTypeName, sizeof(result->statfs.f_fstypename));
+    
     return result;
 }
 
@@ -36,6 +38,72 @@ vnode::vnode(const shared_ptr<mount>& mount) :
 vnode::~vnode()
 {
     assert(this->ioCount == 0);
+}
+
+static string ParentPathString(const string& path)
+{
+    assert(path.length() > 0);
+    size_t lastSlashPos = path.find_last_of('/');
+    assert(lastSlashPos != string::npos);
+    if (lastSlashPos == 0)
+    {
+        return "/";
+    }
+    else if (lastSlashPos == path.length() - 1) // path ends in "/"
+    {
+        lastSlashPos = path.find_last_of('/', lastSlashPos - 1);
+    }
+    
+    return path.substr(0, lastSlashPos);
+}
+
+// This creates a vnode at the given path below the mount point, and ensures
+// that a hierarchy of directory vnodes exists all the way to the root.
+//
+// For example:
+// mount->CreateVnodeTree("/path/to/file", VREG) will produce:
+// vnode VREG "/path/to/file"
+// vnode VDIR "/path/to"
+// vnode VDIR "/path"
+// vnode VDIR "/"
+// While walking up the path, we stop creating vnodes if one already exists for
+// a particular directory. For example, if the example above is followed by:
+// mount->CreateVnodeTree("/path/for/other/file", VREG) will only generate:
+// vnode VREG "/path/for/other/file"
+// vnode VDIR "/path/for/other"
+// vnode VDIR "/path/for"
+// Because the vnode generated for "/path" in the previous example will be
+// re-used as the parent for the "/path/for" vnode.
+shared_ptr<vnode> mount::CreateVnodeTree(const string& path, vtype vnodeType)
+{
+    assert(path[0] == '/'); // Only absolute paths allowed
+    shared_ptr<vnode> parentVnode;
+    
+    if (path != "/")
+    {
+        string parentPath = ParentPathString(path);
+        PathToVnodeMap::const_iterator found = s_vnodesByPath.find(parentPath);
+    
+        if (found != s_vnodesByPath.end())
+        {
+            parentVnode = found->second.lock();
+        }
+        
+        if (!parentVnode)
+        {
+            parentVnode = this->CreateVnodeTree(parentPath, VDIR);
+        }
+    }
+    
+    shared_ptr<vnode> fileVnode = vnode::Create(this->weakSelfPointer.lock(), path.c_str(), vnodeType);
+    fileVnode->parent = parentVnode;
+    
+    if (path == "/")
+    {
+        this->rootVnode = fileVnode;
+    }
+    
+    return fileVnode;
 }
 
 shared_ptr<vnode> vnode::Create(const shared_ptr<mount>& mount, const char* path, vtype vnodeType)
@@ -61,6 +129,7 @@ void vnode::StartRecycling()
     this->path.clear();
     this->type = VBAD;
     this->vid++;
+    this->parent.reset();
     this->isRecycling = true;
 }
 
@@ -238,4 +307,27 @@ void MockVnodes_CheckAndClear()
     }
     
     s_allVnodes.clear();
+}
+
+
+SizeOrError Vnode_ReadXattr(vnode_t _Nonnull vnode, const char* _Nonnull xattrName, void* _Nullable buffer, size_t bufferSize)
+{
+    assert(false); // TODO: implement
+    return SizeOrError{};
+}
+
+vnode_t vnode_getparent(vnode_t vnode)
+{
+    shared_ptr<struct vnode> parentVnode = vnode->GetParentVnode();
+    if (parentVnode)
+    {
+        parentVnode->RetainIOCount();
+    }
+    
+    return parentVnode.get();
+}
+
+int vnode_isvroot(vnode_t vnode)
+{
+    return vnode->GetMountPoint()->GetRootVnode().get() == vnode;
 }

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
@@ -8,6 +8,13 @@
 #include <vector>
 #include <unordered_map>
 
+struct VnodeCreationProperties
+{
+    vtype type = VREG;
+    uint64_t inode = UINT64_MAX; // auto-generate
+    std::shared_ptr<vnode> parent;
+};
+
 // The struct names mount and vnode are dictated by mount_t and vnode_t's
 // definitions as (opaque/forward declared) pointers to those structs.
 // As the (testable) kext treats them as entirely opaque, we can implement
@@ -25,6 +32,7 @@ public:
     static std::shared_ptr<mount> Create(const char* fileSystemTypeName, fsid_t fsid, uint64_t initialInode);
     
     std::shared_ptr<vnode> CreateVnodeTree(const std::string& path, vtype vnodeType = VREG);
+    std::shared_ptr<vnode> CreateVnode(std::string path, VnodeCreationProperties properties);
     
     fsid_t GetFsid() const { return this->statfs.f_fsid; }
     std::shared_ptr<vnode> GetRootVnode() const { return this->rootVnode.lock(); }
@@ -58,7 +66,8 @@ private:
     void SetAndRegisterPath(const std::string& path);
 
     explicit vnode(const std::shared_ptr<mount>& mount);
-    
+    explicit vnode(const std::shared_ptr<mount>& mount, VnodeCreationProperties properties);
+
     vnode(const vnode&) = delete;
     vnode& operator=(const vnode&) = delete;
     

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
@@ -48,7 +48,7 @@ private:
     std::string path;
     const char* name;
     
-    void SetPath(const std::string& path);
+    void SetAndRegisterPath(const std::string& path);
 
     explicit vnode(const std::shared_ptr<mount>& mount);
     

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
@@ -5,6 +5,8 @@
 #include "../PrjFSKext/public/FsidInode.h"
 #include <memory>
 #include <string>
+#include <vector>
+#include <unordered_map>
 
 // The struct names mount and vnode are dictated by mount_t and vnode_t's
 // definitions as (opaque/forward declared) pointers to those structs.
@@ -37,7 +39,12 @@ private:
     std::weak_ptr<vnode> weakSelfPointer;
     std::shared_ptr<mount> mountPoint;
     std::shared_ptr<vnode> parent;
-    
+
+public:
+    typedef std::unordered_map<std::string, std::vector<uint8_t>> XattrMap;
+    XattrMap xattrs;
+
+private:
     bool isRecycling = false;
     vtype type = VREG;
     uint64_t inode;
@@ -67,6 +74,14 @@ public:
     bool IsRecycling() const           { return this->isRecycling; }
     vtype GetVnodeType() const         { return this->type; }
     std::shared_ptr<vnode> const GetParentVnode() { return this->parent; }
+    
+    struct BytesOrError
+    {
+        errno_t error;
+        std::vector<uint8_t> bytes;
+    };
+    
+    BytesOrError ReadXattr(const char* xattrName);
 
     void SetGetPathError(errno_t error);
     void StartRecycling();

--- a/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
@@ -17,6 +17,10 @@ void RWLock_ReleaseExclusive(RWLock& lock)
 {
 }
 
+void RWLock_AcquireShared(RWLock& lock)
+{
+}
+
 void RWLock_DropExclusiveToShared(RWLock& lock)
 {
 }

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -91,7 +91,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
 {
     const char* path = "/Users/test/code/NotADirectory.cpp";
     
-    shared_ptr<vnode> vnode = vnode::Create(self->testMountPoint, path);
+    shared_ptr<vnode> vnode = self->testMountPoint->CreateVnode(path);
     
     VirtualizationRootResult result = VirtualizationRoot_RegisterProviderForPath(&self->dummyClient, self->dummyClientPid, path);
     XCTAssertEqual(result.error, ENOTDIR);
@@ -261,7 +261,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     
     oldVnode->StartRecycling();
     
-    shared_ptr<vnode> newVnode = vnode::Create(self->testMountPoint, path, VDIR, oldVnode->GetInode());
+    shared_ptr<vnode> newVnode = self->testMountPoint->CreateVnode(path, VnodeCreationProperties{ VDIR, oldVnode->GetInode() });
     
     VirtualizationRootResult result = VirtualizationRoot_RegisterProviderForPath(&self->dummyClient, self->dummyClientPid, path);
     XCTAssertEqual(result.error, 0);

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -283,16 +283,19 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
 {
     const char* repoPath = "/Users/test/code/Repo";
     const char* filePath = "/Users/test/code/Repo/file";
-    
+    const char* deeplyNestedPath = "/Users/test/code/Repo/deeply/nested/sub/directories/with/a/file";
+
     shared_ptr<vnode> repoRootVnode = self->testMountPoint->CreateVnodeTree(repoPath, VDIR);
     shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
-    
+    shared_ptr<vnode> deepFileVnode = self->testMountPoint->CreateVnodeTree(deeplyNestedPath);
     
     VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
 
     VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
+    XCTAssertEqual(foundRoot, repoRootHandle);
     
+    foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, deepFileVnode.get(), self->dummyVFSContext);
     XCTAssertEqual(foundRoot, repoRootHandle);
 }
 
@@ -368,6 +371,8 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     }
 }
 
+// A variation on the above 2 tests but starting with a directory vnode, taking
+// the 'if (vnode_isdir(vnode))' branch in VirtualizationRoot_FindForVnode.
 - (void)testFindForVnode_DirectoryInUndetectedRoot
 {
     const char* repoPath = "/Users/test/code/Repo";

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -6,6 +6,7 @@
 #include "../PrjFSKext/Locks.hpp"
 #include "../PrjFSKext/VnodeUtilities.hpp"
 #include "../PrjFSKext/KextLog.hpp"
+#include "../PrjFSKext/public/PrjFSXattrs.h"
 #include "KextMockUtilities.hpp"
 #include "MockVnodeAndMount.hpp"
 
@@ -14,6 +15,7 @@
 #include <string>
 
 using std::shared_ptr;
+using std::vector;
 
 class PrjFSProviderUserClient
 {
@@ -25,6 +27,13 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     MockCalls::RecordFunctionCall(ProviderUserClient_UpdatePathProperty, userClient, providerPath);
 }
 
+static void SetRootXattrData(shared_ptr<vnode> vnode)
+{
+    PrjFSVirtualizationRootXAttrData rootXattr = {};
+    vector<uint8_t> rootXattrData(sizeof(rootXattr), 0x00);
+    memcpy(rootXattrData.data(), &rootXattr, rootXattrData.size());
+    vnode->xattrs.insert(make_pair(PrjFSVirtualizationRootXAttrName, rootXattrData));
+}
 
 @interface VirtualizationRootsTests : XCTestCase
 
@@ -36,6 +45,7 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     pid_t dummyClientPid;
     PerfTracer dummyTracer;
     shared_ptr<mount> testMountPoint;
+    vfs_context_t dummyVFSContext;
 }
 
 - (void)setUp
@@ -53,10 +63,13 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     
     kern_return_t initResult = VirtualizationRoots_Init();
     XCTAssertEqual(initResult, KERN_SUCCESS);
+    
+    self->dummyVFSContext = vfs_context_create(nullptr);
 }
 
 - (void)tearDown
 {
+    vfs_context_rele(self->dummyVFSContext);
     VirtualizationRoots_Cleanup();
 
     MockVnodes_CheckAndClear();
@@ -268,8 +281,6 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
 // Check that VirtualizationRoot_FindForVnode correctly identifies the virtualization root for files below that root.
 - (void)testFindForVnode_FileInRoot
 {
-    vfs_context_t context = vfs_context_create(nullptr);
-    
     const char* repoPath = "/Users/test/code/Repo";
     const char* filePath = "/Users/test/code/Repo/file";
     
@@ -280,17 +291,14 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
 
-    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), context);
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
     
     XCTAssertEqual(foundRoot, repoRootHandle);
-    vfs_context_rele(context);
 }
 
 // Check that files outside a root are correctly identified as such by VirtualizationRoot_FindForVnode
 - (void)testFindForVnode_FileNotInRoot
 {
-    vfs_context_t context = vfs_context_create(nullptr);
-    
     const char* repoPath = "/Users/test/code/Repo";
     const char* filePath = "/Users/test/code/NotVirtualizedRepo/file";
     
@@ -301,10 +309,85 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
     
-    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), context);
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
     
     XCTAssertEqual(foundRoot, RootHandle_None);
-    vfs_context_rele(context);
 }
+
+// Check that VirtualizationRoot_FindForVnode can discover virtualization roots from the root directory's xattr
+- (void)testFindForVnode_FileInUndetectedRoot
+{
+    const char* repoPath = "/Users/test/code/Repo";
+    const char* filePath = "/Users/test/code/Repo/file";
+    
+    shared_ptr<vnode> repoRootVnode = self->testMountPoint->CreateVnodeTree(repoPath, VDIR);
+    shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
+
+    SetRootXattrData(repoRootVnode);
+
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
+    
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(foundRoot));
+}
+
+// A regression test of VirtualizationRoot_FindForVnode for bug #797.
+//  * Verify the virtualization root ends up with the inode of the root directory vnode.
+//  * Verify that the virtualization root does not change identity when the root directory vnode is recycled.
+//  * Verify that the root vnode registered in the virtualization root is refreshed to the new root vnode.
+- (void)testFindForVnode_DetectRootRecycleThenFindRootForOtherFile
+{
+    const char* repoPath = "/Users/test/code/Repo";
+    const char* filePath = "/Users/test/code/Repo/file";
+    const char* otherFilePath = "/Users/test/code/Repo/some/otherfile";
+
+    shared_ptr<vnode> repoRootVnode = self->testMountPoint->CreateVnodeTree(repoPath, VDIR);
+    shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
+
+    SetRootXattrData(repoRootVnode);
+
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
+
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(foundRoot));
+    
+    if (VirtualizationRoot_IsValidRootHandle(foundRoot))
+    {
+        uint64_t inode = repoRootVnode->GetInode();
+        XCTAssertEqual(s_virtualizationRoots[foundRoot].rootInode, inode);
+        
+        repoRootVnode->StartRecycling();
+        
+        shared_ptr<vnode> newRepoRootVnode = self->testMountPoint->CreateVnode(repoPath, VnodeCreationProperties { .inode = repoRootVnode->GetInode(), .type = VDIR });
+        
+        shared_ptr<vnode> otherTestFileVnode = self->testMountPoint->CreateVnodeTree(otherFilePath);
+        VirtualizationRootHandle foundRootForOther = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, otherTestFileVnode.get(), self->dummyVFSContext);
+        
+        XCTAssertEqual(foundRootForOther, foundRoot, "Despite recycling the repo root vnode, we should end up with the same handle");
+        XCTAssertEqual(s_virtualizationRoots[foundRootForOther].rootVNode, newRepoRootVnode.get(), "Vnode should be refreshed");
+        XCTAssertEqual(s_virtualizationRoots[foundRootForOther].rootVNodeVid, newRepoRootVnode->GetVid(), "Vnode VID should be refreshed");
+        XCTAssertEqual(s_virtualizationRoots[foundRoot].rootInode, inode);
+    }
+}
+
+- (void)testFindForVnode_DirectoryInUndetectedRoot
+{
+    const char* repoPath = "/Users/test/code/Repo";
+    const char* subdirPath = "/Users/test/code/Repo/some/nested/subdir";
+    
+    shared_ptr<vnode> repoRootVnode = self->testMountPoint->CreateVnodeTree(repoPath, VDIR);
+    shared_ptr<vnode> testSubdirVnode = self->testMountPoint->CreateVnodeTree(subdirPath, VDIR);
+
+    XCTAssertTrue(vnode_isdir(testSubdirVnode.get()));
+
+    SetRootXattrData(repoRootVnode);
+
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testSubdirVnode.get(), self->dummyVFSContext);
+    
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(foundRoot));
+    if (VirtualizationRoot_IsValidRootHandle(foundRoot))
+    {
+        XCTAssertEqual(s_virtualizationRoots[foundRoot].rootInode, repoRootVnode->GetInode());
+    }
+}
+
 
 @end

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -34,6 +34,7 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
 {
     PrjFSProviderUserClient dummyClient;
     pid_t dummyClientPid;
+    PerfTracer dummyTracer;
     shared_ptr<mount> testMountPoint;
 }
 
@@ -262,6 +263,26 @@ void ProviderUserClient_UpdatePathProperty(PrjFSProviderUserClient* userClient, 
     s_virtualizationRoots[result.root].providerUserClient = nullptr;
     vnode_put(newVnode.get());
 
+}
+
+// Check that VirtualizationRoot_FindForVnode correctly identifies the virtualization root for files below that root.
+- (void)testFindForVnode_FileInRepo
+{
+    vfs_context_t context = vfs_context_create(nullptr);
+    
+    const char* repoPath = "/Users/test/code/Repo";
+    const char* filePath = "/Users/test/code/Repo/file";
+    
+    shared_ptr<vnode> repoRootVnode = self->testMountPoint->CreateVnodeTree(repoPath, VDIR);
+    shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
+    
+    
+    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
+    
+    VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), context);
+    
+    XCTAssertEqual(foundRoot, repoRootHandle);
+    vfs_context_rele(context);
 }
 
 @end


### PR DESCRIPTION
This sequence of patches builds up enough kext unit testing infrastructure to implement #862.

- [x] Tests calling `VirtualizationRoot_FindForVnode` successfully build & link.
- [x] `VirtualizationRoot_FindForVnode` expects to be able to walk a directory tree of vnodes.
- [x] `VirtualizationRoot_FindForVnode` expects to be able to call `Vnode_ReadXattr()` on each directory.
- [x] Tests with recycled vnodes
- [x] Tests that would have caught #797.
- [x] 100% test coverage in `VirtualizationRoot_FindForVnode`*

<span>*</span> Not quite 100% as we actually don't handle the `vnode_getparent()` failure case satisfactorily yet (#338), and I don't want to add tests that verify *incorrect* behaviour.