### PR TITLE
Mac kext: Move provider messaging to separate source file

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -63,6 +63,10 @@
 		4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
 		4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */; };
+		4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
+		4A558DBB22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
+		4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
+		4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
 		4A781DA52220946000DB7733 /* VirtualizationRootsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */; };
 		4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8A721E42AC50008103C /* VirtualizationRoots.cpp */; };
 		4A781DAB222330F700DB7733 /* KextMockUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DAA222330F700DB7733 /* KextMockUtilities.cpp */; };
@@ -179,6 +183,8 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
+		4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessaging.hpp; sourceTree = "<group>"; };
 		4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualizationRootsTests.mm; sourceTree = "<group>"; };
 		4A781DA6222094C300DB7733 /* VirtualizationRootsPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRootsPrivate.hpp; sourceTree = "<group>"; };
 		4A781DA82222C6EA00DB7733 /* PrjFSProviderUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSProviderUserClient.hpp; sourceTree = "<group>"; };
@@ -316,6 +322,8 @@
 				4A781DA82222C6EA00DB7733 /* PrjFSProviderUserClient.hpp */,
 				4391F89A21E42AC40008103C /* PrjFSService.cpp */,
 				4391F89921E42AC40008103C /* PrjFSService.hpp */,
+				4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */,
+				4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */,
 				4391F89621E42AC40008103C /* public */,
 				4391F8A721E42AC50008103C /* VirtualizationRoots.cpp */,
 				4391F89421E42AC40008103C /* VirtualizationRoots.hpp */,
@@ -390,6 +398,7 @@
 				4391F8AE21E42AC50008103C /* VirtualizationRoots.hpp in Headers */,
 				4391F8BE21E42AC50008103C /* KauthHandler.hpp in Headers */,
 				4391F8AC21E42AC50008103C /* KextLog.hpp in Headers */,
+				4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */,
 				4391F8B321E42AC50008103C /* PrjFSService.hpp in Headers */,
 				4391F8B721E42AC50008103C /* PrjFSClasses.hpp in Headers */,
 				4391F8BC21E42AC50008103C /* VnodeUtilities.hpp in Headers */,
@@ -412,6 +421,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -627,6 +637,7 @@
 				4391F8AD21E42AC50008103C /* KauthHandler.cpp in Sources */,
 				4391F8AF21E42AC50008103C /* PrjFSProviderUserClient.cpp in Sources */,
 				4391F8BA21E42AC50008103C /* PrjFSLogUserClient.cpp in Sources */,
+				4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,
 				4391F8B621E42AC50008103C /* PrjFSKext.cpp in Sources */,
 				4391F8AB21E42AC50008103C /* KextLog.cpp in Sources */,
 				4391F8B421E42AC50008103C /* PrjFSService.cpp in Sources */,
@@ -665,6 +676,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A558DBB22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,
 				4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */,
 				4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */,
 			);

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
@@ -7,7 +7,4 @@
 kern_return_t KauthHandler_Init();
 kern_return_t KauthHandler_Cleanup();
 
-void KauthHandler_HandleKernelMessageResponse(VirtualizationRootHandle providerVirtualizationRootHandle, uint64_t messageId, MessageType responseType);
-void KauthHandler_AbortOutstandingEventsForProvider(VirtualizationRootHandle providerVirtualizationRootHandle);
-
 #endif /* KauthHandler_h */

--- a/ProjFS.Mac/PrjFSKext/Locks.cpp
+++ b/ProjFS.Mac/PrjFSKext/Locks.cpp
@@ -3,6 +3,7 @@
 #include <kern/thread.h>
 #include <kern/assert.h>
 #include <libkern/OSAtomic.h>
+#include <sys/proc.h>
 
 #include "public/PrjFSCommon.h"
 #include "Locks.hpp"
@@ -64,6 +65,15 @@ void Mutex_Acquire(Mutex mutex)
 void Mutex_Release(Mutex mutex)
 {
     lck_mtx_unlock(mutex.p);
+}
+
+void Mutex_Sleep(int seconds, void* channel, Mutex* _Nullable mutex)
+{
+    struct timespec timeout;
+    timeout.tv_sec  = seconds;
+    timeout.tv_nsec = 0;
+    
+    msleep(channel, nullptr != mutex ? mutex->p : nullptr, PUSER, "org.vfsforgit.PrjFSKext.Sleep", &timeout);
 }
 
 // RWLock implementation functions

--- a/ProjFS.Mac/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/Locks.hpp
@@ -21,6 +21,7 @@ bool Mutex_IsValid(Mutex mutex);
 
 void Mutex_Acquire(Mutex mutex);
 void Mutex_Release(Mutex mutex);
+void Mutex_Sleep(int seconds, void* channel, Mutex* mutex);
 
 typedef struct __lck_rw_t__ lck_rw_t;
 struct thread;

--- a/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -2,7 +2,7 @@
 #include "public/PrjFSCommon.h"
 #include "public/PrjFSProviderClientShared.h"
 #include "public/Message.h"
-#include "KauthHandler.hpp"
+#include "ProviderMessaging.hpp"
 #include "VirtualizationRoots.hpp"
 
 #include <IOKit/IOSharedDataQueue.h>
@@ -217,7 +217,7 @@ IOReturn PrjFSProviderUserClient::kernelMessageResponse(
 
 IOReturn PrjFSProviderUserClient::kernelMessageResponse(uint64_t messageId, MessageType responseType)
 {
-    KauthHandler_HandleKernelMessageResponse(this->virtualizationRootHandle, messageId, responseType);
+    ProviderMessaging_HandleKernelMessageResponse(this->virtualizationRootHandle, messageId, responseType);
     return kIOReturnSuccess;
 }
 

--- a/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
+++ b/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
@@ -1,0 +1,233 @@
+#include "ProviderMessaging.hpp"
+#include "Locks.hpp"
+#include "KextLog.hpp"
+
+#include <kern/assert.h>
+#include <sys/proc.h>
+#include <libkern/OSAtomic.h>
+#include <sys/kauth.h>
+
+// Structs
+struct OutstandingMessage
+{
+    MessageHeader                  request;
+    MessageType                    result;
+    bool                           receivedResult;
+    VirtualizationRootHandle       rootHandle;
+    
+    LIST_ENTRY(OutstandingMessage) _list_privates;
+    
+};
+
+// State
+static LIST_HEAD(OutstandingMessage_Head, OutstandingMessage) s_outstandingMessages = LIST_HEAD_INITIALIZER(OutstandingMessage_Head);
+static Mutex s_outstandingMessagesMutex = {};
+static volatile int s_nextMessageId;
+static volatile bool s_isShuttingDown;
+
+
+bool ProviderMessaging_Init()
+{
+    LIST_INIT(&s_outstandingMessages);
+    s_nextMessageId = 1;
+    
+    s_isShuttingDown = false;
+    
+    s_outstandingMessagesMutex = Mutex_Alloc();
+    if (!Mutex_IsValid(s_outstandingMessagesMutex))
+    {
+        goto CleanupAndFail;
+    }
+        
+    return true;
+
+CleanupAndFail:
+    ProviderMessaging_Cleanup();
+    return false;
+}
+
+
+void ProviderMessaging_Cleanup()
+{
+    if (Mutex_IsValid(s_outstandingMessagesMutex))
+    {
+        Mutex_FreeMemory(&s_outstandingMessagesMutex);
+    }
+}
+
+
+void ProviderMessaging_HandleKernelMessageResponse(VirtualizationRootHandle providerVirtualizationRootHandle, uint64_t messageId, MessageType responseType)
+{
+    switch (responseType)
+    {
+        case MessageType_Response_Success:
+        case MessageType_Response_Fail:
+        {
+            Mutex_Acquire(s_outstandingMessagesMutex);
+            {
+                OutstandingMessage* outstandingMessage;
+                LIST_FOREACH(outstandingMessage, &s_outstandingMessages, _list_privates)
+                {
+                    if (outstandingMessage->request.messageId == messageId && outstandingMessage->rootHandle == providerVirtualizationRootHandle)
+                    {
+                        // Save the response for the blocked thread.
+                        outstandingMessage->result = responseType;
+                        outstandingMessage->receivedResult = true;
+                        
+                        wakeup(outstandingMessage);
+                        
+                        break;
+                    }
+                }
+            }
+            Mutex_Release(s_outstandingMessagesMutex);
+            break;
+        }
+        
+        // The follow are not valid responses to kernel messages
+        case MessageType_Invalid:
+        case MessageType_KtoU_EnumerateDirectory:
+        case MessageType_KtoU_RecursivelyEnumerateDirectory:
+        case MessageType_KtoU_HydrateFile:
+        case MessageType_KtoU_NotifyFileModified:
+        case MessageType_KtoU_NotifyFilePreDelete:
+        case MessageType_KtoU_NotifyDirectoryPreDelete:
+        case MessageType_KtoU_NotifyFileCreated:
+        case MessageType_KtoU_NotifyFileRenamed:
+        case MessageType_KtoU_NotifyDirectoryRenamed:
+        case MessageType_KtoU_NotifyFileHardLinkCreated:
+        case MessageType_Result_Aborted:
+        default:
+            KextLog_Error("KauthHandler_HandleKernelMessageResponse: Unexpected responseType: %d", responseType);
+            break;
+    }
+    
+    return;
+}
+
+void ProviderMessaging_AbortOutstandingEventsForProvider(VirtualizationRootHandle providerVirtualizationRootHandle)
+{
+    // Mark all outstanding messages for this root as aborted and wake up the waiting threads
+    Mutex_Acquire(s_outstandingMessagesMutex);
+    {
+        OutstandingMessage* outstandingMessage;
+        LIST_FOREACH(outstandingMessage, &s_outstandingMessages, _list_privates)
+        {
+            if (outstandingMessage->rootHandle == providerVirtualizationRootHandle)
+            {
+                outstandingMessage->receivedResult = true;
+                outstandingMessage->result = MessageType_Result_Aborted;
+                wakeup(outstandingMessage);
+            }
+        }
+    }
+    Mutex_Release(s_outstandingMessagesMutex);
+}
+
+bool ProviderMessaging_TrySendRequestAndWaitForResponse(
+    VirtualizationRootHandle root,
+    MessageType messageType,
+    const vnode_t vnode,
+    const FsidInode& vnodeFsidInode,
+    const char* vnodePath,
+    int pid,
+    const char* procname,
+    int* kauthResult,
+    int* kauthError)
+{
+    // To be useful, the message needs to either provide an FSID/inode pair or a path
+    assert(vnodePath != nullptr || (vnodeFsidInode.fsid.val[0] != 0 || vnodeFsidInode.fsid.val[1] != 0));
+    bool result = false;
+    const char* relativePath = nullptr;
+    
+    OutstandingMessage message =
+    {
+        .receivedResult = false,
+        .rootHandle = root,
+    };
+    
+    if (nullptr != vnodePath)
+    {
+        relativePath = VirtualizationRoot_GetRootRelativePath(root, vnodePath);
+    }
+    
+    int nextMessageId = OSIncrementAtomic(&s_nextMessageId);
+    
+    Message messageSpec = {};
+    Message_Init(
+        &messageSpec,
+        &(message.request),
+        nextMessageId,
+        messageType,
+        vnodeFsidInode,
+        pid,
+        procname,
+        relativePath);
+
+    if (s_isShuttingDown)
+    {
+        return false;
+    }
+    
+    Mutex_Acquire(s_outstandingMessagesMutex);
+    {
+        LIST_INSERT_HEAD(&s_outstandingMessages, &message, _list_privates);
+    }
+    Mutex_Release(s_outstandingMessagesMutex);
+    
+    errno_t sendError = ActiveProvider_SendMessage(root, messageSpec);
+   
+    Mutex_Acquire(s_outstandingMessagesMutex);
+    {
+        if (0 != sendError)
+        {
+            // TODO: appropriately handle unresponsive providers
+            *kauthResult = KAUTH_RESULT_DEFER;
+        }
+        else
+        {
+            while (!message.receivedResult &&
+                   !s_isShuttingDown)
+            {
+                Mutex_Sleep(5, &message, &s_outstandingMessagesMutex);
+            }
+        
+            if (s_isShuttingDown)
+            {
+                *kauthResult = KAUTH_RESULT_DENY;
+            }
+            else if (MessageType_Response_Success == message.result)
+            {
+                *kauthResult = KAUTH_RESULT_DEFER;
+                result = true;
+            }
+            else
+            {
+                // Default error code is EACCES. See errno.h for more codes.
+                *kauthError = EAGAIN;
+                *kauthResult = KAUTH_RESULT_DENY;
+            }
+        }
+        
+        LIST_REMOVE(&message, _list_privates);
+    }
+    Mutex_Release(s_outstandingMessagesMutex);
+    
+    return result;
+}
+
+void ProviderMessaging_AbortAllOutstandingEvents()
+{
+    // Wake up all sleeping threads so they can see that that we're shutting down and return an error
+    Mutex_Acquire(s_outstandingMessagesMutex);
+    {
+        s_isShuttingDown = true;
+        
+        OutstandingMessage* outstandingMessage;
+        LIST_FOREACH(outstandingMessage, &s_outstandingMessages, _list_privates)
+        {
+            wakeup(outstandingMessage);
+        }
+    }
+    Mutex_Release(s_outstandingMessagesMutex);
+}

--- a/ProjFS.Mac/PrjFSKext/ProviderMessaging.hpp
+++ b/ProjFS.Mac/PrjFSKext/ProviderMessaging.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "VirtualizationRoots.hpp"
+#include "public/Message.h"
+
+bool ProviderMessaging_Init();
+void ProviderMessaging_AbortAllOutstandingEvents();
+void ProviderMessaging_Cleanup();
+
+bool ProviderMessaging_TrySendRequestAndWaitForResponse(
+    VirtualizationRootHandle root,
+    MessageType messageType,
+    const vnode_t vnode,
+    const FsidInode& vnodeFsidInode,
+    const char* vnodePath,
+    int pid,
+    const char* procname,
+    int* kauthResult,
+    int* kauthError);
+
+void ProviderMessaging_HandleKernelMessageResponse(VirtualizationRootHandle providerVirtualizationRootHandle, uint64_t messageId, MessageType responseType);
+void ProviderMessaging_AbortOutstandingEventsForProvider(VirtualizationRootHandle providerVirtualizationRootHandle);

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -10,7 +10,7 @@
 #include "Locks.hpp"
 #include "KextLog.hpp"
 #include "PrjFSProviderUserClient.hpp"
-#include "KauthHandler.hpp"
+#include "ProviderMessaging.hpp"
 #include "kernel-header-wrappers/mount.h"
 #include "VnodeUtilities.hpp"
 #include "PerformanceTracing.hpp"
@@ -558,7 +558,7 @@ void ActiveProvider_Disconnect(VirtualizationRootHandle rootIndex, PrjFSProvider
 
         RWLock_DropExclusiveToShared(s_virtualizationRootsLock);
 
-        KauthHandler_AbortOutstandingEventsForProvider(rootIndex);
+        ProviderMessaging_AbortOutstandingEventsForProvider(rootIndex);
     }
     RWLock_ReleaseShared(s_virtualizationRootsLock);
 }


### PR DESCRIPTION
I'm about to do some work in this area for the remaining (`vnode_getparent`) aspect of #338, so this seemed about as good a time as any to sort out something that's been bugging me for a while.

KauthHandler.cpp has thus far covered 2 main areas of responsibility:

 * The handler callback functions for kauth listeners (as the name suggests)
 * Sending & waiting for messages to providers

The 2 blocks of functionality are almost entirely independent from one another, and as KauthHandler.cpp is a large file, it makes more sense to move the messaging aspect to a separate source file.

There are no functional changes. A few functions have had their prefix changed or turned from static to global.