### PR TITLE
Update git to 2ab7360 and include new Git Credential Manager

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190228.1</GitPackageVersion>
+    <GitPackageVersion>2.20190312.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
Updates git and dependencies. The main update is to Git Credential
Manager, which includes a fix to erase credentials when requested. Git
was also updated with a change to block filters and EOL conversions.

git updated to commit: 2ab7360
https://github.com/Microsoft/git/commit/2ab73608a0c5baf0c979cd767ea15e7404771bbe