### PR TITLE
Make `TelemetryDaemonEventListener` and `JsonTracer` thread-safe and async

### DIFF
--- a/GVFS/GVFS.Common/Tracing/DiagnosticConsoleEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/DiagnosticConsoleEventListener.cs
@@ -8,8 +8,8 @@ namespace GVFS.Common.Tracing
     /// </summary>
     public class DiagnosticConsoleEventListener : EventListener
     {
-        public DiagnosticConsoleEventListener(EventLevel maxVerbosity, Keywords keywordFilter)
-            : base(maxVerbosity, keywordFilter)
+        public DiagnosticConsoleEventListener(EventLevel maxVerbosity, Keywords keywordFilter, IEventListenerEventSink eventSink)
+            : base(maxVerbosity, keywordFilter, eventSink)
         {
         }
 

--- a/GVFS/GVFS.Common/Tracing/IEventListenerEventSink.cs
+++ b/GVFS/GVFS.Common/Tracing/IEventListenerEventSink.cs
@@ -1,0 +1,9 @@
+namespace GVFS.Common.Tracing
+{
+    public interface IEventListenerEventSink
+    {
+        void OnListenerRecovery(EventListener listener);
+
+        void OnListenerFailure(EventListener listener, string errorMessage);
+    }
+}

--- a/GVFS/GVFS.Common/Tracing/IQueuedPipeStringWriterEventSink.cs
+++ b/GVFS/GVFS.Common/Tracing/IQueuedPipeStringWriterEventSink.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace GVFS.Common.Tracing
+{
+    public interface IQueuedPipeStringWriterEventSink
+    {
+        void OnStateChanged(QueuedPipeStringWriter writer, QueuedPipeStringWriterState state, Exception exception);
+    }
+}

--- a/GVFS/GVFS.Common/Tracing/LogFileEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/LogFileEventListener.cs
@@ -8,8 +8,8 @@ namespace GVFS.Common.Tracing
         private FileStream logFile;
         private TextWriter writer;
 
-        public LogFileEventListener(string logFilePath, EventLevel maxVerbosity, Keywords keywordFilter)
-            : base(maxVerbosity, keywordFilter)
+        public LogFileEventListener(string logFilePath, EventLevel maxVerbosity, Keywords keywordFilter, IEventListenerEventSink eventSink)
+            : base(maxVerbosity, keywordFilter, eventSink)
         {
             this.SetLogFilePath(logFilePath);
         }

--- a/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
@@ -12,8 +12,8 @@ namespace GVFS.Common.Tracing
     {
         private static object consoleLock = new object();
 
-        public PrettyConsoleEventListener(EventLevel maxVerbosity, Keywords keywordFilter)
-            : base(maxVerbosity, keywordFilter)
+        public PrettyConsoleEventListener(EventLevel maxVerbosity, Keywords keywordFilter, IEventListenerEventSink eventSink)
+            : base(maxVerbosity, keywordFilter, eventSink)
         {
         }
 

--- a/GVFS/GVFS.Common/Tracing/QueuedPipeStringWriter.cs
+++ b/GVFS/GVFS.Common/Tracing/QueuedPipeStringWriter.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+
+namespace GVFS.Common.Tracing
+{
+    public enum QueuedPipeStringWriterState
+    {
+        Unknown = 0,
+        Stopped = 1,
+        Failing = 2,
+        Healthy = 3,
+    }
+
+    /// <summary>
+    /// Accepts string messages from multiple threads and dispatches them over a named pipe from a
+    /// background thread.
+    /// </summary>
+    public class QueuedPipeStringWriter : IDisposable
+    {
+        private const int DEFAULT_MAX_QUEUE_SIZE = 256;
+
+        private readonly Func<NamedPipeClientStream> createPipeFunc;
+        private readonly IQueuedPipeStringWriterEventSink eventSink;
+        private readonly BlockingCollection<string> queue;
+
+        private Thread writerThread;
+        private NamedPipeClientStream pipeClient;
+        private QueuedPipeStringWriterState state = QueuedPipeStringWriterState.Unknown;
+        private bool isDisposed;
+
+        public QueuedPipeStringWriter(Func<NamedPipeClientStream> createPipeFunc, IQueuedPipeStringWriterEventSink eventSink, int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE)
+        {
+            this.createPipeFunc = createPipeFunc;
+            this.eventSink = eventSink;
+            this.queue = new BlockingCollection<string>(new ConcurrentQueue<string>(), boundedCapacity: maxQueueSize);
+        }
+
+        public void Start()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(QueuedPipeStringWriter));
+            }
+
+            if (this.writerThread != null)
+            {
+                return;
+            }
+
+            this.writerThread = new Thread(this.BackgroundWriterThreadProc)
+            {
+                Name = nameof(QueuedPipeStringWriter),
+                IsBackground = true,
+            };
+
+            this.writerThread.Start();
+        }
+
+        public bool TryEnqueue(string message)
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(QueuedPipeStringWriter));
+            }
+
+            return this.queue.TryAdd(message);
+        }
+
+        public void Stop()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(QueuedPipeStringWriter));
+            }
+
+            if (this.queue.IsAddingCompleted)
+            {
+                return;
+            }
+
+            // Signal to the queue draining thread that it should drain once more and then terminate.
+            this.queue.CompleteAdding();
+            this.writerThread.Join();
+
+            Debug.Assert(this.queue.IsCompleted, "Message queue should be empty after being stopped");
+        }
+
+        public void Dispose()
+        {
+            if (!this.isDisposed)
+            {
+                this.Stop();
+
+                this.pipeClient?.Dispose();
+                this.pipeClient = null;
+
+                this.writerThread = null;
+
+                this.queue.Dispose();
+            }
+
+            this.isDisposed = true;
+        }
+
+        private void RaiseStateChanged(QueuedPipeStringWriterState newState, Exception ex)
+        {
+            if (this.state != newState)
+            {
+                this.state = newState;
+                this.eventSink?.OnStateChanged(this, newState, ex);
+            }
+        }
+
+        private void BackgroundWriterThreadProc()
+        {
+            // Drain the queue of all messages currently in the queue.
+            // TryTake() using an infinite timeout will block until either a message is available (returns true)
+            // or the queue has been marked as completed _and_ is empty (returns false).
+            string message;
+            while (this.queue.TryTake(out message, Timeout.Infinite))
+            {
+                if (message != null)
+                {
+                    this.WriteMessage(message);
+                }
+            }
+
+            this.RaiseStateChanged(QueuedPipeStringWriterState.Stopped, null);
+        }
+
+        private void WriteMessage(string message)
+        {
+            // Create pipe if this is the first message, or if the last connection broke for any reason
+            if (this.pipeClient == null)
+            {
+                try
+                {
+                    // Create a new pipe stream instance using the provided factory
+                    NamedPipeClientStream pipe = this.createPipeFunc();
+
+                    // Specify a instantaneous timeout because we don't want to hold up the
+                    // background thread loop if the pipe is not available; we will just drop this event.
+                    // The pipe server should already be running and waiting for connections from us.
+                    pipe.Connect(timeout: 0);
+
+                    // Keep a hold of this connected pipe for future messages
+                    this.pipeClient = pipe;
+                }
+                catch (Exception ex)
+                {
+                    this.RaiseStateChanged(QueuedPipeStringWriterState.Failing, ex);
+                    return;
+                }
+            }
+
+            try
+            {
+                // If we're in byte/stream transmission mode rather than message mode
+                // we should signal the end of each message with a line-feed (LF) character.
+                if (this.pipeClient.TransmissionMode == PipeTransmissionMode.Byte)
+                {
+                    message += '\n';
+                }
+
+                byte[] data = Encoding.UTF8.GetBytes(message);
+                this.pipeClient.Write(data, 0, data.Length);
+                this.pipeClient.Flush();
+
+                this.RaiseStateChanged(QueuedPipeStringWriterState.Healthy, null);
+            }
+            catch (Exception ex)
+            {
+                // We can't send this message for some reason (e.g., broken pipe); we attempt no recovery or retry
+                // mechanism and drop this message. We will try to recreate/connect the pipe on the next message.
+                this.pipeClient.Dispose();
+                this.pipeClient = null;
+                this.RaiseStateChanged(QueuedPipeStringWriterState.Failing, ex);
+                return;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Common/Tracing/MockListener.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/Tracing/MockListener.cs
@@ -6,7 +6,7 @@ namespace GVFS.UnitTests.Mock.Common.Tracing
     public class MockListener : EventListener
     {
         public MockListener(EventLevel maxVerbosity, Keywords keywordFilter)
-            : base(maxVerbosity, keywordFilter)
+            : base(maxVerbosity, keywordFilter, null)
         {
         }
 

--- a/GVFS/GVFS.UnitTests/Tracing/QueuedPipeStringWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Tracing/QueuedPipeStringWriterTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.IO.Pipes;
+using System.Threading;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using Moq;
+using NUnit.Framework;
+
+namespace GVFS.UnitTests.Tracing
+{
+    [TestFixture]
+    public class QueuedPipeStringWriterTests
+    {
+        [TestCase]
+        public void Stop_RaisesStateStopped()
+        {
+            // Capture event invocations
+            Mock<IQueuedPipeStringWriterEventSink> eventSink = new Mock<IQueuedPipeStringWriterEventSink>();
+
+            // createPipeFunc returns `null` since the test will never enqueue any messaged to write
+            QueuedPipeStringWriter writer = new QueuedPipeStringWriter(
+                () => null,
+                eventSink.Object);
+
+            // Try to write some dummy data
+            writer.Start();
+            writer.Stop();
+
+            eventSink.Verify(
+                x => x.OnStateChanged(writer, QueuedPipeStringWriterState.Stopped, null),
+                Times.Once);
+        }
+
+        [TestCase]
+        public void MissingPipe_RaisesStateFailing()
+        {
+            const string inputMessage = "FooBar";
+
+            // Capture event invocations
+            Mock<IQueuedPipeStringWriterEventSink> eventSink = new Mock<IQueuedPipeStringWriterEventSink>();
+
+            QueuedPipeStringWriter writer = new QueuedPipeStringWriter(
+                () => throw new Exception("Failing pipe connection"),
+                eventSink.Object);
+
+            // Try to write some dummy data
+            writer.Start();
+            bool queueOk = writer.TryEnqueue(inputMessage);
+            writer.Stop();
+
+            queueOk.ShouldBeTrue();
+            eventSink.Verify(
+                x => x.OnStateChanged(writer, QueuedPipeStringWriterState.Failing, It.IsAny<Exception>()),
+                Times.Once);
+            eventSink.Verify(
+                x => x.OnStateChanged(writer, QueuedPipeStringWriterState.Stopped, It.IsAny<Exception>()),
+                Times.Once);
+        }
+
+        [TestCase]
+        public void GoodPipe_WritesDataAndRaisesStateHealthy()
+        {
+            const string inputMessage = "FooBar";
+            byte[] expectedData =
+            {
+                0x46, 0x6F, 0x6F, 0x42, 0x61, 0x72, (byte)'\n', // "FooBar\n"
+                0x46, 0x6F, 0x6F, 0x42, 0x61, 0x72, (byte)'\n', // "FooBar\n"
+                0x46, 0x6F, 0x6F, 0x42, 0x61, 0x72, (byte)'\n', // "FooBar\n"
+            };
+
+            string pipeName = Guid.NewGuid().ToString("N");
+
+            // Capture event invocations
+            Mock<IQueuedPipeStringWriterEventSink> eventSink = new Mock<IQueuedPipeStringWriterEventSink>();
+
+            QueuedPipeStringWriter writer = new QueuedPipeStringWriter(
+                () => new NamedPipeClientStream(".", pipeName, PipeDirection.Out),
+                eventSink.Object);
+
+            using (TestPipeReaderWorker pipeWorker = new TestPipeReaderWorker(pipeName, PipeTransmissionMode.Byte))
+            {
+                // Start the pipe reader worker first and wait until the pipe server has been stood-up
+                // before starting the pipe writer/enqueuing messages because the writer does not wait
+                // for the pipe to be ready to accept (it returns and drops messages immediately).
+                pipeWorker.Start();
+                pipeWorker.WaitForReadyToAccept();
+                writer.Start();
+
+                // Try to write some dummy data
+                bool queueOk1 = writer.TryEnqueue(inputMessage);
+                bool queueOk2 = writer.TryEnqueue(inputMessage);
+                bool queueOk3 = writer.TryEnqueue(inputMessage);
+
+                // Wait until we've received all the sent messages before shuting down
+                // the pipe worker thread.
+                pipeWorker.WaitForRecievedBytes(count: expectedData.Length);
+                pipeWorker.Stop();
+                writer.Stop();
+
+                queueOk1.ShouldBeTrue();
+                queueOk2.ShouldBeTrue();
+                queueOk3.ShouldBeTrue();
+
+                byte[] actualData = pipeWorker.GetReceivedDataSnapshot();
+                CollectionAssert.AreEqual(expectedData, actualData);
+
+                // Should only receive one 'healthy' state change per successfully written message
+                eventSink.Verify(
+                    x => x.OnStateChanged(writer, QueuedPipeStringWriterState.Healthy, It.IsAny<Exception>()),
+                    Times.Once);
+                eventSink.Verify(
+                    x => x.OnStateChanged(writer, QueuedPipeStringWriterState.Stopped, It.IsAny<Exception>()),
+                    Times.Once);
+            }
+        }
+
+        private class TestPipeReaderWorker : IDisposable
+        {
+            private readonly string pipeName;
+            private readonly PipeTransmissionMode transmissionMode;
+            private readonly AutoResetEvent receivedData = new AutoResetEvent(initialState: false);
+            private readonly ManualResetEvent readyToAccept = new ManualResetEvent(initialState: false);
+            private readonly ManualResetEvent shutdownEvent = new ManualResetEvent(initialState: false);
+
+            private int bufferLength = 0;
+            private byte[] buffer = new byte[16*1024];
+            private object bufferLock = new object();
+            private Thread thread;
+            private bool isRunning;
+            private bool isDisposed;
+
+            public TestPipeReaderWorker(string pipeName, PipeTransmissionMode transmissionMode)
+            {
+                this.pipeName = pipeName;
+                this.transmissionMode = transmissionMode;
+            }
+
+            public void Start()
+            {
+                if (!this.isRunning)
+                {
+                    this.isRunning = true;
+                    this.thread = new Thread(this.ThreadProc)
+                    {
+                        Name = nameof(TestPipeReaderWorker),
+                        IsBackground = true
+                    };
+                    this.thread.Start();
+                }
+            }
+
+            public void WaitForReadyToAccept()
+            {
+                this.readyToAccept.WaitOne();
+            }
+
+            public void WaitForRecievedBytes(int count)
+            {
+                if (!this.isRunning)
+                {
+                    throw new InvalidOperationException("Worker has been stopped so will never receieve new data");
+                }
+
+                int length;
+
+                while (true)
+                {
+                    // Since the buffer can only grow (and we only care about waiting for a minimum length), we
+                    // don't care that the length could increase after we've released the lock.
+                    lock (this.bufferLock)
+                    {
+                        length = this.bufferLength;
+                    }
+
+                    if (length >= count)
+                    {
+                        break;
+                    }
+
+                    // Wait for more data (the buffer will grow)
+                    this.receivedData.WaitOne();
+                }
+            }
+
+            public byte[] GetReceivedDataSnapshot()
+            {
+                if (this.isRunning)
+                {
+                    throw new InvalidOperationException("Should stop the test pipe worker first");
+                }
+
+                if (this.isDisposed)
+                {
+                    throw new ObjectDisposedException($"{nameof(TestPipeReaderWorker)}");
+                }
+
+                byte[] snapshot;
+
+                lock (this.bufferLock)
+                {
+                    snapshot = new byte[this.bufferLength];
+                    Array.Copy(this.buffer, snapshot, snapshot.Length);
+                }
+
+                return snapshot;
+            }
+
+            public void Stop()
+            {
+                if (this.isRunning)
+                {
+                    this.isRunning = false;
+                    this.shutdownEvent.Set();
+                    this.thread.Join();
+                }
+            }
+
+            public void Dispose()
+            {
+                if (this.isDisposed)
+                {
+                    return;
+                }
+
+                this.Stop();
+                this.isDisposed = true;
+            }
+
+            private void ThreadProc()
+            {
+                using (NamedPipeServerStream pipe = new NamedPipeServerStream(this.pipeName, PipeDirection.In, -1, this.transmissionMode, PipeOptions.Asynchronous))
+                {
+                    // Signal that the pipe has been created and we're ready to accept clients
+                    this.readyToAccept.Set();
+
+                    pipe.WaitForConnection();
+
+                    while (this.isRunning)
+                    {
+                        byte[] readBuffer = new byte[1024];
+
+                        IAsyncResult asyncResult = pipe.BeginRead(readBuffer, offset: 0, count: readBuffer.Length, callback: null, state: null);
+
+                        // Wait for a read operation to complete, or until we're told to shutdown
+                        WaitHandle.WaitAny(new[] { asyncResult.AsyncWaitHandle, this.shutdownEvent });
+
+                        if (this.isRunning)
+                        {
+                            // Complete the read
+                            int nr = pipe.EndRead(asyncResult);
+                            if (nr > 0)
+                            {
+                                // We actually read some data so append this to the main buffer
+                                lock (this.bufferLock)
+                                {
+                                    Array.Copy(readBuffer, 0, this.buffer, this.bufferLength, nr);
+                                    this.bufferLength += nr;
+                                }
+
+                                this.receivedData.Set();
+                            }
+                            else
+                            {
+                                // We got here because the pipe has been closed.
+                                // If we've been asked to shutdown we will break on the next while-loop evaluation.
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
+++ b/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -37,14 +38,14 @@ namespace GVFS.UnitTests.Tracing
                 },
             };
 
-            TelemetryDaemonEventListener.TelemetryMessage message = new TelemetryDaemonEventListener.TelemetryMessage
+            TelemetryDaemonEventListener.PipeMessage message = new TelemetryDaemonEventListener.PipeMessage
             {
                 Version = vfsVersion,
                 ProviderName = providerName,
                 EventName = eventName,
                 EventLevel = level,
                 EventOpcode = opcode,
-                Payload = new TelemetryDaemonEventListener.TelemetryMessage.TelemetryMessagePayload
+                Payload = new TelemetryDaemonEventListener.PipeMessage.PipeMessagePayload
                 {
                     EnlistmentId = enlistmentId,
                     MountId = mountId,
@@ -57,20 +58,20 @@ namespace GVFS.UnitTests.Tracing
 
             Dictionary<string, object> actualDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(messageJson);
 
-            Assert.AreEqual(expectedDict.Count, actualDict.Count);
-            Assert.AreEqual(expectedDict["version"], actualDict["version"]);
-            Assert.AreEqual(expectedDict["providerName"], actualDict["providerName"]);
-            Assert.AreEqual(expectedDict["eventName"], actualDict["eventName"]);
-            Assert.AreEqual(expectedDict["eventLevel"], actualDict["eventLevel"]);
-            Assert.AreEqual(expectedDict["eventOpcode"], actualDict["eventOpcode"]);
+            actualDict.Count.ShouldEqual(expectedDict.Count);
+            actualDict["version"].ShouldEqual(expectedDict["version"]);
+            actualDict["providerName"].ShouldEqual(expectedDict["providerName"]);
+            actualDict["eventName"].ShouldEqual(expectedDict["eventName"]);
+            actualDict["eventLevel"].ShouldEqual(expectedDict["eventLevel"]);
+            actualDict["eventOpcode"].ShouldEqual(expectedDict["eventOpcode"]);
 
             Dictionary<string, string> expectedPayloadDict = (Dictionary<string, string>)expectedDict["payload"];
             Dictionary<string, string> actualPayloadDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(actualDict["payload"].ToString());
-            Assert.AreEqual(expectedPayloadDict.Count, actualPayloadDict.Count);
-            Assert.AreEqual(expectedPayloadDict["enlistmentId"], actualPayloadDict["enlistmentId"]);
-            Assert.AreEqual(expectedPayloadDict["mountId"], actualPayloadDict["mountId"]);
-            Assert.AreEqual(expectedPayloadDict["gitCommandSessionId"], actualPayloadDict["gitCommandSessionId"]);
-            Assert.AreEqual(expectedPayloadDict["json"], actualPayloadDict["json"]);
+            actualPayloadDict.Count.ShouldEqual(expectedPayloadDict.Count);
+            actualPayloadDict["enlistmentId"].ShouldEqual(expectedPayloadDict["enlistmentId"]);
+            actualPayloadDict["mountId"].ShouldEqual(expectedPayloadDict["mountId"]);
+            actualPayloadDict["gitCommandSessionId"].ShouldEqual(expectedPayloadDict["gitCommandSessionId"]);
+            actualPayloadDict["json"].ShouldEqual(expectedPayloadDict["json"]);
         }
     }
 }


### PR DESCRIPTION
Ensure that modifications and enumeration of the `JsonTracer::listeners` collection is safe with multiple threads adding/removing listeners at the same time as we're writing messages. A `ConcurrentBag` is used to achieve this aim.

The 'dispose' flag of the `JsonTracer` has been updated to be read and compared/written atomically to prevent threading issues with listeners being added after disposal has started.

Also ensure the `TelemetryDaemonEventListener` does not hold up calling threads posting messages over the pipe by queuing up messages to be sent on a single background thread.

Fixes #903 