### PR TITLE
Mac kext: Fixes potential issues flagged by clang static analyser

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -233,8 +233,8 @@ static int HandleVnodeOperation(
     vtype vnodeType;
     uint32_t currentVnodeFileFlags;
     FsidInode vnodeFsidInode;
-    int pid;
-    char procname[MAXCOMLEN + 1];
+    int pid = 0;
+    char procname[MAXCOMLEN + 1] = "";
     bool isDeleteAction = false;
     bool isDirectory = false;
 

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -125,14 +125,15 @@ VirtualizationRootHandle VirtualizationRoot_FindForVnode(
     PerfTracer* _Nonnull perfTracer,
     PrjFSPerfCounter functionCounter,
     PrjFSPerfCounter innerLoopCounter,
-    vnode_t _Nonnull vnode,
+    vnode_t _Nonnull initialVnode,
     vfs_context_t context)
 {
     PerfSample findForVnodeSample(perfTracer, functionCounter);
     
     VirtualizationRootHandle rootHandle = RootHandle_None;
     errno_t error = 0;
-    
+    vnode_t vnode = initialVnode;
+
     if (vnode_isdir(vnode))
     {
         error = vnode_get(vnode);


### PR DESCRIPTION
I noticed someone has turned on running clang static analysis by default when building the ProjFS for Mac code. Thanks for that!

The analyser was flagging some potential issues in the existing code. Although relatively benign, this change fixes those issues.