### PR TITLE
Fix credential interactions

### DIFF
--- a/GVFS/GVFS.Common/Git/GitConfigSetting.cs
+++ b/GVFS/GVFS.Common/Git/GitConfigSetting.cs
@@ -6,7 +6,7 @@ namespace GVFS.Common.Git
     {
         public const string CoreVirtualizeObjectsName = "core.virtualizeobjects";
         public const string CoreVirtualFileSystemName = "core.virtualfilesystem";
-        public const string CredentialUseHttpPath = "credential.useHttpPath";
+        public const string CredentialUseHttpPath = "credential.\"https://dev.azure.com\".useHttpPath";
 
         public const string HttpSslCert = "http.sslcert";
         public const string HttpSslVerify = "http.sslverify";

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -179,7 +179,7 @@ namespace GVFS.Common.Git
             string stdinConfig = sb.ToString();
 
             this.InvokeGitOutsideEnlistment(
-                "credential reject",
+                GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
                 null);
         }
@@ -195,7 +195,7 @@ namespace GVFS.Common.Git
             string stdinConfig = sb.ToString();
 
             this.InvokeGitOutsideEnlistment(
-                "credential approve",
+                GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
                 null);
         }
@@ -269,7 +269,7 @@ namespace GVFS.Common.Git
             using (ITracer activity = tracer.StartActivity("TryGetCredentials", EventLevel.Informational))
             {
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
-                    $"-c {GitConfigSetting.CredentialUseHttpPath}=true credential fill",
+                    GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
                     parseStdOutLine: null);
 
@@ -758,6 +758,11 @@ namespace GVFS.Common.Git
             {
                 this.executingProcess = null;
             }
+        }
+
+        private static string GenerateCredentialVerbCommand(string verb)
+        {
+            return $"-c {GitConfigSetting.CredentialUseHttpPath}=true credential {verb}";
         }
 
         private static string ParseValue(string contents, string prefix)

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -164,15 +164,10 @@ namespace GVFS.Common.Git
             // Credential helpers that support it can use the provided username/password values to
             // perform a check that they're being asked to delete the same stored credential that
             // the caller is asking them to erase.
-            if (username != null)
-            {
-                sb.AppendFormat("username={0}\n", username);
-            }
-
-            if (password != null)
-            {
-                sb.AppendFormat("password={0}\n", password);
-            }
+            // Ideally, we would provide these values if available, however it does not work as expected
+            // with our main credential helper - Windows GCM. With GCM for Windows, the credential acquired
+            // with credential fill for dev.azure.com URLs are not erased when the user name / password are passed in.
+            // Until the default credential helper works with this pattern, reject credential with just the URL.
 
             sb.Append("\n");
 

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -12,6 +12,7 @@ namespace GVFS.UnitTests.Git
     public class GitAuthenticationTests
     {
         private const string CertificatePath = "certificatePath";
+        private const string AzureDevOpsUseHttpPathString = "-c credential.\"https://dev.azure.com\".useHttpPath=true";
 
         private readonly bool sslSettingsPresent;
 
@@ -262,11 +263,11 @@ namespace GVFS.UnitTests.Git
             int approvals = 0;
             int rejections = 0;
             gitProcess.SetExpectedCommandResult(
-                "-c credential.useHttpPath=true credential fill",
+                $"{AzureDevOpsUseHttpPathString} credential fill",
                 () => new GitProcess.Result("username=username\r\npassword=password" + rejections + "\r\n", string.Empty, GitProcess.Result.SuccessCode));
 
             gitProcess.SetExpectedCommandResult(
-                "credential approve",
+                $"{AzureDevOpsUseHttpPathString} credential approve",
                 () =>
                 {
                     approvals++;
@@ -274,7 +275,7 @@ namespace GVFS.UnitTests.Git
                 });
 
             gitProcess.SetExpectedCommandResult(
-                "credential reject",
+                $"{AzureDevOpsUseHttpPathString} credential reject",
                 () =>
                 {
                     rejections++;


### PR DESCRIPTION
In testing, there were 2 changes necessary to reject credentials:

1) Make sure the `usehttppath` option is specified, so that the credential lookup and rejection use the same context

2) The call to reject credentials with username / password was not rejecting the credential (with GCM 1.18.5).

Additionally, since `usehttppath` only needs to be applied to `https://dev.azure.com` urls, we scope this setting. This should improve the experience when other remote URLs are used.

Fixes #916, #928  
Related: #949 