### PR TITLE
.Net core porting - GVFS.FunctionalTests.LockHolder

### DIFF
--- a/GVFS.sln
+++ b/GVFS.sln
@@ -389,9 +389,11 @@ Global
 		{BD7C5776-82F2-40C6-AF01-B3CC1E2D83AF}.Release.Windows|x64.ActiveCfg = Release|x64
 		{BD7C5776-82F2-40C6-AF01-B3CC1E2D83AF}.Release.Windows|x64.Build.0 = Release|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Debug.Mac|x64.ActiveCfg = Debug|x64
+		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Debug.Mac|x64.Build.0 = Debug|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Debug.Windows|x64.ActiveCfg = Debug|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Debug.Windows|x64.Build.0 = Debug|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Release.Mac|x64.ActiveCfg = Release|x64
+		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Release.Mac|x64.Build.0 = Debug|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Release.Windows|x64.ActiveCfg = Release|x64
 		{FA273F69-5762-43D8-AEA1-B4F08090D624}.Release.Windows|x64.Build.0 = Release|x64
 		{4CC2A90D-D240-4382-B4BF-5E175515E492}.Debug.Mac|x64.ActiveCfg = Debug|x64

--- a/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
@@ -1,9 +1,11 @@
 ﻿using CommandLine;
 using GVFS.Common;
 using GVFS.Common.NamedPipes;
+using GVFS.Platform.Mac;
 using GVFS.Platform.Windows;
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.LockHolder
 {
@@ -20,20 +22,14 @@ namespace GVFS.FunctionalTests.LockHolder
 
         public void Execute()
         {
-            string normalizedCurrentDirectory;
             string errorMessage;
-            if (!WindowsFileSystem.TryGetNormalizedPathImplementation(Environment.CurrentDirectory, out normalizedCurrentDirectory, out errorMessage))
-            {
-                throw new Exception("Unable to get normalized path: " + errorMessage);
-            }
-
             string enlistmentRoot;
-            if (!WindowsPlatform.TryGetGVFSEnlistmentRootImplementation(Environment.CurrentDirectory, out enlistmentRoot, out errorMessage))
+            if (!TryGetGVFSEnlistmentRootImplementation(Environment.CurrentDirectory, out enlistmentRoot, out errorMessage))
             {
                 throw new Exception("Unable to get GVFS Enlistment root: " + errorMessage);
             }
 
-            string enlistmentPipename = GVFSPlatform.Instance.GetNamedPipeName(enlistmentRoot);
+            string enlistmentPipename = GetNamedPipeNameImplementation(enlistmentRoot);
 
             AcquireLock(enlistmentPipename);
 
@@ -43,6 +39,43 @@ namespace GVFS.FunctionalTests.LockHolder
             {
                 ReleaseLock(enlistmentPipename, enlistmentRoot);
             }
+        }
+
+        private static bool TryGetGVFSEnlistmentRootImplementation(string directory, out string enlistmentRoot, out string errorMessage)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MacPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
+            }
+
+            // Not able to use WindowsPlatform here - because of its dependency on WindowsIdentity (and also kernel32.dll).
+            enlistmentRoot = null;
+
+            string finalDirectory;
+            if (!WindowsFileSystem.TryGetNormalizedPathImplementation(directory, out finalDirectory, out errorMessage))
+            {
+                return false;
+            }
+
+            enlistmentRoot = Paths.GetRoot(finalDirectory, GVFSConstants.DotGVFS.Root);
+            if (enlistmentRoot == null)
+            {
+                errorMessage = $"Failed to find the root directory for {GVFSConstants.DotGVFS.Root} in {finalDirectory}";
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string GetNamedPipeNameImplementation(string enlistmentRoot)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MacPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
+            }
+
+            // Not able to use WindowsPlatform here - because of its dependency on WindowsIdentity (and also kernel32.dll).
+            return "GVFS_" + enlistmentRoot.ToUpper().Replace(':', '_');
         }
 
         private static void AcquireLock(string enlistmentPipename)

--- a/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
@@ -1,87 +1,42 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\GVFS\GVFS.Build\GVFS.cs.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\GVFS.Build\GVFS.cs.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <ProjectGuid>{FA273F69-5762-43D8-AEA1-B4F08090D624}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <Platforms>x64</Platforms>
+    <!-- see https://github.com/NuGet/Home/issues/4837 for reference to CopyLocalLockFileAssemblies -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <RootNamespace>GVFS.FunctionalTests.LockHolder</RootNamespace>
     <AssemblyName>GVFS.FunctionalTests.LockHolder</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <PlatformTarget>x64</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <Version>$(GVFSVersion)</Version>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <PlatformTarget>x64</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <Version>$(GVFSVersion)</Version>
   </PropertyGroup>
+  
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\CommandLineParser.2.1.1-beta\lib\net45\CommandLine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Reflection.TypeExtensions.4.1.0\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <Compile Include="..\GVFS.Platform.Mac\MacFileSystem.Shared.cs" Link="MacFileSystem.Shared.cs" />
+    <Compile Include="..\GVFS.Platform.Mac\MacPlatform.Shared.cs" Link="MacPlatform.Shared.cs" />
+    <Compile Include="..\GVFS.Platform.Windows\WindowsFileSystem.Shared.cs" Link="WindowsFileSystem.Shared.cs" />
   </ItemGroup>
+  
   <ItemGroup>
-    <Compile Include="AcquireGVFSLock.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Windows.cs">
-      <Link>PlatformLoader.Windows.cs</Link>
-    </Compile>
+    <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj" />
+    <ProjectReference Include="..\GVFS.Virtualization\GVFS.Virtualization.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj">
-      <Project>{374bf1e5-0b2d-4d4a-bd5e-4212299def09}</Project>
-      <Name>GVFS.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GVFS.Platform.Windows\GVFS.Platform.Windows.csproj">
-      <Project>{4CE404E7-D3FC-471C-993C-64615861EA63}</Project>
-      <Name>GVFS.Platform.Windows</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\GVFS.Virtualization\GVFS.Virtualization.csproj">
-      <Project>{f468b05a-95e5-46bc-8c67-b80a78527b7d}</Project>
-      <Name>GVFS.Virtualization</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GVFS/GVFS.FunctionalTests.LockHolder/Program.cs
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/Program.cs
@@ -1,5 +1,4 @@
 ﻿using CommandLine;
-using GVFS.PlatformLoader;
 
 namespace GVFS.FunctionalTests.LockHolder
 {
@@ -7,8 +6,6 @@ namespace GVFS.FunctionalTests.LockHolder
     {
         public static void Main(string[] args)
         {
-            GVFSPlatformLoader.Initialize();
-
             Parser.Default.ParseArguments<AcquireGVFSLockVerb>(args)
                     .WithParsed(acquireGVFSLock => acquireGVFSLock.Execute());
         }

--- a/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
+++ b/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
@@ -186,7 +186,7 @@
       xcopy /Y $(BuildOutputDir)\FastFetch\bin\$(Platform)\$(Configuration)\* $(TargetDir)
       xcopy /Y $(BuildOutputDir)\GVFS.NativeTests\bin\$(Platform)\$(Configuration)\* $(TargetDir)
       xcopy /Y $(BuildOutputDir)\GVFS.Hooks.Windows\bin\$(Platform)\$(Configuration)\* $(TargetDir)
-      xcopy /Y $(BuildOutputDir)\GVFS.FunctionalTests.LockHolder\bin\$(Platform)\$(Configuration)\* $(TargetDir)
+      xcopy /Y $(BuildOutputDir)\GVFS.FunctionalTests.LockHolder\bin\$(Platform)\$(Configuration)\netcoreapp2.1\* $(TargetDir)
 
       REM If there is an inbox version of the ProjFS dll, we must use that one to guarantee compat with the sys, so delete whatever is in our TargetDir
       if exist c:\Windows\System32\ProjectedFSLib.dll del $(TargetDir)\ProjectedFSLib.dll

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -15,9 +15,6 @@
             // machines but not on the build agents
             public const string FailsOnBuildAgent = "FailsOnBuildAgent";
 
-            // Tests that require the LockHolder project to be converted to .NET Core (#150)
-            public const string NeedsLockHolder = "NeedsDotCoreLockHolder";
-
             // Tests that require #356 (old paths to be delivered with rename notifications)
             public const string NeedsRenameOldPath = "NeedsRenameOldPath";
 

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -73,7 +73,6 @@ namespace GVFS.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                excludeCategories.Add(Categories.MacTODO.NeedsLockHolder);
                 excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
                 excludeCategories.Add(Categories.MacTODO.NeedsRenameOldPath);
                 excludeCategories.Add(Categories.MacTODO.M3);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -191,7 +191,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(8)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void ModifiedFileWillGetAddedToModifiedPathsFile()
         {
             string gitFileToTest = "GVFS/GVFS.Common/RetryWrapper.cs";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
@@ -48,7 +48,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitCommandWaitsWhileAnotherIsRunning()
         {
             int pid;
@@ -59,7 +58,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitAliasNamedAfterKnownCommandAcquiresLock()
         {
             string alias = nameof(this.GitAliasNamedAfterKnownCommandAcquiresLock);
@@ -72,7 +70,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock()
         {
             string alias = nameof(this.GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock);
@@ -89,7 +86,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(7)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void ExternalLockHolderReportedWhenBackgroundTasksArePending()
         {
             int pid;
@@ -107,7 +103,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(8)]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void OrphanedGVFSLockIsCleanedUp()
         {
             int pid;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
@@ -34,7 +34,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void UnmountWaitsForLock()
         {
             ManualResetEventSlim lockHolder = GitHelpers.AcquireGVFSLock(this.Enlistment, out _);
@@ -51,7 +50,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsLockHolder)]
         public void UnmountSkipLock()
         {
             ManualResetEventSlim lockHolder = GitHelpers.AcquireGVFSLock(this.Enlistment, out _, Timeout.Infinite, true);

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -1,4 +1,6 @@
 ﻿using GVFS.Common;
+using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace GVFS.Platform.Mac
@@ -15,7 +17,15 @@ namespace GVFS.Platform.Mac
 
         public static bool IsProcessActiveImplementation(int processId)
         {
-            // TODO(Mac): Implement proper check
+            try
+            {
+                Process process = Process.GetProcessById(processId);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/Scripts/Mac/CleanupFunctionalTests.sh
+++ b/Scripts/Mac/CleanupFunctionalTests.sh
@@ -3,6 +3,7 @@
 pkill -9 -l GVFS.FunctionalTests
 pkill -9 -l git
 pkill -9 -l gvfs
+pkill -9 -l GVFS.Mount
 pkill -9 -l prjfs-log
 
 $VFS_SRCDIR/ProjFS.Mac/Scripts/UnloadPrjFSKext.sh


### PR DESCRIPTION
Porting FunctionalTests.LockHolder to .netcore
- Migrated the project file to new format 
- Removed GVFS.Platform.Windows dependency 
- Directly using WindowsFileSystem.Shared.cs 
- Updated GitHelper to launch GVFS.FunctionalTests.LockHolder.dll using dotnet command. Previously it was an exe and launched directly 
- Replaced WindowsPlatform code (GVFSPlatform.Instance.GetNamedPipeName) with private implementation 
- Removed Categories.MacTODO.NeedsLockHolder 7.Implemented IsProcessActiveImplementation on MacPlatform.

Fixes #701, #150