### PR TITLE
Add check for existing pipe and better error messaging

### DIFF
--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -455,6 +455,11 @@ namespace GVFS.CommandLine
             {
                 this.ReportErrorAndExit("Error: You can't clone inside an existing GVFS repo ({0})", existingEnlistmentRoot);
             }
+
+            if (this.IsExistingPipeListening(normalizedEnlistmentRootPath))
+            {
+                this.ReportErrorAndExit($"Error: There is currently a GVFS.Mount process running for '{normalizedEnlistmentRootPath}'. This process must be stopped before cloning.");
+            }
         }
 
         private bool TryDetermineLocalCacheAndInitializePaths(

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -353,6 +353,19 @@ namespace GVFS.CommandLine
             return serverGVFSConfig;
         }
 
+        protected bool IsExistingPipeListening(string enlistmentRoot)
+        {
+            using (NamedPipeClient pipeClient = new NamedPipeClient(GVFSPlatform.Instance.GetNamedPipeName(enlistmentRoot)))
+            {
+                if (pipeClient.Connect(500))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         protected void ValidateClientVersions(ITracer tracer, GVFSEnlistment enlistment, ServerGVFSConfig gvfsConfig, bool showWarnings)
         {
             this.CheckGitVersion(tracer, enlistment, out string gitVersion);

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -61,12 +61,9 @@ namespace GVFS.CommandLine
 
             if (!this.SkipMountedCheck)
             {
-                using (NamedPipeClient pipeClient = new NamedPipeClient(GVFSPlatform.Instance.GetNamedPipeName(enlistmentRoot)))
+                if (this.IsExistingPipeListening(enlistmentRoot))
                 {
-                    if (pipeClient.Connect(500))
-                    {
-                        this.ReportErrorAndExit(tracer: null, exitCode: ReturnCode.Success, error: "This repo is already mounted.");
-                    }
+                    this.ReportErrorAndExit(tracer: null, exitCode: ReturnCode.Success, error: $"The repo at '{enlistmentRoot}' is already mounted.");
                 }
             }
 


### PR DESCRIPTION
When cloning and the GVFS.Mount process somehow was left running but the
enlistment directory was deleted, the clone would hang because the hook
was communicating to the wrong pipe.  The only way we have found to get
into this state is by formatting the drive that has a mounted repo and
then clone to where the mounted repo was.  This will remove all directories
allowing the clone to proceed but leave the mount process running with
the pipe listening.

This change will check for a listening pipe when cloning to determine if
there is still a running mount process that needs to be stopped before
the clone can run.

Fixes #940 