### PR TITLE
Update GVFS.Service to log why repos were determined to be invalid

### DIFF
--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -104,13 +104,13 @@ namespace GVFS.Common
                 string enlistmentRoot;
                 if (!GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(directory, out enlistmentRoot, out errorMessage))
                 {
-                    return null;
+                    throw new InvalidRepoException($"Could not get enlistment root. Error: {errorMessage}");
                 }
 
                 return new GVFSEnlistment(enlistmentRoot, gitBinRoot, gvfsHooksRoot, authentication);
             }
 
-            return null;
+            throw new InvalidRepoException($"Directory '{directory}' does not exist");
         }
 
         public static string GetNewGVFSLogFileName(string logsRoot, string logFileType)

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -79,24 +79,12 @@ namespace GVFS.Common
             get { return this.gvfsHooksVersion; }
         }
 
-        public static GVFSEnlistment CreateWithoutRepoUrlFromDirectory(string directory, string gitBinRoot, string gvfsHooksRoot, GitAuthentication authentication)
-        {
-            if (Directory.Exists(directory))
-            {
-                string errorMessage;
-                string enlistmentRoot;
-                if (!GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(directory, out enlistmentRoot, out errorMessage))
-                {
-                    return null;
-                }
-
-                return new GVFSEnlistment(enlistmentRoot, string.Empty, gitBinRoot, gvfsHooksRoot, authentication);
-            }
-
-            return null;
-        }
-
-        public static GVFSEnlistment CreateFromDirectory(string directory, string gitBinRoot, string gvfsHooksRoot, GitAuthentication authentication)
+        public static GVFSEnlistment CreateFromDirectory(
+            string directory,
+            string gitBinRoot,
+            string gvfsHooksRoot,
+            GitAuthentication authentication,
+            bool createWithoutRepoURL = false)
         {
             if (Directory.Exists(directory))
             {
@@ -105,6 +93,11 @@ namespace GVFS.Common
                 if (!GVFSPlatform.Instance.TryGetGVFSEnlistmentRoot(directory, out enlistmentRoot, out errorMessage))
                 {
                     throw new InvalidRepoException($"Could not get enlistment root. Error: {errorMessage}");
+                }
+
+                if (createWithoutRepoURL)
+                {
+                    return new GVFSEnlistment(enlistmentRoot, string.Empty, gitBinRoot, gvfsHooksRoot, authentication);
                 }
 
                 return new GVFSEnlistment(enlistmentRoot, gitBinRoot, gvfsHooksRoot, authentication);

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -172,12 +172,6 @@ namespace GVFS.Mount
             try
             {
                 enlistment = GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, ProcessHelper.GetCurrentProcessLocation(), authentication: null);
-                if (enlistment == null)
-                {
-                    this.ReportErrorAndExit(
-                        "Error: '{0}' is not a valid GVFS enlistment",
-                        enlistmentRootPath);
-                }
             }
             catch (InvalidRepoException e)
             {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12_0To12_1Upgrade_StatusAheadBehind.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12_0To12_1Upgrade_StatusAheadBehind.cs
@@ -18,15 +18,13 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string errorMessage;
             if (!this.TrySetGitConfig(
                 tracer,
                 enlistmentRoot,
                 new Dictionary<string, string>
                 {
                     { "status.aheadbehind", "false" },
-                },
-                out errorMessage))
+                }))
             {
                 return false;
             }

--- a/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
@@ -78,13 +78,15 @@ namespace GVFS.Service.Handlers
             {
                 enlistment = GVFSEnlistment.CreateFromDirectory(repoRoot, gitBinPath, hooksPath, authentication: null);
             }
-            catch (InvalidRepoException)
+            catch (InvalidRepoException e)
             {
-                return false;
-            }
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add(nameof(repoRoot), repoRoot);
+                metadata.Add(nameof(gitBinPath), gitBinPath);
+                metadata.Add(nameof(hooksPath), hooksPath);
+                metadata.Add("Exception", e.ToString());
+                this.tracer.RelatedInfo(metadata, $"{nameof(this.IsValidRepo)}: Found invalid repo");
 
-            if (enlistment == null)
-            {
                 return false;
             }
 

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -1120,14 +1120,12 @@ You can specify a URL, a name of a configured cache server, or the special names
                 GVFSEnlistment enlistment = null;
                 try
                 {
-                    if (this.validateOriginURL)
-                    {
-                        enlistment = GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, hooksPath, authentication);
-                    }
-                    else
-                    {
-                        enlistment = GVFSEnlistment.CreateWithoutRepoUrlFromDirectory(enlistmentRootPath, gitBinPath, hooksPath, authentication);
-                    }
+                    enlistment = GVFSEnlistment.CreateFromDirectory(
+                        enlistmentRootPath,
+                        gitBinPath,
+                        hooksPath,
+                        authentication,
+                        createWithoutRepoURL: !this.validateOriginURL);
                 }
                 catch (InvalidRepoException e)
                 {

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -1128,13 +1128,6 @@ You can specify a URL, a name of a configured cache server, or the special names
                     {
                         enlistment = GVFSEnlistment.CreateWithoutRepoUrlFromDirectory(enlistmentRootPath, gitBinPath, hooksPath, authentication);
                     }
-
-                    if (enlistment == null)
-                    {
-                        this.ReportErrorAndExit(
-                            "Error: '{0}' is not a valid GVFS enlistment",
-                            enlistmentRootPath);
-                    }
                 }
                 catch (InvalidRepoException e)
                 {


### PR DESCRIPTION
Resolves #795

Prior to the changes in this PR, when GVFS.Service removed an entry for an invalid repo it would not log why the repo was invalid:

```
[2019-03-19 15:25:17 -07:00] Information {"Message":"Removed invalid repo entry from registry: M:\\testMove"}
[2019-03-19 15:25:17 -07:00] Information {"Message":"Removed invalid repo entry from registry: I:\\ForTests"}
[2019-03-19 15:25:17 -07:00] Information {"Message":"Removed invalid repo entry from registry: M:\\ForTests"}
```

With this change the service will log why the repo was determined to be invalid:

```
[2019-03-19 15:30:39 -07:00] Information {"repoRoot":"M:\\ForTests","gitBinPath":"C:\\Program Files\\Git\\cmd\\git.exe","hooksPath":"C:\\Program Files\\GVFS","Exception":"GVFS.Common.InvalidRepoException: Directory 'M:\\ForTests' does not exist\r\n   at GVFS.Common.GVFSEnlistment.CreateFromDirectory(String directory, String gitBinRoot, String gvfsHooksRoot, GitAuthentication authentication)\r\n   at GVFS.Service.Handlers.GetActiveRepoListHandler.IsValidRepo(String repoRoot) in C:\\Repos\\VFSForGit\\src\\GVFS\\GVFS.Service\\Handlers\\GetActiveRepoListHandler.cs:line 72","Message":"IsValidRepo: Found invalid repo"}
[2019-03-19 15:30:39 -07:00] Information {"Message":"Removed invalid repo entry from registry: M:\\ForTests"}
[2019-03-19 15:36:36 -07:00] Information {"repoRoot":"I:\\ForTests","gitBinPath":"C:\\Program Files\\Git\\cmd\\git.exe","hooksPath":"C:\\Program Files\\GVFS","Exception":"GVFS.Common.InvalidRepoException: Could not get origin url. git error: Error while reading 'remote.origin.url' from config: fatal: unable to access 'I:\\ForTests\\src\\.git/config': Invalid argument\n\r\n   at GVFS.Common.Enlistment..ctor(String enlistmentRoot, String workingDirectoryRoot, String repoUrl, String gitBinPath, String gvfsHooksRoot, Boolean flushFileBuffersForPacks, GitAuthentication authentication)\r\n   at GVFS.Common.GVFSEnlistment..ctor(String enlistmentRoot, String repoUrl, String gitBinPath, String gvfsHooksRoot, GitAuthentication authentication)\r\n   at GVFS.Common.GVFSEnlistment.CreateFromDirectory(String directory, String gitBinRoot, String gvfsHooksRoot, GitAuthentication authentication)\r\n   at GVFS.Service.Handlers.GetActiveRepoListHandler.IsValidRepo(String repoRoot) in C:\\Repos\\VFSForGit\\src\\GVFS\\GVFS.Service\\Handlers\\GetActiveRepoListHandler.cs:line 72","Message":"IsValidRepo: Found invalid repo"}
[2019-03-19 15:36:36 -07:00] Information {"Message":"Removed invalid repo entry from registry: I:\\ForTests"}
```

Additional changes\cleanup:

- `TrySetGitConfig` was not setting its `out errorMessage` and nothing was checking it so it has been removed
- Updated all callers of `CreateFromDirectory` to catch `InvalidRepoException`
- Updated `CreateFromDirectory` to *always* throw `InvalidRepoException` if it fails to create a `GVFSEnlistment`.  Previously `CreateFromDirectory` would return either `null` *or* throw `InvalidRepoException`.  Always throwing `InvalidRepoException` simplified the caller's code and made it easier to deliver the error message up to GVFS.Service.  (Because `InvalidRepoException` was also being thrown by the enlistment constructors the `TryXXX` patter was not a good fit).