### PR TITLE
NuGetUpgrader: defer credential acquisition

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -66,7 +66,7 @@ namespace GVFS.Common.Git
                         string password;
                         if (TryParseCredentialString(this.cachedCredentialString, out username, out password))
                         {
-                            this.git.ApproveCredentials(this.repoUrl, username, password);
+                            this.git.TryStoreCredential(tracer, this.repoUrl, username, password, out string error);
                             this.isCachedCredentialStringApproved = true;
                         }
                         else
@@ -97,7 +97,7 @@ namespace GVFS.Common.Git
                     string password;
                     if (TryParseCredentialString(this.cachedCredentialString, out username, out password))
                     {
-                        this.git.RejectCredentials(this.repoUrl, username, password);
+                        this.git.TryDeleteCredential(tracer, this.repoUrl, username, password, out string error);
                     }
                     else
                     {
@@ -109,7 +109,7 @@ namespace GVFS.Common.Git
                             ["CredentialString"] = this.cachedCredentialString
                         });
                         tracer.RelatedWarning(metadata, "Failed to parse credential string for rejection. Rejecting any credential for this repo URL.");
-                        this.git.RejectCredentials(this.repoUrl);
+                        this.git.TryDeleteCredential(tracer, this.repoUrl, null, null, out string error);
                     }
 
                     this.cachedCredentialString = null;
@@ -297,7 +297,7 @@ namespace GVFS.Common.Git
         {
             string gitUsername;
             string gitPassword;
-            if (!this.git.TryGetCredentials(tracer, this.repoUrl, out gitUsername, out gitPassword, out errorMessage))
+            if (!this.git.TryGetCredential(tracer, this.repoUrl, out gitUsername, out gitPassword, out errorMessage))
             {
                 this.UpdateBackoff();
                 return false;

--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -79,7 +79,6 @@ namespace GVFS.Common.Git
                             EventMetadata metadata = new EventMetadata(new Dictionary<string, object>
                             {
                                 ["RepoUrl"] = this.repoUrl,
-                                ["CredentialString"] = this.cachedCredentialString
                             });
                             tracer.RelatedError(metadata, "Failed to parse credential string for approval");
                         }
@@ -115,7 +114,6 @@ namespace GVFS.Common.Git
                         EventMetadata metadata = new EventMetadata(new Dictionary<string, object>
                         {
                             ["RepoUrl"] = this.repoUrl,
-                            ["CredentialString"] = this.cachedCredentialString
                         });
                         tracer.RelatedWarning(metadata, "Failed to parse credential string for rejection. Rejecting any credential for this repo URL.");
                         this.credentialStore.TryDeleteCredential(tracer, this.repoUrl, username: null, password: null, error: out string error);

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -155,7 +155,7 @@ namespace GVFS.Common.Git
             }
         }
 
-        public virtual void RejectCredentials(string repoUrl, string username = null, string password = null)
+        public virtual bool TryDeleteCredential(ITracer tracer, string repoUrl, string username, string password, out string errorMessage)
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("url={0}\n", repoUrl);
@@ -173,13 +173,24 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            this.InvokeGitOutsideEnlistment(
+            Result result = this.InvokeGitOutsideEnlistment(
                 GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
                 null);
+
+            if (result.ExitCodeIsFailure)
+            {
+                tracer.RelatedWarning("Git could not reject credentials: {0}", result.Errors);
+
+                errorMessage = result.Errors;
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
         }
 
-        public virtual void ApproveCredentials(string repoUrl, string username, string password)
+        public virtual bool TryStoreCredential(ITracer tracer, string repoUrl, string username, string password, out string errorMessage)
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("url={0}\n", repoUrl);
@@ -189,10 +200,21 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            this.InvokeGitOutsideEnlistment(
+            Result result = this.InvokeGitOutsideEnlistment(
                 GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
                 null);
+
+            if (result.ExitCodeIsFailure)
+            {
+                tracer.RelatedWarning("Git could not approve credentials: {0}", result.Errors);
+
+                errorMessage = result.Errors;
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
         }
 
         /// <summary>
@@ -250,7 +272,7 @@ namespace GVFS.Common.Git
             }
         }
 
-        public virtual bool TryGetCredentials(
+        public virtual bool TryGetCredential(
             ITracer tracer,
             string repoUrl,
             out string username,
@@ -261,7 +283,7 @@ namespace GVFS.Common.Git
             password = null;
             errorMessage = null;
 
-            using (ITracer activity = tracer.StartActivity("TryGetCredentials", EventLevel.Informational))
+            using (ITracer activity = tracer.StartActivity(nameof(this.TryGetCredential), EventLevel.Informational))
             {
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
                     GenerateCredentialVerbCommand("fill"),

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace GVFS.Common.Git
 {
-    public class GitProcess
+    public class GitProcess : ICredentialStore
     {
         private const int HResultEHANDLE = -2147024890; // 0x80070006 E_HANDLE
 

--- a/GVFS/GVFS.Common/Git/ICredentialStore.cs
+++ b/GVFS/GVFS.Common/Git/ICredentialStore.cs
@@ -1,0 +1,13 @@
+﻿using GVFS.Common.Tracing;
+
+namespace GVFS.Common.Git
+{
+    public interface ICredentialStore
+    {
+        bool TryGetCredential(ITracer tracer, string url, out string username, out string password, out string error);
+
+        bool TryStoreCredential(ITracer tracer, string url, string username, string password, out string error);
+
+        bool TryDeleteCredential(ITracer tracer, string url, string username, string password, out string error);
+    }
+}

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -63,7 +63,7 @@ namespace GVFS.Common.NuGetUpgrade
             this.sourceCacheContext = null;
         }
 
-        public void SetCredentials(string credential)
+        public virtual void SetCredentials(string credential)
         {
             this.personalAccessToken = credential;
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -470,13 +470,13 @@ namespace GVFS.Common.NuGetUpgrade
         private static bool TryGetPersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer, out string token, out string error)
         {
             GitProcess gitProcess = new GitProcess(gitBinaryPath, null, null);
-            return gitProcess.TryGetCredentials(tracer, credentialUrl, out string username, out token, out error);
+            return gitProcess.TryGetCredential(tracer, credentialUrl, out string username, out token, out error);
         }
 
         private static void ErasePersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer)
         {
             GitProcess gitProcess = new GitProcess(gitBinaryPath, null, null);
-            gitProcess.RejectCredentials(credentialUrl);
+            gitProcess.TryDeleteCredential(tracer, credentialUrl, null, null, out string error);
         }
 
         private static bool TryReacquirePersonalAccessToken(string gitBinaryPath, string credentialUrl, ITracer tracer, out string token, out string error)

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -66,6 +66,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.downloadDirectoryPath,
                 null,
                 this.tracer);
+            this.mockNuGetFeed.Setup(feed => feed.SetCredentials(It.IsAny<string>()));
 
             this.mockFileSystem = new MockFileSystem(
                 new MockDirectory(

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common.Git;
+using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using System;
@@ -33,7 +34,7 @@ namespace GVFS.UnitTests.Mock.Git
             this.expectedCommandInfos.Add(commandInfo);
         }
 
-        public override void ApproveCredentials(string repoUrl, string username, string password)
+        public override bool TryStoreCredential(ITracer tracer, string repoUrl, string username, string password, out string error)
         {
             Credential credential = new Credential(username, password);
 
@@ -50,10 +51,10 @@ namespace GVFS.UnitTests.Mock.Git
             // Store the credential
             this.StoredCredentials[repoUrl] = credential;
 
-            base.ApproveCredentials(repoUrl, username, password);
+            return base.TryStoreCredential(tracer, repoUrl, username, password, out error);
         }
 
-        public override void RejectCredentials(string repoUrl, string username, string password)
+        public override bool TryDeleteCredential(ITracer tracer, string repoUrl, string username, string password, out string error)
         {
             Credential credential = new Credential(username, password);
 
@@ -70,7 +71,7 @@ namespace GVFS.UnitTests.Mock.Git
             // Erase the credential
             this.StoredCredentials.Remove(repoUrl);
 
-            base.RejectCredentials(repoUrl, username, password);
+            return base.TryDeleteCredential(tracer, repoUrl, username, password, out error);
         }
 
         protected override Result InvokeGitImpl(


### PR DESCRIPTION
The goal of this change is to enable NuGet Upgrader to defer credential acquisition until it performs an operation that requires authentication. This will enable the functionality of the NuGet Upgrader that does not require authentication to be used without having a credential.

The initial design of NuGet upgrader was that it would have the credentials passed into it, and it was not involved in credential management. Later, NuGetUpgrader became responsible for re-acquiring credentials if they were no longer valid, but this logic was not covered by tests. With this change, NuGet Upgrader will be responsible for the entire credential management lifecycle, and this will be more testable.

### Changes
This change introduces an `ICredentialStore` interface, which includes just the methods required to interact with the credentials on a system. This allows tests to pass in this dependency to NuGet upgrader during tests.

NuGet Upgrader now defers getting credentials until it performs an operation that requires credentials