### PR TITLE
Pass session id through to mount process for correlation with git trace2

### DIFF
--- a/GVFS/GVFS.Common/GVFSLock.Shared.cs
+++ b/GVFS/GVFS.Common/GVFSLock.Shared.cs
@@ -17,9 +17,10 @@ namespace GVFS.Common
             bool isConsoleOutputRedirectedToFile,
             bool checkAvailabilityOnly,
             string gvfsEnlistmentRoot,
+            string gitCommandSessionId,
             out string result)
         {
-            NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid, isElevated, checkAvailabilityOnly, fullCommand);
+            NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid, isElevated, checkAvailabilityOnly, fullCommand, gitCommandSessionId);
 
             NamedPipeMessages.Message requestMessage = request.CreateMessage(NamedPipeMessages.AcquireLock.AcquireRequest);
             pipeClient.SendRequest(requestMessage);
@@ -30,8 +31,6 @@ namespace GVFS.Common
             switch (response.Result)
             {
                 case NamedPipeMessages.AcquireLock.AcceptResult:
-                    return CheckAcceptResponse(response, checkAvailabilityOnly, out result);
-
                 case NamedPipeMessages.AcquireLock.AvailableResult:
                     return CheckAcceptResponse(response, checkAvailabilityOnly, out result);
 
@@ -67,8 +66,6 @@ namespace GVFS.Common
                         switch (response.Result)
                         {
                             case NamedPipeMessages.AcquireLock.AcceptResult:
-                                return CheckAcceptResponse(response, checkAvailabilityOnly, out _);
-
                             case NamedPipeMessages.AcquireLock.AvailableResult:
                                 return CheckAcceptResponse(response, checkAvailabilityOnly, out _);
 
@@ -112,7 +109,7 @@ namespace GVFS.Common
             string waitingMessage = "",
             int spinnerDelay = 0)
         {
-            NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid, isElevated, checkAvailabilityOnly: false, parsedCommand: fullCommand);
+            NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid, isElevated, checkAvailabilityOnly: false, parsedCommand: fullCommand, gitCommandSessionId: string.Empty);
 
             NamedPipeMessages.Message requestMessage = request.CreateMessage(NamedPipeMessages.ReleaseLock.Request);
 

--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -196,6 +196,7 @@ namespace GVFS.Common
                 if (externalHolderTerminatedWithoutReleasingLock)
                 {
                     this.ReleaseLockForTerminatedProcess(existingExternalHolder.PID);
+                    this.tracer.SetGitCommandSessionId(string.Empty);
                     existingExternalHolder = null;
                 }
 

--- a/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/LockNamedPipeMessages.cs
@@ -297,9 +297,9 @@ namespace GVFS.Common.NamedPipes
                     bool checkAvailabilityOnly = false;
                     string parsedCommand = null;
 
-                    if (dataParts.Length < 5)
+                    if (dataParts.Length < 7)
                     {
-                        throw new InvalidOperationException(string.Format("Invalid lock message. Expected at least 5 parts, got: {0} from message: '{1}'", dataParts.Length, body));
+                        throw new InvalidOperationException(string.Format("Invalid lock message. Expected at least 7 parts, got: {0} from message: '{1}'", dataParts.Length, body));
                     }
 
                     if (!int.TryParse(dataParts[0], out pid))

--- a/GVFS/GVFS.Common/Tracing/ITracer.cs
+++ b/GVFS/GVFS.Common/Tracing/ITracer.cs
@@ -9,6 +9,8 @@ namespace GVFS.Common.Tracing
         ITracer StartActivity(string activityName, EventLevel level, EventMetadata metadata);
         ITracer StartActivity(string activityName, EventLevel level, Keywords startStopKeywords, EventMetadata metadata);
 
+        void SetGitCommandSessionId(string sessionId);
+
         void RelatedEvent(EventLevel level, string eventName, EventMetadata metadata);
 
         void RelatedEvent(EventLevel level, string eventName, EventMetadata metadata, Keywords keywords);

--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -81,6 +81,15 @@ namespace GVFS.Common.Tracing
             }
         }
 
+        public void SetGitCommandSessionId(string sessionId)
+        {
+            TelemetryDaemonEventListener daemonListener = this.listeners.FirstOrDefault(x => x is TelemetryDaemonEventListener) as TelemetryDaemonEventListener;
+            if (daemonListener != null)
+            {
+                daemonListener.GitCommandSessionId = sessionId;
+            }
+        }
+
         public void AddEventListener(EventListener listener)
         {
             this.listeners.Add(listener);

--- a/GVFS/GVFS.Common/Tracing/TelemetryDaemonEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/TelemetryDaemonEventListener.cs
@@ -30,6 +30,8 @@ namespace GVFS.Common.Tracing
             this.vfsVersion = ProcessHelper.GetCurrentProcessVersion();
         }
 
+        public string GitCommandSessionId { get; set; }
+
         public static TelemetryDaemonEventListener CreateIfEnabled(string gitBinRoot, string providerName, string enlistmentId, string mountId)
         {
             // This listener is disabled unless the user specifies the proper git config setting.
@@ -85,6 +87,7 @@ namespace GVFS.Common.Tracing
                 {
                     EnlistmentId = this.enlistmentId,
                     MountId = this.mountId,
+                    GitCommandSessionId = this.GitCommandSessionId,
                     Json = message.Payload
                 },
 
@@ -163,6 +166,8 @@ namespace GVFS.Common.Tracing
                 public string EnlistmentId { get; set; }
                 [JsonProperty("mountId")]
                 public string MountId { get; set; }
+                [JsonProperty("gitCommandSessionId")]
+                public string GitCommandSessionId { get; set; }
                 [JsonProperty("json")]
                 public string Json { get; set; }
             }

--- a/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
@@ -99,6 +99,7 @@ namespace GVFS.FunctionalTests.LockHolder
                     isConsoleOutputRedirectedToFile: false,
                     checkAvailabilityOnly: false,
                     gvfsEnlistmentRoot: null,
+                    gitCommandSessionId: string.Empty,
                     result: out result))
                 {
                     throw new Exception(result);
@@ -117,7 +118,7 @@ namespace GVFS.FunctionalTests.LockHolder
 
                 int pid = Process.GetCurrentProcess().Id;
 
-                NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid: pid, isElevated: false, checkAvailabilityOnly: false, parsedCommand: AcquireGVFSLockVerb.fullCommand);
+                NamedPipeMessages.LockRequest request = new NamedPipeMessages.LockRequest(pid: pid, isElevated: false, checkAvailabilityOnly: false, parsedCommand: AcquireGVFSLockVerb.fullCommand, gitCommandSessionId: string.Empty);
                 NamedPipeMessages.Message requestMessage = request.CreateMessage(NamedPipeMessages.ReleaseLock.Request);
 
                 pipeClient.SendRequest(requestMessage);

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -464,13 +464,7 @@ namespace GVFS.Hooks
         {
             try
             {
-                string parent_sid = Environment.GetEnvironmentVariable("GIT_TR2_PARENT_SID", EnvironmentVariableTarget.Process);
-                if (parent_sid == null)
-                {
-                    parent_sid = string.Empty;
-                }
-
-                return parent_sid;
+                return Environment.GetEnvironmentVariable("GIT_TR2_PARENT_SID", EnvironmentVariableTarget.Process) ?? string.Empty;
             }
             catch (Exception)
             {

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -314,6 +314,7 @@ namespace GVFS.Mount
                 else if (lockAcquired)
                 {
                     response = new NamedPipeMessages.AcquireLock.Response(NamedPipeMessages.AcquireLock.AcceptResult);
+                    this.tracer.SetGitCommandSessionId(requester.GitCommandSessionId);
                 }
                 else if (existingExternalHolder == null)
                 {
@@ -340,6 +341,11 @@ namespace GVFS.Mount
             }
 
             NamedPipeMessages.ReleaseLock.Response response = this.fileSystemCallbacks.TryReleaseExternalLock(request.RequestData.PID);
+            if (response.Result == NamedPipeMessages.ReleaseLock.SuccessResult)
+            {
+                this.tracer.SetGitCommandSessionId(string.Empty);
+            }
+
             connection.TrySendResponse(response.CreateMessage());
         }
 

--- a/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
@@ -16,7 +16,8 @@ namespace GVFS.UnitTests.Common
             pid: 1234,
             isElevated: false,
             checkAvailabilityOnly: false,
-            parsedCommand: "git command");
+            parsedCommand: "git command",
+            gitCommandSessionId: "123");
 
         [TestCase]
         public void TryAcquireAndReleaseLockForExternalRequestor()
@@ -115,7 +116,7 @@ namespace GVFS.UnitTests.Common
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
             GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
 
-            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new");
+            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "123");
             NamedPipeMessages.LockData existingExternalHolder;
             gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeFalse();
             this.ValidateLockHeld(gvfsLock, DefaultLockData);
@@ -130,7 +131,7 @@ namespace GVFS.UnitTests.Common
             GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
             mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
 
-            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new");
+            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "123");
             mockPlatform.ActiveProcesses.Add(newLockData.PID);
             NamedPipeMessages.LockData existingExternalHolder;
             gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeTrue();
@@ -200,6 +201,7 @@ namespace GVFS.UnitTests.Common
                 actual.IsElevated.ShouldEqual(expected.IsElevated);
                 actual.CheckAvailabilityOnly.ShouldEqual(expected.CheckAvailabilityOnly);
                 actual.ParsedCommand.ShouldEqual(expected.ParsedCommand);
+                actual.GitCommandSessionId.ShouldEqual(expected.GitCommandSessionId);
             }
             else
             {

--- a/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
@@ -1,9 +1,11 @@
 ﻿using GVFS.Common;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Virtual;
+using Moq;
 using NUnit.Framework;
 using System;
 
@@ -22,64 +24,87 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void TryAcquireAndReleaseLockForExternalRequestor()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ReleaseLockHeldByExternalProcess", It.IsAny<EventMetadata>(), Keywords.Telemetry));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
 
             mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
             gvfsLock.ReleaseLockHeldByExternalProcess(DefaultLockData.PID);
             this.ValidateLockIsFree(gvfsLock);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void ReleaseLockHeldByExternalProcess_WhenNoLock()
         {
-            GVFSLock gvfsLock = new GVFSLock(new MockTracer());
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ReleaseLockHeldByExternalProcess", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            GVFSLock gvfsLock = new GVFSLock(mockTracer.Object);
             this.ValidateLockIsFree(gvfsLock);
             gvfsLock.ReleaseLockHeldByExternalProcess(DefaultLockData.PID).ShouldBeFalse();
             this.ValidateLockIsFree(gvfsLock);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void ReleaseLockHeldByExternalProcess_DifferentPID()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ReleaseLockHeldByExternalProcess", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
             gvfsLock.ReleaseLockHeldByExternalProcess(4321).ShouldBeFalse();
             this.ValidateLockHeld(gvfsLock, DefaultLockData);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void ReleaseLockHeldByExternalProcess_WhenGVFSHasLock()
         {
-            GVFSLock gvfsLock = this.AcquireGVFSLock();
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockInternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ReleaseLockHeldByExternalProcess", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            GVFSLock gvfsLock = this.AcquireGVFSLock(mockTracer.Object);
 
             gvfsLock.ReleaseLockHeldByExternalProcess(DefaultLockData.PID).ShouldBeFalse();
             this.ValidateLockHeldByGVFS(gvfsLock);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ReleaseLockHeldByGVFS_WhenNoLock()
         {
-            GVFSLock gvfsLock = new GVFSLock(new MockTracer());
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            GVFSLock gvfsLock = new GVFSLock(mockTracer.Object);
             this.ValidateLockIsFree(gvfsLock);
             Assert.Throws<InvalidOperationException>(() => gvfsLock.ReleaseLockHeldByGVFS());
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ReleaseLockHeldByGVFS_WhenExternalHasLockShouldThrow()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
 
             Assert.Throws<InvalidOperationException>(() => gvfsLock.ReleaseLockHeldByGVFS());
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void TryAcquireLockForGVFS()
         {
-            GVFSLock gvfsLock = this.AcquireGVFSLock();
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockInternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "ReleaseLockHeldByGVFS", It.IsAny<EventMetadata>()));
+            GVFSLock gvfsLock = this.AcquireGVFSLock(mockTracer.Object);
 
             // Should be able to call again when GVFS has the lock
             gvfsLock.TryAcquireLockForGVFS().ShouldBeTrue();
@@ -87,34 +112,46 @@ namespace GVFS.UnitTests.Common
 
             gvfsLock.ReleaseLockHeldByGVFS();
             this.ValidateLockIsFree(gvfsLock);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void TryAcquireLockForGVFS_WhenExternalLock()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockInternal", It.IsAny<EventMetadata>()));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
 
             gvfsLock.TryAcquireLockForGVFS().ShouldBeFalse();
             mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void TryAcquireLockForExternalRequestor_WhenGVFSLock()
         {
-            GVFSLock gvfsLock = this.AcquireGVFSLock();
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockInternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            GVFSLock gvfsLock = this.AcquireGVFSLock(mockTracer.Object);
 
             NamedPipeMessages.LockData existingExternalHolder;
             gvfsLock.TryAcquireLockForExternalRequestor(DefaultLockData, out existingExternalHolder).ShouldBeFalse();
             this.ValidateLockHeldByGVFS(gvfsLock);
             existingExternalHolder.ShouldBeNull();
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void TryAcquireLockForExternalRequestor_WhenExternalLock()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
 
             NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "123");
             NamedPipeMessages.LockData existingExternalHolder;
@@ -122,13 +159,18 @@ namespace GVFS.UnitTests.Common
             this.ValidateLockHeld(gvfsLock, DefaultLockData);
             this.ValidateExistingExternalHolder(DefaultLockData, existingExternalHolder);
             mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
+            mockTracer.VerifyAll();
         }
 
         [TestCase]
         public void TryAcquireLockForExternalRequestor_WhenExternalHolderTerminated()
         {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ExternalLockHolderExited", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            mockTracer.Setup(x => x.SetGitCommandSessionId(string.Empty));
             MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
-            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform);
+            GVFSLock gvfsLock = this.AcquireDefaultLock(mockPlatform, mockTracer.Object);
             mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
 
             NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "123");
@@ -137,11 +179,12 @@ namespace GVFS.UnitTests.Common
             gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeTrue();
             existingExternalHolder.ShouldBeNull();
             this.ValidateLockHeld(gvfsLock, newLockData);
+            mockTracer.VerifyAll();
         }
 
-        private GVFSLock AcquireDefaultLock(MockPlatform mockPlatform)
+        private GVFSLock AcquireDefaultLock(MockPlatform mockPlatform, ITracer mockTracer)
         {
-            GVFSLock gvfsLock = new GVFSLock(new MockTracer());
+            GVFSLock gvfsLock = new GVFSLock(mockTracer);
             this.ValidateLockIsFree(gvfsLock);
             NamedPipeMessages.LockData existingExternalHolder;
             gvfsLock.TryAcquireLockForExternalRequestor(DefaultLockData, out existingExternalHolder).ShouldBeTrue();
@@ -151,9 +194,9 @@ namespace GVFS.UnitTests.Common
             return gvfsLock;
         }
 
-        private GVFSLock AcquireGVFSLock()
+        private GVFSLock AcquireGVFSLock(ITracer mockTracer)
         {
-            GVFSLock gvfsLock = new GVFSLock(new MockTracer());
+            GVFSLock gvfsLock = new GVFSLock(mockTracer);
             this.ValidateLockIsFree(gvfsLock);
             gvfsLock.TryAcquireLockForGVFS().ShouldBeTrue();
             this.ValidateLockHeldByGVFS(gvfsLock);

--- a/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
@@ -16,7 +16,7 @@ namespace GVFS.UnitTests.Common
     [TestFixture]
     public class GitStatusCacheTests
     {
-        private static NamedPipeMessages.LockData statusCommandLockData = new NamedPipeMessages.LockData(123, false, false, "git status");
+        private static NamedPipeMessages.LockData statusCommandLockData = new NamedPipeMessages.LockData(123, false, false, "git status", "123");
 
         private MockFileSystem fileSystem;
         private MockGitProcess gitProcess;

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
@@ -14,20 +14,22 @@ namespace GVFS.UnitTests.Common
         public void LockData_FromBody_Parsing()
         {
             // Verify simple vanilla parsing
-            LockData lockDataBefore = new LockData(1, true, true, "git status --serialize=D:\\Sources\\tqoscy2l.ud0_status.tmp --ignored=matching --untracked-files=complete");
+            LockData lockDataBefore = new LockData(1, true, true, "git status --serialize=D:\\Sources\\tqoscy2l.ud0_status.tmp --ignored=matching --untracked-files=complete", "123");
             LockData lockDataAfter = LockData.FromBody(lockDataBefore.ToMessage());
             lockDataAfter.PID.ShouldEqual(1);
             lockDataAfter.IsElevated.ShouldEqual(true);
             lockDataAfter.CheckAvailabilityOnly.ShouldEqual(true);
             lockDataAfter.ParsedCommand.ShouldEqual("git status --serialize=D:\\Sources\\tqoscy2l.ud0_status.tmp --ignored=matching --untracked-files=complete");
+            lockDataAfter.GitCommandSessionId.ShouldEqual("123");
 
             // Verify strings with "|" will work
-            LockData lockDataWithPipeBefore = new LockData(1, true, true, "git commit -m 'message with a | and another |'");
+            LockData lockDataWithPipeBefore = new LockData(1, true, true, "git commit -m 'message with a | and another |'", "123|321");
             LockData lockDataWithPipeAfter = LockData.FromBody(lockDataWithPipeBefore.ToMessage());
             lockDataWithPipeAfter.PID.ShouldEqual(1);
             lockDataWithPipeAfter.IsElevated.ShouldEqual(true);
             lockDataWithPipeAfter.CheckAvailabilityOnly.ShouldEqual(true);
             lockDataWithPipeAfter.ParsedCommand.ShouldEqual("git commit -m 'message with a | and another |'");
+            lockDataWithPipeAfter.GitCommandSessionId.ShouldEqual("123|321");
 
             // Verify exception cases and messages
             this.ValidateError("1|true|true", "Invalid lock message. Expected at least 5 parts, got: 3 from message: '1|true|true'");

--- a/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NamedPipeTests.cs
@@ -10,8 +10,7 @@ namespace GVFS.UnitTests.Common
     public class NamedPipeTests
     {
         [TestCase]
-        [Category(CategoryConstants.ExceptionExpected)]
-        public void LockData_FromBody_Parsing()
+        public void LockData_FromBody_Simple()
         {
             // Verify simple vanilla parsing
             LockData lockDataBefore = new LockData(1, true, true, "git status --serialize=D:\\Sources\\tqoscy2l.ud0_status.tmp --ignored=matching --untracked-files=complete", "123");
@@ -21,7 +20,11 @@ namespace GVFS.UnitTests.Common
             lockDataAfter.CheckAvailabilityOnly.ShouldEqual(true);
             lockDataAfter.ParsedCommand.ShouldEqual("git status --serialize=D:\\Sources\\tqoscy2l.ud0_status.tmp --ignored=matching --untracked-files=complete");
             lockDataAfter.GitCommandSessionId.ShouldEqual("123");
+        }
 
+        [TestCase]
+        public void LockData_FromBody_WithDelimiters()
+        {
             // Verify strings with "|" will work
             LockData lockDataWithPipeBefore = new LockData(1, true, true, "git commit -m 'message with a | and another |'", "123|321");
             LockData lockDataWithPipeAfter = LockData.FromBody(lockDataWithPipeBefore.ToMessage());
@@ -30,19 +33,24 @@ namespace GVFS.UnitTests.Common
             lockDataWithPipeAfter.CheckAvailabilityOnly.ShouldEqual(true);
             lockDataWithPipeAfter.ParsedCommand.ShouldEqual("git commit -m 'message with a | and another |'");
             lockDataWithPipeAfter.GitCommandSessionId.ShouldEqual("123|321");
-
-            // Verify exception cases and messages
-            this.ValidateError("1|true|true", "Invalid lock message. Expected at least 5 parts, got: 3 from message: '1|true|true'");
-            this.ValidateError("blah|true|true|10|git status", "Invalid lock message. Expected PID, got: blah from message: 'blah|true|true|10|git status'");
-            this.ValidateError("1|true|1|10|git status", "Invalid lock message. Expected bool for checkAvailabilityOnly, got: 1 from message: '1|true|1|10|git status'");
-            this.ValidateError("1|1|true|10|git status", "Invalid lock message. Expected bool for isElevated, got: 1 from message: '1|1|true|10|git status'");
-            this.ValidateError("1|true|true|true|git status", "Invalid lock message. Expected command length, got: true from message: '1|true|true|true|git status'");
-            this.ValidateError("1|true|true|5|git status", "Invalid lock message. The parsedCommand is an unexpected length, got: 5 from message: '1|true|true|5|git status'");
         }
 
-        private void ValidateError(string body, string exceptionMessage)
+        [TestCase("1|true|true", "Invalid lock message. Expected at least 7 parts, got: 3 from message: '1|true|true'")]
+        [TestCase("123|true|true|10|git status", "Invalid lock message. Expected at least 7 parts, got: 5 from message: '123|true|true|10|git status'")]
+        [TestCase("blah|true|true|10|git status|9|sessionId", "Invalid lock message. Expected PID, got: blah from message: 'blah|true|true|10|git status|9|sessionId'")]
+        [TestCase("1|true|1|10|git status|9|sessionId", "Invalid lock message. Expected bool for checkAvailabilityOnly, got: 1 from message: '1|true|1|10|git status|9|sessionId'")]
+        [TestCase("1|1|true|10|git status|9|sessionId", "Invalid lock message. Expected bool for isElevated, got: 1 from message: '1|1|true|10|git status|9|sessionId'")]
+        [TestCase("1|true|true|true|git status|9|sessionId", "Invalid lock message. Expected command length, got: true from message: '1|true|true|true|git status|9|sessionId'")]
+        [TestCase("1|true|true|5|git status|9|sessionId", "Invalid lock message. Expected session id length, got: atus from message: '1|true|true|5|git status|9|sessionId'")]
+        [TestCase("1|true|true|10|git status|bad|sessionId", "Invalid lock message. Expected session id length, got: bad from message: '1|true|true|10|git status|bad|sessionId'")]
+        [TestCase("1|true|true|20|git status|9|sessionId", "Invalid lock message. Expected session id length, got: d from message: '1|true|true|20|git status|9|sessionId'")]
+        [TestCase("1|true|true|10|git status|5|sessionId", "Invalid lock message. The sessionId is an unexpected length, got: 5 from message: '1|true|true|10|git status|5|sessionId'")]
+        [TestCase("1|true|true|10|git status|20|sessionId", "Invalid lock message. The sessionId is an unexpected length, got: 20 from message: '1|true|true|10|git status|20|sessionId'")]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void LockData_FromBody_Exception(string body, string exceptionMessage)
         {
-            Assert.Throws<InvalidOperationException>(() => LockData.FromBody(body)).Message.Equals(exceptionMessage);
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => LockData.FromBody(body));
+            exception.Message.ShouldEqual(exceptionMessage);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -132,6 +132,10 @@ namespace GVFS.UnitTests.Mock.Common
             return TimeSpan.Zero;
         }
 
+        public void SetGitCommandSessionId(string sessionId)
+        {
+        }
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
+++ b/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
@@ -18,6 +18,7 @@ namespace GVFS.UnitTests.Tracing
             const EventOpcode opcode = EventOpcode.Start;
             const string enlistmentId = "test-enlistmentId";
             const string mountId = "test-mountId";
+            const string gitCommandSessionId = "test_sessionId";
             const string payload = "test-payload";
 
             Dictionary<string, object> expectedDict = new Dictionary<string, object>
@@ -31,6 +32,7 @@ namespace GVFS.UnitTests.Tracing
                 {
                     ["enlistmentId"] = enlistmentId,
                     ["mountId"] = mountId,
+                    ["gitCommandSessionId"] = gitCommandSessionId,
                     ["json"] = payload,
                 },
             };
@@ -46,6 +48,7 @@ namespace GVFS.UnitTests.Tracing
                 {
                     EnlistmentId = enlistmentId,
                     MountId = mountId,
+                    GitCommandSessionId = gitCommandSessionId,
                     Json = payload
                 },
             };
@@ -66,6 +69,7 @@ namespace GVFS.UnitTests.Tracing
             Assert.AreEqual(expectedPayloadDict.Count, actualPayloadDict.Count);
             Assert.AreEqual(expectedPayloadDict["enlistmentId"], actualPayloadDict["enlistmentId"]);
             Assert.AreEqual(expectedPayloadDict["mountId"], actualPayloadDict["mountId"]);
+            Assert.AreEqual(expectedPayloadDict["gitCommandSessionId"], actualPayloadDict["gitCommandSessionId"]);
             Assert.AreEqual(expectedPayloadDict["json"], actualPayloadDict["json"]);
         }
     }

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -164,7 +164,8 @@ namespace GVFS.UnitTests.Virtualization
                         pid: 0,
                         isElevated: false,
                         checkAvailabilityOnly: false,
-                        parsedCommand: "git dummy-command"),
+                        parsedCommand: "git dummy-command",
+                        gitCommandSessionId: "123"),
                     out denyMessage).ShouldBeFalse();
                 denyMessage.ShouldEqual("Waiting for GVFS to parse index and update placeholder files");
 
@@ -176,7 +177,8 @@ namespace GVFS.UnitTests.Virtualization
                         pid: 0,
                         isElevated: false,
                         checkAvailabilityOnly: false,
-                        parsedCommand: "git dummy-command"),
+                        parsedCommand: "git dummy-command",
+                        gitCommandSessionId: "123"),
                     out denyMessage).ShouldBeFalse();
                 denyMessage.ShouldEqual("Waiting for GVFS to parse index and update placeholder files");
 
@@ -188,7 +190,8 @@ namespace GVFS.UnitTests.Virtualization
                         pid: 0,
                         isElevated: false,
                         checkAvailabilityOnly: false,
-                        parsedCommand: "git dummy-command"),
+                        parsedCommand: "git dummy-command",
+                        gitCommandSessionId: "123"),
                     out denyMessage).ShouldBeFalse();
                 denyMessage.ShouldEqual("Waiting for GVFS to release the lock");
 
@@ -199,7 +202,8 @@ namespace GVFS.UnitTests.Virtualization
                         pid: 0,
                         isElevated: false,
                         checkAvailabilityOnly: false,
-                        parsedCommand: "git dummy-command"),
+                        parsedCommand: "git dummy-command",
+                        gitCommandSessionId: "123"),
                     out denyMessage).ShouldBeTrue();
                 denyMessage.ShouldEqual("Waiting for GVFS to release the lock");
 

--- a/GVFS/GVFS/CommandLine/UnmountVerb.cs
+++ b/GVFS/GVFS/CommandLine/UnmountVerb.cs
@@ -223,6 +223,7 @@ namespace GVFS.CommandLine
                             isConsoleOutputRedirectedToFile: GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
                             checkAvailabilityOnly: false,
                             gvfsEnlistmentRoot: enlistmentRoot,
+                            gitCommandSessionId: string.Empty,
                             result: out result))
                     {
                         this.ReportErrorAndExit("Unable to acquire the lock prior to unmount. " + result);


### PR DESCRIPTION
git trace2 creates a session id for the git command and by passing this
through to the mount process, logging will be able to have this correlation
id to be able to join the git trace2 data with any logged data from the mount
process.