### PR TITLE
Fix GVFS.FunctionalTests.Windows so that they can be run from the IDE

### DIFF
--- a/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
+++ b/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
@@ -186,7 +186,8 @@
       xcopy /Y $(BuildOutputDir)\FastFetch\bin\$(Platform)\$(Configuration)\* $(TargetDir)
       xcopy /Y $(BuildOutputDir)\GVFS.NativeTests\bin\$(Platform)\$(Configuration)\* $(TargetDir)
       xcopy /Y $(BuildOutputDir)\GVFS.Hooks.Windows\bin\$(Platform)\$(Configuration)\* $(TargetDir)
-      xcopy /Y $(BuildOutputDir)\GVFS.FunctionalTests.LockHolder\bin\$(Platform)\$(Configuration)\netcoreapp2.1\* $(TargetDir)
+      mkdir  $(TargetDir)\netcoreapp2.1
+      xcopy /Y $(BuildOutputDir)\GVFS.FunctionalTests.LockHolder\bin\$(Platform)\$(Configuration)\netcoreapp2.1\* $(TargetDir)\netcoreapp2.1
 
       REM If there is an inbox version of the ProjFS dll, we must use that one to guarantee compat with the sys, so delete whatever is in our TargetDir
       if exist c:\Windows\System32\ProjectedFSLib.dll del $(TargetDir)\ProjectedFSLib.dll


### PR DESCRIPTION
The `xcopy` step was overwriting .NET Framework assemblies with .NET Core assemblies, and as a result Test.GVFS.Service was unable to start when running the functional tests locally.

The tests were passing on the build machine because they are run against the installed version of VFS4G rather than the version in the functional tests output directory.

I am still not sure how this code was working:

```
// On Windows, FT is run from the Output directory of GVFS.FunctionalTest project.
// LockHolder is a .netcore assembly and can be found inside netcoreapp2.1
// subdirectory of GVFS.FunctionalTest Output directory.
return Path.Combine(
    Settings.Default.CurrentDirectory,
    "netcoreapp2.1",
    LockHolderCommand);
```

Because as best as I could tell the "netcoreapp2.1" folder was not getting created.