### PR TITLE
Credentials: consistently use usehttppath for dev.azure.com scope

### DIFF
--- a/GVFS/GVFS.Common/Git/GitConfigSetting.cs
+++ b/GVFS/GVFS.Common/Git/GitConfigSetting.cs
@@ -6,7 +6,7 @@ namespace GVFS.Common.Git
     {
         public const string CoreVirtualizeObjectsName = "core.virtualizeobjects";
         public const string CoreVirtualFileSystemName = "core.virtualfilesystem";
-        public const string CredentialUseHttpPath = "credential.useHttpPath";
+        public const string CredentialUseHttpPath = "credential.\"https://dev.azure.com\".useHttpPath";
 
         public const string HttpSslCert = "http.sslcert";
         public const string HttpSslVerify = "http.sslverify";

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -179,7 +179,7 @@ namespace GVFS.Common.Git
             string stdinConfig = sb.ToString();
 
             this.InvokeGitOutsideEnlistment(
-                "credential reject",
+                GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
                 null);
         }
@@ -195,7 +195,7 @@ namespace GVFS.Common.Git
             string stdinConfig = sb.ToString();
 
             this.InvokeGitOutsideEnlistment(
-                "credential approve",
+                GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
                 null);
         }
@@ -269,7 +269,7 @@ namespace GVFS.Common.Git
             using (ITracer activity = tracer.StartActivity("TryGetCredentials", EventLevel.Informational))
             {
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
-                    $"-c {GitConfigSetting.CredentialUseHttpPath}=true credential fill",
+                    GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
                     parseStdOutLine: null);
 
@@ -758,6 +758,11 @@ namespace GVFS.Common.Git
             {
                 this.executingProcess = null;
             }
+        }
+
+        private static string GenerateCredentialVerbCommand(string verb)
+        {
+            return $"-c {GitConfigSetting.CredentialUseHttpPath}=true credential {verb}";
         }
 
         private static string ParseValue(string contents, string prefix)

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -262,11 +262,11 @@ namespace GVFS.UnitTests.Git
             int approvals = 0;
             int rejections = 0;
             gitProcess.SetExpectedCommandResult(
-                "-c credential.useHttpPath=true credential fill",
+                "-c credential.\"https://dev.azure.com\".useHttpPath=true credential fill",
                 () => new GitProcess.Result("username=username\r\npassword=password" + rejections + "\r\n", string.Empty, GitProcess.Result.SuccessCode));
 
             gitProcess.SetExpectedCommandResult(
-                "credential approve",
+                "-c credential.\"https://dev.azure.com\".useHttpPath=true credential approve",
                 () =>
                 {
                     approvals++;
@@ -274,7 +274,7 @@ namespace GVFS.UnitTests.Git
                 });
 
             gitProcess.SetExpectedCommandResult(
-                "credential reject",
+                "-c credential.\"https://dev.azure.com\".useHttpPath=true credential reject",
                 () =>
                 {
                     rejections++;


### PR DESCRIPTION
The git credential commands are not consistent in whether they set
usehttppath or not. This can lead to inconsistencies in how credentials
are generatated and cleared. VFSForGit might retrieve / create
credentials using the full http path, but clear with the only the host
name. This leads to the incorrect behavior where VFSForGit is unable to
erase bad / stale credentials.

Additionally, only dev.azure.com URLs need to set the useHttpPath
setting - so scope it to these URLs.