### PR TITLE
Fix EventMetadata construction in TryDownloadPrefetchPacks

### DIFF
--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -151,9 +151,8 @@ namespace GVFS.Common.Git
                     }
                     else
                     {
-                        EventMetadata error = CreateEventMetadata();
+                        EventMetadata error = CreateEventMetadata(result.Error);
                         error.Add("latestTimestamp", latestTimestamp);
-                        error.Add("Exception", result.Error);
                         error.Add(nameof(this.GitObjectRequestor.CacheServer.PrefetchEndpointUrl), this.GitObjectRequestor.CacheServer.PrefetchEndpointUrl);
                         activity.RelatedWarning(error, "DownloadPrefetchPacks failed.", Keywords.Telemetry);
                     }


### PR DESCRIPTION
Fixes #960 

`TryDownloadPrefetchPacks` was not calling `ToString` on the exception it was adding to the `EventMetadata`.  Rather that calling `ToString` the code has been updated to pass the exception to `CreateEventMetadata` which will do the right thing.