### PR TITLE
Install GVFS.Service as a Launch Agent on Mac

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -38,6 +38,7 @@ STAGINGDIR="${BUILDOUTPUTDIR}/Staging"
 PACKAGESTAGINGDIR="${BUILDOUTPUTDIR}/Packages"
 VFSFORGITDESTINATION="usr/local/vfsforgit"
 DAEMONPLISTDESTINATION="Library/LaunchDaemons"
+AGENTPLISTDESTINATION="Library/LaunchAgents"
 LIBRARYEXTENSIONSDESTINATION="Library/Extensions"
 INSTALLERPACKAGENAME="VFSForGit.$PACKAGEVERSION"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
@@ -75,6 +76,9 @@ function CreateInstallerRoot()
     
     mkdirBin="mkdir -p \"${STAGINGDIR}/$DAEMONPLISTDESTINATION\""
     eval $mkdirBin || exit 1
+    
+    mkdirBin="mkdir -p \"${STAGINGDIR}/$AGENTPLISTDESTINATION\""
+    eval $mkdirBin || exit 1
 }
 
 function CopyBinariesToInstall()
@@ -105,6 +109,9 @@ function CopyBinariesToInstall()
     
     copyPrjFS="cp -Rf \"${VFS_OUTPUTDIR}/ProjFS.Mac/Native/$CONFIGURATION/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist\" \"${STAGINGDIR}/${DAEMONPLISTDESTINATION}/.\""
     eval $copyPrjFS || exit 1
+    
+    copyServicePlist="cp -Rf \"${SOURCEDIRECTORY}/../GVFS.Service/Mac/org.vfsforgit.service.plist\" \"${STAGINGDIR}/${AGENTPLISTDESTINATION}/.\""
+    eval $copyServicePlist || exit 1
     
     currentDirectory=`pwd`
     cd "${STAGINGDIR}/usr/local/bin"

--- a/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
+++ b/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
+    <title>VFS For Git</title>
     <pkg-ref id="com.vfsforgit.pkg"/>
     <pkg-ref id="com.git.pkg"/>
     <options customize="never" allow-external-scripts="true"/>

--- a/GVFS/GVFS.Installer.Mac/scripts/postinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/postinstall
@@ -2,3 +2,17 @@
 loadCmd="sudo launchctl load -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
 echo "Loading PrjFSKextLogDaemon: '$loadCmd'..."
 eval $loadCmd || exit 1
+
+# Load Service in all active User sessions
+# There will be one loginwindow instance for each logged in user, 
+# get its uid (this will correspond to the logged in user's id.) 
+# Then use launchctl bootstrap gui/uid to auto load the Service 
+# for each user.
+servicePlist="/Library/LaunchAgents/org.vfsforgit.service.plist"
+if [ -f "${servicePlist}" ]; then
+    for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+        loadCmd="launchctl bootstrap gui/$uid ${servicePlist}"
+        echo "Loading Service: '$loadCmd'..."
+        eval $loadCmd || exit 1
+    done    
+fi

--- a/GVFS/GVFS.Installer.Mac/scripts/preinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/preinstall
@@ -5,6 +5,20 @@ if [ -f /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist ]; t
     eval $unloadCmd || exit 1
 fi
 
+# Unload Service in all active User sessions
+# There will be one loginwindow instance for each logged in user, 
+# get its uid (this will correspond to the logged in user's id.) 
+# Then use launchctl bootstrap gui/uid to auto load the Service 
+# for each user.
+servicePlist="/Library/LaunchAgents/org.vfsforgit.service.plist"
+if [ -f "${servicePlist}" ]; then
+    for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+        unloadCmd="launchctl bootout gui/$uid ${servicePlist}"
+        echo "Unloading Service: '$unloadCmd'..."
+        eval $unloadCmd || exit 1
+    done    
+fi
+
 KEXTBUNDLEID="org.vfsforgit.PrjFSKext"
 isKextLoadedCmd="/usr/sbin/kextstat -l -b $KEXTBUNDLEID | wc -l"
 isKextLoaded=$(eval $isKextLoadedCmd)

--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -4,7 +4,9 @@ KEXTFILENAME="PrjFSKext.kext"
 VFSFORDIRECTORY="/usr/local/vfsforgit"
 PRJFSKEXTDIRECTORY="/Library/Extensions"
 LAUNCHDAEMONDIRECTORY="/Library/LaunchDaemons"
+LAUNCHAGENTDIRECTORY="/Library/LaunchAgents"
 LOGDAEMONLAUNCHDFILENAME="org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
+SERVICEAGENTLAUNCHDFILENAME="org.vfsforgit.service.plist"
 GVFSCOMMANDPATH="/usr/local/bin/gvfs"
 UNINSTALLERCOMMANDPATH="/usr/local/bin/uninstall_vfsforgit.sh"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
@@ -39,6 +41,23 @@ function UnInstallVFSForGit()
         echo "$unloadCmd..."
         eval $unloadCmd || exit 1
         rmCmd="sudo /bin/rm -Rf ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
+        echo "$rmCmd..."
+        eval $rmCmd || exit 1
+    fi
+    
+    # Unloading Service LaunchAgent for each user
+    # There will be one loginwindow instance for each logged in user, 
+    # get its uid (this will correspond to the logged in user's id.) 
+    # Then use launchctl bootstrap gui/uid to auto load the Service 
+    # for each user.
+    if [ -f "${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME" ]; then
+        for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+            unloadCmd="sudo launchctl bootout gui/$uid ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME"
+            echo "$unloadCmd..."
+            eval $unloadCmd || exit 1
+        done
+        
+        rmCmd="sudo /bin/rm -Rf ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME"
         echo "$rmCmd..."
         eval $rmCmd || exit 1
     fi

--- a/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
+++ b/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.vfsforgit.service</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/share/dotnet/dotnet</string>
+        <string>/usr/local/vfsforgit/GVFS.Service.dll</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/usr/local/vfsforgit</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>OnDemand</key>
+    <false/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/> 
+</dict>
+</plist>


### PR DESCRIPTION
#### Install GVFS.Service as a Launch Agent on Mac

* Added new Launchd plist for GVFS.Service. 
* Updated Mac installer to auto-load the Service as a User agent for all logged in users. 
* Updated Uninstaller to unload the service. 
* Also added title text to Mac installer.