### PR TITLE
[Linux] Remove Mono dependency from Linux MirrorProvider

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -106,18 +106,21 @@ namespace MirrorProvider.Linux
                     else
                     {
                         string childRelativePath = Path.Combine(relativePath, child.Name);
+                        string childFullPathInMirror = this.GetFullPathInMirror(childRelativePath);
                         NativeMethods.StatBuffer statBuffer = new NativeMethods.StatBuffer();
+                        byte[] childFullPathInMirrorBuf = GetBytesUTF8(childFullPathInMirror);
+                        int statResult;
                         unsafe
                         {
-                            //// TODO(Linux): need to marshal from UTF8
-                            IntPtr childFullPathInMirror = Marshal.StringToHGlobalAnsi(this.GetFullPathInMirror(childRelativePath));
-                            int statResult = NativeMethods.LStat((byte*)childFullPathInMirror, out statBuffer);
-                            Marshal.FreeHGlobal(childFullPathInMirror);
-                            if (statResult == -1)
+                            fixed (byte* childFullPathInMirrorPtr = childFullPathInMirrorBuf)
                             {
-                                Console.WriteLine($"NativeMethods.LStat failed: {Marshal.GetLastWin32Error()}");
-                                return Result.EIOError;
+                                statResult = NativeMethods.LStat(childFullPathInMirrorPtr, out statBuffer);
                             }
+                        }
+                        if (statResult == -1)
+                        {
+                            Console.WriteLine($"NativeMethods.LStat failed: {Marshal.GetLastWin32Error()}");
+                            return Result.EIOError;
                         }
                         uint fileMode = statBuffer.Mode & 0xFFF;  // 07777 = ALLPERMS
 
@@ -235,24 +238,24 @@ namespace MirrorProvider.Linux
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
             symLinkTarget = null;
+            string fullPathInMirror = this.GetFullPathInMirror(relativePath);
+            byte[] fullPathInMirrorBuf = GetBytesUTF8(fullPathInMirror);
             const ulong BufSize = 4096;
             byte[] targetBuffer = new byte[BufSize];
+            long bytesRead;
             unsafe
             {
-                fixed (byte* bufPtr = targetBuffer)
+                fixed (byte* fullPathInMirrorPtr = fullPathInMirrorBuf, bufPtr = targetBuffer)
                 {
-                    //// TODO(Linux): need to marshal from UTF8
-                    IntPtr fullPathInMirror = Marshal.StringToHGlobalAnsi(this.GetFullPathInMirror(relativePath));
-                    long bytesRead = NativeMethods.Readlink((byte*)fullPathInMirror, bufPtr, BufSize);
-                    Marshal.FreeHGlobal(fullPathInMirror);
-                    if (bytesRead < 0)
-                    {
-                        Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
-                        return false;
-                    }
-                    targetBuffer[bytesRead] = 0;
+                    bytesRead = NativeMethods.Readlink(fullPathInMirrorPtr, bufPtr, BufSize);
                 }
             }
+            if (bytesRead < 0)
+            {
+                Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
+                return false;
+            }
+            targetBuffer[bytesRead] = 0;
             symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
             if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
@@ -273,6 +276,14 @@ namespace MirrorProvider.Linux
             bytes[0] = version;
 
             return bytes;
+        }
+
+        private static byte[] GetBytesUTF8(string str)
+        {
+            int bufLen = Encoding.UTF8.GetByteCount(str);
+            byte[] buf = new byte[bufLen + 1];
+            Encoding.UTF8.GetBytes(str, 0, str.Length, buf, 0);
+            return buf;
         }
 
         private static unsafe class NativeMethods

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -108,14 +108,10 @@ namespace MirrorProvider.Linux
                         string childRelativePath = Path.Combine(relativePath, child.Name);
                         string childFullPathInMirror = this.GetFullPathInMirror(childRelativePath);
                         NativeMethods.StatBuffer statBuffer = new NativeMethods.StatBuffer();
-                        byte[] childFullPathInMirrorBuf = GetBytesUTF8(childFullPathInMirror);
                         int statResult;
                         unsafe
                         {
-                            fixed (byte* childFullPathInMirrorPtr = childFullPathInMirrorBuf)
-                            {
-                                statResult = NativeMethods.LStat(childFullPathInMirrorPtr, out statBuffer);
-                            }
+                            statResult = NativeMethods.LStat(childFullPathInMirror, out statBuffer);
                         }
                         if (statResult == -1)
                         {
@@ -239,22 +235,16 @@ namespace MirrorProvider.Linux
         {
             symLinkTarget = null;
             string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-            byte[] fullPathInMirrorBuf = GetBytesUTF8(fullPathInMirror);
+
             const ulong BufSize = 4096;
             byte[] targetBuffer = new byte[BufSize];
-            long bytesRead;
-            unsafe
-            {
-                fixed (byte* fullPathInMirrorPtr = fullPathInMirrorBuf, bufPtr = targetBuffer)
-                {
-                    bytesRead = NativeMethods.Readlink(fullPathInMirrorPtr, bufPtr, BufSize);
-                }
-            }
+            long bytesRead = ReadLink(fullPathInMirror, targetBuffer, BufSize);
             if (bytesRead < 0)
             {
                 Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
                 return false;
             }
+
             targetBuffer[bytesRead] = 0;
             symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
@@ -276,14 +266,6 @@ namespace MirrorProvider.Linux
             bytes[0] = version;
 
             return bytes;
-        }
-
-        private static byte[] GetBytesUTF8(string str)
-        {
-            int bufLen = Encoding.UTF8.GetByteCount(str);
-            byte[] buf = new byte[bufLen + 1];
-            Encoding.UTF8.GetBytes(str, 0, str.Length, buf, 0);
-            return buf;
         }
 
         private static unsafe class NativeMethods
@@ -321,17 +303,20 @@ namespace MirrorProvider.Linux
                 public long[] Reserved;     /* RESERVED: DO NOT USE! */
             }
 
-            public static int LStat(byte *name, [Out] out StatBuffer buf)
+            public static int LStat(string pathname, [Out] out StatBuffer buf)
             {
-                return __LXStat64(STAT_VER, name, out buf);
+                return __LXStat64(STAT_VER, pathname, out buf);
             }
 
             // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
             [DllImport("libc", EntryPoint = "__lxstat64", SetLastError = true)]
-            public static extern int __LXStat64(int vers, byte* name, [Out] out StatBuffer buf);
-
-            [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
-            public static extern long Readlink(byte* name, byte* buf, ulong bufsiz);
+            private static extern int __LXStat64(int vers, string pathname, [Out] out StatBuffer buf);
         }
+
+        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+        private static extern long ReadLink(
+            string path,
+            byte[] buf,
+            ulong bufsize);
     }
 }

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -3,7 +3,6 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using Mono.Unix.Native;
 
 namespace MirrorProvider.Linux
 {
@@ -107,12 +106,20 @@ namespace MirrorProvider.Linux
                     else
                     {
                         string childRelativePath = Path.Combine(relativePath, child.Name);
-                        int statResult = Syscall.lstat(this.GetFullPathInMirror(childRelativePath), out Stat stat);
-                        if (statResult == -1)
+                        NativeMethods.StatBuffer statBuffer = new NativeMethods.StatBuffer();
+                        unsafe
                         {
-                            return Result.EIOError;
+                            //// TODO(Linux): need to marshal from UTF8
+                            IntPtr childFullPathInMirror = Marshal.StringToHGlobalAnsi(this.GetFullPathInMirror(childRelativePath));
+                            int statResult = NativeMethods.LStat((byte*)childFullPathInMirror, out statBuffer);
+                            Marshal.FreeHGlobal(childFullPathInMirror);
+                            if (statResult == -1)
+                            {
+                                Console.WriteLine($"NativeMethods.LStat failed: {Marshal.GetLastWin32Error()}");
+                                return Result.EIOError;
+                            }
                         }
-                        uint fileMode = (uint)(stat.st_mode & FilePermissions.ALLPERMS);
+                        uint fileMode = statBuffer.Mode & 0xFFF;  // 07777 = ALLPERMS
 
                         Result result = this.virtualizationInstance.WritePlaceholderFile(
                             childRelativePath,
@@ -228,18 +235,24 @@ namespace MirrorProvider.Linux
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
             symLinkTarget = null;
-            string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-
             const ulong BufSize = 4096;
             byte[] targetBuffer = new byte[BufSize];
-            long bytesRead = Syscall.readlink(fullPathInMirror, targetBuffer);
-            if (bytesRead < 0)
+            unsafe
             {
-                Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
-                return false;
+                fixed (byte* bufPtr = targetBuffer)
+                {
+                    //// TODO(Linux): need to marshal from UTF8
+                    IntPtr fullPathInMirror = Marshal.StringToHGlobalAnsi(this.GetFullPathInMirror(relativePath));
+                    long bytesRead = NativeMethods.Readlink((byte*)fullPathInMirror, bufPtr, BufSize);
+                    Marshal.FreeHGlobal(fullPathInMirror);
+                    if (bytesRead < 0)
+                    {
+                        Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
+                        return false;
+                    }
+                    targetBuffer[bytesRead] = 0;
+                }
             }
-
-            targetBuffer[bytesRead] = 0;
             symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
             if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
@@ -260,6 +273,54 @@ namespace MirrorProvider.Linux
             bytes[0] = version;
 
             return bytes;
+        }
+
+        private static unsafe class NativeMethods
+        {
+            // #define _STAT_VER   1
+            private static readonly int STAT_VER = 1;
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct TimeSpec
+            {
+                public long Sec;
+                public long Nsec;
+            }
+
+            // TODO(Linux): assumes stat64 field layout of x86-64 architecture
+            [StructLayout(LayoutKind.Sequential)]
+            public struct StatBuffer
+            {
+                public ulong Dev;           /* ID of device containing file */
+                public ulong Ino;           /* File serial number */
+                public ulong NLink;         /* Number of hard links */
+                public uint Mode;           /* Mode of file (see below) */
+                public uint UID;            /* User ID of the file */
+                public uint GID;            /* Group ID of the file */
+                public uint Padding;        /* RESERVED: DO NOT USE! */
+                public ulong RDev;          /* Device ID if special file */
+                public long Size;           /* file size, in bytes */
+                public long BlkSize;        /* optimal blocksize for I/O */
+                public long Blocks;         /* blocks allocated for file */
+                public TimeSpec ATimespec;  /* time of last access */
+                public TimeSpec MTimespec;  /* time of last data modification */
+                public TimeSpec CTimespec;  /* time of last status change */
+
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+                public long[] Reserved;     /* RESERVED: DO NOT USE! */
+            }
+
+            public static int LStat(byte *name, [Out] out StatBuffer buf)
+            {
+                return __LXStat64(STAT_VER, name, out buf);
+            }
+
+            // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
+            [DllImport("libc", EntryPoint = "__lxstat64", SetLastError = true)]
+            public static extern int __LXStat64(int vers, byte* name, [Out] out StatBuffer buf);
+
+            [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+            public static extern long Readlink(byte* name, byte* buf, ulong bufsiz);
         }
     }
 }

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -106,13 +106,7 @@ namespace MirrorProvider.Linux
                     else
                     {
                         string childRelativePath = Path.Combine(relativePath, child.Name);
-                        string childFullPathInMirror = this.GetFullPathInMirror(childRelativePath);
-                        NativeMethods.StatBuffer statBuffer = new NativeMethods.StatBuffer();
-                        int statResult;
-                        unsafe
-                        {
-                            statResult = NativeMethods.LStat(childFullPathInMirror, out statBuffer);
-                        }
+                        int statResult = NativeMethods.LStat(this.GetFullPathInMirror(childRelativePath), out NativeMethods.StatBuffer statBuffer);
                         if (statResult == -1)
                         {
                             Console.WriteLine($"NativeMethods.LStat failed: {Marshal.GetLastWin32Error()}");
@@ -268,7 +262,7 @@ namespace MirrorProvider.Linux
             return bytes;
         }
 
-        private static unsafe class NativeMethods
+        private static class NativeMethods
         {
             // #define _STAT_VER   1
             private static readonly int STAT_VER = 1;

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -40,7 +40,4 @@
     <None Include="$(BuildOutputDir)\ProjFS.Linux\Native\Build\Products\$(Configuration)\libprojfs.so" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   -->
-  <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-  </ItemGroup>
 </Project>

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -19,14 +19,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType></DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE;RELEASE</DefineConstants>

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -19,12 +19,14 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType></DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE;RELEASE</DefineConstants>

--- a/MirrorProvider/Scripts/Linux/Build.sh
+++ b/MirrorProvider/Scripts/Linux/Build.sh
@@ -11,9 +11,27 @@ SRCDIR=$SCRIPTDIR/../../..
 ROOTDIR=$SRCDIR/..
 SLN=$SRCDIR/MirrorProvider/MirrorProvider.sln
 
+ARCH=$(uname -m)
+if test "$ARCH" != "x86_64"; then
+  >&2 echo "architecture must be x86_64 for struct stat; stopping"
+  exit 1
+fi
+
+CC=${CC:-cc}
+
+echo 'main(){int i=1;const char *n="n";struct stat b;i=__lxstat64(i,n,&b);}' | \
+  cc -xc -include sys/stat.h -o /dev/null - 2>/dev/null
+
+if test $? != 0; then
+  >&2 echo "__lxstat64() not found in libc ABI; stopping"
+  exit 1
+fi
+
 # Build the ProjFS library interface
-$SRCDIR/ProjFS.Linux/Scripts/Build.sh $CONFIGURATION
+$SRCDIR/ProjFS.Linux/Scripts/Build.sh $CONFIGURATION || exit 1
 
 # Build the MirrorProvider
 dotnet restore $SLN /p:Configuration="$CONFIGURATION.Linux" --packages $ROOTDIR/packages
 dotnet build $SLN --configuration $CONFIGURATION.Linux
+
+exit 0


### PR DESCRIPTION
@jrbriggs and @wilbaker -- after the rebase in #976, would you be able to look at this PR which removes the Mono dependency in the Linux `MirrorProvider`?

The one question mark I have is that I've tied the implementation to systems with GNU libc-compatible ABIs for `libc.so` and also to those with `struct stat` field layouts as found on x86 64-bit architectures.  See my ["item A" comments](https://github.com/Microsoft/VFSForGit/pull/848#issuecomment-476827046) in #848 for more background, but it basically boils down to the heterogeneity and history of implementations of `stat(2)` and friends.  If this seems too fragile to you (or you, @kivikakk) for the longer-term, we could definitely add a small wrapper `.so` library around `stat()`, `lstat()`, etc.

/cc @kivikakk