### PR TITLE
Mac kext: Replaces use of OSAtomic with standard C11 atomic operations

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -1,9 +1,7 @@
 #include <kern/debug.h>
 #include <sys/kauth.h>
 #include <sys/proc.h>
-#include <libkern/OSAtomic.h>
 #include <kern/assert.h>
-#include <stdatomic.h>
 
 #include "public/PrjFSCommon.h"
 #include "public/PrjFSPerfCounter.h"
@@ -15,6 +13,7 @@
 #include "PrjFSProviderUserClient.hpp"
 #include "PerformanceTracing.hpp"
 #include "kernel-header-wrappers/mount.h"
+#include "kernel-header-wrappers/stdatomic.h"
 #include "KextLog.hpp"
 #include "ProviderMessaging.hpp"
 #include "public/PrjFSXattrs.h"

--- a/ProjFS.Mac/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/Locks.hpp
@@ -1,13 +1,13 @@
 #ifndef Locks_h
 #define Locks_h
 
-#if DEBUG
-// Enables validation of shared/exclusive lock invariants and owner checking
+#if DEBUG && !defined(KEXT_UNIT_TESTING)
+// Enables validation of shared/exclusive lock invariants and owner checking (unit tests will use their own checks)
 #define PRJFS_LOCK_CORRECTNESS_CHECKS 1
 #endif
 
 #include <mach/kern_return.h>
-#include <stdint.h>
+#include "kernel-header-wrappers/stdatomic.h"
 
 typedef struct __lck_mtx_t__ lck_mtx_t;
 typedef struct { lck_mtx_t* p; } Mutex;
@@ -31,8 +31,8 @@ struct RWLock
     lck_rw_t* p;
 #if PRJFS_LOCK_CORRECTNESS_CHECKS
     struct thread* exclOwner;
-    uint32_t sharedOwnersXor;
-    uint32_t sharedOwnersCount;
+    atomic_uint_least32_t sharedOwnersXor;
+    atomic_uint_least32_t sharedOwnersCount;
 #endif
 };
 

--- a/ProjFS.Mac/PrjFSKext/PerformanceTracing.cpp
+++ b/ProjFS.Mac/PrjFSKext/PerformanceTracing.cpp
@@ -1,7 +1,7 @@
 #include "PerformanceTracing.hpp"
 #include "KextLog.hpp"
+#include "kernel-header-wrappers/stdatomic.h"
 #include <sys/types.h>
-#include <stdatomic.h>
 #include <IOKit/IOUserClient.h>
 
 #if PRJFS_PERFORMANCE_TRACING_ENABLE

--- a/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
@@ -7,7 +7,6 @@
 #include "VirtualizationRoots.hpp"
 
 #include <IOKit/IOLib.h>
-#include <libkern/OSAtomic.h>
 #include <kern/assert.h>
 #include <sys/proc.h>
 

--- a/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
+++ b/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
@@ -1,10 +1,10 @@
 #include "ProviderMessaging.hpp"
 #include "Locks.hpp"
 #include "KextLog.hpp"
+#include "kernel-header-wrappers/stdatomic.h"
 
 #include <kern/assert.h>
 #include <sys/proc.h>
-#include <libkern/OSAtomic.h>
 #include <sys/kauth.h>
 
 // Structs
@@ -22,7 +22,7 @@ struct OutstandingMessage
 // State
 static LIST_HEAD(OutstandingMessage_Head, OutstandingMessage) s_outstandingMessages = LIST_HEAD_INITIALIZER(OutstandingMessage_Head);
 static Mutex s_outstandingMessagesMutex = {};
-static volatile int s_nextMessageId;
+static atomic_uint_least64_t s_nextMessageId;
 static volatile bool s_isShuttingDown;
 
 
@@ -151,7 +151,7 @@ bool ProviderMessaging_TrySendRequestAndWaitForResponse(
         relativePath = VirtualizationRoot_GetRootRelativePath(root, vnodePath);
     }
     
-    int nextMessageId = OSIncrementAtomic(&s_nextMessageId);
+    uint64_t nextMessageId = atomic_fetch_add(&s_nextMessageId, UINT64_C(1));
     
     Message messageSpec = {};
     Message_Init(

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -1,6 +1,5 @@
 #include <kern/debug.h>
 #include <kern/assert.h>
-#include <stdatomic.h>
 
 #include "public/PrjFSCommon.h"
 #include "public/PrjFSXattrs.h"
@@ -12,6 +11,7 @@
 #include "PrjFSProviderUserClient.hpp"
 #include "ProviderMessaging.hpp"
 #include "kernel-header-wrappers/mount.h"
+#include "kernel-header-wrappers/stdatomic.h"
 #include "VnodeUtilities.hpp"
 #include "PerformanceTracing.hpp"
 

--- a/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
+++ b/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef KEXT_UNIT_TESTING
+#include <atomic>
+#define _Atomic(X) std::atomic< X >
+using std::atomic_uint_least32_t;
+using std::atomic_uint_least64_t;
+using std::atomic_int;
+using std::memory_order_seq_cst;
+#else
+#include <stdatomic.h>
+#endif


### PR DESCRIPTION
The OSAtomic APIs are not available in that form in user space, and so caused errors when attempting to call functions (`ProviderMessaging_TrySendRequestAndWaitForResponse()`!) that use them in the kext testing target. The similar user space equivalents are already deprecated in any case, so replacing the kext versions' use with the standardised C11 operations is the sensible choice.