### PR TITLE
Added Code Coverage to build

### DIFF
--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -9,6 +9,7 @@ SCRIPTDIR=$(dirname ${BASH_SOURCE[0]})
 SRCDIR=$SCRIPTDIR/../..
 ROOTDIR=$SRCDIR/..
 PACKAGES=$ROOTDIR/packages
+COVERAGEDIR=$ROOTDIR/BuildOutput/ProjFS.Mac/Coverage
 
 PROJFS=$SRCDIR/ProjFS.Mac
 
@@ -21,8 +22,71 @@ fi
 
 # Run Tests and put output into a xml file
 set -o pipefail
-xcodebuild -configuration $CONFIGURATION -project $PROJFS/PrjFS.xcodeproj -scheme 'Build All' test | xcpretty -r junit --output $PROJFS/TestResultJunit.xml || exit 1
+xcodebuild -configuration $CONFIGURATION -enableCodeCoverage YES -project $PROJFS/PrjFS.xcodeproj -derivedDataPath $COVERAGEDIR -scheme 'Build All' test | xcpretty -r junit --output $PROJFS/TestResultJunit.xml || exit 1
 set +o pipefail
+
+while read -rd $'\0' file; do
+  COVERAGE_FILE="$file"
+done < <(find $COVERAGEDIR -name "*xccovreport" -print0)
+
+if [[ $COVERAGE_FILE == "" ]]; then
+  echo "Error: No coverage file found"
+  exit 1
+fi
+
+# xcperfect will display pretty output for code coverage.  The terminal output isn't supported by our build system yet, but a bug has been filed.  Once support is added we'll switch to the prettier format.
+#if !(gem list --local | grep xcperfect); then
+#  echo "Attempting to run 'sudo gem install xcperfect'.  This may ask you for your password to gain admin privileges"
+#  sudo gem install xcperfect
+#fi
+#xcrun xccov view "$COVERAGE_FILE" --json | TERM=xterm-256color xcperfect
+
+printf "\n\nCode Coverage Report\n"
+xcrun xccov view "$COVERAGE_FILE" | tee $PROJFS/CoverageResult.txt 
+
+# Fail on any line that doesn't show %100 coverage and isn't on the exclusion list or hpp/cpp
+while read line; do
+  if [[ $line != *"100.00%"* ]] && 
+     [[ $line == *"%"* ]] && 
+	 [[ $line != *"KauthHandler_Init"* ]] && 
+	 [[ $line != *"KauthHandler_Cleanup"* ]] && 
+	 [[ $line != *"UseMainForkIfNamedStream"* ]] &&                  #SHOULD ADD COVERAGE
+	 [[ $line != *"HandleVnodeOperation"* ]] &&                      #SHOULD ADD COVERAGE
+	 [[ $line != *"HandleFileOpOperation"* ]] &&                     #SHOULD ADD COVERAGE
+	 [[ $line != *"TryGetVirtualizationRoot"* ]] &&                  #SHOULD ADD COVERAGE
+	 [[ $line != *"CurrentProcessWasSpawnedByRegularUser"* ]] &&     #SHOULD ADD COVERAGE
+	 [[ $line != *"ShouldHandleFileOpEvent"* ]] &&                   #SHOULD ADD COVERAGE
+	 [[ $line != *"ShouldIgnoreVnodeType"* ]] &&                     #SHOULD ADD COVERAGE
+	 [[ $line != *"WaitForListenerCompletion"* ]] && 
+	 [[ $line != *"KextLog_"* ]] && 
+	 [[ $line != *"Definition"* ]] && 
+	 [[ $line != *"PerfTracer"* ]] && 
+	 [[ $line != *"VirtualizationRoot_GetActiveProvider"* ]] &&      #SHOULD ADD COVERAGE
+	 [[ $line != *"VirtualizationRoots_Init"* ]] && 
+	 [[ $line != *"VirtualizationRoots_Cleanup"* ]] && 
+	 [[ $line != *"FindOrDetectRootAtVnode"* ]] &&                   #SHOULD ADD COVERAGE
+	 [[ $line != *"FindUnusedIndexOrGrow_Locked"* ]] &&              #SHOULD ADD COVERAGE
+	 [[ $line != *"FindRootAtVnode_Locked"* ]] &&                    #SHOULD ADD COVERAGE
+	 [[ $line != *"ActiveProvider_"* ]] && 
+	 [[ $line != *"GetRelativePath"* ]] && 
+	 [[ $line != *"VirtualizationRoot_GetRootRelativePath"* ]] && 
+	 [[ $line != *"MockCalls"* ]] && 
+	 [[ $line != *"PerfTracing_"* ]] && 
+	 [[ $line != *"proc_"* ]] && 
+	 [[ $line != *"ParentPathString"* ]] && 
+	 [[ $line != *"SetAndRegisterPath"* ]] && 
+	 [[ $line != *"vn_"* ]] && 
+	 [[ $line != *"vnode_lookup"* ]] && 
+	 [[ $line != *"RetainIOCount"* ]] && 
+	 [[ $line != *"ProviderMessaging_"* ]] && 
+	 [[ $line != *"RWLock_DropExclusiveToShared"* ]] && 
+	 [[ $line != *".xctest"* ]] && 
+	 [[ $line != *".cpp"* ]] && 
+	 [[ $line != *".hpp"* ]]; then
+       printf "\nError: Not at 100% Code Coverage: $line"
+       exit 1
+  fi
+done < $PROJFS/CoverageResult.txt 
 
 # If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
 if [ "$CONFIGURATION" == "Profiling(Release)" ]; then


### PR DESCRIPTION
We include code coverage reports in the build.  You can see this in the logs.
 
        WaitForListenerCompletion()                                                                                                                                                                                                                            0.00% (0/14)       
        GetPid(vfs_context*)                                                                                                                                                                                                                                   100.00% (4/4)      
        GetVNodeAttributes(vnode*, vfs_context*, vnode_attr*)                                                                                                                                                                                                  100.00% (6/6)      
        TryReadVNodeFileFlags(vnode*, vfs_context*, unsigned int*)                                                                                                                                                                                             100.00% (19/19)    
        FileFlagsBitIsSet(unsigned int, unsigned int)                                                                                                                                                                                                          100.00% (4/4)      
        TryGetFileIsFlaggedAsInRoot(vnode*, vfs_context*, bool*)                                                                                                                                                                                               100.00% (11/11)    
        ActionBitIsSet(int, int)                                                                                                                                                                                                                               100.00% (3/3)      
        IsFileSystemCrawler(char const*)                                                                                                                                                                                                                       100.00% (13/13)
        CurrentProcessWasSpawnedByRegularUser()                                                                                                                                                                                                                53.66% (22/41)     
        ShouldHandleFileOpEvent(PerfTracer*, vfs_context*, vnode*, int, short*, FsidInode*, int*)                                                                                                                                                              68.42% (39/57)     
        WaitForListenerCompletion()                                                                                                                                                                                                                            0.00% (0/14)       
        GetPid(vfs_context*)               

We will fail on Kext functions not on the exclusion list and is not at 100%.

We hope to move to the json format and a prettier output in the future, once we have full ansci support on the build logs.


