### PR TITLE
Fetching all sizes before index update

### DIFF
--- a/GVFS/GVFS.Common/Git/Sha1Id.cs
+++ b/GVFS/GVFS.Common/Git/Sha1Id.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace GVFS.Common.Git
@@ -87,6 +88,11 @@ namespace GVFS.Common.Git
                     shaBytes17Through20 = *(uint*)thirdChunk;
                 }
             }
+        }
+
+        public static string ShaStringFromBuffer(byte[] shaBuffer)
+        {
+            return new string(shaBuffer.SelectMany(b => new[] { GetHexValue(b / 16),  GetHexValue(b % 16) }).ToArray());
         }
 
         public void ToBuffer(byte[] shaBuffer)

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1161,6 +1161,8 @@ namespace GVFS.Virtualization.Projection
                         new HashSet<string>(placeholderFoldersListCopy.Select(x => x.Path), StringComparer.OrdinalIgnoreCase) :
                         null;
 
+                    var sizes = blobSizesConnection.GetAllSizes();
+
                     // Order the folders in decscending order so that we walk the tree from bottom up.
                     // Traversing the folders in this order:
                     //  1. Ensures child folders are deleted before their parents
@@ -1206,7 +1208,7 @@ namespace GVFS.Virtualization.Projection
                                         $"{nameof(updatedPlaceholderDictionary)} must be used when enumeration expands directories");
                                 }
 
-                                this.ReExpandFolder(blobSizesConnection, folderPlaceholder.Path, updatedPlaceholderDictionary, folderPlaceholders);
+                                this.ReExpandFolder(blobSizesConnection, folderPlaceholder.Path, updatedPlaceholderDictionary, folderPlaceholders, sizes);
                             }
                         }
                     }
@@ -1402,7 +1404,8 @@ namespace GVFS.Virtualization.Projection
             BlobSizes.BlobSizesConnection blobSizesConnection,
             string relativeFolderPath,
             ConcurrentDictionary<string, IPlaceholderData> updatedPlaceholderList,
-            HashSet<string> existingFolderPlaceholders)
+            HashSet<string> existingFolderPlaceholders,
+            Dictionary<string, long> availableSizes)
         {
             FolderData folderData;
             if (!this.TryGetOrAddFolderDataFromCache(relativeFolderPath, out folderData))
@@ -1416,7 +1419,7 @@ namespace GVFS.Virtualization.Projection
                 this.context.Tracer,
                 this.gitObjects,
                 blobSizesConnection,
-                availableSizes: null,
+                availableSizes,
                 cancellationToken: CancellationToken.None);
 
             for (int i = 0; i < folderData.ChildEntries.Count; i++)


### PR DESCRIPTION
If we have ~100k placeholders, getting their sizes one-by-one during index update (so during every checkout, even if you're checking out the same revision, that you're on) from the on-disk size DB takes 2+s. If we preload all sizes from DB into an in-memory dictionary, that takes around 800ms.

There's a risk though, that with time, as the SQLite DB of sizes grows, the proportion of sizes needed during index update will become lower. However, I believe that this falls into its own class of problems, that VFS4G has yet to address - evicting data from on-disk caches (that includes sizes and blobs), as the repository moves on and that data is not needed anymore.