### PR TITLE
Test reliability issue fix

### DIFF
--- a/Scripts/UninstallGVFS.bat
+++ b/Scripts/UninstallGVFS.bat
@@ -20,6 +20,7 @@ for /F "delims=" %%f in ('dir "c:\Program Files\GVFS\unins*.exe" /B /S /O:-D') d
 :deleteGVFS
 rmdir /q/s "c:\Program Files\GVFS"
 
-if exist "C:\ProgramData\GVFS\GVFS.Upgrade" rmdir /q/s "C:\ProgramData\GVFS\GVFS.Upgrade"
+REM Delete ProgramData\GVFS directory (logs, downloaded upgrades, repo-registry, gvfs.config). It can affect the behavior of a future GVFS install.
+if exist "C:\ProgramData\GVFS" rmdir /q/s "C:\ProgramData\GVFS"
 
 :end


### PR DESCRIPTION
VFSForGit installer was trying to mount repositories that were registered for auto-mount by previous test runs. Subsequent Installers used to fail sometimes, with error `17` while trying to auto-mount such repositories. Un-installer was already removing` ProgramData\GVFS\GVFS.Upgrade` directory. Updated it to rather remove `ProgramData\GVFS` so that repo-registry and other state info associated with current install is removed, before the next tests are run.

Fixes #911