### PR TITLE
Add more logging when test gets access denied from moving src folder

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -166,6 +166,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             ProcessResult result = this.RunDehydrateProcess(confirm, noStatus);
             result.ExitCode.ShouldEqual(0, $"mount exit code was {result.ExitCode}. Output: {result.Output}");
+
+            if (result.Output.Contains("Failed to move the src folder: Access to the path"))
+            {
+                string output = this.RunHandleProcess(Path.Combine(this.Enlistment.EnlistmentRoot, "src"));
+                TestContext.Out.WriteLine(output);
+            }
+
             result.Output.ShouldContain(expectedOutput);
         }
 
@@ -199,6 +206,25 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             processInfo.RedirectStandardOutput = true;
 
             return ProcessHelper.Run(processInfo);
+        }
+
+        private string RunHandleProcess(string path)
+        {
+            try
+            {
+                ProcessStartInfo processInfo = new ProcessStartInfo("handle.exe");
+                processInfo.Arguments = "-p " + path;
+                processInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                processInfo.WorkingDirectory = this.Enlistment.EnlistmentRoot;
+                processInfo.UseShellExecute = false;
+                processInfo.RedirectStandardOutput = true;
+
+                return "handle.exe output: " + ProcessHelper.Run(processInfo).Output;
+            }
+            catch (Exception ex)
+            {
+                return $"Exception running handle.exe - {ex.Message}";
+            }
         }
     }
 }


### PR DESCRIPTION
This is to hopefully get more information when a test hits #781 so that we will be able to find out what process has the handle open and is causing the access denied from the move.

This adds the dependency on `handle.exe` but the code is catching all exceptions when running it so if it isn't found it will only output that it wasn't found.  It will also only be ran in the very specific case of moving the `src` folder failing on access right now. So it will not cause a test to fail or succeed, only output information.