### PR TITLE
Test reliability issue #852

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgraderInfo.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderInfo.cs
@@ -58,11 +58,21 @@ namespace GVFS.Common
                 if (this.fileSystem.FileExists(highestAvailableVersionFile))
                 {
                     this.fileSystem.DeleteFile(highestAvailableVersionFile);
+
+                    if (this.tracer != null)
+                    {
+                        this.tracer.RelatedInfo($"{nameof(this.RecordHighestAvailableVersion)}: Deleted upgrade reminder marker file");
+                    }
                 }
             }
             else
             {
                 this.fileSystem.WriteAllText(highestAvailableVersionFile, highestAvailableVersion.ToString());
+
+                if (this.tracer != null)
+                {
+                    this.tracer.RelatedInfo($"{nameof(this.RecordHighestAvailableVersion)}: Created upgrade reminder marker file");
+                }
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -229,7 +229,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void VerifyServiceRestartStopsReminder()
         {
             this.CreateUpgradeAvailableMarkerFile();
-            this.ReminderMessagingEnabled().ShouldBeTrue();
+            this.ReminderMessagingEnabled().ShouldBeTrue("Upgrade marker file did not trigger reminder messaging");
             this.SetUpgradeRing(AlwaysUpToDateRing);
             this.RestartService();
 
@@ -242,16 +242,16 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 timeToWait = timeToWait.Subtract(TimeSpan.FromSeconds(5));
             }
 
-            reminderMessagingEnabled.ShouldBeFalse();
+            reminderMessagingEnabled.ShouldBeFalse("Service restart did not stop Upgrade reminder messaging");
         }
 
         private void VerifyUpgradeVerbStopsReminder()
         {
             this.SetUpgradeRing(AlwaysUpToDateRing);
             this.CreateUpgradeAvailableMarkerFile();
-            this.ReminderMessagingEnabled().ShouldBeTrue();
+            this.ReminderMessagingEnabled().ShouldBeTrue("Marker file did not trigger Upgrade reminder messaging");
             this.RunUpgradeCommand();
-            this.ReminderMessagingEnabled().ShouldBeFalse();
+            this.ReminderMessagingEnabled().ShouldBeFalse("Upgrade verb did not stop Upgrade reminder messaging");
         }
     }
 }


### PR DESCRIPTION
About the test failure - when Upgrade reminder marker file is created by the `Service`, `git` hooks should start showing reminder messaging. That does not seem to happen sometimes. It is not clear whether it was  a failure in the `Service` (the `Service` was not able to create the marker file) or if it was the `git` hooks which failed to display the reminder. 

Added better logging - Log details on failures. Updated Service to log message when upgrade reminder marker file is created or deleted.