### PR TITLE
Add additional diagnostics to GitStatusAfterRenameFileIntoRepo functional test

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -191,8 +191,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             filePath.ShouldBeAFile(this.fileSystem).WithContents(this.testFileContents);
 
             string renamedFileName = Path.Combine("GVFlt_MoveFileTest", "GitStatusAfterRenameFileIntoRepo.cs");
-            this.fileSystem.MoveFile(filePath, this.Enlistment.GetVirtualPathTo(renamedFileName));
-            this.Enlistment.GetVirtualPathTo(filePath).ShouldNotExistOnDisk(this.fileSystem);
+            string renamedFilePath = this.Enlistment.GetVirtualPathTo(renamedFileName);
+            this.fileSystem.MoveFile(filePath, renamedFilePath);
+            filePath.ShouldNotExistOnDisk(this.fileSystem);
+            renamedFilePath.ShouldBeAFile(this.fileSystem);
 
             GitHelpers.CheckGitCommandAgainstGVFSRepo(
                 this.Enlistment.RepoRoot,


### PR DESCRIPTION
GitStatusAfterRenameFileIntoRepo was occasionally failing (see #890 for details).

From the failure report in #890, it was unclear if the failure was due to the move/rename failing, or the rename notification not being delivered to VFS4G.

Changes in this PR:

- `ShouldNotExistOnDisk` was being called with the wrong path, this has been fixed
- Added validation that the renamed file *does* exist at the location we expect it to before calling git status.
