### PR TITLE
Do not attempt to approve credentials for anonymous access

### DIFF
--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -99,7 +99,7 @@ namespace GVFS.Common.Http
 
             request.Headers.UserAgent.Add(this.userAgentHeader);
 
-            if (!string.IsNullOrEmpty(authString))
+            if (!this.authentication.IsAnonymous)
             {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authString);
             }
@@ -147,7 +147,11 @@ namespace GVFS.Common.Http
                     string contentType = GetSingleHeaderOrEmpty(response.Content.Headers, "Content-Type");
                     responseMetadata.Add("ContentType", contentType);
 
-                    this.authentication.ApproveCredentials(this.Tracer, authString);
+                    if (!this.authentication.IsAnonymous)
+                    {
+                        this.authentication.ApproveCredentials(this.Tracer, authString);
+                    }
+
                     Stream responseStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 
                     gitEndPointResponseData = new GitEndPointResponseData(


### PR DESCRIPTION
he current logic has an issue where it will attempt to approve
credentials when communicating with anonymous access, even though there
are no credentials to approve. The other logic in this method guards
credential operations to non-anonymous auth scenarios. Update logic to
only approve / store credentials to non-anonymous auth scenarios.

This can be observed in the functional test logs that connect with anonymous auth.
These tests generate error logs indicating that it was unable to parse the credential string:

`Error "Failed to parse credential string for approval"`