### PR TITLE
Mac uninstaller launchd issue

### DIFF
--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -24,48 +24,59 @@ function UnloadKext()
 
 function UnInstallVFSForGit()
 {
-    if [ -d "${VFSFORDIRECTORY}" ]; then
-        rmCmd="sudo /bin/rm -Rf ${VFSFORDIRECTORY}"
-        echo "$rmCmd..."
-        eval $rmCmd || exit 1
-    fi
-    
     if [ -d "${PRJFSKEXTDIRECTORY}/$KEXTFILENAME" ]; then
         rmCmd="sudo /bin/rm -Rf ${PRJFSKEXTDIRECTORY}/$KEXTFILENAME"
         echo "$rmCmd..."
-        eval $rmCmd || exit 1
+        eval $rmCmd || { echo "Error: Could not delete ${PRJFSKEXTDIRECTORY}/$KEXTFILENAME. Delete it manually."; exit 1; }
     fi
     
     if [ -f "${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME" ]; then
-        unloadCmd="sudo launchctl unload -w ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
-        echo "$unloadCmd..."
-        eval $unloadCmd || exit 1
+        # Check if the daemon is loaded. Unload only if necessary.
+        isLoadedCmd="sudo launchctl kill SIGCONT system/org.vfsforgit.prjfs.PrjFSKextLogDaemon"
+        echo "$isLoadedCmd"
+        if $isLoadedCmd; then
+            unloadCmd="sudo launchctl unload -w ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
+            echo "$unloadCmd..."
+            eval $unloadCmd || { echo "Error: Could not unload ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME. Unload it manually (\"$unloadCmd\")."; exit 1; }
+        fi
+        
         rmCmd="sudo /bin/rm -Rf ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
         echo "$rmCmd..."
-        eval $rmCmd || exit 1
+        eval $rmCmd || { echo "Error: Could not delete ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME. Delete it manually."; exit 1; }
     fi
-    
+        
     # Unloading Service LaunchAgent for each user
     # There will be one loginwindow instance for each logged in user, 
     # get its uid (this will correspond to the logged in user's id.) 
-    # Then use launchctl bootstrap gui/uid to auto load the Service 
+    # Then use launchctl bootout gui/uid to unload the Service 
     # for each user.
     if [ -f "${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME" ]; then
         for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
-            unloadCmd="sudo launchctl bootout gui/$uid ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME"
-            echo "$unloadCmd..."
-            eval $unloadCmd || exit 1
+            # Check if the Service is loaded. Unload only if necessary.
+            isLoadedCmd="sudo launchctl kill SIGCONT gui/$uid/org.vfsforgit.service"
+            echo "$isLoadedCmd"
+            if $isLoadedCmd; then
+                unloadCmd="sudo launchctl bootout gui/$uid ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME"
+                echo "$unloadCmd..."
+                eval $unloadCmd || { echo "Error: Could not unload ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME. Unload it manually (\"$unloadCmd\")."; exit 1; }
+            fi
         done
         
         rmCmd="sudo /bin/rm -Rf ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME"
         echo "$rmCmd..."
-        eval $rmCmd || exit 1
+        eval $rmCmd || { echo "Error: Could not delete ${LAUNCHAGENTDIRECTORY}/$SERVICEAGENTLAUNCHDFILENAME. Delete it manually."; exit 1; }
     fi
     
     if [ -s "${GVFSCOMMANDPATH}" ]; then
         rmCmd="sudo /bin/rm -Rf ${GVFSCOMMANDPATH}"
         echo "$rmCmd..."
-        eval $rmCmd || exit 1
+        eval $rmCmd || { echo "Error: Could not delete ${GVFSCOMMANDPATH}. Delete it manually."; exit 1; }
+    fi
+    
+    if [ -d "${VFSFORDIRECTORY}" ]; then
+        rmCmd="sudo /bin/rm -Rf ${VFSFORDIRECTORY}"
+        echo "$rmCmd..."
+        eval $rmCmd || { echo "Error: Could not delete ${VFSFORDIRECTORY}. Delete it manually."; exit 1; }
     fi
 }
 


### PR DESCRIPTION
Un-installer was not deleting launchd plist files when LaunchAgent unload fails. This was causing a dangling launchd plist file that was pointing to VFSForGit assemblies that no longer exist on disc. Launchd disables the VFSForGit services, causing future VFSForGit installs to fail. Updated un-installer to remove the launchd plist file even when the unloading fails. When such a failure happens, user will have to manually logout and re-login for the un-install to be complete.

Fixes #1005 