### PR TITLE
Remove Code Coverage Exclusion for ShouldIgnoreVnodeType

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -1057,13 +1057,14 @@ KEXT_STATIC bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode)
 	case VREG:
     case VDIR:
     case VLNK:
-        return false;
+        break;
     case VSTR:
     case VCPLX:
         KextLog_FileInfo(vnode, "vnode with type %s encountered", vnodeType == VSTR ? "VSTR" : "VCPLX");
-        return false;
+        break;
     default:
         KextLog_FileInfo(vnode, "vnode with unknown type %d encountered", vnodeType);
-        return false;
     }
+    
+    return false;
 }

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -82,7 +82,7 @@ while read line; do
 	 [[ $line != *".xctest"* ]] && 
 	 [[ $line != *".cpp"* ]] && 
 	 [[ $line != *".hpp"* ]]; then
-       printf "\nError: Not at 100% Code Coverage: $line"
+       echo "Error: not at 100% Code Coverage $line"
        exit 1
   fi
 done < $PROJFS/CoverageResult.txt 

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -56,7 +56,6 @@ while read line; do
 	 [[ $line != *"TryGetVirtualizationRoot"* ]] &&                  #SHOULD ADD COVERAGE
 	 [[ $line != *"CurrentProcessWasSpawnedByRegularUser"* ]] &&     #SHOULD ADD COVERAGE
 	 [[ $line != *"ShouldHandleFileOpEvent"* ]] &&                   #SHOULD ADD COVERAGE
-	 [[ $line != *"ShouldIgnoreVnodeType"* ]] &&                     #SHOULD ADD COVERAGE
 	 [[ $line != *"WaitForListenerCompletion"* ]] && 
 	 [[ $line != *"KextLog_"* ]] && 
 	 [[ $line != *"Definition"* ]] && 


### PR DESCRIPTION
ShouldIgnoreVnodeType can be removed from the exclusion list since it has code coverage at 100%