### PR TITLE
[Linux] Pin callback delegates and simplify marshalling in ProjFS.Linux

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/CallbackDelegates.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/CallbackDelegates.cs
@@ -18,16 +18,6 @@ namespace PrjFSLib.Linux
         string triggeringProcessName,
         int fd);
 
-    public delegate Result NotifyOperationCallback(
-        ulong commandId,
-        string relativePath,
-        byte[] providerId,
-        byte[] contentId,
-        int triggeringProcessId,
-        string triggeringProcessName,
-        bool isDirectory,
-        NotificationType notificationType);
-
     public delegate void LogErrorCallback(
         string errorMessage);
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -192,13 +192,13 @@ namespace PrjFSLib.Linux.Interop
             uint nattrs);
 
         [StructLayout(LayoutKind.Sequential)]
-        public unsafe struct Event
+        public struct Event
         {
             public IntPtr Fs;
             public ulong Mask;
             public int Pid;
-            public byte* Path;
-            public byte* TargetPath;
+            public IntPtr Path;
+            public IntPtr TargetPath;
             public int Fd;
         }
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -319,8 +319,16 @@ namespace PrjFSLib.Linux
 
                 if (!isDirectory)
                 {
+                    string currentRelativePath = relativePath;
+
+                    // TODO(Linux): can other intermediate file ops race us here?
+                    if (nt == NotificationType.FileRenamed)
+                    {
+                        currentRelativePath = PtrToStringUTF8(ev.TargetPath);
+                    }
+
                     result = this.projfs.GetProjAttrs(
-                        relativePath,
+                        currentRelativePath,
                         providerId,
                         contentId);
                 }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -259,36 +259,36 @@ namespace PrjFSLib.Linux
                 relativePath = PtrToStringUTF8(ev.Path);
             }
 
-                if ((ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0)
+            if ((ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0)
+            {
+                result = this.OnEnumerateDirectory(
+                    commandId: 0,
+                    relativePath: relativePath,
+                    triggeringProcessId: ev.Pid,
+                    triggeringProcessName: triggeringProcessName);
+            }
+            else
+            {
+                byte[] providerId = new byte[PlaceholderIdLength];
+                byte[] contentId = new byte[PlaceholderIdLength];
+
+                result = this.projfs.GetProjAttrs(
+                    relativePath,
+                    providerId,
+                    contentId);
+
+                if (result == Result.Success)
                 {
-                    result = this.OnEnumerateDirectory(
+                    result = this.OnGetFileStream(
                         commandId: 0,
                         relativePath: relativePath,
+                        providerId: providerId,
+                        contentId: contentId,
                         triggeringProcessId: ev.Pid,
-                        triggeringProcessName: triggeringProcessName);
+                        triggeringProcessName: triggeringProcessName,
+                        fd: ev.Fd);
                 }
-                else
-                {
-                    byte[] providerId = new byte[PlaceholderIdLength];
-                    byte[] contentId = new byte[PlaceholderIdLength];
-
-                    result = this.projfs.GetProjAttrs(
-                        relativePath,
-                        providerId,
-                        contentId);
-
-                    if (result == Result.Success)
-                    {
-                        result = this.OnGetFileStream(
-                            commandId: 0,
-                            relativePath: relativePath,
-                            providerId: providerId,
-                            contentId: contentId,
-                            triggeringProcessId: ev.Pid,
-                            triggeringProcessName: triggeringProcessName,
-                            fd: ev.Fd);
-                    }
-                }
+            }
 
             return -result.ToErrno();
         }
@@ -326,37 +326,37 @@ namespace PrjFSLib.Linux
                 relativePath = PtrToStringUTF8(ev.Path);
             }
 
-                if (!isDirectory)
-                {
-                    string currentRelativePath = relativePath;
+            if (!isDirectory)
+            {
+                string currentRelativePath = relativePath;
 
-                    // TODO(Linux): can other intermediate file ops race us here?
-                    if (nt == NotificationType.FileRenamed)
+                // TODO(Linux): can other intermediate file ops race us here?
+                if (nt == NotificationType.FileRenamed)
+                {
+                    unsafe
                     {
-                        unsafe
-                        {
                         currentRelativePath = PtrToStringUTF8(ev.TargetPath);
-                        }
                     }
-
-                    result = this.projfs.GetProjAttrs(
-                        currentRelativePath,
-                        providerId,
-                        contentId);
                 }
 
-                if (result == Result.Success)
-                {
-                    result = this.OnNotifyOperation(
-                        commandId: 0,
-                        relativePath: relativePath,
-                        providerId: providerId,
-                        contentId: contentId,
-                        triggeringProcessId: ev.Pid,
-                        triggeringProcessName: triggeringProcessName,
-                        isDirectory: isDirectory,
-                        notificationType: nt);
-                }
+                result = this.projfs.GetProjAttrs(
+                    currentRelativePath,
+                    providerId,
+                    contentId);
+            }
+
+            if (result == Result.Success)
+            {
+                result = this.OnNotifyOperation(
+                    commandId: 0,
+                    relativePath: relativePath,
+                    providerId: providerId,
+                    contentId: contentId,
+                    triggeringProcessId: ev.Pid,
+                    triggeringProcessName: triggeringProcessName,
+                    isDirectory: isDirectory,
+                    notificationType: nt);
+            }
 
             int ret = -result.ToErrno();
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 using PrjFSLib.Linux.Interop;
 using static PrjFSLib.Linux.Interop.Errno;
 
@@ -237,27 +236,22 @@ namespace PrjFSLib.Linux
         }
 
         // TODO(Linux): replace with netstandard2.1 Marshal.PtrToStringUTF8()
-        private static unsafe string PtrToStringUTF8(byte* ptr)
+        private static string PtrToStringUTF8(IntPtr ptr)
         {
-            if (ptr == (byte*)IntPtr.Zero)
+            if (ptr == IntPtr.Zero)
             {
                 return null;
             }
 
-            ulong length = NativeMethods.Strlen(ptr);
-            return Encoding.UTF8.GetString(ptr, (int)length);
+            return Marshal.PtrToStringAnsi(ptr);
         }
 
         private int HandleProjEvent(ref ProjFS.Event ev)
         {
             string triggeringProcessName = GetProcCmdline(ev.Pid);
-            string relativePath;
-            Result result;
+            string relativePath = PtrToStringUTF8(ev.Path);
 
-            unsafe
-            {
-                relativePath = PtrToStringUTF8(ev.Path);
-            }
+            Result result;
 
             if ((ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0)
             {
@@ -318,13 +312,8 @@ namespace PrjFSLib.Linux
             string triggeringProcessName = GetProcCmdline(ev.Pid);
             byte[] providerId = new byte[PlaceholderIdLength];
             byte[] contentId = new byte[PlaceholderIdLength];
-            string relativePath;
+            string relativePath = PtrToStringUTF8(ev.Path);
             Result result = Result.Success;
-
-            unsafe
-            {
-                relativePath = PtrToStringUTF8(ev.Path);
-            }
 
             if (!isDirectory)
             {
@@ -333,10 +322,7 @@ namespace PrjFSLib.Linux
                 // TODO(Linux): can other intermediate file ops race us here?
                 if (nt == NotificationType.FileRenamed)
                 {
-                    unsafe
-                    {
-                        currentRelativePath = PtrToStringUTF8(ev.TargetPath);
-                    }
+                    currentRelativePath = PtrToStringUTF8(ev.TargetPath);
                 }
 
                 result = this.projfs.GetProjAttrs(
@@ -425,9 +411,6 @@ namespace PrjFSLib.Linux
 
         private static unsafe class NativeMethods
         {
-            [DllImport("libc", EntryPoint = "strlen")]
-            public static extern ulong Strlen(byte* s);
-
             [DllImport("libc", EntryPoint = "write", SetLastError = true)]
             public static extern long Write(int fd, byte* buf, ulong count);
         }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -81,24 +81,9 @@ namespace PrjFSLib.Linux
             byte[] bytes,
             uint byteCount)
         {
-            unsafe
+            if (!NativeFileWriter.TryWrite(fd, bytes, byteCount))
             {
-                 fixed (byte* bytesPtr = bytes)
-                 {
-                     byte* bytesToWrite = bytesPtr;
-
-                     while (byteCount > 0)
-                     {
-                        long res = NativeMethods.Write(fd, bytesToWrite, byteCount);
-                        if (res == -1)
-                        {
-                            return Result.EIOError;
-                        }
-
-                        bytesToWrite += res;
-                        byteCount -= (uint)res;
-                    }
-                }
+                return Result.EIOError;
             }
 
             return Result.Success;
@@ -409,10 +394,32 @@ namespace PrjFSLib.Linux
             return Result.ENotYetImplemented;
         }
 
-        private static unsafe class NativeMethods
+        private static unsafe class NativeFileWriter
         {
+            public static bool TryWrite(int fd, byte[] bytes, uint byteCount)
+            {
+                 fixed (byte* bytesPtr = bytes)
+                 {
+                     byte* bytesIndexPtr = bytesPtr;
+
+                     while (byteCount > 0)
+                     {
+                        long res = Write(fd, bytesIndexPtr, byteCount);
+                        if (res == -1)
+                        {
+                            return false;
+                        }
+
+                        bytesIndexPtr += res;
+                        byteCount -= (uint)res;
+                    }
+                }
+
+                return true;
+            }
+
             [DllImport("libc", EntryPoint = "write", SetLastError = true)]
-            public static extern long Write(int fd, byte* buf, ulong count);
+            private static extern long Write(int fd, byte* buf, ulong count);
         }
     }
 }

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -223,11 +223,6 @@ namespace PrjFSLib.Linux
         // TODO(Linux): replace with netstandard2.1 Marshal.PtrToStringUTF8()
         private static string PtrToStringUTF8(IntPtr ptr)
         {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-
             return Marshal.PtrToStringAnsi(ptr);
         }
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -11,6 +11,11 @@ namespace PrjFSLib.Linux
 
         private Interop.ProjFS projfs;
 
+        // We must hold a reference to the delegates to prevent garbage collection
+        private Interop.ProjFS.EventHandler preventGCOnProjEventDelegate;
+        private Interop.ProjFS.EventHandler preventGCOnNotifyEventDelegate;
+        private Interop.ProjFS.EventHandler preventGCOnPermEventDelegate;
+
         // References held to these delegates via class properties
         public virtual EnumerateDirectoryCallback OnEnumerateDirectory { get; set; }
         public virtual GetFileStreamCallback OnGetFileStream { get; set; }
@@ -35,9 +40,9 @@ namespace PrjFSLib.Linux
 
             Interop.ProjFS.Handlers handlers = new Interop.ProjFS.Handlers
             {
-                HandleProjEvent = this.HandleProjEvent,
-                HandleNotifyEvent = this.HandleNotifyEvent,
-                HandlePermEvent = this.HandlePermEvent,
+                HandleProjEvent = this.preventGCOnProjEventDelegate = new Interop.ProjFS.EventHandler(this.HandleProjEvent),
+                HandleNotifyEvent = this.preventGCOnNotifyEventDelegate = new Interop.ProjFS.EventHandler(this.HandleNotifyEvent),
+                HandlePermEvent = this.preventGCOnPermEventDelegate = new Interop.ProjFS.EventHandler(this.HandlePermEvent)
             };
 
             Interop.ProjFS fs = Interop.ProjFS.New(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -251,11 +251,13 @@ namespace PrjFSLib.Linux
         private int HandleProjEvent(ref ProjFS.Event ev)
         {
             string triggeringProcessName = GetProcCmdline(ev.Pid);
+            string relativePath;
             Result result;
 
             unsafe
             {
-                string relativePath = PtrToStringUTF8(ev.Path);
+                relativePath = PtrToStringUTF8(ev.Path);
+            }
 
                 if ((ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0)
                 {
@@ -287,7 +289,6 @@ namespace PrjFSLib.Linux
                             fd: ev.Fd);
                     }
                 }
-            }
 
             return -result.ToErrno();
         }
@@ -317,11 +318,13 @@ namespace PrjFSLib.Linux
             string triggeringProcessName = GetProcCmdline(ev.Pid);
             byte[] providerId = new byte[PlaceholderIdLength];
             byte[] contentId = new byte[PlaceholderIdLength];
+            string relativePath;
             Result result = Result.Success;
 
             unsafe
             {
-                string relativePath = PtrToStringUTF8(ev.Path);
+                relativePath = PtrToStringUTF8(ev.Path);
+            }
 
                 if (!isDirectory)
                 {
@@ -330,7 +333,10 @@ namespace PrjFSLib.Linux
                     // TODO(Linux): can other intermediate file ops race us here?
                     if (nt == NotificationType.FileRenamed)
                     {
+                        unsafe
+                        {
                         currentRelativePath = PtrToStringUTF8(ev.TargetPath);
+                        }
                     }
 
                     result = this.projfs.GetProjAttrs(
@@ -351,7 +357,6 @@ namespace PrjFSLib.Linux
                         isDirectory: isDirectory,
                         notificationType: nt);
                 }
-            }
 
             int ret = -result.ToErrno();
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using PrjFSLib.Linux.Interop;
 using static PrjFSLib.Linux.Interop.Errno;
 
 namespace PrjFSLib.Linux
@@ -9,12 +10,12 @@ namespace PrjFSLib.Linux
     {
         public const int PlaceholderIdLength = 128;
 
-        private Interop.ProjFS projfs;
+        private ProjFS projfs;
 
         // We must hold a reference to the delegates to prevent garbage collection
-        private Interop.ProjFS.EventHandler preventGCOnProjEventDelegate;
-        private Interop.ProjFS.EventHandler preventGCOnNotifyEventDelegate;
-        private Interop.ProjFS.EventHandler preventGCOnPermEventDelegate;
+        private ProjFS.EventHandler preventGCOnProjEventDelegate;
+        private ProjFS.EventHandler preventGCOnNotifyEventDelegate;
+        private ProjFS.EventHandler preventGCOnPermEventDelegate;
 
         // References held to these delegates via class properties
         public virtual EnumerateDirectoryCallback OnEnumerateDirectory { get; set; }
@@ -38,14 +39,14 @@ namespace PrjFSLib.Linux
                 throw new InvalidOperationException();
             }
 
-            Interop.ProjFS.Handlers handlers = new Interop.ProjFS.Handlers
+            ProjFS.Handlers handlers = new ProjFS.Handlers
             {
-                HandleProjEvent = this.preventGCOnProjEventDelegate = new Interop.ProjFS.EventHandler(this.HandleProjEvent),
-                HandleNotifyEvent = this.preventGCOnNotifyEventDelegate = new Interop.ProjFS.EventHandler(this.HandleNotifyEvent),
-                HandlePermEvent = this.preventGCOnPermEventDelegate = new Interop.ProjFS.EventHandler(this.HandlePermEvent)
+                HandleProjEvent = this.preventGCOnProjEventDelegate = new ProjFS.EventHandler(this.HandleProjEvent),
+                HandleNotifyEvent = this.preventGCOnNotifyEventDelegate = new ProjFS.EventHandler(this.HandleNotifyEvent),
+                HandlePermEvent = this.preventGCOnPermEventDelegate = new ProjFS.EventHandler(this.HandlePermEvent)
             };
 
-            Interop.ProjFS fs = Interop.ProjFS.New(
+            ProjFS fs = ProjFS.New(
                 storageRootFullPath,
                 virtualizationRootFullPath,
                 handlers);
@@ -111,7 +112,7 @@ namespace PrjFSLib.Linux
         {
             /*
             UpdateFailureCause deleteFailureCause = UpdateFailureCause.NoFailure;
-            Result result = Interop.PrjFSLib.DeleteFile(
+            Result result = ProjFS.DeleteFile(
                 relativePath,
                 updateFlags,
                 ref deleteFailureCause);
@@ -169,14 +170,14 @@ namespace PrjFSLib.Linux
             out UpdateFailureCause failureCause)
         {
             /*
-            if (providerId.Length != Interop.PrjFSLib.PlaceholderIdLength ||
-                contentId.Length != Interop.PrjFSLib.PlaceholderIdLength)
+            if (providerId.Length != ProjFS.PlaceholderIdLength ||
+                contentId.Length != ProjFS.PlaceholderIdLength)
             {
                 throw new ArgumentException();
             }
 
             UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
-            Result result = Interop.PrjFSLib.UpdatePlaceholderFileIfNeeded(
+            Result result = ProjFS.UpdatePlaceholderFileIfNeeded(
                 relativePath,
                 providerId,
                 contentId,
@@ -200,7 +201,7 @@ namespace PrjFSLib.Linux
         {
             /*
             UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
-            Result result = Interop.PrjFSLib.ReplacePlaceholderFileWithSymLink(
+            Result result = ProjFS.ReplacePlaceholderFileWithSymLink(
                 relativePath,
                 symLinkTarget,
                 updateFlags,
@@ -247,7 +248,7 @@ namespace PrjFSLib.Linux
             return Encoding.UTF8.GetString(ptr, (int)length);
         }
 
-        private int HandleProjEvent(ref Interop.ProjFS.Event ev)
+        private int HandleProjEvent(ref ProjFS.Event ev)
         {
             string triggeringProcessName = GetProcCmdline(ev.Pid);
             Result result;
@@ -256,7 +257,7 @@ namespace PrjFSLib.Linux
             {
                 string relativePath = PtrToStringUTF8(ev.Path);
 
-                if ((ev.Mask & Interop.ProjFS.Constants.PROJFS_ONDIR) != 0)
+                if ((ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0)
                 {
                     result = this.OnEnumerateDirectory(
                         commandId: 0,
@@ -291,19 +292,19 @@ namespace PrjFSLib.Linux
             return -result.ToErrno();
         }
 
-        private int HandleNonProjEvent(ref Interop.ProjFS.Event ev, bool perm)
+        private int HandleNonProjEvent(ref ProjFS.Event ev, bool perm)
         {
             NotificationType nt;
 
-            if ((ev.Mask & Interop.ProjFS.Constants.PROJFS_DELETE_SELF) != 0)
+            if ((ev.Mask & ProjFS.Constants.PROJFS_DELETE_SELF) != 0)
             {
                 nt = NotificationType.PreDelete;
             }
-            else if ((ev.Mask & Interop.ProjFS.Constants.PROJFS_MOVE_SELF) != 0)
+            else if ((ev.Mask & ProjFS.Constants.PROJFS_MOVE_SELF) != 0)
             {
                 nt = NotificationType.FileRenamed;
             }
-            else if ((ev.Mask & Interop.ProjFS.Constants.PROJFS_CREATE_SELF) != 0)
+            else if ((ev.Mask & ProjFS.Constants.PROJFS_CREATE_SELF) != 0)
             {
                 nt = NotificationType.NewFileCreated;
             }
@@ -312,7 +313,7 @@ namespace PrjFSLib.Linux
                 return 0;
             }
 
-            bool isDirectory = (ev.Mask & Interop.ProjFS.Constants.PROJFS_ONDIR) != 0;
+            bool isDirectory = (ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0;
             string triggeringProcessName = GetProcCmdline(ev.Pid);
             byte[] providerId = new byte[PlaceholderIdLength];
             byte[] contentId = new byte[PlaceholderIdLength];
@@ -358,23 +359,23 @@ namespace PrjFSLib.Linux
             {
                 if (ret == 0)
                 {
-                    ret = (int)Interop.ProjFS.Constants.PROJFS_ALLOW;
+                    ret = (int)ProjFS.Constants.PROJFS_ALLOW;
                 }
-                else if (ret == -Interop.Errno.Constants.EPERM)
+                else if (ret == -Errno.Constants.EPERM)
                 {
-                    ret = (int)Interop.ProjFS.Constants.PROJFS_DENY;
+                    ret = (int)ProjFS.Constants.PROJFS_DENY;
                 }
             }
 
             return ret;
         }
 
-        private int HandleNotifyEvent(ref Interop.ProjFS.Event ev)
+        private int HandleNotifyEvent(ref ProjFS.Event ev)
         {
             return this.HandleNonProjEvent(ref ev, false);
         }
 
-        private int HandlePermEvent(ref Interop.ProjFS.Event ev)
+        private int HandlePermEvent(ref ProjFS.Event ev)
         {
             return this.HandleNonProjEvent(ref ev, true);
         }

--- a/ProjFS.Linux/Scripts/GenerateConstants.sh
+++ b/ProjFS.Linux/Scripts/GenerateConstants.sh
@@ -14,7 +14,7 @@ echo | >"$TMPFILE" \
   $CC -E -xc-header -dM $CFLAGS $CPPFLAGS -include projfs_notify.h -
 
 PROJFS_CONSTS=$(cat "$TMPFILE" |
-  awk '/^#define PROJFS_\S+ \S+$/ { print length($3) " " $0 }' |
+  awk '/^#define PROJFS_[^ ]+ [^ ]+$/ { print length($3) " " $0 }' |
   sort -k 1,1n -k4,4 | sed 's/.*PROJFS/PROJFS/' |
   sed 's/himask(0x\([0-9]\{4\}\))/0x\100000000/')
 


### PR DESCRIPTION
Hi @kivikakk, @jrbriggs, and @wilbaker -- I'll be interested in your comments on this one!

It might best be reviewed by looking at the individual commits; the overall summary is that this fixes several issues in our `ProjFS.Linux` `VirtualizationInstance` implementation, and tidies up the marshalling of UTF-8 strings.

1. We need to retain class references to our callback delegates in the [same way](https://github.com/Microsoft/VFSForGit/blob/master/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs#L38) the Mac `VirtualizationInstance` does or else we get crashes on callbacks when testing with the GVFS provider.  (3e2147f)

2. We weren't retrieving our extended attributes correctly after a file rename.  At first I thought my quick fix in 5e250f3 had an obvious race against other file operations, but now I'm not convinced of that, since libprojfs will not return from its FUSE `rename` operation until the event notification to the C# provider is complete, and so FUSE won't have returned success to the Linux VFS.  So it really depends on the exact `rename()` locking semantics within the Linux kernel.  If there is a race condition, we'll need a more comprehensive fix which will involve changes to libprojfs, so I'd like to get this into place now as at least a stopgap before we deal with it more comprehensively.

3. Based on my [stumbling](https://github.com/Microsoft/VFSForGit/pull/848#issuecomment-476827046) around the question of UTF-8 marshalling it appears (and testing appears to confirm) that on recent .NET Core platforms, encoding to/from UTF-8 is the default when marshalling unmanaged strings, so we can simplify a fair bit of our handling of those.  The only downside is that we lose the clarity of having `byte*` in our `Event` structure; it becomes a more generic `IntPtr`.  @kivikakk, do you (or others) may have particular concerns about that?  (1e6e827)

4. I moved the write-bytes-to-file loop down into a `NativeFileWriter` class, which I think [parallels](https://github.com/Microsoft/VFSForGit/blob/master/GVFS/GVFS.Platform.Mac/MacFileSystem.cs#L153) the `NativeFileReader` found in `GVFS.Platform.Mac.MacFileSystem`.  That also tidies up the main class in `VirtualizationInstance` a bit.  (d6c3e12)

5. Ashe fixed a problem where I was inadvertently relying on GNU awk extensions in one of our build scripts.  (1a331b8)

6. And lastly I don't think we need the `NotifyOperationCallback` delegate at all on Linux, given how we've implemented other callbacks.  (Also in 5e250f3)