### PR TITLE
Check the projection for the folder before attempting to delete

### DIFF
--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1157,7 +1157,6 @@ namespace GVFS.Virtualization.Projection
                     //  1. Ensures child folders are deleted before their parents
                     //  2. Ensures that folders that have been deleted by git (but are still in the projection) are found before their
                     //     parent folder is re-expanded (only applies on platforms where EnumerationExpandsDirectories is true)
-                    Dictionary<string, long> availableSizes = new Dictionary<string, long>();
                     foreach (PlaceholderListDatabase.PlaceholderData folderPlaceholder in placeholderFoldersListCopy.OrderByDescending(x => x.Path))
                     {
                         bool keepFolder = true;
@@ -1471,11 +1470,8 @@ namespace GVFS.Virtualization.Projection
         /// </summary>
         /// <returns>
         /// <c>true</c>If the folder placeholder was deleted
-        /// <c>false</c>If RemoveFolderPlaceholderIfEmpty did not attempt to remove the folder placeholder
+        /// <c>false</c>If RemoveFolderPlaceholderIfEmpty failed attempting to remove the folder placeholder
         /// </returns>
-        /// <remarks>
-        /// If the platform expands on enumeration the folder will only be removed if it's not in the projection
-        /// </remarks>
         private bool RemoveFolderPlaceholderIfEmpty(PlaceholderListDatabase.PlaceholderData placeholder)
         {
             UpdateFailureReason failureReason = UpdateFailureReason.NoFailure;
@@ -1496,10 +1492,6 @@ namespace GVFS.Virtualization.Projection
                     metadata.Add("result.RawResult", result.RawResult);
                     metadata.Add("UpdateFailureCause", failureReason.ToString());
                     this.context.Tracer.RelatedEvent(EventLevel.Informational, nameof(this.RemoveFolderPlaceholderIfEmpty) + "_DeleteFileFailure", metadata);
-
-                    // TODO(Mac): Issue #245, handle failures DeleteFile on Mac.  If we don't do anything we could leave an untracked folder
-                    // placeholder on disk that will never be updated by Git or VFSForGit
-
                     return false;
             }
         }


### PR DESCRIPTION
Because attempting to delete a folder placeholder is an expensive operation
especially when there are hundreds of thousands, we want to reduce the
number that we need to try to delete.  There are a few criteria for attempting
the delete.

First if the folder is in the `folderPlaceholdersToKeep` list it will not be
deleted.  Then if one of the following is true it will try to delete the folder placeholder.

1. If the path is no longer in the projection
2. If the path is in the projection but is a file and not a folder
3. If the path no longer exists on the file system - this is in the case
of tombstones on windows.

Fixes #480 
Closes #245 

Testing with ~325,000 folder placeholder the delete was taking a little over 60 seconds.  With these changes it is only taking ~20 seconds.