### PR TITLE
Mac: Check the return value of stat in PrjFS_DeleteFile

### DIFF
--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -549,7 +549,18 @@ PrjFS_Result PrjFS_DeleteFile(
     CombinePaths(s_virtualizationRootFullPath.c_str(), relativePath, fullPath);
     
     struct stat path_stat;
-    stat(fullPath, &path_stat);
+    if (0 != stat(fullPath, &path_stat))
+    {
+        switch(errno)
+        {
+            case ENOENT:  // A component of fullPath does not exist
+            case ENOTDIR: // A component of fullPath is not a directory
+                return PrjFS_Result_Success;
+            default:
+                return PrjFS_Result_EIOError;
+        }
+    }
+    
     if (!(S_ISREG(path_stat.st_mode) || S_ISDIR(path_stat.st_mode)))
     {
         // Only files and directories can be deleted with PrjFS_DeleteFile


### PR DESCRIPTION
Fixes #1019

`PrjFS_DeleteFile` is incorrectly returning `PrjFS_Result_EVirtualizationInvalidOperation` when it's called for files/directories that do not exist.

This results in a lot of misleading messages being recorded in the GVFS mount process log files.

_Example log message_

>[2019-04-08 13:18:54 -07:00] RemoveFolderPlaceholderIfEmpty_DeleteFileFailure {"Area":"GitIndexProjection","Folder Path":"Test_EPF_GitCommandsTestOnlyFileFolder","result.Result":"VirtualizationInvalidOperation","result.RawResult":536871936,"UpdateFailureCause":"DirtyData"}

Prior to this PR the functional tests recorded `RemoveFolderPlaceholderIfEmpty_DeleteFileFailure` 129 times.  With this change the message is not recorded at all during the functional test runs.