### PR TITLE
[POSIX] rename common Mac hook code to share with Linux

### DIFF
--- a/GVFS/GVFS.NativeHooks.Common/common.h
+++ b/GVFS/GVFS.NativeHooks.Common/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstring>
+
 #ifdef __APPLE__
 typedef std::string PATH_STRING;
 typedef int PIPE_HANDLE;

--- a/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
+++ b/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
@@ -31,22 +31,22 @@ PATH_STRING GetGVFSPipeName(const char *appName)
     }
     
     PATH_STRING finalRootPath(GetFinalPathName(enlistmentRoot));
-    size_t resultLength = strlcpy(enlistmentRoot, finalRootPath.c_str(), sizeof(enlistmentRoot));
-    if (resultLength >= sizeof(enlistmentRoot))
+    size_t enlistmentRootLength = strlen(finalRootPath.c_str());
+    if (enlistmentRootLength + 2 > sizeof(enlistmentRoot))
     {
         die(ReturnCode::PipeConnectError,
-            "Could not copy finalRootPath: %ls, insufficient buffer. resultLength: %d, sizeof(enlistmentRoot): %d\n",
+            "Could not copy finalRootPath: %ls, insufficient buffer. enlistmentRootLength: %d, sizeof(enlistmentRoot): %d\n",
             finalRootPath.c_str(),
-            resultLength,
+            enlistmentRootLength,
             sizeof(enlistmentRoot));
     }
     
-    size_t enlistmentRootLength = strlen(enlistmentRoot);
+    memcpy(enlistmentRoot, finalRootPath.c_str(), enlistmentRootLength);
     if ('/' != enlistmentRoot[enlistmentRootLength - 1])
     {
-        strlcat(enlistmentRoot, "/", sizeof(enlistmentRoot));
-        enlistmentRootLength++;
+        enlistmentRoot[enlistmentRootLength++] = '/';
     }
+    enlistmentRoot[enlistmentRootLength] = '\0';
     
     // Walk up enlistmentRoot looking for a folder named .gvfs
     char* lastslash = enlistmentRoot + enlistmentRootLength - 1;
@@ -116,17 +116,19 @@ PIPE_HANDLE CreatePipeToGVFS(const PATH_STRING& pipeName)
     memset(&socket_address, 0, sizeof(struct sockaddr_un));
     
     socket_address.sun_family = AF_UNIX;
-    size_t resultLength = strlcpy(socket_address.sun_path, pipeName.c_str(), sizeof(socket_address.sun_path));
-    
-    if (resultLength >= sizeof(socket_address.sun_path))
+    size_t pathLength = strlen(pipeName.c_str());
+    if (pathLength + 1 > sizeof(socket_address.sun_path))
     {
         die(ReturnCode::PipeConnectError,
-            "Could not copy pipeName: %ls, insufficient buffer. resultLength: %d, sizeof(socket_address.sun_path): %d\n",
+            "Could not copy pipeName: %ls, insufficient buffer. pathLength: %d, sizeof(socket_address.sun_path): %d\n",
             pipeName.c_str(),
-            resultLength,
+            pathLength,
             sizeof(socket_address.sun_path));
     }
     
+    memcpy(socket_address.sun_path, pipeName.c_str(), pathLength);
+    socket_address.sun_path[pathLength] = '\0';
+
     if(connect(socket_fd, (struct sockaddr *) &socket_address, sizeof(struct sockaddr_un)) != 0)
     {
         die(ReturnCode::PipeConnectError, "Failed to connect socket, pipeName: %s, error: %d\n", pipeName.c_str(), errno);

--- a/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
+++ b/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
@@ -31,7 +31,8 @@ PATH_STRING GetGVFSPipeName(const char *appName)
     }
     
     PATH_STRING finalRootPath(GetFinalPathName(enlistmentRoot));
-    size_t enlistmentRootLength = strlen(finalRootPath.c_str());
+    size_t enlistmentRootLength = finalRootPath.length();
+    // allow an extra byte in case we need to add a trailing slash
     if (enlistmentRootLength + 2 > sizeof(enlistmentRoot))
     {
         die(ReturnCode::PipeConnectError,
@@ -42,7 +43,7 @@ PATH_STRING GetGVFSPipeName(const char *appName)
     }
     
     memcpy(enlistmentRoot, finalRootPath.c_str(), enlistmentRootLength);
-    if ('/' != enlistmentRoot[enlistmentRootLength - 1])
+    if (enlistmentRootLength == 0 || enlistmentRoot[enlistmentRootLength - 1] != '/')
     {
         enlistmentRoot[enlistmentRootLength++] = '/';
     }
@@ -116,7 +117,7 @@ PIPE_HANDLE CreatePipeToGVFS(const PATH_STRING& pipeName)
     memset(&socket_address, 0, sizeof(struct sockaddr_un));
     
     socket_address.sun_family = AF_UNIX;
-    size_t pathLength = strlen(pipeName.c_str());
+    size_t pathLength = pipeName.length();
     if (pathLength + 1 > sizeof(socket_address.sun_path))
     {
         die(ReturnCode::PipeConnectError,

--- a/GVFS/GVFS.PostIndexChangedHook/GVFS.PostIndexChangedHook.Mac.xcodeproj/project.pbxproj
+++ b/GVFS/GVFS.PostIndexChangedHook/GVFS.PostIndexChangedHook.Mac.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		267A836C20EE9F27005E6B60 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 267A836B20EE9F27005E6B60 /* main.cpp */; };
-		26E839D920FD4026004E53CE /* common.mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D620FD29D6004E53CE /* common.mac.cpp */; };
+		26E839D920FD4026004E53CE /* common.posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D620FD29D6004E53CE /* common.posix.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +27,7 @@
 		267A836820EE9F27005E6B60 /* GVFS.PostIndexChangedHook */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = GVFS.PostIndexChangedHook; sourceTree = BUILT_PRODUCTS_DIR; };
 		267A836B20EE9F27005E6B60 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = SOURCE_ROOT; };
 		2686926B20EFF2610080F95D /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = ../GVFS.NativeHooks.Common/common.h; sourceTree = SOURCE_ROOT; };
-		26E839D620FD29D6004E53CE /* common.mac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.mac.cpp; path = ../GVFS.NativeHooks.Common/common.mac.cpp; sourceTree = SOURCE_ROOT; };
+		26E839D620FD29D6004E53CE /* common.posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.posix.cpp; path = ../GVFS.NativeHooks.Common/common.posix.cpp; sourceTree = SOURCE_ROOT; };
 		26E839DB20FD5918004E53CE /* stdafx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stdafx.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -46,7 +46,7 @@
 			isa = PBXGroup;
 			children = (
 				26E839DB20FD5918004E53CE /* stdafx.h */,
-				26E839D620FD29D6004E53CE /* common.mac.cpp */,
+				26E839D620FD29D6004E53CE /* common.posix.cpp */,
 				2686926B20EFF2610080F95D /* common.h */,
 				267A836B20EE9F27005E6B60 /* main.cpp */,
 				267A836920EE9F27005E6B60 /* Products */,
@@ -117,7 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				267A836C20EE9F27005E6B60 /* main.cpp in Sources */,
-				26E839D920FD4026004E53CE /* common.mac.cpp in Sources */,
+				26E839D920FD4026004E53CE /* common.posix.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GVFS/GVFS.ReadObjectHook/GVFS.ReadObjectHook.Mac.xcodeproj/project.pbxproj
+++ b/GVFS/GVFS.ReadObjectHook/GVFS.ReadObjectHook.Mac.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		2673FD9620EBDAA900B64B7F /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2673FD9520EBDAA900B64B7F /* main.cpp */; };
 		2673FD9C20EBDEA500B64B7F /* packet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2673FD9B20EBDEA500B64B7F /* packet.cpp */; };
-		26E839D820FD387D004E53CE /* common.mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D720FD29EC004E53CE /* common.mac.cpp */; };
+		26E839D820FD387D004E53CE /* common.posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D720FD29EC004E53CE /* common.posix.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -30,7 +30,7 @@
 		2673FD9A20EBDEA500B64B7F /* packet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet.h; sourceTree = SOURCE_ROOT; };
 		2673FD9B20EBDEA500B64B7F /* packet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet.cpp; sourceTree = SOURCE_ROOT; };
 		2673FD9D20EBDEAA00B64B7F /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = ../GVFS.NativeHooks.Common/common.h; sourceTree = SOURCE_ROOT; };
-		26E839D720FD29EC004E53CE /* common.mac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.mac.cpp; path = ../GVFS.NativeHooks.Common/common.mac.cpp; sourceTree = SOURCE_ROOT; };
+		26E839D720FD29EC004E53CE /* common.posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.posix.cpp; path = ../GVFS.NativeHooks.Common/common.posix.cpp; sourceTree = SOURCE_ROOT; };
 		26E839DA20FD58B8004E53CE /* stdafx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stdafx.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -49,7 +49,7 @@
 			isa = PBXGroup;
 			children = (
 				26E839DA20FD58B8004E53CE /* stdafx.h */,
-				26E839D720FD29EC004E53CE /* common.mac.cpp */,
+				26E839D720FD29EC004E53CE /* common.posix.cpp */,
 				2673FD9D20EBDEAA00B64B7F /* common.h */,
 				2673FD9B20EBDEA500B64B7F /* packet.cpp */,
 				2673FD9A20EBDEA500B64B7F /* packet.h */,
@@ -121,7 +121,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26E839D820FD387D004E53CE /* common.mac.cpp in Sources */,
+				26E839D820FD387D004E53CE /* common.posix.cpp in Sources */,
 				2673FD9620EBDAA900B64B7F /* main.cpp in Sources */,
 				2673FD9C20EBDEA500B64B7F /* packet.cpp in Sources */,
 			);

--- a/GVFS/GVFS.VirtualFileSystemHook/GVFS.VirtualFileSystemHook.Mac.xcodeproj/project.pbxproj
+++ b/GVFS/GVFS.VirtualFileSystemHook/GVFS.VirtualFileSystemHook.Mac.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		267A836C20EE9F27005E6B60 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 267A836B20EE9F27005E6B60 /* main.cpp */; };
-		26E839D920FD4026004E53CE /* common.mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D620FD29D6004E53CE /* common.mac.cpp */; };
+		26E839D920FD4026004E53CE /* common.posix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E839D620FD29D6004E53CE /* common.posix.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,7 +27,7 @@
 		267A836820EE9F27005E6B60 /* GVFS.VirtualFileSystemHook */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = GVFS.VirtualFileSystemHook; sourceTree = BUILT_PRODUCTS_DIR; };
 		267A836B20EE9F27005E6B60 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = SOURCE_ROOT; };
 		2686926B20EFF2610080F95D /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = ../GVFS.NativeHooks.Common/common.h; sourceTree = SOURCE_ROOT; };
-		26E839D620FD29D6004E53CE /* common.mac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.mac.cpp; path = ../GVFS.NativeHooks.Common/common.mac.cpp; sourceTree = SOURCE_ROOT; };
+		26E839D620FD29D6004E53CE /* common.posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = common.posix.cpp; path = ../GVFS.NativeHooks.Common/common.posix.cpp; sourceTree = SOURCE_ROOT; };
 		26E839DB20FD5918004E53CE /* stdafx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stdafx.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -46,7 +46,7 @@
 			isa = PBXGroup;
 			children = (
 				26E839DB20FD5918004E53CE /* stdafx.h */,
-				26E839D620FD29D6004E53CE /* common.mac.cpp */,
+				26E839D620FD29D6004E53CE /* common.posix.cpp */,
 				2686926B20EFF2610080F95D /* common.h */,
 				267A836B20EE9F27005E6B60 /* main.cpp */,
 				267A836920EE9F27005E6B60 /* Products */,
@@ -117,7 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				267A836C20EE9F27005E6B60 /* main.cpp in Sources */,
-				26E839D920FD4026004E53CE /* common.mac.cpp in Sources */,
+				26E839D920FD4026004E53CE /* common.posix.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Rename the `common.mac.cpp` source file to `common.posix.cpp` so it can be used as a basis for Linux hook programs as well.

Also replace the BSD-specific `strlcat()` and `strlcpy()` with generic C string functions from the `<cstring>` standard library header.