### PR TITLE
exclude .a files from code coverage

### DIFF
--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -83,6 +83,7 @@ while read line; do
 	 [[ $line != *"RWLock_DropExclusiveToShared"* ]] && 
 	 [[ $line != *".xctest"* ]] && 
 	 [[ $line != *".cpp"* ]] && 
+	 [[ $line != *".a"* ]] && 
 	 [[ $line != *".hpp"* ]]; then
        echo "Error: not at 100% Code Coverage $line"
        exit 1


### PR DESCRIPTION
We want to see coverage failures on a per function basis, not a full file (.cpp/.hpp./.a).  

The .a (like a .cpp/.hpp) gives a code coverage summary for a set of functions.  

The reason why this caused a failure is that one of the functions in the .a summary report is on the exclusion list.  

However it is a mystery why the .a file is only now being generated.  Perhaps something changed in the build causing this to happen, or the Xcode verison on the machine is slightly different.