### PR TITLE
Add more time for disposal

### DIFF
--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
@@ -147,7 +147,7 @@ namespace GVFS.UnitTests.Common
             result.ShouldEqual(true, string.Format("Unexcepted function result from first call to TryInvoke: {0} ReturnCode: {1}", result, tryInvokeResult1));
             this.numConstructors.ShouldEqual(1);
 
-            this.DisposalTriggers.TryTake(out object _, (int)this.disposalPeriod.TotalMilliseconds * 100).ShouldBeTrue("Did not dispose object in time");
+            this.DisposalTriggers.TryTake(out object _, (int)this.disposalPeriod.TotalMilliseconds * 500).ShouldBeTrue("Did not dispose object in time");
             this.numDisposals.ShouldEqual(1);
             this.numConstructors.ShouldEqual(1);
 


### PR DESCRIPTION
I saw a failure in a unit test, and the new logging helped me diagnose the issue :-)
- The failure was "Did not dispose object in time"

Unfortunately after requeue I no longer see that build, so I can't provide a link.  I'll investigate that in a separate thread.

The current tests waits 100ms for dispose to be called.
This ups the time to 500ms.
If you look at the test class, there is a background timer every 1ms that attempts to dispose.  

My vote is to keep the test on with the 500ms.  If it doesn't dispose in that amount of time, i'd be more wary there is an issue.  