### PR TITLE
Close directory fds when walking directory hierarchy in PrjFSLib

### DIFF
--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -881,6 +881,8 @@ static PrjFS_Result HandleRecursivelyEnumerateDirectoryRequest(const MessageHead
             
             dirEntry = readdir(directory);
         }
+        
+        closedir(directory);
     }
     
 CleanupAndReturn:
@@ -1346,6 +1348,8 @@ static PrjFS_Result RecursivelyMarkAllChildrenAsInRoot(const char* fullDirectory
             
             dirEntry = readdir(directory);
         }
+        
+        closedir(directory);
     }
     
 CleanupAndReturn:


### PR DESCRIPTION
Fixes #1037 

We have two spots in PrjFSLib where we traverse a directory structure, calling `opendir` on directories encountered, but we never call `closedir` on those directories before moving onto the next directory.

Now both HandleRecursivelyEnumerateDirectoryRequest and RecursivelyMarkAllChildrenAsInRoot properly close directory file descriptors when walking the directory hierarchy.

This was detected while standing up the Large Repo Perf Tests on macOS. I noticed that my machine was running out of file descriptors after running a test where thousands of placeholders (files and directories) are created and then deleted. Using `lsof -a -p <PID>` on the PID of GVFS.Mount, I saw that we had a bunch of file descriptors open for folders that were already deleted.