### PR TITLE
Org info server

### DIFF
--- a/GVFS/GVFS.Common/AzDevOpsOrgFromNuGetFeed.cs
+++ b/GVFS/GVFS.Common/AzDevOpsOrgFromNuGetFeed.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace GVFS.Common
+{
+    public class AzDevOpsOrgFromNuGetFeed
+    {
+        /// <summary>
+        /// Given a URL for a NuGet feed hosted on Azure DevOps,
+        /// return the organization that hosts the feed.
+        /// </summary>
+        public static bool TryParseOrg(string packageFeedUrl, out string orgName)
+        {
+            // We expect a URL of the form https://pkgs.dev.azure.com/{org}
+            // and want to convert it to a URL of the form https://{org}.visualstudio.com
+            Regex packageUrlRegex = new Regex(
+                @"^https://pkgs.dev.azure.com/(?<org>.+?)/",
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            Match urlMatch = packageUrlRegex.Match(packageFeedUrl);
+
+            if (!urlMatch.Success)
+            {
+                orgName = null;
+                return false;
+            }
+
+            orgName = urlMatch.Groups["org"].Value;
+            return true;
+        }
+
+        /// <summary>
+        /// Given a URL for a NuGet feed hosted on Azure DevOps,
+        /// return a URL that Git Credential Manager can use to
+        /// query for a credential that is valid for use with the
+        /// NuGet feed.
+        /// </summary>
+        public static bool TryCreateCredentialQueryUrl(string packageFeedUrl, out string azureDevOpsUrl, out string error)
+        {
+            if (!TryParseOrg(packageFeedUrl, out string org))
+            {
+                azureDevOpsUrl = null;
+                error = $"Input URL {packageFeedUrl} did not match expected format for an Azure DevOps Package Feed URL";
+                return false;
+            }
+
+            azureDevOpsUrl = $"https://{org}.visualstudio.com";
+            error = null;
+
+            return true;
+        }
+    }
+}

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -44,6 +44,7 @@ namespace GVFS.Common
             public const string UpgradeRing = "upgrade.ring";
             public const string UpgradeFeedPackageName = "upgrade.feedpackagename";
             public const string UpgradeFeedUrl = "upgrade.feedurl";
+            public const string OrgInfoServerUrl = "upgrade.orgInfoServerUrl";
         }
 
         public static class GitStatusCache

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -25,6 +25,7 @@ namespace GVFS.Common
 
         public GVFSPlatformConstants Constants { get; }
         public UnderConstructionFlags UnderConstruction { get; }
+        public abstract string Name { get; }
 
         public static void Register(GVFSPlatform platform)
         {

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -55,6 +55,8 @@ namespace GVFS.Common
 
         public GitHubUpgraderConfig Config { get; private set; }
 
+        public override bool SupportsAnonymousVersionQuery { get => true; }
+
         public static GitHubUpgrader Create(
             ITracer tracer,
             PhysicalFileSystem fileSystem,

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -1,3 +1,4 @@
+using GVFS.Common;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
@@ -8,7 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace GVFS.Common.NuGetUpgrade
@@ -140,30 +140,6 @@ namespace GVFS.Common.NuGetUpgrade
                 upgraderConfig,
                 ProductUpgraderInfo.GetAssetDownloadsPath(),
                 credentialStore);
-
-            return true;
-        }
-
-        public static bool TryCreateAzDevOrgUrlFromPackageFeedUrl(string packageFeedUrl, out string azureDevOpsUrl, out string error)
-        {
-            // We expect a URL of the form https://pkgs.dev.azure.com/{org}
-            // and want to convert it to a URL of the form https://{org}.visualstudio.com
-            Regex packageUrlRegex = new Regex(
-                @"^https://pkgs.dev.azure.com/(?<org>.+?)/",
-                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-            Match urlMatch = packageUrlRegex.Match(packageFeedUrl);
-
-            if (!urlMatch.Success)
-            {
-                azureDevOpsUrl = null;
-                error = $"Input URL {packageFeedUrl} did not match expected format for an Azure DevOps Package Feed URL";
-                return false;
-            }
-
-            string org = urlMatch.Groups["org"].Value;
-
-            azureDevOpsUrl = urlMatch.Result($"https://{org}.visualstudio.com");
-            error = null;
 
             return true;
         }
@@ -600,7 +576,7 @@ namespace GVFS.Common.NuGetUpgrade
             try
             {
                 string authUrl;
-                if (!TryCreateAzDevOrgUrlFromPackageFeedUrl(this.nuGetUpgraderConfig.FeedUrl, out authUrl, out error))
+                if (!AzDevOpsOrgFromNuGetFeed.TryCreateCredentialQueryUrl(this.nuGetUpgraderConfig.FeedUrl, out authUrl, out error))
                 {
                     return false;
                 }
@@ -631,7 +607,7 @@ namespace GVFS.Common.NuGetUpgrade
                 }
 
                 string authUrl;
-                if (!TryCreateAzDevOrgUrlFromPackageFeedUrl(this.nuGetUpgraderConfig.FeedUrl, out authUrl, out error))
+                if (!AzDevOpsOrgFromNuGetFeed.TryCreateCredentialQueryUrl(this.nuGetUpgraderConfig.FeedUrl, out authUrl, out error))
                 {
                     return false;
                 }

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -81,6 +81,8 @@ namespace GVFS.Common.NuGetUpgrade
 
         public string DownloadedPackagePath { get; private set; }
 
+        public override bool SupportsAnonymousVersionQuery { get => false; }
+
         /// <summary>
         /// Path to unzip the downloaded upgrade package
         /// </summary>

--- a/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
@@ -1,0 +1,262 @@
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using System;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace GVFS.Common.NuGetUpgrade
+{
+    public class OrgNuGetUpgrader : NuGetUpgrader
+    {
+        private HttpClient httpClient;
+        private string platform;
+
+        public OrgNuGetUpgrader(
+           string currentVersion,
+           ITracer tracer,
+           PhysicalFileSystem fileSystem,
+           HttpClient httpClient,
+           bool dryRun,
+           bool noVerify,
+           OrgNuGetUpgraderConfig config,
+           string downloadFolder,
+           string platform,
+           ICredentialStore credentialStore)
+           : base(
+               currentVersion,
+               tracer,
+               fileSystem,
+               dryRun,
+               noVerify,
+               config,
+               downloadFolder,
+               credentialStore)
+        {
+            this.httpClient = httpClient;
+            this.platform = platform;
+        }
+
+        public OrgNuGetUpgrader(
+           string currentVersion,
+           ITracer tracer,
+           PhysicalFileSystem fileSystem,
+           HttpClient httpClient,
+           bool dryRun,
+           bool noVerify,
+           OrgNuGetUpgraderConfig config,
+           string platform,
+           NuGetFeed nuGetFeed,
+           ICredentialStore credentialStore)
+           : base(
+               currentVersion,
+               tracer,
+               dryRun,
+               noVerify,
+               fileSystem,
+               config,
+               nuGetFeed,
+               credentialStore)
+        {
+            this.httpClient = httpClient;
+            this.platform = platform;
+        }
+
+        public override bool SupportsAnonymousVersionQuery { get => true; }
+
+        private OrgNuGetUpgraderConfig Config { get => this.nuGetUpgraderConfig as OrgNuGetUpgraderConfig;  }
+        private string OrgInfoServerUrl { get => this.Config.OrgInfoServer; }
+        private string Ring { get => this.Config.UpgradeRing; }
+
+        public static bool TryCreate(
+            ITracer tracer,
+            PhysicalFileSystem fileSystem,
+            LocalGVFSConfig gvfsConfig,
+            HttpClient httpClient,
+            ICredentialStore credentialStore,
+            bool dryRun,
+            bool noVerify,
+            out OrgNuGetUpgrader upgrader,
+            out string error)
+        {
+            OrgNuGetUpgraderConfig upgraderConfig = new OrgNuGetUpgraderConfig(tracer, gvfsConfig);
+            upgrader = null;
+
+            if (!upgraderConfig.TryLoad(out error))
+            {
+                upgrader = null;
+                return false;
+            }
+
+            if (!upgraderConfig.IsConfigured(out error))
+            {
+                return false;
+            }
+
+            if (!upgraderConfig.IsReady(out error))
+            {
+                return false;
+            }
+
+            string platform = GVFSPlatform.Instance.Name;
+
+            upgrader = new OrgNuGetUpgrader(
+                ProcessHelper.GetCurrentProcessVersion(),
+                tracer,
+                fileSystem,
+                httpClient,
+                dryRun,
+                noVerify,
+                upgraderConfig,
+                ProductUpgraderInfo.GetAssetDownloadsPath(),
+                platform,
+                credentialStore);
+
+            return true;
+        }
+
+        public override bool TryQueryNewestVersion(out Version newVersion, out string message)
+        {
+            newVersion = null;
+
+            if (!TryParseOrgFromNuGetFeedUrl(this.Config.FeedUrl, out string orgName))
+            {
+                message = "OrgNuGetUpgrader is not able to parse org name from NuGet Package Feed URL";
+                return false;
+            }
+
+            OrgInfoApiClient infoServer = new OrgInfoApiClient(this.httpClient, this.OrgInfoServerUrl);
+
+            try
+            {
+                this.highestVersionAvailable = infoServer.QueryNewestVersion(orgName, this.platform, this.Ring);
+            }
+            catch (Exception exception) when (exception is HttpRequestException ||
+                                              exception is TaskCanceledException)
+            {
+                // GetStringAsync can also throw a TaskCanceledException to indicate a timeout
+                // https://github.com/dotnet/corefx/issues/20296
+                message = string.Format("Network error: could not connect to server ({0}). {1}", this.OrgInfoServerUrl, exception.Message);
+                this.TraceException(exception, nameof(this.TryQueryNewestVersion), "Error connecting to server.");
+
+                return false;
+            }
+            catch (SerializationException exception)
+            {
+                message = string.Format("Parse error: could not parse response from server({0}). {1}", this.OrgInfoServerUrl, exception.Message);
+                this.TraceException(exception, nameof(this.TryQueryNewestVersion), "Error parsing response from server.");
+
+                return false;
+            }
+            catch (Exception exception) when (exception is ArgumentException ||
+                                              exception is FormatException ||
+                                              exception is OverflowException)
+            {
+                message = string.Format("Unexpected response from server: could nor parse version({0}). {1}", this.OrgInfoServerUrl, exception.Message);
+                this.TraceException(exception, nameof(this.TryQueryNewestVersion), "Error parsing response from server.");
+
+                return false;
+            }
+
+            if (this.highestVersionAvailable != null &&
+                this.highestVersionAvailable > this.installedVersion)
+            {
+                newVersion = this.highestVersionAvailable;
+            }
+
+            if (newVersion != null)
+            {
+                this.tracer.RelatedInfo($"{nameof(this.TryQueryNewestVersion)} - new version available: installedVersion: {this.installedVersion}, highestVersionAvailable: {newVersion}");
+                message = $"New version {newVersion} is available.";
+                return true;
+            }
+            else if (this.highestVersionAvailable != null)
+            {
+                this.tracer.RelatedInfo($"{nameof(this.TryQueryNewestVersion)} - up-to-date");
+                message = $"Highest version available is {this.highestVersionAvailable}, you are up-to-date";
+                return true;
+            }
+            else
+            {
+                this.tracer.RelatedInfo($"{nameof(this.TryQueryNewestVersion)} - no versions available from feed.");
+                message = "No versions available via endpoint.";
+                return true;
+            }
+        }
+
+        private static bool TryParseOrgFromNuGetFeedUrl(string packageFeedUrl, out string orgName)
+        {
+            // We expect a URL of the form https://pkgs.dev.azure.com/{org}
+            // and want to convert it to a URL of the form https://{org}.visualstudio.com
+            Regex packageUrlRegex = new Regex(
+                @"^https://pkgs.dev.azure.com/(?<org>.+?)/",
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            Match urlMatch = packageUrlRegex.Match(packageFeedUrl);
+
+            if (!urlMatch.Success)
+            {
+                orgName = null;
+                return false;
+            }
+
+            orgName = urlMatch.Groups["org"].Value;
+            return true;
+        }
+
+        public class OrgNuGetUpgraderConfig : NuGetUpgraderConfig
+        {
+            public OrgNuGetUpgraderConfig(ITracer tracer, LocalGVFSConfig localGVFSConfig)
+                : base(tracer, localGVFSConfig)
+            {
+            }
+
+            public string OrgInfoServer { get; set; }
+
+            public string UpgradeRing { get; set; }
+
+            public override bool TryLoad(out string error)
+            {
+                if (!base.TryLoad(out error))
+                {
+                    return false;
+                }
+
+                if (!this.localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.OrgInfoServerUrl, out string orgInfoServerUrl, out error))
+                {
+                    this.tracer.RelatedError(error);
+                    return false;
+                }
+
+                this.OrgInfoServer = orgInfoServerUrl;
+
+                if (!this.localConfig.TryGetConfig(GVFSConstants.LocalGVFSConfig.UpgradeRing, out string upgradeRing, out error))
+                {
+                    this.tracer.RelatedError(error);
+                    return false;
+                }
+
+                this.UpgradeRing = upgradeRing;
+
+                return true;
+            }
+
+            public override bool IsReady(out string error)
+            {
+                if (!base.IsReady(out error) ||
+                    string.IsNullOrEmpty(this.UpgradeRing) ||
+                    string.IsNullOrEmpty(this.OrgInfoServer))
+                {
+                    error = string.Join(
+                        Environment.NewLine,
+                        "One or more required settings for OrgNuGetUpgrader are missing.",
+                        "Use `gvfs config [{GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl} | {GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName} | {GVFSConstants.LocalGVFSConfig.UpgradeRing} | {GVFSConstants.LocalGVFSConfig.OrgInfoServerUrl}] <value>` to set the config.");
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
@@ -1,10 +1,10 @@
+using GVFS.Common;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
 using System.Net.Http;
 using System.Runtime.Serialization;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace GVFS.Common.NuGetUpgrade
@@ -121,7 +121,7 @@ namespace GVFS.Common.NuGetUpgrade
         {
             newVersion = null;
 
-            if (!TryParseOrgFromNuGetFeedUrl(this.Config.FeedUrl, out string orgName))
+            if (!AzDevOpsOrgFromNuGetFeed.TryParseOrg(this.Config.FeedUrl, out string orgName))
             {
                 message = "OrgNuGetUpgrader is not able to parse org name from NuGet Package Feed URL";
                 return false;
@@ -184,25 +184,6 @@ namespace GVFS.Common.NuGetUpgrade
                 message = "No versions available via endpoint.";
                 return true;
             }
-        }
-
-        private static bool TryParseOrgFromNuGetFeedUrl(string packageFeedUrl, out string orgName)
-        {
-            // We expect a URL of the form https://pkgs.dev.azure.com/{org}
-            // and want to convert it to a URL of the form https://{org}.visualstudio.com
-            Regex packageUrlRegex = new Regex(
-                @"^https://pkgs.dev.azure.com/(?<org>.+?)/",
-                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-            Match urlMatch = packageUrlRegex.Match(packageFeedUrl);
-
-            if (!urlMatch.Success)
-            {
-                orgName = null;
-                return false;
-            }
-
-            orgName = urlMatch.Groups["org"].Value;
-            return true;
         }
 
         public class OrgNuGetUpgraderConfig : NuGetUpgraderConfig

--- a/GVFS/GVFS.Common/OrgInfoApiClient.cs
+++ b/GVFS/GVFS.Common/OrgInfoApiClient.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Web;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Class that handles communication with a server that contains version information.
+    /// </summary>
+    public class OrgInfoApiClient
+    {
+        private const string VersionApi = "/api/GetLatestVersion";
+
+        private HttpClient client;
+        private string baseUrl;
+
+        public OrgInfoApiClient(HttpClient client, string baseUrl)
+        {
+            this.client = client;
+            this.baseUrl = baseUrl;
+        }
+
+        private string VersionUrl
+        {
+            get
+            {
+                return this.baseUrl + VersionApi;
+            }
+        }
+
+        public Version QueryNewestVersion(string orgName, string platform, string ring)
+        {
+            Dictionary<string, string> queryParams = new Dictionary<string, string>()
+            {
+                { "Organization", orgName },
+                { "Platform", platform },
+                { "Ring", ring },
+            };
+
+            string responseString = this.client.GetStringAsync(this.ConstructRequest(this.VersionUrl, queryParams)).GetAwaiter().GetResult();
+            VersionResponse versionResponse = VersionResponse.FromJsonString(responseString);
+
+            return new Version(versionResponse.Version);
+        }
+
+        private string ConstructRequest(string baseUrl, Dictionary<string, string> queryParams)
+        {
+            StringBuilder sb = new StringBuilder(baseUrl);
+
+            if (queryParams.Any())
+            {
+                sb.Append("?");
+            }
+
+            bool isFirst = true;
+            foreach (KeyValuePair<string, string> kvp in queryParams)
+            {
+                if (!isFirst)
+                {
+                    sb.Append("&");
+                }
+
+                isFirst = false;
+                sb.Append($"{HttpUtility.UrlEncode(kvp.Key)}={HttpUtility.UrlEncode(kvp.Value)}");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/GVFS/GVFS.Common/OrgInfoApiClient.cs
+++ b/GVFS/GVFS.Common/OrgInfoApiClient.cs
@@ -43,6 +43,11 @@ namespace GVFS.Common
             string responseString = this.client.GetStringAsync(this.ConstructRequest(this.VersionUrl, queryParams)).GetAwaiter().GetResult();
             VersionResponse versionResponse = VersionResponse.FromJsonString(responseString);
 
+            if (string.IsNullOrEmpty(versionResponse.Version))
+            {
+                return null;
+            }
+
             return new Version(versionResponse.Version);
         }
 

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -71,6 +71,8 @@ namespace GVFS.Common
         {
         }
 
+        public abstract bool SupportsAnonymousVersionQuery { get; }
+
         public string UpgradeInstanceId { get; set; } = DateTime.Now.ToString("yyyyMMdd_HHmmss");
 
         public static bool TryCreateUpgrader(

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -3,7 +3,9 @@ using GVFS.Common.Git;
 using GVFS.Common.NuGetUpgrade;
 using GVFS.Common.Tracing;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 
 namespace GVFS.Common
 {
@@ -85,37 +87,80 @@ namespace GVFS.Common
             out ProductUpgrader newUpgrader,
             out string error)
         {
-            // Prefer to use the NuGet upgrader if it is configured. If the NuGet upgrader is not configured,
-            // then try to use the GitHubUpgrader.
-            if (NuGetUpgrader.TryCreate(tracer, fileSystem, gvfsConfig, credentialStore, dryRun, noVerify, out NuGetUpgrader nuGetUpgrader, out bool isConfigured, out error))
+            Dictionary<string, string> entries;
+            if (!gvfsConfig.TryGetAllConfig(out entries, out error))
             {
-                // We were successfully able to load a NuGetUpgrader - use that.
-                newUpgrader = nuGetUpgrader;
-                return true;
-            }
-            else
-            {
-                if (isConfigured)
-                {
-                    tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create upgrader. {error}");
-
-                    // We did not successfully load a NuGetUpgrader, but it is configured.
-                    newUpgrader = null;
-                    return false;
-                }
-
-                // We did not load a NuGetUpgrader, but it is not the configured upgrader.
-                // Try to load other upgraders as appropriate.
-            }
-
-            newUpgrader = GitHubUpgrader.Create(tracer, fileSystem, gvfsConfig, dryRun, noVerify, out error);
-            if (newUpgrader == null)
-            {
-                tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create upgrader. {error}");
+                newUpgrader = null;
                 return false;
             }
 
-            return true;
+            bool containsUpgradeFeedUrl = entries.ContainsKey(GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl);
+            bool containsUpgradePackageName = entries.ContainsKey(GVFSConstants.LocalGVFSConfig.UpgradeFeedPackageName);
+            bool containsOrgInfoServerUrl = entries.ContainsKey(GVFSConstants.LocalGVFSConfig.OrgInfoServerUrl);
+
+            if (containsUpgradeFeedUrl || containsUpgradePackageName)
+            {
+                // We are configured for NuGet - determine if we are using OrgNuGetUpgrader or not
+                if (containsOrgInfoServerUrl)
+                {
+                    if (OrgNuGetUpgrader.TryCreate(
+                        tracer,
+                        fileSystem,
+                        gvfsConfig,
+                        new HttpClient(),
+                        credentialStore,
+                        dryRun,
+                        noVerify,
+                        out OrgNuGetUpgrader orgNuGetUpgrader,
+                        out error))
+                    {
+                        // We were successfully able to load a NuGetUpgrader - use that.
+                        newUpgrader = orgNuGetUpgrader;
+                        return true;
+                    }
+                    else
+                    {
+                        tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create organization based upgrader. {error}");
+                        newUpgrader = null;
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (NuGetUpgrader.TryCreate(
+                        tracer,
+                        fileSystem,
+                        gvfsConfig,
+                        credentialStore,
+                        dryRun,
+                        noVerify,
+                        out NuGetUpgrader nuGetUpgrader,
+                        out bool isConfigured,
+                        out error))
+                    {
+                        // We were successfully able to load a NuGetUpgrader - use that.
+                        newUpgrader = nuGetUpgrader;
+                        return true;
+                    }
+                    else
+                    {
+                        tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create NuGet based upgrader. {error}");
+                        newUpgrader = null;
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                newUpgrader = GitHubUpgrader.Create(tracer, fileSystem, gvfsConfig, dryRun, noVerify, out error);
+                if (newUpgrader == null)
+                {
+                    tracer.RelatedError($"{nameof(TryCreateUpgrader)}: Could not create GitHub based upgrader. {error}");
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         public abstract bool UpgradeAllowed(out string message);

--- a/GVFS/GVFS.Common/VersionResponse.cs
+++ b/GVFS/GVFS.Common/VersionResponse.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+namespace GVFS.Common
+{
+    public class VersionResponse
+    {
+        public string Version { get; set; }
+
+        public static VersionResponse FromJsonString(string jsonString)
+        {
+            return JsonConvert.DeserializeObject<VersionResponse>(jsonString);
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -13,6 +13,7 @@ namespace GVFS.Platform.Mac
 
         public override IDiskLayoutUpgradeData DiskLayoutUpgrade { get; } = new MacDiskLayoutUpgradeData();
         public override IKernelDriver KernelDriver { get; } = new ProjFSKext();
+        public override string Name { get => "macOS"; }
 
         public override string GetOSVersionInformation()
         {

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -37,6 +37,7 @@ namespace GVFS.Platform.Windows
         public override IGitInstallation GitInstallation { get; } = new WindowsGitInstallation();
         public override IDiskLayoutUpgradeData DiskLayoutUpgrade { get; } = new WindowsDiskLayoutUpgradeData();
         public override IPlatformFileSystem FileSystem { get; } = new WindowsFileSystem();
+        public override string Name { get => "Windows"; }
 
         public static string GetStringFromRegistry(string key, string valueName)
         {

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -104,6 +104,17 @@ namespace GVFS.Service
                         return;
                     }
 
+                    if (!productUpgrader.SupportsAnonymousVersionQuery)
+                    {
+                        string message = string.Format(
+                            "{0}.{1}: Configured Product Upgrader does not support anonymous version queries.",
+                            nameof(ProductUpgradeTimer),
+                            nameof(this.TimerCallback),
+                            errorMessage);
+
+                        info.RecordHighestAvailableVersion(highestAvailableVersion: null);
+                    }
+
                     InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);
                     if (!prerunChecker.TryRunPreUpgradeChecks(out errorMessage))
                     {

--- a/GVFS/GVFS.UnitTests/Common/AzDevOpsOrgFromNuGetFeedTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/AzDevOpsOrgFromNuGetFeedTests.cs
@@ -1,0 +1,35 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class NuGetUpgraderTests
+    {
+        [TestCase("https://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
+        [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
+        [TestCase("https://dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
+        [TestCase("http://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
+        public void CanConstructAzureDevOpsUrlFromPackageFeedUrl(string packageFeedUrl, string expectedAzureDevOpsUrl)
+        {
+            bool success = AzDevOpsOrgFromNuGetFeed.TryCreateCredentialQueryUrl(
+                packageFeedUrl,
+                out string azureDevOpsUrl,
+                out string error);
+
+            if (expectedAzureDevOpsUrl != null)
+            {
+                success.ShouldBeTrue();
+                azureDevOpsUrl.ShouldEqual(expectedAzureDevOpsUrl);
+                error.ShouldBeNull();
+            }
+            else
+            {
+                success.ShouldBeFalse();
+                azureDevOpsUrl.ShouldBeNull();
+                error.ShouldNotBeNull();
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -386,31 +386,6 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             NuGetUpgrader.ReplaceArgTokens(sourceStringWithTokens, "unique_id", logDirectory).ShouldEqual(expectedProcessedString, "expected tokens have not been replaced");
         }
 
-        [TestCase("https://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
-        [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
-        [TestCase("https://dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
-        [TestCase("http://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
-        public void CanConstructAzureDevOpsUrlFromPackageFeedUrl(string packageFeedUrl, string expectedAzureDevOpsUrl)
-        {
-            bool success = NuGetUpgrader.TryCreateAzDevOrgUrlFromPackageFeedUrl(
-                packageFeedUrl,
-                out string azureDevOpsUrl,
-                out string error);
-
-            if (expectedAzureDevOpsUrl != null)
-            {
-                success.ShouldBeTrue();
-                azureDevOpsUrl.ShouldEqual(expectedAzureDevOpsUrl);
-                error.ShouldBeNull();
-            }
-            else
-            {
-                success.ShouldBeFalse();
-                azureDevOpsUrl.ShouldBeNull();
-                error.ShouldNotBeNull();
-            }
-        }
-
         [TestCase]
         public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
         {

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
@@ -1,0 +1,191 @@
+using GVFS.Common;
+using GVFS.Common.Git;
+using GVFS.Common.NuGetUpgrade;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using Moq;
+using Moq.Protected;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Common.NuGetUpgrade
+{
+    [TestFixture]
+    public class OrgNuGetUpgraderTests
+    {
+        private const string CurrentVersion = "1.5.1185.0";
+        private const string NewerVersion = "1.6.1185.0";
+
+        private const string DefaultUpgradeFeedPackageName = "package";
+        private const string DefaultUpgradeFeedUrl = "https://pkgs.dev.azure.com/contoso/";
+        private const string DefaultOrgInfoServerUrl = "https://www.contoso.com";
+        private const string DefaultRing = "slow";
+
+        private OrgNuGetUpgrader upgrader;
+
+        private MockTracer tracer;
+
+        private OrgNuGetUpgrader.OrgNuGetUpgraderConfig upgraderConfig;
+
+        private Mock<NuGetFeed> mockNuGetFeed;
+        private MockFileSystem mockFileSystem;
+        private Mock<ICredentialStore> mockCredentialManager;
+        private Mock<HttpMessageHandler> httpMessageHandlerMock;
+
+        private string downloadDirectoryPath = Path.Combine(
+            $"mock:{Path.DirectorySeparatorChar}",
+            ProductUpgraderInfo.UpgradeDirectoryName,
+            ProductUpgraderInfo.DownloadDirectory);
+
+        private interface IHttpMessageHandlerProtectedMembers
+        {
+            Task<HttpResponseMessage> SendAsync(HttpRequestMessage message, CancellationToken token);
+        }
+
+        public static IEnumerable<Exception> NetworkFailureCases()
+        {
+            yield return new HttpRequestException("Response status code does not indicate success: 401: (Unauthorized)");
+            yield return new TaskCanceledException("Task canceled");
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            MockLocalGVFSConfig mockGvfsConfig = new MockLocalGVFSConfigBuilder(
+                DefaultRing,
+                DefaultUpgradeFeedUrl,
+                DefaultUpgradeFeedPackageName,
+                DefaultOrgInfoServerUrl)
+                .WithUpgradeRing()
+                .WithUpgradeFeedPackageName()
+                .WithUpgradeFeedUrl()
+                .WithOrgInfoServerUrl()
+                .Build();
+
+            this.upgraderConfig = new OrgNuGetUpgrader.OrgNuGetUpgraderConfig(this.tracer, mockGvfsConfig);
+            this.upgraderConfig.TryLoad(out _);
+
+            this.tracer = new MockTracer();
+
+            this.mockNuGetFeed = new Mock<NuGetFeed>(
+                DefaultUpgradeFeedUrl,
+                DefaultUpgradeFeedPackageName,
+                this.downloadDirectoryPath,
+                null,
+                this.tracer);
+
+            this.mockFileSystem = new MockFileSystem(
+                new MockDirectory(
+                    Path.GetDirectoryName(this.downloadDirectoryPath),
+                    new[] { new MockDirectory(this.downloadDirectoryPath, null, null) },
+                    null));
+
+            this.mockCredentialManager = new Mock<ICredentialStore>();
+            string credentialManagerString = "value";
+            string emptyString = string.Empty;
+            this.mockCredentialManager.Setup(foo => foo.TryGetCredential(It.IsAny<ITracer>(), It.IsAny<string>(), out credentialManagerString, out credentialManagerString, out credentialManagerString)).Returns(true);
+
+            this.httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            this.httpMessageHandlerMock.Protected().As<IHttpMessageHandlerProtectedMembers>()
+                .Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(this.ConstructResponseContent(NewerVersion))
+                });
+
+            HttpClient httpClient = new HttpClient(this.httpMessageHandlerMock.Object);
+
+            this.upgrader = new OrgNuGetUpgrader(
+                CurrentVersion,
+                this.tracer,
+                this.mockFileSystem,
+                httpClient,
+                false,
+                false,
+                this.upgraderConfig,
+                "windows",
+                this.mockNuGetFeed.Object,
+                this.mockCredentialManager.Object);
+        }
+
+        [TestCase]
+        public void SupportsAnonymousQuery()
+        {
+            this.upgrader.SupportsAnonymousVersionQuery.ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void TryQueryNewestVersion()
+        {
+            Version newVersion;
+            string message;
+
+            bool success = this.upgrader.TryQueryNewestVersion(out newVersion, out message);
+
+            success.ShouldBeTrue();
+            newVersion.ShouldNotBeNull();
+            newVersion.ShouldEqual<Version>(new Version(NewerVersion));
+            message.ShouldNotBeNull();
+            message.ShouldEqual($"New version {OrgNuGetUpgraderTests.NewerVersion} is available.");
+        }
+
+        [TestCaseSource("NetworkFailureCases")]
+        public void HandlesNetworkErrors(Exception ex)
+        {
+            Version newVersion;
+            string message;
+
+            this.httpMessageHandlerMock.Protected().As<IHttpMessageHandlerProtectedMembers>()
+                .Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(ex);
+
+            bool success = this.upgrader.TryQueryNewestVersion(out newVersion, out message);
+
+            success.ShouldBeFalse();
+            newVersion.ShouldBeNull();
+            message.ShouldNotBeNull();
+            message.ShouldContain("Network error");
+        }
+
+        [TestCase]
+        public void HandlesEmptyVersion()
+        {
+            Version newVersion;
+            string message;
+
+            this.httpMessageHandlerMock.Protected().As<IHttpMessageHandlerProtectedMembers>()
+           .Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(new HttpResponseMessage()
+           {
+               StatusCode = HttpStatusCode.OK,
+               Content = new StringContent(this.ConstructResponseContent(string.Empty))
+           });
+
+            bool success = this.upgrader.TryQueryNewestVersion(out newVersion, out message);
+
+            success.ShouldBeTrue();
+            newVersion.ShouldBeNull();
+            message.ShouldNotBeNull();
+            message.ShouldContain("No versions available");
+        }
+
+        private string ConstructResponseContent(string version)
+        {
+            return $"{{\"version\" : \"{version}\"}} ";
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/OrgInfoApiClientTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/OrgInfoApiClientTests.cs
@@ -1,0 +1,110 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class OrgInfoServerTests
+    {
+        public static List<OrgInfo> TestOrgInfo = new List<OrgInfo>()
+        {
+            new OrgInfo() { OrgName = "org1", Platform = "windows", Ring = "fast", Version = "1.2.3.1" },
+            new OrgInfo() { OrgName = "org1", Platform = "windows", Ring = "slow", Version = "1.2.3.2" },
+            new OrgInfo() { OrgName = "org1", Platform = "macOS", Ring = "fast", Version = "1.2.3.3" },
+            new OrgInfo() { OrgName = "org1", Platform = "macOS", Ring = "slow", Version = "1.2.3.4" },
+            new OrgInfo() { OrgName = "org2", Platform = "windows", Ring = "fast", Version = "1.2.3.5" },
+            new OrgInfo() { OrgName = "org2", Platform = "windows", Ring = "slow", Version = "1.2.3.6" },
+            new OrgInfo() { OrgName = "org2", Platform = "macOS", Ring = "fast", Version = "1.2.3.7" },
+            new OrgInfo() { OrgName = "org2", Platform = "macOS", Ring = "slow", Version = "1.2.3.8" },
+        };
+
+        private string baseUrl = "https://www.contoso.com";
+
+        private interface IHttpMessageHandlerProtectedMembers
+        {
+            Task<HttpResponseMessage>  SendAsync(HttpRequestMessage message, CancellationToken token);
+        }
+
+        [TestCaseSource("TestOrgInfo")]
+        public void QueryNewestVersionWithParams(OrgInfo orgInfo)
+        {
+            Mock<HttpMessageHandler> handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().As<IHttpMessageHandlerProtectedMembers>()
+                .Setup(m => m.SendAsync(It.Is<HttpRequestMessage>(request => this.UriMatches(request.RequestUri, this.baseUrl, orgInfo.OrgName, orgInfo.Platform, orgInfo.Ring)), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(this.ConstructResponseContent(orgInfo.Version))
+                });
+
+            HttpClient httpClient = new HttpClient(handlerMock.Object);
+
+            OrgInfoApiClient upgradeChecker = new OrgInfoApiClient(httpClient, this.baseUrl);
+            Version version = upgradeChecker.QueryNewestVersion(orgInfo.OrgName, orgInfo.Platform, orgInfo.Ring);
+
+            version.ShouldEqual(new Version(orgInfo.Version));
+
+            handlerMock.VerifyAll();
+        }
+
+        private bool UriMatches(Uri uri, string baseUrl, string expectedOrgName, string expectedPlatform, string expectedRing)
+        {
+            bool hostMatches = uri.Host.Equals(baseUrl);
+
+            Dictionary<string, string> queryParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string param in uri.Query.Substring(1).Split('&'))
+            {
+                string[] fields = param.Split('=');
+                string key = fields[0];
+                string value = fields[1];
+
+                queryParams.Add(key, value);
+            }
+
+            if (queryParams.Count != 3)
+            {
+                return false;
+            }
+
+            if (!queryParams.TryGetValue("Organization", out string orgName) || !string.Equals(orgName, expectedOrgName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!queryParams.TryGetValue("platform", out string platform) || !string.Equals(platform, expectedPlatform, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!queryParams.TryGetValue("ring", out string ring) || !string.Equals(ring, expectedRing, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private string ConstructResponseContent(string version)
+        {
+            return $"{{\"version\" : \"{version}\"}} ";
+        }
+
+        public class OrgInfo
+        {
+            public string OrgName { get; set; }
+            public string Ring { get; set; }
+            public string Platform { get; set; }
+            public string Version { get; set; }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockLocalGVFSConfigBuilder.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockLocalGVFSConfigBuilder.cs
@@ -8,17 +8,20 @@ namespace GVFS.UnitTests.Mock.Common
         private string defaultRing;
         private string defaultUpgradeFeedUrl;
         private string defaultUpgradeFeedPackageName;
+        private string defaultOrgServerUrl;
 
         private Dictionary<string, string> entries;
 
         public MockLocalGVFSConfigBuilder(
             string defaultRing,
             string defaultUpgradeFeedUrl,
-            string defaultUpgradeFeedPackageName)
+            string defaultUpgradeFeedPackageName,
+            string defaultOrgServerUrl)
         {
             this.defaultRing = defaultRing;
             this.defaultUpgradeFeedUrl = defaultUpgradeFeedUrl;
             this.defaultUpgradeFeedPackageName = defaultUpgradeFeedPackageName;
+            this.defaultOrgServerUrl = defaultOrgServerUrl;
             this.entries = new Dictionary<string, string>();
         }
 
@@ -50,6 +53,16 @@ namespace GVFS.UnitTests.Mock.Common
         public MockLocalGVFSConfigBuilder WithNoUpgradeFeedUrl()
         {
             return this.WithNo(GVFSConstants.LocalGVFSConfig.UpgradeFeedUrl);
+        }
+
+        public MockLocalGVFSConfigBuilder WithOrgInfoServerUrl(string value = null)
+        {
+            return this.With(GVFSConstants.LocalGVFSConfig.OrgInfoServerUrl, value ?? this.defaultUpgradeFeedUrl);
+        }
+
+        public MockLocalGVFSConfigBuilder WithNoOrgInfoServerUrl()
+        {
+            return this.WithNo(GVFSConstants.LocalGVFSConfig.OrgInfoServerUrl);
         }
 
         public MockLocalGVFSConfig Build()

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -26,6 +26,7 @@ namespace GVFS.UnitTests.Mock.Common
         public override IDiskLayoutUpgradeData DiskLayoutUpgrade => throw new NotSupportedException();
 
         public override IPlatformFileSystem FileSystem { get; } = new MockPlatformFileSystem();
+        public override string Name { get => "Mock"; }
 
         public HashSet<int> ActiveProcesses { get; } = new HashSet<int>();
 


### PR DESCRIPTION
Consume an endpoint that provides indicates what version of VFS for Git should be downloaded based on Organization, platform, and ring.

This is a slightly different take than #1034, and focuses on the org info server implementation more than refining the `Upgrader` logic.

If we can require the upgrade logic to always be driven off of the org info server, we could probably collapse the `ModernNuGetUpgrader` logic into `NuGetUpgrader`.