### PR TITLE
Update PrjFSKextLogDaemon to monitor and record vnode cache health

### DIFF
--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
@@ -2,7 +2,7 @@
 #include "public/PrjFSLogClientShared.h"
 #include "KextLog.hpp"
 #include "public/PrjFSCommon.h"
-#include "public/PrjFSHealthData.h"
+#include "public/PrjFSVnodeCacheHealth.h"
 #include "PerformanceTracing.hpp"
 #include "VnodeCache.hpp"
 #include <IOKit/IOSharedDataQueue.h>
@@ -23,13 +23,13 @@ static const IOExternalMethodDispatch LogUserClientDispatch[] =
             .checkScalarOutputCount =   0,
             .checkStructureOutputSize = PrjFSPerfCounter_Count * sizeof(PrjFSPerfCounterResult), // array of results
         },
-    [LogSelector_FetchHealthData] =
+    [LogSelector_FetchVnodeCacheHealth] =
         {
-            .function =                 &PrjFSLogUserClient::fetchHealthData,
+            .function =                 &PrjFSLogUserClient::fetchVnodeCacheHealth,
             .checkScalarInputCount =    0,
             .checkStructureInputSize =  0,
             .checkScalarOutputCount =   0,
-            .checkStructureOutputSize = sizeof(PrjFSHealthData),
+            .checkStructureOutputSize = sizeof(PrjFSVnodeCacheHealth),
         },
 };
 
@@ -192,7 +192,7 @@ IOReturn PrjFSLogUserClient::fetchProfilingData(
     return PerfTracing_ExportDataUserClient(arguments);
 }
 
-IOReturn PrjFSLogUserClient::fetchHealthData(
+IOReturn PrjFSLogUserClient::fetchVnodeCacheHealth(
         OSObject* target,
         void* reference,
         IOExternalMethodArguments* arguments)

--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
@@ -2,7 +2,9 @@
 #include "public/PrjFSLogClientShared.h"
 #include "KextLog.hpp"
 #include "public/PrjFSCommon.h"
+#include "public/PrjFSHealthData.h"
 #include "PerformanceTracing.hpp"
+#include "VnodeCache.hpp"
 #include <IOKit/IOSharedDataQueue.h>
 
 
@@ -20,6 +22,14 @@ static const IOExternalMethodDispatch LogUserClientDispatch[] =
             .checkStructureInputSize =  0,
             .checkScalarOutputCount =   0,
             .checkStructureOutputSize = PrjFSPerfCounter_Count * sizeof(PrjFSPerfCounterResult), // array of results
+        },
+    [LogSelector_FetchHealthData] =
+        {
+            .function =                 &PrjFSLogUserClient::fetchHealthData,
+            .checkScalarInputCount =    0,
+            .checkStructureInputSize =  0,
+            .checkScalarOutputCount =   0,
+            .checkStructureOutputSize = sizeof(PrjFSHealthData),
         },
 };
 
@@ -180,5 +190,13 @@ IOReturn PrjFSLogUserClient::fetchProfilingData(
     IOExternalMethodArguments* arguments)
 {
     return PerfTracing_ExportDataUserClient(arguments);
+}
+
+IOReturn PrjFSLogUserClient::fetchHealthData(
+        OSObject* target,
+        void* reference,
+        IOExternalMethodArguments* arguments)
+{
+    return VnodeCache_ExportHealthData(arguments);
 }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
@@ -39,5 +39,10 @@ public:
         void* reference,
         IOExternalMethodArguments* arguments);
     
+    static IOReturn fetchHealthData(
+        OSObject* target,
+        void* reference,
+        IOExternalMethodArguments* arguments);
+    
     void sendLogMessage(KextLog_MessageHeader* message, uint32_t size);
 };

--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
@@ -39,7 +39,7 @@ public:
         void* reference,
         IOExternalMethodArguments* arguments);
     
-    static IOReturn fetchHealthData(
+    static IOReturn fetchVnodeCacheHealth(
         OSObject* target,
         void* reference,
         IOExternalMethodArguments* arguments);

--- a/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
@@ -5,7 +5,7 @@
 #include "Memory.hpp"
 #include "KextLog.hpp"
 #include "../PrjFSKext/public/PrjFSCommon.h"
-#include "../PrjFSKext/public/PrjFSHealthData.h"
+#include "../PrjFSKext/public/PrjFSVnodeCacheHealth.h"
 
 #include "VnodeCachePrivate.hpp"
 
@@ -230,7 +230,7 @@ void VnodeCache_InvalidateCache(PerfTracer* _Nonnull perfTracer)
 
 IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull arguments)
 {
-    PrjFSHealthData healthData =
+    PrjFSVnodeCacheHealth healthData =
     {
         .cacheCapacity = s_entriesCapacity,
         .cacheEntries = s_cacheStats.cacheEntries, // cacheEntries is reset to 0 when VnodeCache_InvalidateCache is called
@@ -267,7 +267,7 @@ IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull argumen
         return result;
     }
 
-    if (arguments->structureOutput == nullptr || arguments->structureOutputSize != sizeof(PrjFSHealthData))
+    if (arguments->structureOutput == nullptr || arguments->structureOutputSize != sizeof(PrjFSVnodeCacheHealth))
     {
         KextLog("VnodeCache_ExportHealthData: structure output size %u, expected %lu\n", arguments->structureOutputSize, sizeof(healthData));
         return kIOReturnBadArgument;

--- a/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
@@ -280,7 +280,7 @@ IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull argumen
 KEXT_STATIC_INLINE void InvalidateCache_ExclusiveLocked()
 {
     memset(s_entries, 0, s_entriesCapacity * sizeof(VnodeCacheEntry));
-    atomic_exchange_explicit(&s_cacheStats.cacheEntries, 0U, memory_order_relaxed);
+    atomic_store_explicit(&s_cacheStats.cacheEntries, 0U, memory_order_relaxed);
 }
 
 KEXT_STATIC_INLINE uint32_t ComputePow2CacheCapacity(int expectedVnodeCount)
@@ -509,11 +509,11 @@ KEXT_STATIC bool TryInsertOrUpdateEntry_ExclusiveLocked(
 
 KEXT_STATIC_INLINE void InitCacheStats()
 {
-    atomic_exchange_explicit(&s_cacheStats.cacheEntries, 0U, memory_order_relaxed);
+    atomic_store_explicit(&s_cacheStats.cacheEntries, 0U, memory_order_relaxed);
     
     for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
     {
-        atomic_exchange_explicit(&s_cacheStats.healthStats[i], 0ULL, memory_order_relaxed);
+        atomic_store_explicit(&s_cacheStats.healthStats[i], 0ULL, memory_order_relaxed);
     }
 }
 
@@ -530,6 +530,6 @@ KEXT_STATIC_INLINE void AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat healt
                 VnodeCacheHealthStatNames[healthStat],
                 statValue);
         
-        atomic_exchange_explicit(&s_cacheStats.healthStats[healthStat], 0ULL, memory_order_relaxed);
+        atomic_store_explicit(&s_cacheStats.healthStats[healthStat], 0ULL, memory_order_relaxed);
     }
 }

--- a/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
@@ -234,11 +234,10 @@ IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull argumen
     {
         .cacheCapacity = s_entriesCapacity,
         .cacheEntries = s_cacheStats.cacheEntries, // cacheEntries is reset to 0 when VnodeCache_InvalidateCache is called
-        .invalidateEntireCacheCount = atomic_exchange_explicit(
-            &s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], 0ULL, memory_order_relaxed),
+        .invalidateEntireCacheCount = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], 0ULL, memory_order_relaxed),
         .totalCacheLookups = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalCacheLookups], 0ULL, memory_order_relaxed),
         .totalLookupCollisions = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions], 0ULL, memory_order_relaxed),
-        .totalFindRootForVnodeHits = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], 0ULL, memory_order_relaxed),
+        .totalFindRootForVnodeHits = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits], 0ULL, memory_order_relaxed),
         .totalFindRootForVnodeMisses = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses], 0ULL, memory_order_relaxed),
         .totalRefreshRootForVnode = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalRefreshRootForVnode], 0ULL, memory_order_relaxed),
         .totalInvalidateVnodeRoot = atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_TotalInvalidateVnodeRoot], 0ULL, memory_order_relaxed),

--- a/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCache.cpp
@@ -220,7 +220,6 @@ void VnodeCache_InvalidateCache(PerfTracer* _Nonnull perfTracer)
 {
     perfTracer->IncrementCount(PrjFSPerfCounter_CacheInvalidateCount, true /*ignoreSampling*/);
     AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);
-    atomic_exchange(&s_cacheStats.cacheEntries, 0U);
 
     RWLock_AcquireExclusive(s_entriesLock);
     {
@@ -280,6 +279,7 @@ IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull argumen
 KEXT_STATIC_INLINE void InvalidateCache_ExclusiveLocked()
 {
     memset(s_entries, 0, s_entriesCapacity * sizeof(VnodeCacheEntry));
+    atomic_exchange(&s_cacheStats.cacheEntries, 0U);
 }
 
 KEXT_STATIC_INLINE uint32_t ComputePow2CacheCapacity(int expectedVnodeCount)

--- a/ProjFS.Mac/PrjFSKext/VnodeCache.hpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCache.hpp
@@ -7,6 +7,8 @@ kern_return_t VnodeCache_Init();
 
 kern_return_t VnodeCache_Cleanup();
 
+IOReturn VnodeCache_ExportHealthData(IOExternalMethodArguments* _Nonnull arguments);
+
 VirtualizationRootHandle VnodeCache_FindRootForVnode(
         PerfTracer* _Nonnull perfTracer,
         PrjFSPerfCounter cacheHitCounter,

--- a/ProjFS.Mac/PrjFSKext/VnodeCachePrivate.hpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCachePrivate.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "kernel-header-wrappers/stdatomic.h"
+#include "public/ArrayUtils.hpp"
+
 enum UpdateCacheBehavior
 {
     UpdateCacheBehavior_Invalid = 0,
@@ -20,6 +23,38 @@ struct VnodeCacheEntry
     uint32_t vid;   // vnode generation number
     VirtualizationRootHandle virtualizationRoot;
 };
+
+enum VnodeCacheHealthStat : int32_t
+{
+    VnodeCacheHealthStat_InvalidateEntireCacheCount,
+    VnodeCacheHealthStat_TotalCacheLookups,
+    VnodeCacheHealthStat_TotalLookupCollisions,
+    VnodeCacheHealthStat_TotalFindRootForVnodeHits,
+    VnodeCacheHealthStat_TotalFindRootForVnodeMisses,
+    VnodeCacheHealthStat_TotalRefreshRootForVnode,
+    VnodeCacheHealthStat_TotalInvalidateVnodeRoot,
+    
+    VnodeCacheHealthStat_Count
+};
+
+static constexpr const char* const VnodeCacheHealthStatNames[VnodeCacheHealthStat_Count] =
+{
+    [VnodeCacheHealthStat_InvalidateEntireCacheCount]  = "InvalidateEntireCacheCount",
+    [VnodeCacheHealthStat_TotalCacheLookups]           = "TotalCacheLookups",
+    [VnodeCacheHealthStat_TotalLookupCollisions]       = "TotalLookupCollisions",
+    [VnodeCacheHealthStat_TotalFindRootForVnodeHits]   = "TotalFindRootForVnodeHits",
+    [VnodeCacheHealthStat_TotalFindRootForVnodeMisses] = "TotalFindRootForVnodeMisses",
+    [VnodeCacheHealthStat_TotalRefreshRootForVnode]    = "TotalRefreshRootForVnode",
+    [VnodeCacheHealthStat_TotalInvalidateVnodeRoot]    = "TotalInvalidateVnodeRoot",
+};
+
+struct VnodeCacheStats
+{
+    _Atomic(uint32_t) cacheEntries;
+    _Atomic(uint64_t) healthStats[VnodeCacheHealthStat_Count];
+};
+
+static_assert(AllArrayElementsInitialized(VnodeCacheHealthStatNames), "There must be an initialization of VnodeCacheHealthStatNames elements corresponding to each VnodeCacheHealthStat enum value");
 
 // Allow cache the cache to use between 4 MB and 64 MB of memory (assuming 16 bytes per VnodeCacheEntry)
 KEXT_STATIC const uint32_t MinPow2VnodeCacheCapacity = 0x040000;

--- a/ProjFS.Mac/PrjFSKext/VnodeCacheTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeCacheTestable.hpp
@@ -57,8 +57,12 @@ KEXT_STATIC bool TryInsertOrUpdateEntry_ExclusiveLocked(
     bool forceRefreshEntry,
     VirtualizationRootHandle rootHandle);
 
+KEXT_STATIC_INLINE void InitCacheStats();
+KEXT_STATIC_INLINE void AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat healthStat, uint64_t value);
+
 // Static variables used for maintaining Vnode cache state
 extern uint32_t s_entriesCapacity;
 extern uintptr_t s_ModBitmask;
 extern VnodeCacheEntry* _Nullable s_entries;
+extern VnodeCacheStats s_cacheStats;
 

--- a/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
+++ b/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
@@ -7,6 +7,8 @@ using std::atomic_uint_least32_t;
 using std::atomic_uint_least64_t;
 using std::atomic_int;
 using std::memory_order_seq_cst;
+using std::atomic_exchange;
+using std::atomic_fetch_add;
 #else
 #include <stdatomic.h>
 #endif

--- a/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
+++ b/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
@@ -8,6 +8,7 @@ using std::atomic_uint_least64_t;
 using std::atomic_int;
 using std::memory_order_seq_cst;
 using std::memory_order_relaxed;
+using std::atomic_store_explicit;
 using std::atomic_exchange_explicit;
 using std::atomic_fetch_add_explicit;
 #else

--- a/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
+++ b/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
@@ -7,8 +7,9 @@ using std::atomic_uint_least32_t;
 using std::atomic_uint_least64_t;
 using std::atomic_int;
 using std::memory_order_seq_cst;
-using std::atomic_exchange;
-using std::atomic_fetch_add;
+using std::memory_order_relaxed;
+using std::atomic_exchange_explicit;
+using std::atomic_fetch_add_explicit;
 #else
 #include <stdatomic.h>
 #endif

--- a/ProjFS.Mac/PrjFSKext/public/ArrayUtils.hpp
+++ b/ProjFS.Mac/PrjFSKext/public/ArrayUtils.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+template <typename T, size_t N>
+    constexpr bool AllArrayElementsInitialized(T (&array)[N], size_t fromIndex = 0)
+{
+    return
+        fromIndex >= N
+        ? true
+        : (array[fromIndex] != T()
+           && AllArrayElementsInitialized(array, fromIndex + 1));
+}

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSHealthData.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSHealthData.h
@@ -1,0 +1,34 @@
+#pragma once
+
+struct PrjFSHealthData
+{
+    // Total capacity of the vnode cache
+    uint32_t cacheCapacity;
+    
+    // Number of entries in the cache (i.e. the number of slots in use)
+    uint32_t cacheEntries;
+    
+    // Number of times that the entire cache has been invalidated
+    uint64_t invalidateEntireCacheCount;
+    
+    // Number of (internal) lookups in the cache array.  This value tracks how many times
+    // the VnodeCache functions had to perform a lookup in the cache
+    uint64_t totalCacheLookups;
+    
+    // Number of collisions that occurred when looking up entries in the cache.  Each step
+    // of the linear probe counts as a collision.
+    uint64_t totalLookupCollisions;
+    
+    // Number of times that VnodeCache_FindRootForVnode found an up-to-date vnode in the cache
+    uint64_t totalFindRootForVnodeHits;
+    
+    // Number of times that VnodeCache_FindRootForVnode did not find the vnode in the cache (or the
+    // vnode in the cache was not up-to-date).
+    uint64_t totalFindRootForVnodeMisses;
+    
+    // Number of times VnodeCache_RefreshRootForVnode was called
+    uint64_t totalRefreshRootForVnode;
+    
+    // Number of times VnodeCache_InvalidateVnodeRootAndGetLatestRoot was called
+    uint64_t totalInvalidateVnodeRoot;
+};

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
@@ -8,6 +8,7 @@ enum PrjFSLogUserClientSelector
     LogSelector_Invalid = 0,
     
     LogSelector_FetchProfilingData,
+    LogSelector_FetchHealthData,
 };
 
 enum PrjFSLogUserClientMemoryType

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSLogClientShared.h
@@ -8,7 +8,7 @@ enum PrjFSLogUserClientSelector
     LogSelector_Invalid = 0,
     
     LogSelector_FetchProfilingData,
-    LogSelector_FetchHealthData,
+    LogSelector_FetchVnodeCacheHealth,
 };
 
 enum PrjFSLogUserClientMemoryType

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSVnodeCacheHealth.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSVnodeCacheHealth.h
@@ -1,6 +1,6 @@
 #pragma once
 
-struct PrjFSHealthData
+struct PrjFSVnodeCacheHealth
 {
     // Total capacity of the vnode cache
     uint32_t cacheCapacity;

--- a/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
@@ -1,5 +1,5 @@
 #include "../PrjFSKext/public/PrjFSLogClientShared.h"
-#include "../PrjFSKext/public/PrjFSHealthData.h"
+#include "../PrjFSKext/public/PrjFSVnodeCacheHealth.h"
 #include "../PrjFSLib/PrjFSUser.hpp"
 #include <iostream>
 #include <OS/log.h>
@@ -199,9 +199,9 @@ static dispatch_source_t StartKextHealthDataPolling(io_connect_t connection)
 
 static bool TryFetchAndLogKextHealthData(io_connect_t connection)
 {
-    PrjFSHealthData healthData;
+    PrjFSVnodeCacheHealth healthData;
     size_t out_size = sizeof(healthData);
-    IOReturn ret = IOConnectCallStructMethod(connection, LogSelector_FetchHealthData, nullptr, 0, &healthData, &out_size);
+    IOReturn ret = IOConnectCallStructMethod(connection, LogSelector_FetchVnodeCacheHealth, nullptr, 0, &healthData, &out_size);
     if (ret == kIOReturnUnsupported)
     {
         return false;

--- a/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
+++ b/ProjFS.Mac/PrjFSKextLogDaemon/PrjFSKextLogDaemon.cpp
@@ -188,7 +188,7 @@ static dispatch_source_t StartKextHealthDataPolling(io_connect_t connection)
     dispatch_source_set_timer(
         timer,
         DISPATCH_TIME_NOW,      // start
-        15 * 60 * NSEC_PER_SEC, // interval
+        30 * 60 * NSEC_PER_SEC, // interval
         10 * NSEC_PER_SEC);     // leeway
     dispatch_source_set_event_handler(timer, ^{
         TryFetchAndLogKextHealthData(connection);

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -62,11 +62,11 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 - (void)testInitCacheStats {
     // We need to validate that InitCacheStats sets all of the cache health stats to zero, so
     // first set them all to something non-zero
-    atomic_exchange(&s_cacheStats.cacheEntries, 1U);
+    atomic_exchange_explicit(&s_cacheStats.cacheEntries, 1U, memory_order_relaxed);
     
     for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
     {
-        atomic_exchange(&s_cacheStats.healthStats[i], 1ULL);
+        atomic_exchange_explicit(&s_cacheStats.healthStats[i], 1ULL, memory_order_relaxed);
     }
     
     InitCacheStats();
@@ -94,7 +94,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
     
-    atomic_exchange(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], UINT64_MAX - 1000);
+    atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], UINT64_MAX - 1000, memory_order_relaxed);
     AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);
     XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == UINT64_MAX - 999);
     AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -43,6 +43,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     self->testVnodeFile3 = testMount->CreateVnodeTree(repoPath + "/file3");
     self->dummyVFSContext = vfs_context_create(nullptr);
     self->cacheWrapper.AllocateCache();
+    InitCacheStats();
 }
 
 - (void)tearDown
@@ -56,6 +57,50 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     self->testMount.reset();
     MockCalls::Clear();
     VirtualizationRoots_Cleanup();
+}
+
+- (void)testInitCacheStats {
+    // We need to validate that InitCacheStats sets all of the cache health stats to zero, so
+    // first set them all to something non-zero
+    atomic_exchange(&s_cacheStats.cacheEntries, 1U);
+    
+    for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
+    {
+        atomic_exchange(&s_cacheStats.healthStats[i], 1ULL);
+    }
+    
+    InitCacheStats();
+
+    XCTAssertTrue(s_cacheStats.cacheEntries == 0);
+    
+    for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
+    {
+        XCTAssertTrue(s_cacheStats.healthStats[i] == 0);
+    }
+}
+
+- (void)testAtomicFetchAddCacheHealthStat {
+    for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
+    {
+        AtomicFetchAddCacheHealthStat(static_cast<VnodeCacheHealthStat>(i), 1ULL);
+        XCTAssertTrue(s_cacheStats.healthStats[i] == 1);
+    }
+    
+    for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
+    {
+        AtomicFetchAddCacheHealthStat(static_cast<VnodeCacheHealthStat>(i), 2ULL);
+        XCTAssertTrue(s_cacheStats.healthStats[i] == 3);
+    }
+    
+    XCTAssertFalse(MockCalls::DidCallAnyFunctions());
+    
+    atomic_exchange(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], UINT64_MAX - 1000);
+    AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == UINT64_MAX - 999);
+    AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == 0ULL);
+    
+    XCTAssertTrue(MockCalls::DidCallFunction(KextMessageLogged, KEXTLOG_DEFAULT));
 }
 
 - (void)testVnodeCache_FindRootForVnode_EmptyCache {
@@ -80,6 +125,11 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
     
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 0);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalCacheLookups] == 2);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == 0);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -94,6 +144,8 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         self->repoPath.c_str());
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
     
+    self->cacheWrapper.FillAllEntries();
+    
     // We don't care which mocks were called during the initialization code (above)
     MockCalls::Clear();
     
@@ -105,6 +157,16 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         PrjFSPerfCounter_VnodeOp_FindRoot_Iteration,
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
+    
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 0);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 1);
+    
+    // 3 -> The initial lookup, the attempt to update the full cache, the lookup after emptying the cache
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalCacheLookups] == 3);
+    
+    // Capacity * 2 -> The first two lookups (before invalidating the cache), will collide with every entry
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == self->cacheWrapper.GetCapacity() * 2);
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -133,6 +195,10 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
     
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 0);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 1);
+    
     uintptr_t vnodeIndex = ComputeVnodeHashIndex(self->testVnodeFile1.get());
     XCTAssertTrue(self->testVnodeFile1.get() == self->cacheWrapper[vnodeIndex].vnode);
     XCTAssertTrue(self->testVnodeFile1->GetVid() == self->cacheWrapper[vnodeIndex].vid);
@@ -146,6 +212,10 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         PrjFSPerfCounter_VnodeOp_FindRoot_Iteration,
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
+    
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 1);
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -204,6 +274,9 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     XCTAssertTrue(rootHandle == self->cacheWrapper[indexFromHash].virtualizationRoot);
     XCTAssertTrue(self->testVnodeFile1.get() == self->cacheWrapper[indexFromHash].vnode);
     
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalRefreshRootForVnode] == 1);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -261,6 +334,9 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     XCTAssertTrue(testVnodeVid == self->cacheWrapper[indexFromHash].vid);
     XCTAssertTrue(RootHandle_Indeterminate == self->cacheWrapper[indexFromHash].virtualizationRoot);
     
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalInvalidateVnodeRoot] == 1);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -274,6 +350,8 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     VnodeCache_InvalidateCache(&self->dummyPerfTracer);
     XCTAssertTrue(0 == memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
     
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == 1);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -286,6 +364,9 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     
     InvalidateCache_ExclusiveLocked();
     XCTAssertTrue(0 == memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
+    
+    // VnodeCacheHealthStat_InvalidateEntireCacheCount is adjusted by VnodeCache_InvalidateCache
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == 0);
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -527,6 +608,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     uintptr_t cacheIndex;
     XCTAssertTrue(TryFindVnodeIndex_Locked(self->testVnodeFile1.get(), vnodeHashIndex, /* out */ cacheIndex));
     XCTAssertTrue(cacheIndex == vnodeHashIndex);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == 0);
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -540,6 +622,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
             self->testVnodeFile1.get(),
             ComputeVnodeHashIndex(self->testVnodeFile1.get()),
             /* out */ vnodeIndex));
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == self->cacheWrapper.GetCapacity());
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -555,6 +638,9 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     XCTAssertTrue(TryFindVnodeIndex_Locked(self->testVnodeFile1.get(), vnodeHashIndex, /* out */ vnodeIndex));
     XCTAssertTrue(emptyIndex == vnodeIndex);
     
+    uint64_t expectedCollisions = (self->cacheWrapper.GetCapacity() - vnodeHashIndex) + emptyIndex;
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == expectedCollisions);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -569,6 +655,9 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     XCTAssertTrue(TryFindVnodeIndex_Locked(self->testVnodeFile1.get(), vnodeHashIndex, /* out */ vnodeIndex));
     XCTAssertTrue(emptyIndex == vnodeIndex);
 
+    uint64_t expectedCollisions = (self->cacheWrapper.GetCapacity() - 1) - vnodeHashIndex;
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == expectedCollisions);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -583,6 +672,8 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
             self->testVnodeFile1->GetVid(),
             true, // forceRefreshEntry
             DummyRootHandle));
+    
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalLookupCollisions] == self->cacheWrapper.GetCapacity());
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
@@ -634,6 +725,10 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
     
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 0);
+    
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
 }
@@ -673,6 +768,10 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
         PrjFSPerfCounter_VnodeOp_FindRoot_Iteration,
         self->testVnodeFile1.get(),
         self->dummyVFSContext));
+    
+    XCTAssertTrue(s_cacheStats.cacheEntries == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeHits] == 1);
+    XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_TotalFindRootForVnodeMisses] == 0);
     
     // Sanity check: We don't expect any of the mock functions to have been called
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -62,11 +62,11 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 - (void)testInitCacheStats {
     // We need to validate that InitCacheStats sets all of the cache health stats to zero, so
     // first set them all to something non-zero
-    atomic_exchange_explicit(&s_cacheStats.cacheEntries, 1U, memory_order_relaxed);
+    atomic_store_explicit(&s_cacheStats.cacheEntries, 1U, memory_order_relaxed);
     
     for (int32_t i = 0; i < VnodeCacheHealthStat_Count; ++i)
     {
-        atomic_exchange_explicit(&s_cacheStats.healthStats[i], 1ULL, memory_order_relaxed);
+        atomic_store_explicit(&s_cacheStats.healthStats[i], 1ULL, memory_order_relaxed);
     }
     
     InitCacheStats();
@@ -94,7 +94,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     
     XCTAssertFalse(MockCalls::DidCallAnyFunctions());
     
-    atomic_exchange_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], UINT64_MAX - 1000, memory_order_relaxed);
+    atomic_store_explicit(&s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount], UINT64_MAX - 1000, memory_order_relaxed);
     AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);
     XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == UINT64_MAX - 999);
     AtomicFetchAddCacheHealthStat(VnodeCacheHealthStat_InvalidateEntireCacheCount, 1ULL);

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -343,6 +343,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 
 - (void)testVnodeCache_InvalidateCache_SetsMemoryToZeros {
     self->cacheWrapper.FillAllEntries();
+    s_cacheStats.cacheEntries = self->cacheWrapper.GetCapacity();
 
     shared_ptr<VnodeCacheEntry> emptyArray(static_cast<VnodeCacheEntry*>(calloc(self->cacheWrapper.GetCapacity(), sizeof(VnodeCacheEntry))), free);
     XCTAssertTrue(0 != memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
@@ -350,6 +351,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     VnodeCache_InvalidateCache(&self->dummyPerfTracer);
     XCTAssertTrue(0 == memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
     
+    XCTAssertTrue(s_cacheStats.cacheEntries == 0);
     XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == 1);
     
     // Sanity check: We don't expect any of the mock functions to have been called
@@ -358,12 +360,14 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 
 - (void)testInvalidateCache_ExclusiveLocked_SetsMemoryToZeros {
     self->cacheWrapper.FillAllEntries();
+    s_cacheStats.cacheEntries = self->cacheWrapper.GetCapacity();
     
     shared_ptr<VnodeCacheEntry> emptyArray(static_cast<VnodeCacheEntry*>(calloc(self->cacheWrapper.GetCapacity(), sizeof(VnodeCacheEntry))), free);
     XCTAssertTrue(0 != memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
     
     InvalidateCache_ExclusiveLocked();
     XCTAssertTrue(0 == memcmp(emptyArray.get(), s_entries, sizeof(VnodeCacheEntry) * self->cacheWrapper.GetCapacity()));
+    XCTAssertTrue(s_cacheStats.cacheEntries == 0);
     
     // VnodeCacheHealthStat_InvalidateEntireCacheCount is adjusted by VnodeCache_InvalidateCache
     XCTAssertTrue(s_cacheStats.healthStats[VnodeCacheHealthStat_InvalidateEntireCacheCount] == 0);

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -1,4 +1,5 @@
 #include "kext-perf-tracing.hpp"
+#include "../../PrjFSKext/public/ArrayUtils.hpp"
 #include "../../PrjFSKext/public/PrjFSCommon.h"
 #include "../../PrjFSKext/public/PrjFSPerfCounter.h"
 #include "../../PrjFSKext/public/PrjFSLogClientShared.h"
@@ -74,16 +75,6 @@ static constexpr const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
     [PrjFSPerfCounter_CacheInvalidateCount]                                 = "VnodeCacheInvalidationCount",
     [PrjFSPerfCounter_CacheFullCount]                                       = "VnodeCacheFullCount",
 };
-
-template <typename T, size_t N>
-    constexpr bool AllArrayElementsInitialized(T (&array)[N], size_t fromIndex = 0)
-{
-    return
-        fromIndex >= N
-        ? true
-        : (array[fromIndex] != T()
-           && AllArrayElementsInitialized(array, fromIndex + 1));
-}
 
 static_assert(AllArrayElementsInitialized(PerfCounterNames), "There must be an initialization of PerfCounterNames elements corresponding to each PrjFSPerfCounter enum value");
 

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/prjfs-log.cpp
@@ -79,14 +79,8 @@ static void ProcessLogMessagesOnConnection(io_connect_t connection, io_service_t
     dispatch_source_set_event_handler(logState->dataQueue.dispatchSource, ^{
         DataQueue_ClearMachNotification(logState->dataQueue.notificationPort);
         
-        while(true)
+        while(IODataQueueEntry* entry = DataQueue_Peek(logState->dataQueue.queueMemory))
         {
-            IODataQueueEntry* entry = DataQueue_Peek(logState->dataQueue.queueMemory);
-            if(entry == nullptr)
-            {
-                break;
-            }
-            
             int messageSize = entry->size;
             if (messageSize >= sizeof(KextLog_MessageHeader) + 2)
             {

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -48,6 +48,7 @@ xcrun xccov view "$COVERAGE_FILE" | tee $PROJFS/CoverageResult.txt
 while read line; do
   if [[ $line != *"100.00%"* ]] && 
      [[ $line == *"%"* ]] && 
+	 [[ $line != *"AllArrayElementsInitialized"* ]] &&              #Function is used for compile time checks only
 	 [[ $line != *"KauthHandler_Init"* ]] && 
 	 [[ $line != *"KauthHandler_Cleanup"* ]] && 
 	 [[ $line != *"HandleVnodeOperation"* ]] &&                      #SHOULD ADD COVERAGE
@@ -64,6 +65,7 @@ while read line; do
 	 [[ $line != *"VirtualizationRoots_Cleanup"* ]] && 
 	 [[ $line != *"VnodeCache_Init"* ]] && 
 	 [[ $line != *"VnodeCache_Cleanup"* ]] && 
+	 [[ $line != *"VnodeCache_ExportHealthData"* ]] &&               # IOKit related functions are not unit tested
 	 [[ $line != *"FindOrDetectRootAtVnode"* ]] &&                   #SHOULD ADD COVERAGE
 	 [[ $line != *"FindUnusedIndexOrGrow_Locked"* ]] &&              #SHOULD ADD COVERAGE
 	 [[ $line != *"FindRootAtVnode_Locked"* ]] &&                    #SHOULD ADD COVERAGE


### PR DESCRIPTION
Resolves #973 

Updated PrjFSKextLogDaemon to poll the kext every 30 minutes and request information about the health/status of the vnode cache.  This information is then recorded in the macOS logs (where it can be queried by `gvfs diagnose`).

Also updated the vnode cache unit tests to make use of the new stats to perform additional validation.

**Remaining Work**
- [X] Additional local testing of the changes
- [X] Compare large build times with and without this change