### PR TITLE
[Linux] Ignore provider-generated events

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using PrjFSLib.Linux.Interop;
 using static PrjFSLib.Linux.Interop.Errno;
@@ -10,6 +12,7 @@ namespace PrjFSLib.Linux
         public const int PlaceholderIdLength = 128;
 
         private ProjFS projfs;
+        private int currentProcessId = Process.GetCurrentProcess().Id;
 
         // We must hold a reference to the delegates to prevent garbage collection
         private ProjFS.EventHandler preventGCOnProjEventDelegate;
@@ -213,10 +216,18 @@ namespace PrjFSLib.Linux
 
         private static string GetProcCmdline(int pid)
         {
-            using (var stream = System.IO.File.OpenText(string.Format("/proc/{0}/cmdline", pid)))
+            try
             {
-                string[] parts = stream.ReadToEnd().Split('\0');
-                return parts.Length > 0 ? parts[0] : string.Empty;
+                using (var stream = File.OpenText(string.Format("/proc/{0}/cmdline", pid)))
+                {
+                    string[] parts = stream.ReadToEnd().Split('\0');
+                    return parts.Length > 0 ? parts[0] : string.Empty;
+                }
+            }
+            catch (IOException ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+            {
+                // process with given pid may have exited; nothing to be done
+                return string.Empty;
             }
         }
 
@@ -226,8 +237,19 @@ namespace PrjFSLib.Linux
             return Marshal.PtrToStringAnsi(ptr);
         }
 
+        private bool IsProviderEvent(ProjFS.Event ev)
+        {
+            return (ev.Pid == this.currentProcessId);
+        }
+
         private int HandleProjEvent(ref ProjFS.Event ev)
         {
+            // ignore events triggered by own process to prevent deadlocks
+            if (this.IsProviderEvent(ev))
+            {
+                return 0;
+            }
+
             string triggeringProcessName = GetProcCmdline(ev.Pid);
             string relativePath = PtrToStringUTF8(ev.Path);
 
@@ -269,6 +291,12 @@ namespace PrjFSLib.Linux
 
         private int HandleNonProjEvent(ref ProjFS.Event ev, bool perm)
         {
+            // ignore events triggered by own process to prevent deadlocks
+            if (this.IsProviderEvent(ev))
+            {
+                return 0;
+            }
+
             NotificationType nt;
 
             if ((ev.Mask & ProjFS.Constants.PROJFS_DELETE_SELF) != 0)

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -218,7 +218,7 @@ namespace PrjFSLib.Linux
         {
             try
             {
-                using (var stream = File.OpenText(string.Format("/proc/{0}/cmdline", pid)))
+                using (var stream = File.OpenText($"/proc/{pid}/cmdline"))
                 {
                     string[] parts = stream.ReadToEnd().Split('\0');
                     return parts.Length > 0 ? parts[0] : string.Empty;


### PR DESCRIPTION
We want to ignore events triggered by the provider process itself, and we also should handle the case where we can't map a pid to a process command line because the process has already exited.

/cc @kivikakk