### PR TITLE
Fixing failure in full FT

### DIFF
--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -167,7 +167,7 @@ namespace GVFS.Service
             }
 
             string serviceLogsDirectoryPath = Path.Combine(
-                    GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.ServiceName),
+                    GVFSPlatform.Instance.GetDataRootForGVFSComponent(this.serviceName),
                     GVFSConstants.Service.LogDirectory);
 
             // Create the logs directory explicitly *before* creating a log file event listener to ensure that it


### PR DESCRIPTION
#### Failing test info
```
1) Error : GVFS.FunctionalTests.Tests.EnlistmentPerFixture.UpgradeReminderTests.UpgradeTimerScheduledOnServiceStart()
2019-04-18T08:56:41.2887539Z System.IO.DirectoryNotFoundException : Could not find a part of the path 'C:\ProgramData\GVFS\Test.GVFS.Service\Logs'.
2019-04-18T08:56:41.2888198Z    at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
2019-04-18T08:56:41.2889185Z    at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, EnumerationOptions options)
2019-04-18T08:56:41.2889921Z    at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options)
2019-04-18T08:56:41.2890827Z    at System.IO.Enumeration.FileSystemEnumerableFactory.FileInfos(String directory, String expression, EnumerationOptions options)
2019-04-18T08:56:41.2891428Z    at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
2019-04-18T08:56:41.2891966Z    at System.IO.DirectoryInfo.GetFiles(String searchPattern, EnumerationOptions enumerationOptions)
2019-04-18T08:56:41.2892442Z    at System.IO.DirectoryInfo.GetFiles()
2019-04-18T08:56:41.2893375Z    at GVFS.FunctionalTests.Tests.EnlistmentPerFixture.UpgradeReminderTests.ServiceLogContainsUpgradeMessaging() in C:\agent\_work\12\s\GVFS\GVFS.FunctionalTests\Tests\EnlistmentPerFixture\GVFSUpgradeReminderTests.cs:line 139
2019-04-18T08:56:41.2894127Z    at GVFS.FunctionalTests.Tests.EnlistmentPerFixture.UpgradeReminderTests.UpgradeTimerScheduledOnServiceStart() in C:\agent\_work\12\s\GVFS\GVFS.FunctionalTests\Tests\EnlistmentPerFixture\GVFSUpgradeReminderTests.cs:line 86
2019-04-18T08:56:41.2894935Z 
```

#### Cause and fix

When GVFS.Service creates its log directory, the log directory created will be given the name of the Service. Name of the Service can change though. When it is launched by Functional tests, its name would be different. Replaced the hard coded log directory name with run-time name.