### PR TITLE
GVFS.props: Use better path concatenation and initialize SolutionDir

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -9,8 +9,9 @@
   <PropertyGroup Label="DefaultSettings">
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <BuildOutputDir>$(SolutionDir)..\BuildOutput</BuildOutputDir>
-    <PackagesDir>$(SolutionDir)..\packages</PackagesDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..</SolutionDir>
+    <BuildOutputDir>$(SolutionDir)\..\BuildOutput</BuildOutputDir>
+    <PackagesDir>$(SolutionDir)\..\packages</PackagesDir>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
When building a single project using 'dotnet build' from a project
directory instead of building from the solution file, the
SolutionDir property is undefinded. Add a setting to initialize its
location two levels above the project level.

Also add an extra path marker ('\\') between the SolutionDir and the
".." that is intended to move the BuildOutput and package directories
out of the source directory.