### PR TITLE
Fix race condition in MockVirtualizationInstance.CompleteCommand

### DIFF
--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
@@ -2,7 +2,6 @@
 using GVFS.UnitTests.Windows.Windows.Mock;
 using Microsoft.Windows.ProjFS;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 
@@ -28,12 +27,6 @@ namespace GVFS.UnitTests.Windows.Mock
             this.waitForCreateWriteBuffer = new ManualResetEvent(true);
 
             this.WriteFileReturnResult = HResult.Ok;
-        }
-
-        public HResult CompletionResult
-        {
-            get { return this.completionResult; }
-            set { this.completionResult = value; }
         }
 
         public ConcurrentHashSet<string> CreatedPlaceholders { get; private set; }
@@ -132,7 +125,7 @@ namespace GVFS.UnitTests.Windows.Mock
         public HResult WaitForCompletionStatus()
         {
             this.commandCompleted.WaitOne();
-            return this.CompletionResult;
+            return this.completionResult;
         }
 
         public void WaitForPlaceholderCreate()
@@ -172,7 +165,7 @@ namespace GVFS.UnitTests.Windows.Mock
 
         public HResult CompleteCommand(int commandId, HResult completionResult)
         {
-            this.CompletionResult = completionResult;
+            this.completionResult = completionResult;
             this.commandCompleted.Set();
             return HResult.Ok;
         }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockVirtualizationInstance.cs
@@ -15,6 +15,9 @@ namespace GVFS.UnitTests.Windows.Mock
         private ManualResetEvent unblockCreateWriteBuffer;
         private ManualResetEvent waitForCreateWriteBuffer;
 
+        private volatile HResult completionResult;
+        private volatile HResult writeFileReturnResult;
+
         public MockVirtualizationInstance()
         {
             this.commandCompleted = new AutoResetEvent(false);
@@ -27,7 +30,11 @@ namespace GVFS.UnitTests.Windows.Mock
             this.WriteFileReturnResult = HResult.Ok;
         }
 
-        public HResult CompletionResult { get; set; }
+        public HResult CompletionResult
+        {
+            get { return this.completionResult; }
+            set { this.completionResult = value; }
+        }
 
         public ConcurrentHashSet<string> CreatedPlaceholders { get; private set; }
 
@@ -47,7 +54,11 @@ namespace GVFS.UnitTests.Windows.Mock
         public NotifyPreCreateHardlinkCallback OnNotifyPreCreateHardlink { get; set; }
         public QueryFileNameCallback OnQueryFileName { get; set; }
 
-        public HResult WriteFileReturnResult { get; set; }
+        public HResult WriteFileReturnResult
+        {
+            get { return this.writeFileReturnResult; }
+            set { this.writeFileReturnResult = value; }
+        }
 
         public uint NegativePathCacheCount { get; set; }
 
@@ -161,8 +172,8 @@ namespace GVFS.UnitTests.Windows.Mock
 
         public HResult CompleteCommand(int commandId, HResult completionResult)
         {
-            this.commandCompleted.Set();
             this.CompletionResult = completionResult;
+            this.commandCompleted.Set();
             return HResult.Ok;
         }
 


### PR DESCRIPTION
Fixes #1054 

Two fixes:

- Updated `completionResult` and `WriteFileReturnResult` to use `volatile` to ensure that the test and background thread read the most up-to-date values (and removed public `CompletionResult` as it was not needed)
- Fixed a race in `CompleteCommand` where `commandCompleted` was being set too early.