### PR TITLE
GVFS.props: remove extra path marker before BuildOutput and package dir

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -9,9 +9,9 @@
   <PropertyGroup Label="DefaultSettings">
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..</SolutionDir>
-    <BuildOutputDir>$(SolutionDir)\..\BuildOutput</BuildOutputDir>
-    <PackagesDir>$(SolutionDir)\..\packages</PackagesDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <BuildOutputDir>$(SolutionDir)..\BuildOutput</BuildOutputDir>
+    <PackagesDir>$(SolutionDir)..\packages</PackagesDir>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes an issue where incremental builds are broken due to
"GenerateBindingRedirects" task failing.

In commit f212571, a preceding path marker ('\') was added to the
BuildOutput and Package directories. When the SolutionDir already has a
trailing slash, this will result in paths with double slashes. Certain
MSBuild tasks have trouble with double slash, including the
`GenerateBindingRedirects` task.

For example:

`root\src\\..\BuildOutput'

is resolved to:

`root\src\BuildOutput`, instead of `root\BuildOutput` as we intend

This change ensures that the SolutionDir variable has a trailing slash,
and removes the preceding slash in BuildOutput and Package directory
variables.