### PR TITLE
Fix FastFetch build in VS for Mac

### DIFF
--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -19,30 +19,30 @@
     <Version>$(GVFSVersion)</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-  </PropertyGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj" />
     <ProjectReference Include="..\GVFS.Virtualization\GVFS.Virtualization.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(IsOSX)' == 'true'">
-    <ProjectReference Include="..\GVFS.Platform.Mac\GVFS.Platform.Mac.csproj" />
-    <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Mac.cs">
-      <Link>PlatformLoader.Mac.cs</Link>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <ProjectReference Include="..\GVFS.Platform.Windows\GVFS.Platform.Windows.csproj" />
-    <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Windows.cs">
-      <Link>PlatformLoader.Windows.cs</Link>
-    </Compile>
-  </ItemGroup>
-
+  <Choose>
+    <When Condition="'$(OS)' == 'Windows_NT'">
+      <ItemGroup>
+        <ProjectReference Include="..\GVFS.Platform.Windows\GVFS.Platform.Windows.csproj" />
+        <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Windows.cs">
+          <Link>PlatformLoader.Windows.cs</Link>
+        </Compile>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="..\GVFS.Platform.Mac\GVFS.Platform.Mac.csproj" />
+        <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Mac.cs">
+          <Link>PlatformLoader.Mac.cs</Link>
+        </Compile>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.165" />

--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -24,6 +24,8 @@
     <ProjectReference Include="..\GVFS.Virtualization\GVFS.Virtualization.csproj" />
   </ItemGroup>
   
+  <!-- ItemGroup Conditions are not supported on VS for Mac and Choose/When must be
+       Used instead, see https://github.com/mono/monodevelop/issues/7417 -->
   <Choose>
     <When Condition="'$(OS)' == 'Windows_NT'">
       <ItemGroup>


### PR DESCRIPTION
The `ItemGroup` conditions are not working properly in VS for Mac (I noticed this [reported on StackOverflow](https://stackoverflow.com/questions/28851338/why-the-condition-attribute-doesnt-work-for-the-itemgroup-element) for VS 7.5.3 and so we don't appear to be the only ones having this issue).

To work around this limitation I've switched the project to use. `Choose`/`Where`