### PR TITLE
Maintenance: Check Stopping before reacting to error code

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -155,7 +155,8 @@ namespace GVFS.Common.Maintenance
                 this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
 
                 GitProcess.Result verifyAfterExpire = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
-                if (verifyAfterExpire.ExitCodeIsFailure)
+
+                if (!this.Stopping && verifyAfterExpire.ExitCodeIsFailure)
                 {
                     this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
@@ -164,7 +165,8 @@ namespace GVFS.Common.Maintenance
                 this.GetPackFilesInfo(out int afterCount, out long afterSize, out hasKeep);
 
                 GitProcess.Result verifyAfterRepack = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
-                if (verifyAfterRepack.ExitCodeIsFailure)
+
+                if (!this.Stopping && verifyAfterRepack.ExitCodeIsFailure)
                 {
                     this.LogErrorAndRewriteMultiPackIndex(activity);
                 }

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common.Maintenance
                 this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
 
                 GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
-                if (verifyResult.ExitCodeIsFailure)
+                if (!this.Stopping && verifyResult.ExitCodeIsFailure)
                 {
                     this.LogErrorAndRewriteMultiPackIndex(activity);
                 }
@@ -52,7 +52,7 @@ namespace GVFS.Common.Maintenance
                 /*
                 GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyCommitGraph));
 
-                if (verifyResult.ExitCodeIsFailure)
+                if (!this.Stopping && verifyResult.ExitCodeIsFailure)
                 {
                     this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
                 }


### PR DESCRIPTION
When someone unmounts, it triggers a Stop() on the maintenance
step that is currently running. This can interrupt longer-running Git
commands more often than other actions, so check Stopping before
checking the error code for a response.

This is more likely a reason for people to hit this error than any
data-shape issues that we were expecting to cause a problem.

While I am updating the check around the `commit-graph verify`
command, I am not un-commenting it as we don't have the full
fix for the "too many pack-files" case.