### PR TITLE
Teach Enlistment.GetNewGVFSLogFileName to take FileSystem parameter

### DIFF
--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Git;
+﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
 using System;
 using System.IO;
 
@@ -65,13 +66,19 @@ namespace GVFS.Common
 
         public GitAuthentication Authentication { get; }
 
-        public static string GetNewLogFileName(string logsRoot, string prefix, string logId = null)
+        public static string GetNewLogFileName(
+            string logsRoot,
+            string prefix,
+            string logId = null,
+            PhysicalFileSystem fileSystem = null)
         {
+            fileSystem = fileSystem ?? new PhysicalFileSystem();
+
             // TODO: Remove Directory.CreateDirectory() code from here
             // Don't change the state from an accessor.
-            if (!Directory.Exists(logsRoot))
+            if (!fileSystem.DirectoryExists(logsRoot))
             {
-                Directory.CreateDirectory(logsRoot);
+                fileSystem.CreateDirectory(logsRoot);
             }
 
             logId = logId ?? DateTime.Now.ToString("yyyyMMdd_HHmmss");
@@ -81,7 +88,7 @@ namespace GVFS.Common
                 logsRoot,
                 name + ".log");
 
-            if (File.Exists(fullPath))
+            if (fileSystem.FileExists(fullPath))
             {
                 fullPath = Path.Combine(
                     logsRoot,

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -1,3 +1,4 @@
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.NamedPipes;
 using Newtonsoft.Json;
@@ -106,11 +107,16 @@ namespace GVFS.Common
             throw new InvalidRepoException($"Directory '{directory}' does not exist");
         }
 
-        public static string GetNewGVFSLogFileName(string logsRoot, string logFileType)
+        public static string GetNewGVFSLogFileName(
+            string logsRoot,
+            string logFileType,
+            PhysicalFileSystem fileSystem = null)
         {
             return Enlistment.GetNewLogFileName(
                 logsRoot,
-                "gvfs_" + logFileType);
+                "gvfs_" + logFileType,
+                logId: null,
+                fileSystem: fileSystem);
         }
 
         public static bool WaitUntilMounted(string enlistmentRoot, bool unattended, out string errorMessage)

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -416,7 +416,12 @@ namespace GVFS.Common
             {
                 if (!this.dryRun)
                 {
-                    string logFilePath = GVFSEnlistment.GetNewLogFileName(ProductUpgraderInfo.GetLogDirectoryPath(), Path.GetFileNameWithoutExtension(path), this.UpgradeInstanceId);
+                    string logFilePath = GVFSEnlistment.GetNewLogFileName(
+                        ProductUpgraderInfo.GetLogDirectoryPath(),
+                        Path.GetFileNameWithoutExtension(path),
+                        this.UpgradeInstanceId,
+                        this.fileSystem);
+
                     string args = installerArgs + " /Log=" + logFilePath;
                     string certCN = null;
                     string issuerCN = null;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -156,7 +156,8 @@ namespace GVFS.Upgrader
         {
             string logFilePath = GVFSEnlistment.GetNewGVFSLogFileName(
                 this.logDirectory,
-                GVFSConstants.LogFileTypes.UpgradeProcess);
+                GVFSConstants.LogFileTypes.UpgradeProcess,
+                this.fileSystem);
 
             JsonTracer jsonTracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "UpgradeProcess");
 


### PR DESCRIPTION
This will enable the Enlistment.GetNewGVFSLogFileName method to interact with
the file system through the file system abstraction layer, enabling us to unit
test this method and methods that call this method.

With this change, the GitHubUpgrader tests should no longer create actual directories when running the unit tests.