### PR TITLE
GitMaintenanceStep: Throw if stopped while Git is running

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -132,7 +132,12 @@ namespace GVFS.Common.Maintenance
 
                 GitProcess.Result result = work.Invoke(this.MaintenanceGitProcess);
 
-                if (!this.Stopping && result?.ExitCodeIsFailure == true)
+                if (this.Stopping)
+                {
+                    throw new StoppingException();
+                }
+
+                if (result?.ExitCodeIsFailure == true)
                 {
                     string errorMessage = result?.Errors == null ? string.Empty : result.Errors;
                     if (errorMessage.Length > 1000)


### PR DESCRIPTION
The GitMaintenanceStep throws a StoppingException if the
RunGitCommand() method is run after a Stop() call. However,
it doesn't throw when the Stop() call happens during the
Git process. This requires extra handling of the Stopping
boolean after receiving a response from RunGitCommand().
Such extra handling was added in #1064, but would not
be necessary with this change.

The better thing to do is to throw the StoppingException
after the Git process completes.

Add a unit test that verifies we automatically skip the
remainder of a PerformMaintenance() method in a subclass.

Looking through the error logs, all logged instances of a
failure during 'commit-graph verify' or 'multi-pack-index verify'
are actually due to this issue. Otherwise we would see errors
from GitMaintenanceStep saying "Git process {command} failed with errors:"
and those messages do no appear in the logs.