### PR TITLE
GVFS.Service should copy ProjectedFSLib.dll when it's missing and the installed ProjFS version matches the packaged version

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Security;
 using System.Threading;
@@ -201,6 +202,11 @@ namespace GVFS.Common.FileSystem
         public virtual string[] GetFiles(string directoryPath, string mask)
         {
             return Directory.GetFiles(directoryPath, mask);
+        }
+
+        public virtual FileVersionInfo GetVersionInfo(string path)
+        {
+            return FileVersionInfo.GetVersionInfo(path);
         }
 
         public bool TryWriteTempFileAndRename(string destinationPath, string contents, out Exception handledException)

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -120,6 +120,11 @@ namespace GVFS.Common.FileSystem
             return new FileStream(path, fileMode, fileAccess, shareMode, DefaultStreamBufferSize, options);
         }
 
+        public virtual void FlushFileBuffers(string path)
+        {
+            GVFSPlatform.Instance.FileSystem.FlushFileBuffers(path);
+        }
+
         public virtual void CreateDirectory(string path)
         {
             Directory.CreateDirectory(path);
@@ -207,6 +212,16 @@ namespace GVFS.Common.FileSystem
         public virtual FileVersionInfo GetVersionInfo(string path)
         {
             return FileVersionInfo.GetVersionInfo(path);
+        }
+
+        public virtual bool FileVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
+        {
+            return versionInfo1.FileVersion == versionInfo2.FileVersion;
+        }
+
+        public virtual bool ProductVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
+        {
+            return versionInfo1.ProductVersion == versionInfo2.ProductVersion;
         }
 
         public bool TryWriteTempFileAndRename(string destinationPath, string contents, out Exception handledException)

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -253,13 +253,6 @@ namespace GVFS.Platform.Windows
                     return true;
                 }
 
-                if (!isProjFSFeatureAvailable)
-                {
-                    // If enabling ProjFS failed because we were unable to find the optional feature, fallback
-                    // on installing ProjFS via the INF
-                    return TryInstallProjFSViaINF(tracer, fileSystem);
-                }
-
                 return false;
             }
 

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -109,20 +109,20 @@ namespace GVFS.Platform.Windows
         public static bool IsServiceRunningAndInstalled(
             ITracer tracer,
             PhysicalFileSystem fileSystem,
-            out bool isServiceInstalled,
-            out bool isDriverFileInstalled,
-            out bool isNativeLibInstalled)
+            out bool isPrjfltServiceInstalled,
+            out bool isPrjfltDriverInstalled,
+            out bool isNativeProjFSLibInstalled)
         {
             bool isRunning = false;
-            isServiceInstalled = false;
-            isDriverFileInstalled = fileSystem.FileExists(Path.Combine(Environment.SystemDirectory, "drivers", DriverFileName));
-            isNativeLibInstalled = IsNativeLibInstalled(tracer, fileSystem);
+            isPrjfltServiceInstalled = false;
+            isPrjfltDriverInstalled = fileSystem.FileExists(Path.Combine(Environment.SystemDirectory, "drivers", DriverFileName));
+            isNativeProjFSLibInstalled = IsNativeLibInstalled(tracer, fileSystem);
 
             try
             {
                 ServiceController controller = new ServiceController(DriverName);
                 isRunning = controller.Status.Equals(ServiceControllerStatus.Running);
-                isServiceInstalled = true;
+                isPrjfltServiceInstalled = true;
             }
             catch (InvalidOperationException e)
             {
@@ -324,8 +324,8 @@ namespace GVFS.Platform.Windows
             FileVersionInfo system32DriverVersion;
             try
             {
-                packagedDriverVersion = FileVersionInfo.GetVersionInfo(installedPrjfltDriverPath);
-                system32DriverVersion = FileVersionInfo.GetVersionInfo(system32PrjfltDriverPath);
+                packagedDriverVersion = fileSystem.GetVersionInfo(installedPrjfltDriverPath);
+                system32DriverVersion = fileSystem.GetVersionInfo(system32PrjfltDriverPath);
                 if (packagedDriverVersion.FileVersion != system32DriverVersion.FileVersion)
                 {
                     copyNativeDllError = $"Packaged sys FileVersion '{packagedDriverVersion.FileVersion}' does not match System32 sys FileVersion '{system32DriverVersion.FileVersion}'";

--- a/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
@@ -36,28 +36,27 @@ namespace GVFS.Service.Handlers
 
             lock (enablePrjFltLock)
             {
-                bool isServiceInstalled;
-                bool isDriverFileInstalled;
-                bool isNativeLibInstalled;
-                bool isRunning = ProjFSFilter.IsServiceRunningAndInstalled(tracer, fileSystem, out isServiceInstalled, out isDriverFileInstalled, out isNativeLibInstalled);
-                bool isInstalled = isServiceInstalled && isDriverFileInstalled && isNativeLibInstalled;
+                bool isPrjfltServiceInstalled;
+                bool isPrjfltDriverInstalled;
+                bool isNativeProjFSLibInstalled;
+                bool isPrjfltServiceRunning = ProjFSFilter.IsServiceRunningAndInstalled(tracer, fileSystem, out isPrjfltServiceInstalled, out isPrjfltDriverInstalled, out isNativeProjFSLibInstalled);
 
-                prjFltHealthMetadata.Add($"Initial_{nameof(isRunning)}", isRunning);
-                prjFltHealthMetadata.Add($"Initial_{nameof(isServiceInstalled)}", isServiceInstalled);
-                prjFltHealthMetadata.Add($"Initial_{nameof(isDriverFileInstalled)}", isDriverFileInstalled);
-                prjFltHealthMetadata.Add($"Initial_{nameof(isNativeLibInstalled)}", isNativeLibInstalled);
-                prjFltHealthMetadata.Add($"Initial_{nameof(isInstalled)}", isInstalled);
+                prjFltHealthMetadata.Add($"Initial_{nameof(isPrjfltDriverInstalled)}", isPrjfltDriverInstalled);
+                prjFltHealthMetadata.Add($"Initial_{nameof(isPrjfltServiceInstalled)}", isPrjfltServiceInstalled);
+                prjFltHealthMetadata.Add($"Initial_{nameof(isPrjfltServiceRunning)}", isPrjfltServiceRunning);
+                prjFltHealthMetadata.Add($"Initial_{nameof(isNativeProjFSLibInstalled)}", isNativeProjFSLibInstalled);
 
-                if (!isRunning)
+                if (!isPrjfltServiceRunning)
                 {
-                    if (!isInstalled)
+                    if (!isPrjfltServiceInstalled || !isPrjfltDriverInstalled)
                     {
                         uint windowsBuildNumber;
                         bool isInboxProjFSFinalAPI;
                         bool isProjFSFeatureAvailable;
                         if (ProjFSFilter.TryEnableOrInstallDriver(tracer, fileSystem, out windowsBuildNumber, out isInboxProjFSFinalAPI, out isProjFSFeatureAvailable))
                         {
-                            isInstalled = true;
+                            isPrjfltServiceInstalled = true;
+                            isPrjfltDriverInstalled = true;
                         }
                         else
                         {
@@ -70,11 +69,11 @@ namespace GVFS.Service.Handlers
                         prjFltHealthMetadata.Add(nameof(isProjFSFeatureAvailable), isProjFSFeatureAvailable);
                     }
 
-                    if (isInstalled)
+                    if (isPrjfltServiceInstalled)
                     {
                         if (ProjFSFilter.TryStartService(tracer))
                         {
-                            isRunning = true;
+                            isPrjfltServiceRunning = true;
                         }
                         else
                         {
@@ -84,28 +83,46 @@ namespace GVFS.Service.Handlers
                     }
                 }
 
-                isNativeLibInstalled = ProjFSFilter.IsNativeLibInstalled(tracer, new PhysicalFileSystem());
-                if (!isNativeLibInstalled)
+                // Check again if the native library is installed.  If the code above enabled the
+                // ProjFS optional feature then the native library will now be installed.
+                isNativeProjFSLibInstalled = ProjFSFilter.IsNativeLibInstalled(tracer, fileSystem);
+                if (!isNativeProjFSLibInstalled)
                 {
-                    if (isRunning)
+                    if (isPrjfltServiceRunning)
                     {
-                        tracer.RelatedInfo($"{nameof(TryEnablePrjFlt)}: Native ProjFS library is not installed, attempting to copy packaged version");
-                        string copyNativeDllError;
+                        tracer.RelatedInfo($"{nameof(TryEnablePrjFlt)}: Native ProjFS library is not installed, attempting to copy version packaged with VFS for Git");
+
+                        EventLevel eventLevel;
+                        EventMetadata copyNativeLibMetadata = new EventMetadata();
+                        copyNativeLibMetadata.Add("Area", EtwArea);
+                        string copyNativeDllError = string.Empty;
                         if (ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(tracer, new PhysicalFileSystem(), out copyNativeDllError))
                         {
-                            tracer.RelatedInfo($"{nameof(TryEnablePrjFlt)}: Successfully copied packaged ProjFS native library");
-                            isNativeLibInstalled = true;
+                            isNativeProjFSLibInstalled = true;
+
+                            eventLevel = EventLevel.Warning;
+                            copyNativeLibMetadata.Add(TracingConstants.MessageKey.WarningMessage, $"{nameof(TryEnablePrjFlt)}: Successfully copied ProjFS native library");
                         }
                         else
                         {
-                            tracer.RelatedError($"{nameof(TryEnablePrjFlt)}: Failed to copy packaged ProjFS native library {copyNativeDllError}");
+                            error = $"Native ProjFS library is not installed and could not be copied: {copyNativeDllError}";
+
+                            eventLevel = EventLevel.Error;
+                            copyNativeLibMetadata.Add(nameof(copyNativeDllError), copyNativeDllError);
+                            copyNativeLibMetadata.Add(TracingConstants.MessageKey.ErrorMessage, $"{nameof(TryEnablePrjFlt)}: Failed to copy ProjFS native library");
                         }
+
+                        copyNativeLibMetadata.Add(nameof(isNativeProjFSLibInstalled), isNativeProjFSLibInstalled);
+                        tracer.RelatedEvent(
+                            eventLevel,
+                            $"{nameof(TryEnablePrjFlt)}_{nameof(ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch)}",
+                            copyNativeLibMetadata,
+                            Keywords.Telemetry);
                     }
                     else
                     {
-                        string missingNativeLibMessage = "Native ProjFS library is not installed";
-                        error = string.IsNullOrEmpty(error) ? missingNativeLibMessage : $"{error}. {missingNativeLibMessage}";
-                        tracer.RelatedError($"{nameof(TryEnablePrjFlt)}: {missingNativeLibMessage}");
+                        error = "Native ProjFS library is not installed, did not attempt to copy library because prjflt service is not running";
+                        tracer.RelatedError($"{nameof(TryEnablePrjFlt)}: {error}");
                     }
                 }
 
@@ -124,13 +141,14 @@ namespace GVFS.Service.Handlers
                     }
                 }
 
-                prjFltHealthMetadata.Add(nameof(isInstalled), isInstalled);
-                prjFltHealthMetadata.Add(nameof(isRunning), isRunning);
+                prjFltHealthMetadata.Add(nameof(isPrjfltDriverInstalled), isPrjfltDriverInstalled);
+                prjFltHealthMetadata.Add(nameof(isPrjfltServiceInstalled), isPrjfltServiceInstalled);
+                prjFltHealthMetadata.Add(nameof(isPrjfltServiceRunning), isPrjfltServiceRunning);
+                prjFltHealthMetadata.Add(nameof(isNativeProjFSLibInstalled), isNativeProjFSLibInstalled);
                 prjFltHealthMetadata.Add(nameof(isAutoLoggerEnabled), isAutoLoggerEnabled);
-                prjFltHealthMetadata.Add(nameof(isNativeLibInstalled), isNativeLibInstalled);
                 tracer.RelatedEvent(EventLevel.Informational, $"{nameof(TryEnablePrjFlt)}_Summary", prjFltHealthMetadata, Keywords.Telemetry);
 
-                return isInstalled && isRunning;
+                return isPrjfltDriverInstalled && isPrjfltServiceInstalled && isPrjfltServiceRunning && isNativeProjFSLibInstalled;
             }
         }
 

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Windows\Mock\MockGitHubUpgrader.cs" />
     <Compile Include="Windows\Mock\MockTextWriter.cs" />
     <Compile Include="Windows\Mock\MockWriteBuffer.cs" />
+    <Compile Include="Windows\Platform\ProjFSFilterTests.cs" />
     <Compile Include="Windows\Service\RepoRegistryTests.cs" />
     <Compile Include="Windows\Upgrader\ProductUpgraderTests.cs" />
     <Compile Include="Windows\Upgrader\UpgradeOrchestratorWithGitHubUpgraderTests.cs" />

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Platform/ProjFSFilterTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Platform/ProjFSFilterTests.cs
@@ -32,11 +32,13 @@ namespace GVFS.UnitTests.Windows.Platform
         private readonly FileVersionInfo dummyVersionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
 
         private Mock<PhysicalFileSystem> mockFileSystem;
+        private MockTracer mockTracer;
 
         [SetUp]
         public void Setup()
         {
             this.mockFileSystem = new Mock<PhysicalFileSystem>(MockBehavior.Strict);
+            this.mockTracer = new MockTracer();
         }
 
         [TearDown]
@@ -50,7 +52,7 @@ namespace GVFS.UnitTests.Windows.Platform
         {
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(true);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
-            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeTrue();
+            ProjFSFilter.IsNativeLibInstalled(this.mockTracer, this.mockFileSystem.Object).ShouldBeTrue();
         }
 
         [TestCase]
@@ -58,21 +60,21 @@ namespace GVFS.UnitTests.Windows.Platform
         {
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(true);
-            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeTrue();
+            ProjFSFilter.IsNativeLibInstalled(this.mockTracer, this.mockFileSystem.Object).ShouldBeTrue();
         }
 
         [TestCase]
         public void IsNativeLibInstalled_ReturnsFalseWhenNativeLibraryDoesNotExistInAnyInstallLocation()
         {
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(It.IsAny<string>())).Returns(false);
-            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeFalse();
+            ProjFSFilter.IsNativeLibInstalled(this.mockTracer, this.mockFileSystem.Object).ShouldBeFalse();
         }
 
         [TestCase]
         public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenLibInSystem32()
         {
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(true);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -80,7 +82,7 @@ namespace GVFS.UnitTests.Windows.Platform
         {
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(true);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -89,7 +91,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(false);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -99,7 +101,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(false);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -110,7 +112,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(false);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -125,7 +127,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.packagedDriverPath)).Returns(this.dummyVersionInfo);
             this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(false);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -141,7 +143,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
             this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
             this.mockFileSystem.Setup(fileSystem => fileSystem.ProductVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(false);
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -160,7 +162,7 @@ namespace GVFS.UnitTests.Windows.Platform
             this.mockFileSystem.Setup(fileSystem => fileSystem.ProductVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
 
             this.mockFileSystem.Setup(fileSystem => fileSystem.CopyFile(this.packagedNativeLibPath, this.nonInboxNativeLibInstallPath, true)).Throws(new IOException());
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeFalse();
         }
 
         [TestCase]
@@ -179,7 +181,7 @@ namespace GVFS.UnitTests.Windows.Platform
 
             this.mockFileSystem.Setup(fileSystem => fileSystem.CopyFile(this.packagedNativeLibPath, this.nonInboxNativeLibInstallPath, true));
             this.mockFileSystem.Setup(fileSystem => fileSystem.FlushFileBuffers(this.nonInboxNativeLibInstallPath));
-            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeTrue();
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(this.mockTracer, this.mockFileSystem.Object, out string _).ShouldBeTrue();
         }
     }
 }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Platform/ProjFSFilterTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Platform/ProjFSFilterTests.cs
@@ -1,0 +1,185 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Platform.Windows;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
+using GVFS.UnitTests.Mock.Common;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace GVFS.UnitTests.Windows.Platform
+{
+    [TestFixture]
+    public class ProjFSFilterTests
+    {
+        private const string System32DriversRoot = @"%SystemRoot%\System32\drivers";
+        private const string PrjFltDriverName = "prjflt.sys";
+        private const string ProjFSNativeLibFileName = "ProjectedFSLib.dll";
+
+        private readonly string system32NativeLibPath = Path.Combine(Environment.SystemDirectory, ProjFSNativeLibFileName);
+        private readonly string nonInboxNativeLibInstallPath = Path.Combine(ProcessHelper.GetCurrentProcessLocation(), ProjFSNativeLibFileName);
+        private readonly string packagedNativeLibPath = Path.Combine(ProcessHelper.GetCurrentProcessLocation(), "ProjFS", ProjFSNativeLibFileName);
+
+        private readonly string packagedDriverPath = Path.Combine(ProcessHelper.GetCurrentProcessLocation(), "Filter", PrjFltDriverName);
+        private readonly string system32DriverPath = Path.Combine(Environment.ExpandEnvironmentVariables(System32DriversRoot), PrjFltDriverName);
+
+        // .NET doesn't allow us to create custom FileVersionInfos, and so use the version for our assembly and mock
+        // the version comparison methods
+        private readonly FileVersionInfo dummyVersionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
+
+        private Mock<PhysicalFileSystem> mockFileSystem;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.mockFileSystem = new Mock<PhysicalFileSystem>(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.mockFileSystem.VerifyAll();
+        }
+
+        [TestCase]
+        public void IsNativeLibInstalled_ReturnsTrueWhenLibInSystem32()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void IsNativeLibInstalled_ReturnsTrueWhenLibInNonInboxInstallLocation()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(true);
+            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void IsNativeLibInstalled_ReturnsFalseWhenNativeLibraryDoesNotExistInAnyInstallLocation()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(It.IsAny<string>())).Returns(false);
+            ProjFSFilter.IsNativeLibInstalled(new MockTracer(), this.mockFileSystem.Object).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenLibInSystem32()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(true);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenLibAtNonInboxInstallLocation()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(true);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenLibMissingFromPackagedLocation()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(false);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenDriverMissingFromPackagedLocation()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(false);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenDriverMissingFromSystem32()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(false);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenFileVersionDoesNotMatch()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.packagedDriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(false);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenProductVersionDoesNotMatch()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.packagedDriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.ProductVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(false);
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsFalseWhenCopyingNativeLibFails()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.packagedDriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.ProductVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.CopyFile(this.packagedNativeLibPath, this.nonInboxNativeLibInstallPath, true)).Throws(new IOException());
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryCopyNativeLibIfDriverVersionsMatch_ReturnsTrueOnSuccess()
+        {
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32NativeLibPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.nonInboxNativeLibInstallPath)).Returns(false);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedNativeLibPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.packagedDriverPath)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileExists(this.system32DriverPath)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.packagedDriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.GetVersionInfo(this.system32DriverPath)).Returns(this.dummyVersionInfo);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FileVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
+            this.mockFileSystem.Setup(fileSystem => fileSystem.ProductVersionsMatch(this.dummyVersionInfo, this.dummyVersionInfo)).Returns(true);
+
+            this.mockFileSystem.Setup(fileSystem => fileSystem.CopyFile(this.packagedNativeLibPath, this.nonInboxNativeLibInstallPath, true));
+            this.mockFileSystem.Setup(fileSystem => fileSystem.FlushFileBuffers(this.nonInboxNativeLibInstallPath));
+            ProjFSFilter.TryCopyNativeLibIfDriverVersionsMatch(new MockTracer(), this.mockFileSystem.Object, out string _).ShouldBeTrue();
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -140,6 +140,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
             return file.GetContentStream();
         }
 
+        public override void FlushFileBuffers(string path)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void WriteAllText(string path, string contents)
         {
             MockFile file = new MockFile(path, contents);
@@ -327,6 +332,16 @@ namespace GVFS.UnitTests.Mock.FileSystem
         }
 
         public override FileVersionInfo GetVersionInfo(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool FileVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool ProductVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -5,6 +5,7 @@ using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace GVFS.UnitTests.Mock.FileSystem
@@ -323,6 +324,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
             }
 
             return files.ToArray();
+        }
+
+        public override FileVersionInfo GetVersionInfo(string path)
+        {
+            throw new NotImplementedException();
         }
 
         private Stream CreateAndOpenFileStream(string path)


### PR DESCRIPTION
Fixes #127, fixes #423 

Updated GVFS.Service so that if the native ProjFS library is missing *and* the installed version of prjflt matches the version that ships with VFS4G, GVFS.Service will copy the native ProjFS library into `C:\Program Files\GVFS`.

_Manual testing_

- Installed the non-inbox ProjFS that ships with VFS4G and removed ProjectedFSLib.dll.  Restarted GVFS.Service and verified that it copied `ProjectedFSLib.dll` from `C:\Program Files\GVFS\ProjFS` to `C:\Program Files\GVFS`. 

- Installed an older version of the ProjFS driver and removed ProjectedFSLib.dll.  Restarted GVFS.Service and verified that it did not copy `ProjectedFSLib.dll` because the packaged prjflt version didn't match the installed prjflt version.