### PR TITLE
Support alternate names for the .gvfs folder

### DIFF
--- a/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrade.cs
@@ -314,7 +314,7 @@ namespace GVFS.DiskLayoutUpgrades
             majorVersion = 0;
             minorVersion = 0;
 
-            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
 
             if (!GVFSPlatform.Instance.DiskLayoutUpgrade.TryParseLegacyDiskLayoutVersion(dotGVFSPath, out majorVersion))
             {
@@ -340,7 +340,7 @@ namespace GVFS.DiskLayoutUpgrades
             {
                 tracer.AddLogFileEventListener(
                     GVFSEnlistment.GetNewGVFSLogFileName(
-                        Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.LogPath),
+                        Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.LogName),
                         GVFSConstants.LogFileTypes.MountUpgrade),
                     EventLevel.Informational,
                     Keywords.Any);
@@ -364,7 +364,7 @@ namespace GVFS.DiskLayoutUpgrades
             protected bool TryIncrementMajorVersion(ITracer tracer, string enlistmentRoot)
             {
                 string newMajorVersion = (this.SourceMajorVersion + 1).ToString();
-                string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+                string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
                 string error;
                 if (!RepoMetadata.TryInitialize(tracer, dotGVFSPath, out error))
                 {
@@ -390,7 +390,7 @@ namespace GVFS.DiskLayoutUpgrades
             protected bool TryIncrementMinorVersion(ITracer tracer, string enlistmentRoot)
             {
                 string newMinorVersion = (this.SourceMinorVersion + 1).ToString();
-                string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+                string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
                 string error;
                 if (!RepoMetadata.TryInitialize(tracer, dotGVFSPath, out error))
                 {

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -101,11 +101,8 @@ namespace GVFS.Common
 
         public static class DotGVFS
         {
-            public const string Root = ".gvfs";
             public const string CorruptObjectsName = "CorruptObjects";
-
-            public static readonly string LogPath = Path.Combine(DotGVFS.Root, "logs");
-            public static readonly string CorruptObjectsPath = Path.Combine(DotGVFS.Root, CorruptObjectsName);
+            public const string LogName = "logs";
 
             public static class Databases
             {

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -31,10 +31,10 @@ namespace GVFS.Common
                   authentication: authentication)
         {
             this.NamedPipeName = GVFSPlatform.Instance.GetNamedPipeName(this.EnlistmentRoot);
-            this.DotGVFSRoot = Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGVFS.Root);
+            this.DotGVFSRoot = Path.Combine(this.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             this.GitStatusCacheFolder = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.Name);
             this.GitStatusCachePath = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.CachePath);
-            this.GVFSLogsRoot = Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGVFS.LogPath);
+            this.GVFSLogsRoot = Path.Combine(this.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.LogName);
             this.LocalObjectsRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Objects.Root);
         }
 

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -94,6 +94,7 @@ namespace GVFS.Common
             public abstract string ExecutableExtension { get; }
             public abstract string InstallerExtension { get; }
             public abstract string WorkingDirectoryBackingRootPath { get; }
+            public abstract string DotGVFSRoot { get; }
 
             public abstract string GVFSBinDirectoryPath { get; }
 

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -195,7 +195,7 @@ namespace GVFS.Common.Git
             {
                 if (corruptLooseObject)
                 {
-                    string corruptBlobsFolderPath = Path.Combine(this.enlistment.EnlistmentRoot, GVFSConstants.DotGVFS.CorruptObjectsPath);
+                    string corruptBlobsFolderPath = Path.Combine(this.enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.CorruptObjectsName);
                     string corruptBlobPath = Path.Combine(corruptBlobsFolderPath, Path.GetRandomFileName());
 
                     EventMetadata metadata = new EventMetadata();

--- a/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/AcquireGVFSLock.cs
@@ -1,7 +1,7 @@
 ﻿using CommandLine;
 using GVFS.Common;
 using GVFS.Common.NamedPipes;
-using GVFS.Platform.POSIX;
+using GVFS.Platform.Mac;
 using GVFS.Platform.Windows;
 using System;
 using System.Diagnostics;
@@ -45,7 +45,7 @@ namespace GVFS.FunctionalTests.LockHolder
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
+                return MacPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
             }
 
             // Not able to use WindowsPlatform here - because of its dependency on WindowsIdentity (and also kernel32.dll).
@@ -57,10 +57,11 @@ namespace GVFS.FunctionalTests.LockHolder
                 return false;
             }
 
-            enlistmentRoot = Paths.GetRoot(finalDirectory, GVFSConstants.DotGVFS.Root);
+            const string dotGVFSRoot = ".gvfs";
+            enlistmentRoot = Paths.GetRoot(finalDirectory, dotGVFSRoot);
             if (enlistmentRoot == null)
             {
-                errorMessage = $"Failed to find the root directory for {GVFSConstants.DotGVFS.Root} in {finalDirectory}";
+                errorMessage = $"Failed to find the root directory for {dotGVFSRoot} in {finalDirectory}";
                 return false;
             }
 
@@ -71,7 +72,7 @@ namespace GVFS.FunctionalTests.LockHolder
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
+                return MacPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
             }
 
             // Not able to use WindowsPlatform here - because of its dependency on WindowsIdentity (and also kernel32.dll).

--- a/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="..\GVFS.Platform.POSIX\POSIXFileSystem.Shared.cs" Link="POSIXFileSystem.Shared.cs" />
     <Compile Include="..\GVFS.Platform.POSIX\POSIXPlatform.Shared.cs" Link="POSIXPlatform.Shared.cs" />
+    <Compile Include="..\GVFS.Platform.Mac\MacPlatform.Shared.cs" Link="MacPlatform.Shared.cs" />
     <Compile Include="..\GVFS.Platform.Windows\WindowsFileSystem.Shared.cs" Link="WindowsFileSystem.Shared.cs" />
   </ItemGroup>
   

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -28,5 +28,7 @@ namespace GVFS.FunctionalTests
                     Path.Combine(Properties.Settings.Default.CurrentDirectory, Properties.Settings.Default.PathToGVFS);
             }
         }
+
+        public static string DotGVFSRoot { get; set; }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -101,6 +101,8 @@ namespace GVFS.FunctionalTests
                 excludeCategories.Add(Categories.MacOnly);
             }
 
+            GVFSTestConfig.DotGVFSRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ".vfsforgit" : ".gvfs";
+
             GVFSTestConfig.RepoToClone =
                 runner.GetCustomArgWithParam("--repo-to-clone")
                 ?? Properties.Settings.Default.RepoToClone;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -66,7 +66,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             ProcessResult result = ProcessHelper.Run(processInfo);
             result.ExitCode.ShouldEqual(0, result.Errors);
 
-            string dotGVFSRoot = Path.Combine(newEnlistmentRoot, ".gvfs");
+            string dotGVFSRoot = Path.Combine(newEnlistmentRoot, GVFSTestConfig.DotGVFSRoot);
             dotGVFSRoot.ShouldBeADirectory(fileSystem);
             string localCacheRoot = GVFSHelpers.GetPersistedLocalCacheRoot(dotGVFSRoot);
             string gitObjectsRoot = GVFSHelpers.GetPersistedGitObjectsRoot(dotGVFSRoot);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -63,14 +63,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             backupFolder.ShouldBeADirectory(this.fileSystem);
             string[] backupFolderItems = this.fileSystem.EnumerateDirectory(backupFolder).Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             backupFolderItems.Length.ShouldEqual(1);
-            this.DirectoryShouldContain(backupFolderItems[0], ".git", ".gvfs", "src");
+            this.DirectoryShouldContain(backupFolderItems[0], ".git", GVFSTestConfig.DotGVFSRoot, "src");
 
             // .git folder items
             string gitFolder = Path.Combine(backupFolderItems[0], ".git");
             this.DirectoryShouldContain(gitFolder, "index");
 
             // .gvfs folder items
-            string gvfsFolder = Path.Combine(backupFolderItems[0], ".gvfs");
+            string gvfsFolder = Path.Combine(backupFolderItems[0], GVFSTestConfig.DotGVFSRoot);
             this.DirectoryShouldContain(gvfsFolder, "databases", "GVFS_projection");
 
             string gvfsDatabasesFolder = Path.Combine(gvfsFolder, "databases");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -238,7 +238,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string persistedDeleteFileTask = $"A 1\0{this.fileDeletedBackgroundOperationCode}\0{deleteFilePath}\0";
             string persistedDeleteDirectoryTask = $"A 2\0{this.directoryDeletedBackgroundOperationCode}\0{deleteDirPath}\0";
             this.fileSystem.WriteAllText(
-                Path.Combine(this.Enlistment.EnlistmentRoot, ".gvfs", "databases", "BackgroundGitOperations.dat"),
+                Path.Combine(this.Enlistment.EnlistmentRoot, GVFSTestConfig.DotGVFSRoot, "databases", "BackgroundGitOperations.dat"),
                 $"{persistedDeleteFileTask}\r\n{persistedDeleteDirectoryTask}\r\n");
 
             // Background queue should process the delete messages and modifiedPaths should show the change

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/UnmountTests.cs
@@ -25,7 +25,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSProcess gvfsProcess = new GVFSProcess(
                 GVFSTestConfig.PathToGVFS,
                 this.Enlistment.EnlistmentRoot,
-                Path.Combine(this.Enlistment.EnlistmentRoot, ".gvfs"));
+                Path.Combine(this.Enlistment.EnlistmentRoot, GVFSTestConfig.DotGVFSRoot));
 
             if (!gvfsProcess.IsEnlistmentMounted())
             {

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -66,7 +66,7 @@ namespace GVFS.FunctionalTests.Tools
 
         public string DotGVFSRoot
         {
-            get { return Path.Combine(this.EnlistmentRoot, ".gvfs"); }
+            get { return Path.Combine(this.EnlistmentRoot, GVFSTestConfig.DotGVFSRoot); }
         }
 
         public string GVFSLogsRoot
@@ -314,7 +314,7 @@ namespace GVFS.FunctionalTests.Tools
 
         private static string GetRepoSpecificLocalCacheRoot(string enlistmentRoot)
         {
-            return Path.Combine(enlistmentRoot, ".gvfs", ".gvfsCache");
+            return Path.Combine(enlistmentRoot, GVFSTestConfig.DotGVFSRoot, ".gvfsCache");
         }
 
         private bool WaitForStatus(int maxWaitMilliseconds, string statusShouldContain)

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
@@ -109,7 +109,4 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Mac\" />
-  </ItemGroup>
 </Project>

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.Mac.csproj
@@ -93,12 +93,14 @@
     <Compile Include="..\GVFS.Common\Tracing\Keywords.cs">
       <Link>Common\Tracing\Keywords.cs</Link>
     </Compile>
-    <Compile Include="..\GVFS.Platform.Mac\MacPlatform.Shared.cs" Link="MacPlatform.Shared.cs" />
     <Compile Include="..\GVFS.Platform.POSIX\POSIXFileSystem.Shared.cs">
       <Link>POSIX\POSIXFileSystem.Shared.cs</Link>
     </Compile>
     <Compile Include="..\GVFS.Platform.POSIX\POSIXPlatform.Shared.cs">
       <Link>POSIX\POSIXPlatform.Shared.cs</Link>
+    </Compile>
+    <Compile Include="..\GVFS.Platform.Mac\MacPlatform.Shared.cs">
+      <Link>Mac\MacPlatform.Shared.cs</Link>
     </Compile>
   </ItemGroup>
   
@@ -106,5 +108,8 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Mac\" />
   </ItemGroup>
 </Project>

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
@@ -8,5 +8,15 @@ namespace GVFS.Hooks.HooksPlatform
         {
             return MacPlatform.GetDataRootForGVFSImplementation();
         }
+
+        public static bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
+        {
+            return MacPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
+        }
+
+        public static string GetNamedPipeName(string enlistmentRoot)
+        {
+            return MacPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
+        }
     }
 }

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.POSIX.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.POSIX.cs
@@ -14,19 +14,9 @@ namespace GVFS.Hooks.HooksPlatform
             return POSIXPlatform.IsProcessActiveImplementation(processId);
         }
 
-        public static string GetNamedPipeName(string enlistmentRoot)
-        {
-            return POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
-        }
-
         public static bool IsConsoleOutputRedirectedToFile()
         {
             return POSIXPlatform.IsConsoleOutputRedirectedToFileImplementation();
-        }
-
-        public static bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
-        {
-            return POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
         }
 
         public static bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using GVFS.Platform.POSIX;
 
 namespace GVFS.Platform.Mac
 {
@@ -23,12 +24,12 @@ namespace GVFS.Platform.Mac
 
         public static bool TryGetGVFSEnlistmentRootImplementation(string directory, out string enlistmentRoot, out string errorMessage)
         {
-            return POSIX.POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, DotGVFSRoot, out enlistmentRoot, out errorMessage);
+            return POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, DotGVFSRoot, out enlistmentRoot, out errorMessage);
         }
 
         public static string GetNamedPipeNameImplementation(string enlistmentRoot)
         {
-            return POSIX.POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot, DotGVFSRoot);
+            return POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot, DotGVFSRoot);
         }
     }
 }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -5,6 +5,8 @@ namespace GVFS.Platform.Mac
 {
     public partial class MacPlatform
     {
+        public const string DotGVFSRoot = ".gvfs";
+
         public static string GetDataRootForGVFSImplementation()
         {
             return Path.Combine(
@@ -17,6 +19,16 @@ namespace GVFS.Platform.Mac
         public static string GetDataRootForGVFSComponentImplementation(string componentName)
         {
             return Path.Combine(GetDataRootForGVFSImplementation(), componentName);
+        }
+
+        public static bool TryGetGVFSEnlistmentRootImplementation(string directory, out string enlistmentRoot, out string errorMessage)
+        {
+            return POSIX.POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, DotGVFSRoot, out enlistmentRoot, out errorMessage);
+        }
+
+        public static string GetNamedPipeNameImplementation(string enlistmentRoot)
+        {
+            return POSIX.POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot, DotGVFSRoot);
         }
     }
 }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -34,6 +34,16 @@ namespace GVFS.Platform.Mac
             return MacPlatform.GetDataRootForGVFSComponentImplementation(componentName);
         }
 
+        public override bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
+        {
+            return MacPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
+        }
+
+        public override string GetNamedPipeName(string enlistmentRoot)
+        {
+            return MacPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
+        }
+
         public override FileBasedLock CreateFileBasedLock(
             PhysicalFileSystem fileSystem,
             ITracer tracer,
@@ -52,6 +62,11 @@ namespace GVFS.Platform.Mac
             public override string WorkingDirectoryBackingRootPath
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
+            }
+
+            public override string DotGVFSRoot
+            {
+                get { return MacPlatform.DotGVFSRoot; }
             }
 
             public override string GVFSBinDirectoryPath

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.Shared.cs
@@ -28,10 +28,10 @@ namespace GVFS.Platform.POSIX
             return true;
         }
 
-        public static string GetNamedPipeNameImplementation(string enlistmentRoot)
+        public static string GetNamedPipeNameImplementation(string enlistmentRoot, string dotGVFSRoot)
         {
             // Pipes are stored as files on POSIX, use a rooted pipe name to keep full control of the location of the file
-            return Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root, "GVFS_NetCorePipe");
+            return Path.Combine(enlistmentRoot, dotGVFSRoot, "GVFS_NetCorePipe");
         }
 
         public static bool IsConsoleOutputRedirectedToFileImplementation()
@@ -40,7 +40,7 @@ namespace GVFS.Platform.POSIX
             return false;
         }
 
-        public static bool TryGetGVFSEnlistmentRootImplementation(string directory, out string enlistmentRoot, out string errorMessage)
+        public static bool TryGetGVFSEnlistmentRootImplementation(string directory, string dotGVFSRoot, out string enlistmentRoot, out string errorMessage)
         {
             // TODO(POSIX): Merge this code with the implementation in WindowsPlatform
 
@@ -52,10 +52,10 @@ namespace GVFS.Platform.POSIX
                 return false;
             }
 
-            enlistmentRoot = Paths.GetRoot(finalDirectory, GVFSConstants.DotGVFS.Root);
+            enlistmentRoot = Paths.GetRoot(finalDirectory, dotGVFSRoot);
             if (enlistmentRoot == null)
             {
-                errorMessage = $"Failed to find the root directory for {GVFSConstants.DotGVFS.Root} in {finalDirectory}";
+                errorMessage = $"Failed to find the root directory for {dotGVFSRoot} in {finalDirectory}";
                 return false;
             }
 

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -117,11 +117,6 @@ namespace GVFS.Platform.POSIX
         {
         }
 
-        public override string GetNamedPipeName(string enlistmentRoot)
-        {
-            return POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
-        }
-
         public override string GetGVFSServiceNamedPipeName(string serviceName)
         {
             // Pipes are stored as files on POSIX, use a rooted pipe name
@@ -137,11 +132,6 @@ namespace GVFS.Platform.POSIX
         public override bool IsElevated()
         {
             return POSIXPlatform.IsElevatedImplementation();
-        }
-
-        public override bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
-        {
-            return POSIXPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
         }
 
         public override bool TryGetDefaultLocalCacheRoot(string enlistmentRoot, out string localCacheRoot, out string localCacheRootError)

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout11to12Upgrade_SharedLocalCache.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout11to12Upgrade_SharedLocalCache.cs
@@ -17,7 +17,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             string error;
             if (!RepoMetadata.TryInitialize(tracer, dotGVFSPath, out error))
             {
@@ -44,7 +44,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         private bool TryUpgradeGitObjectPath(ITracer tracer, string enlistmentRoot)
         {
             string gitObjectsRoot;
-            string legacyDotGVFSGitObjectCachePath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root, "gitObjectCache");
+            string legacyDotGVFSGitObjectCachePath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, "gitObjectCache");
             if (Directory.Exists(legacyDotGVFSGitObjectCachePath))
             {
                 gitObjectsRoot = legacyDotGVFSGitObjectCachePath;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
@@ -23,7 +23,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             try
             {
                 string error;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout13to14Upgrade_BlobSizes.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout13to14Upgrade_BlobSizes.cs
@@ -25,7 +25,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSPath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             string error;
             if (!RepoMetadata.TryInitialize(tracer, dotGVFSPath, out error))
             {
@@ -68,7 +68,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
             {
                 // This is an old repo that was cloned prior to the shared cache
                 // Blob sizes root should be <root>\.gvfs\databases\blobSizes
-                newBlobSizesRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root, GVFSConstants.DotGVFS.Databases.Name, GVFSEnlistment.BlobSizesCacheName);
+                newBlobSizesRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.Databases.Name, GVFSEnlistment.BlobSizesCacheName);
             }
             else
             {
@@ -89,7 +89,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
         private void MigrateBlobSizes(ITracer tracer, string enlistmentRoot, string newBlobSizesRoot)
         {
-            string esentBlobSizeFolder = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root, BlobSizesName);
+            string esentBlobSizeFolder = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, BlobSizesName);
             PhysicalFileSystem fileSystem = new PhysicalFileSystem();
             if (!fileSystem.DirectoryExists(esentBlobSizeFolder))
             {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout14to15Upgrade_ModifiedPaths.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout14to15Upgrade_ModifiedPaths.cs
@@ -19,7 +19,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
             {
                 PhysicalFileSystem fileSystem = new PhysicalFileSystem();
 
-                string modifiedPathsDatabasePath = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root, GVFSConstants.DotGVFS.Databases.ModifiedPaths);
+                string modifiedPathsDatabasePath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.Databases.ModifiedPaths);
                 string error;
                 if (!ModifiedPathsDatabase.TryLoadOrCreate(tracer, modifiedPathsDatabasePath, fileSystem, out modifiedPaths, out error))
                 {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
@@ -18,7 +18,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             try
             {
                 string error;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout7to8Upgrade_NewOperationType.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout7to8Upgrade_NewOperationType.cs
@@ -20,7 +20,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             string esentRepoMetadata = Path.Combine(dotGVFSRoot, WindowsDiskLayoutUpgradeData.EsentRepoMetadataName);
             try
             {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout8to9Upgrade_RepoMetadataToJson.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout8to9Upgrade_RepoMetadataToJson.cs
@@ -20,7 +20,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             if (!this.UpdateRepoMetadata(tracer, dotGVFSRoot))
             {
                 return false;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout9to10Upgrade_BackgroundAndPlaceholderListToFileBased.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout9to10Upgrade_BackgroundAndPlaceholderListToFileBased.cs
@@ -26,7 +26,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
         /// </summary>
         public override bool TryUpgrade(ITracer tracer, string enlistmentRoot)
         {
-            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSConstants.DotGVFS.Root);
+            string dotGVFSRoot = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             if (!this.UpdateBackgroundOperations(tracer, dotGVFSRoot))
             {
                 return false;

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -10,6 +10,8 @@ namespace GVFS.Platform.Windows
 {
     public partial class WindowsPlatform
     {
+        public const string DotGVFSRoot = ".gvfs";
+
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
 
         private enum StdHandle
@@ -99,10 +101,10 @@ namespace GVFS.Platform.Windows
                 return false;
             }
 
-            enlistmentRoot = Paths.GetRoot(finalDirectory, GVFSConstants.DotGVFS.Root);
+            enlistmentRoot = Paths.GetRoot(finalDirectory, DotGVFSRoot);
             if (enlistmentRoot == null)
             {
-                errorMessage = $"Failed to find the root directory for {GVFSConstants.DotGVFS.Root} in {finalDirectory}";
+                errorMessage = $"Failed to find the root directory for {DotGVFSRoot} in {finalDirectory}";
                 return false;
             }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -416,6 +416,11 @@ namespace GVFS.Platform.Windows
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }
 
+            public override string DotGVFSRoot
+            {
+                get { return WindowsPlatform.DotGVFSRoot; }
+            }
+
             public override string GVFSBinDirectoryPath
             {
                 get

--- a/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Common
             MockTracer tracer = new MockTracer();
 
             string enlistmentRoot = Path.Combine("mock:", "GVFS", "UnitTests", "Repo");
-            string statusCachePath = Path.Combine("mock:", "GVFS", "UnitTests", "Repo", ".gvfs", "gitStatusCache");
+            string statusCachePath = Path.Combine("mock:", "GVFS", "UnitTests", "Repo", GVFSPlatform.Instance.Constants.DotGVFSRoot, "gitStatusCache");
 
             this.gitProcess = new MockGitProcess();
             this.gitProcess.SetExpectedCommandResult($"--no-optional-locks status \"--serialize={statusCachePath}", () => new GitProcess.Result(string.Empty, string.Empty, 0), true);

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -23,7 +23,7 @@ namespace GVFS.UnitTests.Git
         private const string ValidTestObjectFileContents = "421dc4df5e1de427e363b8acd9ddb2d41385dbdf";
         private const string TestEnlistmentRoot = "mock:\\src";
         private const string TestLocalCacheRoot = "mock:\\.gvfs";
-        private const string TestObjecRoot = "mock:\\.gvfs\\gitObjectCache";
+        private const string TestObjectRoot = "mock:\\.gvfs\\gitObjectCache";
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
@@ -139,7 +139,7 @@ namespace GVFS.UnitTests.Git
         {
             MockTracer tracer = new MockTracer();
             GVFSEnlistment enlistment = new GVFSEnlistment(TestEnlistmentRoot, "https://fakeRepoUrl", "fakeGitBinPath", gvfsHooksRoot: null, authentication: null);
-            enlistment.InitializeCachePathsFromKey(TestLocalCacheRoot, TestObjecRoot);
+            enlistment.InitializeCachePathsFromKey(TestLocalCacheRoot, TestObjectRoot);
             GitRepo repo = new GitRepo(tracer, enlistment, fileSystem, () => new MockLibGit2Repo(tracer));
 
             GVFSContext context = new GVFSContext(tracer, fileSystem, repo, enlistment);

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -177,7 +177,7 @@ namespace GVFS.UnitTests.Mock.Common
 
             public override string DotGVFSRoot
             {
-                get { return ".vfsforgit"; }
+                get { return ".mockvfsforgit"; }
             }
 
             public override string GVFSBinDirectoryPath

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -175,6 +175,11 @@ namespace GVFS.UnitTests.Mock.Common
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }
 
+            public override string DotGVFSRoot
+            {
+                get { return ".vfsforgit"; }
+            }
+
             public override string GVFSBinDirectoryPath
             {
                 get { return Path.Combine("MockProgramFiles", this.GVFSBinDirectoryName); }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -276,7 +276,7 @@ of your enlistment's src folder.
         {
             string backupSrc = Path.Combine(backupRoot, "src");
             string backupGit = Path.Combine(backupRoot, ".git");
-            string backupGvfs = Path.Combine(backupRoot, ".gvfs");
+            string backupGvfs = Path.Combine(backupRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             string backupDatabases = Path.Combine(backupGvfs, GVFSConstants.DotGVFS.Databases.Name);
 
             string errorMessage = string.Empty;

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -89,7 +89,7 @@ namespace GVFS.CommandLine
                     () =>
                     {
                         // .gvfs
-                        this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSConstants.DotGVFS.Root, copySubFolders: false);
+                        this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSPlatform.Instance.Constants.DotGVFSRoot, copySubFolders: false);
 
                         // driver
                         if (this.FlushKernelDriverLogs())
@@ -112,13 +112,13 @@ namespace GVFS.CommandLine
                         this.LogLooseObjectCount(enlistment.WorkingDirectoryRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGit.Objects.Root), GVFSConstants.DotGit.Objects.Root, "objects-local.txt");
 
                         // databases
-                        this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGVFS.Root), GVFSConstants.DotGVFS.Databases.Name, copySubFolders: false);
+                        this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSPlatform.Instance.Constants.DotGVFSRoot), GVFSConstants.DotGVFS.Databases.Name, copySubFolders: false);
 
                         // local cache
                         this.CopyLocalCacheData(archiveFolderPath, localCacheRoot, gitObjectsRoot);
 
                         // corrupt objects
-                        this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGVFS.Root), GVFSConstants.DotGVFS.CorruptObjectsName, copySubFolders: false);
+                        this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSPlatform.Instance.Constants.DotGVFSRoot), GVFSConstants.DotGVFS.CorruptObjectsName, copySubFolders: false);
 
                         // service
                         this.CopyAllFiles(
@@ -165,7 +165,7 @@ namespace GVFS.CommandLine
                     "Mounting",
                     suppressGvfsLogMessage: true);
 
-                this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSConstants.DotGVFS.Root), "logs", copySubFolders: false);
+                this.CopyAllFiles(enlistment.DotGVFSRoot, Path.Combine(archiveFolderPath, GVFSPlatform.Instance.Constants.DotGVFSRoot), "logs", copySubFolders: false);
             }
 
             string zipFilePath = archiveFolderPath + ".zip";
@@ -274,7 +274,7 @@ namespace GVFS.CommandLine
                 using (ITracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "DiagnoseVerb"))
                 {
                     string error;
-                    if (RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSConstants.DotGVFS.Root), out error))
+                    if (RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), out error))
                     {
                         RepoMetadata.Instance.TryGetLocalCacheRoot(out localCacheRoot, out error);
                         RepoMetadata.Instance.TryGetGitObjectsRoot(out gitObjectsRoot, out error);

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -106,7 +106,7 @@ namespace GVFS.CommandLine
             {
                 gitStatusCachePath = Path.Combine(
                     enlistment.EnlistmentRoot,
-                    GVFSConstants.DotGVFS.Root,
+                    GVFSPlatform.Instance.Constants.DotGVFSRoot,
                     GVFSConstants.DotGVFS.GitStatusCache.CachePath);
 
                 gitStatusCachePath = Paths.ConvertPathToGitFormat(gitStatusCachePath);
@@ -860,7 +860,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 CacheServerInfo cacheServer)
             {
                 string error;
-                if (!RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSConstants.DotGVFS.Root), out error))
+                if (!RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), out error))
                 {
                     this.ReportErrorAndExit(tracer, "Failed to initialize repo metadata: " + error);
                 }

--- a/GVFS/GVFS/CommandLine/LogVerb.cs
+++ b/GVFS/GVFS/CommandLine/LogVerb.cs
@@ -48,7 +48,8 @@ namespace GVFS.CommandLine
 
             string gvfsLogsRoot = Path.Combine(
                 enlistmentRoot,
-                GVFSConstants.DotGVFS.LogPath);
+                GVFSPlatform.Instance.Constants.DotGVFSRoot,
+                GVFSConstants.DotGVFS.LogName);
 
             if (this.LogType == null)
             {


### PR DESCRIPTION
On Linux, the existence of a GNOME Virtual file system `.gvfs` directory precludes the use of VFS for Git entirely. For both this reason, and to fully disambiguate the VFSForGit project from GVfs, it would be preferable to use a different folder name for VFSForGit's metadata, such as `.vfsforgit`.

This PR introduces support for modifying the name of `.gvfs` folder on a per-platform basis. `GVFSPlatform.Instance.Constants.DotGVFSRoot` now holds the appropriate name of that folder.

Fixes #987. 

/cc @chrisd8088 @jrbriggs @wilbaker @nickgra 