### PR TITLE
Replace use of Count on FileSystemTaskQueue with IsEmpty

### DIFF
--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/Background/MockBackgroundTaskManager.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/Background/MockBackgroundTaskManager.cs
@@ -17,6 +17,8 @@ namespace GVFS.UnitTests.Mock.Virtualization.Background
 
         public List<FileSystemTask> BackgroundTasks { get; private set; }
 
+        public override bool IsEmpty => this.BackgroundTasks.Count == 0;
+
         public override int Count
         {
             get

--- a/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
+++ b/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
@@ -65,6 +65,18 @@ namespace GVFS.Virtualization.Background
             ShuttingDown
         }
 
+        public virtual bool IsEmpty
+        {
+            get { return this.backgroundTasks.IsEmpty; }
+        }
+
+        /// <summary>
+        /// Gets the count of tasks in the background queue
+        /// </summary>
+        /// <remarks>
+        /// This is an expensive call on .net core and you should avoid calling in performance critical paths.
+        /// Use the IsEmpty property when checking if the queue has any items instead of Count.
+        /// </remarks>
         public virtual int Count
         {
             get { return this.backgroundTasks.Count; }
@@ -81,7 +93,7 @@ namespace GVFS.Virtualization.Background
         public virtual void Start()
         {
             this.backgroundThread = Task.Factory.StartNew((Action)this.ProcessBackgroundTasks, TaskCreationOptions.LongRunning);
-            if (this.backgroundTasks.Count > 0)
+            if (!this.backgroundTasks.IsEmpty)
             {
                 this.wakeUpThread.Set();
             }
@@ -248,7 +260,7 @@ namespace GVFS.Virtualization.Background
                 if (acquireLockResult == AcquireGVFSLockResult.LockAcquired)
                 {
                     this.RunCallbackUntilSuccess(this.postCallback, "PostCallback");
-                    if (this.backgroundTasks.Count == 0)
+                    if (this.backgroundTasks.IsEmpty)
                     {
                         this.context.Repository.GVFSLock.ReleaseLockHeldByGVFS();
                     }

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
@@ -22,6 +22,18 @@ namespace GVFS.Virtualization.Background
         {
         }
 
+        public bool IsEmpty
+        {
+            get { return this.data.IsEmpty; }
+        }
+
+        /// <summary>
+        /// Gets the count of tasks in the queue
+        /// </summary>
+        /// <remarks>
+        /// This is an expensive call on .net core and you should avoid calling in performance critical paths.
+        /// Use the IsEmpty property when checking if the queue has any items instead of Count.
+        /// </remarks>
         public int Count
         {
             get { return this.data.Count; }
@@ -75,7 +87,7 @@ namespace GVFS.Virtualization.Background
 
                     this.WriteRemoveEntry(kvp.Key.ToString());
 
-                    this.DeleteDataFileIfCondition(() => this.data.Count == 0);
+                    this.DeleteDataFileIfCondition(() => this.data.IsEmpty);
                 }
                 else
                 {

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -144,6 +144,13 @@ namespace GVFS.Virtualization
             get { return this.GitIndexProjection; }
         }
 
+        /// <summary>
+        /// Gets the count of tasks in the background operation queue
+        /// </summary>
+        /// <remarks>
+        /// This is an expensive call on .net core and you should avoid calling
+        /// in performance critical paths.
+        /// </remarks>
         public int BackgroundOperationCount
         {
             get { return this.backgroundFileSystemTaskRunner.Count; }
@@ -243,7 +250,7 @@ namespace GVFS.Virtualization
 
         public bool IsReadyForExternalAcquireLockRequests(NamedPipeMessages.LockData requester, out string denyMessage)
         {
-            if (this.BackgroundOperationCount != 0)
+            if (!this.backgroundFileSystemTaskRunner.IsEmpty)
             {
                 denyMessage = "Waiting for GVFS to release the lock";
                 return false;
@@ -353,7 +360,7 @@ namespace GVFS.Virtualization
 
             // If there are background tasks queued up, then it will be
             // refreshed after they have been processed.
-            if (this.backgroundFileSystemTaskRunner.Count == 0)
+            if (this.backgroundFileSystemTaskRunner.IsEmpty)
             {
                 this.gitStatusCache.RefreshAsynchronously();
             }


### PR DESCRIPTION
Using `Count` on `ConcurrentQueue` carries a significant performance cost when using .Net Core.  This should be fixed in an upcoming version but in the meantime `IsEmpty` is much more performant and recommended.  This change replaces the use of `Count` in performance critical paths for the Background operations.

See [Extremely poor performance of ConcurrentQueue.Count](https://github.com/dotnet/corefx/issues/29759)