### PR TITLE
Do not take GVFSLock for git submodule commands

### DIFF
--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -417,6 +417,18 @@ namespace GVFS.Hooks
                 case "version":
                 case "web--browse":
                     return false;
+
+                /*
+                 * There are several git commands that are "unsupoorted" in virtualized (VFS4G)
+                 * enlistments that are blocked by git. Usually, these are blocked before they acquire
+                 * a GVFSLock, but the submodule command is different, and is blocked after acquiring the
+                 * GVFS lock. This can cause issues if another action is attempting to create placeholders.
+                 * As we know the submodule command is a no-op, allow it to proceed without acquiring the
+                 * GVFSLock. I have filed issue #1164 to track having git block all unsupported commands
+                 * before calling the pre-command hook.
+                 */
+                case "submodule":
+                    return false;
             }
 
             if (gitCommand == "reset" && args.Contains("--soft"))


### PR DESCRIPTION
### Issue

Running unsupported git commands inside of a VFS for Git enlistment can block placeholder creation, resulting in VFS for Git returning "File not Found" for virtualized files that should otherwise exist.

In one scenario, this caused issues with a build system that runs git submodule commands as part of the build execution, causing builds to fail with a "file not found" error, even though the files are expected to exist.

### Background

Placeholder creation is blocked when an unsupported git command is running inside of a VFS for Git enlistment.

There are is only a small set of git commands during which placeholders are allowed to be created while the git command is running. Git commands that are not supported in VFS for Git are not included in this list. The unsupported Git commands are blocked inside of git.exe and not at the pre-command hook, and they result in the GVFS being acquired when they are run. This means there is a window during which they can block placeholder creation (the window between when the command takes the GVFS lock and when the lock is released after the git command fails).

While the GVFS lock is held, Placeholder creation will fail and a "File not Found" result will be returned to the filter driver for the paths that we could not create placeholders for.

This causes issues with build systems that run unsupported commands in the background, even if the commands do not succeed in VFS for Git Enlistment, as files needed for build are reported as missing.

### Potential fixes
There are several options to address this on the VFS for Git side. Here is the option chosen, along with some alternatives:

#### Proposed Fix VFS for Git can just not take GVFS lock for unsupported commands.
In this case, VFS for Git expects that the command will be a no-op, as it will be rejected by git.exe. As the command will not affect the git data, there is no need to take a GVFS lock.

This approach has a couple of nice properties:
- No change to current error messages, so no chance of breaking any scripts that might have a dependency on the output
- This is in line with our longer term goal of removing the need for a GVFS lock. With this approach, when we remove the GVFS lock, there will be no behavior change here.

#### Alternative 1) Add "unsupported" commands to list of commands that VFS for Git allows placeholder creation for.

With this approach, we would include the known "blocked" commands to the list of commands that we allow placeholder creation to proceed during, as we know these commands will. not affect git data. If we do not take the GVFS lock, then there is no need for this additional change.

#### Alternative 2) VFS for Git can reject unsupported command from taking GVFS lock.
This would make the block of the command explicit, but would change the output of blocked commands, and does not align with our longer term goals of removing the GVFS hook.
