### PR TITLE
Enable building with Visual Studio 2019

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,12 @@ If you'd like to build your own VFS for Git Windows installer:
 build will fail, and the second and subsequent builds will succeed. This is because the build requires a prebuild code generation step.
 For details, see the build script in the previous step.
 
+You can also use Visual Studio 2019. There are a couple of options for getting all the dependencies.
+* You can install Visual Studio 2017 side by side with Visual Studio 2019, and make sure that you have all the dependencies from Visual Studio 2017 installed
+* Alternatively, if you only want to have Visual Studio 2019 installed, install the following extra dependencies:
+  * MSVC v141 VS 2017 C++ build tools via the optional components in the Visual Studio 2019 installer. It is under the "Desktop Development with C++" heading.
+  * Windows 10 SDK (10.0.10240.0) via the archived SDK page: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive
+
 The installer can now be found at `C:\Repos\VFSForGit\BuildOutput\GVFS.Installer\bin\x64\[Debug|Release]\SetupGVFS.<version>.exe`
 
 ## Building VFS for Git on Mac


### PR DESCRIPTION
Update the Windows build script to be able to build with Visual
Studio 2019 tooling and update Readme with details. Includes the
following changes:

  * Tweak logic to find msbuild for different Visual Studio versions

  * Remove checks for unnecessary packages

  * Add checks for .Net Core 2.1 development packages

  * Tweak check for Windows 10 SDK (10.0.10240.0)

Note: I have not tested this yet without VS 2017 installed.

Related PR: #1093 