### PR TITLE
Use published version of Service

### DIFF
--- a/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
+++ b/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
@@ -18,8 +18,7 @@
     <string>org.vfsforgit.service</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/share/dotnet/dotnet</string>
-        <string>/usr/local/vfsforgit/GVFS.Service.dll</string>
+        <string>/usr/local/vfsforgit/GVFS.Service</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/usr/local/vfsforgit</string>


### PR DESCRIPTION
On the Mac, use published version of `GVFS.Service` rather than running it using the `dotnet` command - `dotnet GVFS.Service.dll`

Fixes #1095