### PR TITLE
Rename LocalStorageRoot

### DIFF
--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -252,7 +252,7 @@ namespace FastFetch
 
         private void HandleAllFileAddOperations()
         {
-            using (FastFetchLibGit2Repo repo = new FastFetchLibGit2Repo(this.tracer, this.enlistment.LocalStorageRoot))
+            using (FastFetchLibGit2Repo repo = new FastFetchLibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot))
             {
                 string availableBlob;
                 while (this.AvailableBlobShas.TryTake(out availableBlob, Timeout.Infinite))

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -24,8 +24,8 @@ namespace GVFS.Common
 
             this.EnlistmentRoot = enlistmentRoot;
             this.WorkingDirectoryRoot = workingDirectoryRoot;
-            this.LocalStorageRoot = localStorageRoot;
-            this.DotGitRoot = Path.Combine(this.LocalStorageRoot, GVFSConstants.DotGit.Root);
+            this.WorkingDirectoryBackingRoot = localStorageRoot;
+            this.DotGitRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Root);
             this.GitBinPath = gitBinPath;
             this.GVFSHooksRoot = gvfsHooksRoot;
             this.FlushFileBuffersForPacks = flushFileBuffersForPacks;
@@ -55,8 +55,15 @@ namespace GVFS.Common
         }
 
         public string EnlistmentRoot { get; }
+
+        // Path to the root of the working (i.e. "src") directory.
+        // On platforms where the contents of the working directory are stored
+        // at a different location (e.g. Linux), WorkingDirectoryBackingRoot is the path of that backing
+        // storage location.  On all other platforms WorkingDirectoryRoot and WorkingDirectoryBackingRoot
+        // are the same.
         public string WorkingDirectoryRoot { get; }
-        public string LocalStorageRoot { get; }
+        public string WorkingDirectoryBackingRoot { get; }
+
         public string DotGitRoot { get; private set; }
         public abstract string GitObjectsRoot { get; protected set; }
         public abstract string LocalObjectsRoot { get; protected set; }

--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -57,7 +57,7 @@ namespace GVFS.Common.FileSystem
                 foreach (HookData hook in NativeHooks)
                 {
                     string installedHookPath = Path.Combine(ExecutingDirectory, hook.ExecutableName);
-                    string targetHookPath = Path.Combine(context.Enlistment.LocalStorageRoot, hook.Path + GVFSPlatform.Instance.Constants.ExecutableExtension);
+                    string targetHookPath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, hook.Path + GVFSPlatform.Instance.Constants.ExecutableExtension);
                     if (!TryHooksInstallationAction(() => CopyHook(context, installedHookPath, targetHookPath), out error))
                     {
                         error = "Failed to copy " + installedHookPath + "\n" + error;
@@ -65,13 +65,13 @@ namespace GVFS.Common.FileSystem
                     }
                 }
 
-                string precommandHookPath = Path.Combine(context.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Hooks.PreCommandPath);
+                string precommandHookPath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Hooks.PreCommandPath);
                 if (!GVFSPlatform.Instance.TryInstallGitCommandHooks(context, ExecutingDirectory, GVFSConstants.DotGit.Hooks.PreCommandHookName, precommandHookPath, out error))
                 {
                     return false;
                 }
 
-                string postcommandHookPath = Path.Combine(context.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Hooks.PostCommandPath);
+                string postcommandHookPath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Hooks.PostCommandPath);
                 if (!GVFSPlatform.Instance.TryInstallGitCommandHooks(context, ExecutingDirectory, GVFSConstants.DotGit.Hooks.PostCommandHookName, postcommandHookPath, out error))
                 {
                     return false;
@@ -156,7 +156,7 @@ namespace GVFS.Common.FileSystem
             out string errorMessage)
         {
             bool copyHook = false;
-            string enlistmentHookPath = Path.Combine(context.Enlistment.LocalStorageRoot, hook.Path + GVFSPlatform.Instance.Constants.ExecutableExtension);
+            string enlistmentHookPath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, hook.Path + GVFSPlatform.Instance.Constants.ExecutableExtension);
             string installedHookPath = Path.Combine(ExecutingDirectory, hook.ExecutableName);
 
             if (!context.FileSystem.FileExists(installedHookPath))

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -23,7 +23,7 @@ namespace GVFS.Common
             : base(
                   enlistmentRoot,
                   Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName),
-                  Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.LocalStorageRoot),
+                  Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.WorkingDirectoryBackingRootName),
                   repoUrl,
                   gitBinPath,
                   gvfsHooksRoot,
@@ -35,7 +35,7 @@ namespace GVFS.Common
             this.GitStatusCacheFolder = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.Name);
             this.GitStatusCachePath = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.CachePath);
             this.GVFSLogsRoot = Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGVFS.LogPath);
-            this.LocalObjectsRoot = Path.Combine(this.LocalStorageRoot, GVFSConstants.DotGit.Objects.Root);
+            this.LocalObjectsRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Objects.Root);
         }
 
         // Existing, configured enlistment

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -92,7 +92,7 @@ namespace GVFS.Common
             public static readonly char PathSeparator = Path.DirectorySeparatorChar;
             public abstract string ExecutableExtension { get; }
             public abstract string InstallerExtension { get; }
-            public abstract string LocalStorageRoot { get; }
+            public abstract string WorkingDirectoryBackingRootName { get; }
 
             public abstract string GVFSBinDirectoryPath { get; }
 

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -62,7 +62,7 @@ namespace GVFS.Common.Git
         }
 
         public GitProcess(Enlistment enlistment)
-            : this(enlistment.GitBinPath, enlistment.LocalStorageRoot, enlistment.GVFSHooksRoot)
+            : this(enlistment.GitBinPath, enlistment.WorkingDirectoryBackingRoot, enlistment.GVFSHooksRoot)
         {
         }
 
@@ -85,7 +85,7 @@ namespace GVFS.Common.Git
 
         public static Result Init(Enlistment enlistment)
         {
-            return new GitProcess(enlistment).InvokeGitOutsideEnlistment("init \"" + enlistment.LocalStorageRoot + "\"");
+            return new GitProcess(enlistment).InvokeGitOutsideEnlistment("init \"" + enlistment.WorkingDirectoryBackingRoot + "\"");
         }
 
         public static ConfigResult GetFromGlobalConfig(string gitBinPath, string settingName)

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -26,7 +26,7 @@ namespace GVFS.Common.Git
 
             this.libgit2RepoInvoker = new LibGit2RepoInvoker(
                 tracer,
-                repoFactory ?? (() => new LibGit2Repo(this.tracer, this.enlistment.LocalStorageRoot)));
+                repoFactory ?? (() => new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot)));
         }
 
         // For Unit Testing

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -253,7 +253,7 @@ namespace GVFS.Common.Prefetch
             this.DownloadMissingCommit(commitToFetch, this.GitObjects);
 
             // For FastFetch only, examine the shallow file to determine the previous commit that had been fetched
-            string shallowFile = Path.Combine(this.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Shallow);
+            string shallowFile = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Shallow);
             string previousCommit = null;
 
             // Use the shallow file to find a recent commit to diff against to try and reduce the number of SHAs to check.
@@ -435,7 +435,7 @@ namespace GVFS.Common.Prefetch
             }
 
             // Update shallow file to ensure this is a valid shallow repo
-            AppendToNewlineSeparatedFile(Path.Combine(this.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Shallow), commitSha);
+            AppendToNewlineSeparatedFile(Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Shallow), commitSha);
         }
 
         protected bool UpdateRef(ITracer tracer, string refName, string targetCommitish)
@@ -474,7 +474,7 @@ namespace GVFS.Common.Prefetch
 
             using (ITracer activity = this.Tracer.StartActivity("DownloadTrees", EventLevel.Informational, Keywords.Telemetry, startMetadata))
             {
-                using (LibGit2Repo repo = new LibGit2Repo(this.Tracer, this.Enlistment.LocalStorageRoot))
+                using (LibGit2Repo repo = new LibGit2Repo(this.Tracer, this.Enlistment.WorkingDirectoryBackingRoot))
                 {
                     if (!repo.ObjectExists(commitSha))
                     {

--- a/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
@@ -82,7 +82,7 @@ namespace GVFS.Common.Prefetch.Git
         {
             string targetTreeSha;
             string headTreeSha;
-            using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.LocalStorageRoot))
+            using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot))
             {
                 targetTreeSha = repo.GetTreeSha(targetCommitSha);
                 headTreeSha = repo.GetTreeSha("HEAD");
@@ -125,7 +125,7 @@ namespace GVFS.Common.Prefetch.Git
                     GitProcess.Result result = this.git.DiffTree(
                         sourceTreeSha,
                         targetTreeSha,
-                        line => this.EnqueueOperationsFromDiffTreeLine(this.tracer, this.enlistment.LocalStorageRoot, line));
+                        line => this.EnqueueOperationsFromDiffTreeLine(this.tracer, this.enlistment.WorkingDirectoryBackingRoot, line));
 
                     if (result.ExitCodeIsFailure)
                     {
@@ -202,7 +202,7 @@ namespace GVFS.Common.Prefetch.Git
 
         private void EnqueueOperationsFromLsTreeLine(ITracer activity, string line)
         {
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(line, this.enlistment.LocalStorageRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(line, this.enlistment.WorkingDirectoryBackingRoot);
             if (result == null)
             {
                 this.tracer.RelatedError("Unrecognized ls-tree line: {0}", line);

--- a/GVFS/GVFS.Common/Prefetch/Pipeline/FindBlobsStage.cs
+++ b/GVFS/GVFS.Common/Prefetch/Pipeline/FindBlobsStage.cs
@@ -55,7 +55,7 @@ namespace GVFS.Common.Prefetch.Pipeline
         protected override void DoWork()
         {
             string blobId;
-            using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.LocalStorageRoot))
+            using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot))
             {
                 while (this.requiredBlobs.TryTake(out blobId, Timeout.Infinite))
                 {

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -164,13 +164,13 @@ namespace GVFS.Mount
 
         private void ValidateMountPoints()
         {
-            DirectoryInfo workingDirectoryRootInfo = new DirectoryInfo(this.enlistment.LocalStorageRoot);
+            DirectoryInfo workingDirectoryRootInfo = new DirectoryInfo(this.enlistment.WorkingDirectoryBackingRoot);
             if (!workingDirectoryRootInfo.Exists)
             {
-                this.FailMountAndExit("Failed to initialize file system callbacks. Directory \"{0}\" must exist.", this.enlistment.LocalStorageRoot);
+                this.FailMountAndExit("Failed to initialize file system callbacks. Directory \"{0}\" must exist.", this.enlistment.WorkingDirectoryBackingRoot);
             }
 
-            string dotGitPath = Path.Combine(this.enlistment.LocalStorageRoot, GVFSConstants.DotGit.Root);
+            string dotGitPath = Path.Combine(this.enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Root);
             DirectoryInfo dotGitPathInfo = new DirectoryInfo(dotGitPath);
             if (!dotGitPathInfo.Exists)
             {

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.Mac
                 get { return ".dmg"; }
             }
 
-            public override string LocalStorageRoot
+            public override string WorkingDirectoryBackingRootName
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -406,7 +406,7 @@ namespace GVFS.Platform.Windows
                 get { return ".exe"; }
             }
 
-            public override string LocalStorageRoot
+            public override string WorkingDirectoryBackingRootName
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
@@ -47,7 +47,7 @@ namespace GVFS.UnitTests.Common
             MockGVFSEnlistment enlistment = new MockGVFSEnlistment(enlistmentRoot, "fake://repoUrl", "fake://gitBinPath", null, this.gitProcess);
             enlistment.InitializeCachePathsFromKey("fake:\\gvfsSharedCache", "fakeCacheKey");
 
-            this.gitParentPath = enlistment.LocalStorageRoot;
+            this.gitParentPath = enlistment.WorkingDirectoryBackingRoot;
             this.gvfsMetadataPath = enlistment.DotGVFSRoot;
 
             this.enlistmentDirectory = new MockDirectory(

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -165,7 +165,7 @@ namespace GVFS.UnitTests.Mock.Common
                 get { return ".mockexe"; }
             }
 
-            public override string LocalStorageRoot
+            public override string WorkingDirectoryBackingRootName
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -130,7 +130,7 @@ namespace GVFS.Virtualization
             // This lets us from having to add null checks to callsites into GitStatusCache.
             this.gitStatusCache = gitStatusCache ?? new GitStatusCache(context, TimeSpan.Zero);
 
-            this.logsHeadPath = Path.Combine(this.context.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Logs.Head);
+            this.logsHeadPath = Path.Combine(this.context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Logs.Head);
 
             EventMetadata metadata = new EventMetadata();
             metadata.Add("placeholders.Count", placeholders.EstimatedCount);
@@ -312,7 +312,7 @@ namespace GVFS.Virtualization
             metadata.Add(
                 "PhysicalDiskInfo",
                 GVFSPlatform.Instance.GetPhysicalDiskInfo(
-                    this.context.Enlistment.LocalStorageRoot,
+                    this.context.Enlistment.WorkingDirectoryBackingRoot,
                     sizeStatsOnly: true));
 
             return metadata;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -104,7 +104,7 @@ namespace GVFS.Virtualization.Projection
             this.projectionParseComplete = new ManualResetEventSlim(initialState: false);
             this.wakeUpIndexParsingThread = new AutoResetEvent(initialState: false);
             this.projectionIndexBackupPath = Path.Combine(this.context.Enlistment.DotGVFSRoot, ProjectionIndexBackupName);
-            this.indexPath = Path.Combine(this.context.Enlistment.LocalStorageRoot, GVFSConstants.DotGit.Index);
+            this.indexPath = Path.Combine(this.context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Index);
             this.placeholderList = placeholderList;
             this.modifiedPaths = modifiedPaths;
         }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -560,7 +560,7 @@ namespace GVFS.CommandLine
             }
 
             File.WriteAllText(
-                Path.Combine(enlistment.LocalStorageRoot, GVFSConstants.DotGit.Head),
+                Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Head),
                 "ref: refs/heads/" + branch);
 
             if (!this.TryDownloadRootGitAttributes(enlistment, gitObjects, gitRepo, out errorMessage))
@@ -646,7 +646,7 @@ namespace GVFS.CommandLine
             // Prepare the working directory folder for GVFS last to ensure that gvfs mount will fail if gvfs clone has failed
             Exception exception;
             string prepFileSystemError;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.LocalStorageRoot, out prepFileSystemError, out exception))
+            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryBackingRoot, out prepFileSystemError, out exception))
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add(nameof(prepFileSystemError), prepFileSystemError);
@@ -688,7 +688,7 @@ git %*
 
         private Result TryInitRepo(ITracer tracer, GitRefs refs, Enlistment enlistmentToInit)
         {
-            string repoPath = enlistmentToInit.LocalStorageRoot;
+            string repoPath = enlistmentToInit.WorkingDirectoryBackingRoot;
             GitProcess.Result initResult = GitProcess.Init(enlistmentToInit);
             if (initResult.ExitCodeIsFailure)
             {

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -258,7 +258,7 @@ of your enlistment's src folder.
         {
             Exception exception;
             string error;
-            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.LocalStorageRoot, out error, out exception))
+            if (!GVFSPlatform.Instance.KernelDriver.TryPrepareFolderForCallbacks(enlistment.WorkingDirectoryBackingRoot, out error, out exception))
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add(nameof(error), error);

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -98,7 +98,7 @@ namespace GVFS.CommandLine
 
         public static bool TrySetRequiredGitConfigSettings(Enlistment enlistment)
         {
-            string expectedHooksPath = Path.Combine(enlistment.LocalStorageRoot, GVFSConstants.DotGit.Hooks.Root);
+            string expectedHooksPath = Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Hooks.Root);
             expectedHooksPath = Paths.ConvertPathToGitFormat(expectedHooksPath);
 
             string gitStatusCachePath = null;
@@ -683,7 +683,7 @@ You can specify a URL, a name of a configured cache server, or the special names
 
         private string GetAlternatesPath(GVFSEnlistment enlistment)
         {
-            return Path.Combine(enlistment.LocalStorageRoot, GVFSConstants.DotGit.Objects.Info.Alternates);
+            return Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Objects.Info.Alternates);
         }
 
         private void CheckFileSystemSupportsRequiredFeatures(ITracer tracer, Enlistment enlistment)

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -233,7 +233,7 @@ namespace GVFS.CommandLine
 
             try
             {
-                GitIndexProjection.ReadIndex(tracer, Path.Combine(enlistment.LocalStorageRoot, GVFSConstants.DotGit.Index));
+                GitIndexProjection.ReadIndex(tracer, Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Index));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Follow up to #1074 (see comment here https://github.com/Microsoft/VFSForGit/pull/1074#issuecomment-489677734)

This PR makes a few tweaks to the changes in #1074:

- Renamed `Enlistment.LocalStorageRoot` to `WorkingDirectoryBackingRoot`
- Added comments to `Enlistment.WorkingDirectoryBackingRoot`
- Renamed `GVFSPlatform.LocalStorageRoot` to `WorkingDirectoryBackingRootName` to make it clearer that this property is not a path.

Please let me know if you can think of a better name than `WorkingDirectoryBackingRoot`, the goal of this PR is to replace `LocalStorageRoot` with a more descriptive name.