### PR TITLE
Enable Rename tests on Mac and add additional tests for coverage

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -15,11 +15,8 @@
             // machines but not on the build agents
             public const string FailsOnBuildAgent = "FailsOnBuildAgent";
 
-            // Tests that require #356 (old paths to be delivered with rename notifications)
-            public const string NeedsRenameOldPath = "NeedsRenameOldPath";
-
-            // Git related tests that are not yet passing on Mac
-            public const string M3 = "M3_AllGitCommands";
+            // Tests that require #360 (detecting/handling new empty folders)
+            public const string NeedsNewFolderCreateNotification = "NeedsNewFolderCreateNotification";
 
             // Tests for GVFS features that are not required for correct git functionality
             public const string M4 = "M4_GVFSFeatures";

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -133,7 +133,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void RenameDirectory(string workingDirectory, string source, string target)
         {
-            MoveFileEx(Path.Combine(workingDirectory, source), Path.Combine(workingDirectory, target), 0);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                MoveFileEx(Path.Combine(workingDirectory, source), Path.Combine(workingDirectory, target), 0);
+            }
+            else
+            {
+                Rename(Path.Combine(workingDirectory, source), Path.Combine(workingDirectory, target));
+            }
         }
 
         public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
@@ -221,6 +228,9 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
         private static extern int Chmod(string pathname, ushort mode);
+
+        [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
+        private static extern int Rename(string oldPath, string newPath);
 
         [DllImport("kernel32.dll", EntryPoint = "CreateHardLink", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern bool WindowsCreateHardLink(

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -87,8 +87,7 @@ namespace GVFS.FunctionalTests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
-                excludeCategories.Add(Categories.MacTODO.NeedsRenameOldPath);
-                excludeCategories.Add(Categories.MacTODO.M3);
+                excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.M4);
                 excludeCategories.Add(Categories.MacTODO.FlakyTest);
                 excludeCategories.Add(Categories.WindowsOnly);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -355,6 +355,42 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             fileToSupersedePath.ShouldBeAFile(this.fileSystem).WithContents(newContent);
         }
 
+        [TestCase, Order(16)]
+        public void FileMovedFromOutsideRepoToInside()
+        {
+            string fileName = "OutsideRepoToInside.txt";
+            string fileOutsideRepo = Path.Combine(this.Enlistment.EnlistmentRoot, fileName);
+            this.fileSystem.WriteAllText(fileOutsideRepo, "Contents for the new file");
+            fileOutsideRepo.ShouldBeAFile(this.fileSystem);
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileName);
+
+            string fileMovedInsideRepo = this.Enlistment.GetVirtualPathTo(fileName);
+            this.fileSystem.MoveFile(fileOutsideRepo, fileMovedInsideRepo);
+            fileMovedInsideRepo.ShouldBeAFile(this.fileSystem);
+            fileOutsideRepo.ShouldNotExistOnDisk(this.fileSystem);
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, fileName);
+        }
+
+        [TestCase, Order(17)]
+        public void FileMovedFromInsideRepoToOutside()
+        {
+            string fileName = "InsideRepoToOutside.txt";
+            string fileInsideRepo = this.Enlistment.GetVirtualPathTo(fileName);
+            this.fileSystem.WriteAllText(fileInsideRepo, "Contents for the new file");
+            fileInsideRepo.ShouldBeAFile(this.fileSystem);
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, fileName);
+
+            string fileMovedOutsideRepo = Path.Combine(this.Enlistment.EnlistmentRoot, fileName);
+            this.fileSystem.MoveFile(fileInsideRepo, fileMovedOutsideRepo);
+            fileInsideRepo.ShouldNotExistOnDisk(this.fileSystem);
+            fileMovedOutsideRepo.ShouldBeAFile(this.fileSystem);
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileName);
+        }
+
         [DllImport("GVFS.NativeTests.dll", CharSet = CharSet.Unicode)]
         private static extern bool SupersedeFile(string path, [MarshalAs(UnmanagedType.LPStr)]string newContent);
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -80,7 +80,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(4)]
-        [Category(Categories.MacTODO.NeedsRenameOldPath)]
         public void RenameEmptyFolderTest()
         {
             string folderName = "folder3a";
@@ -101,7 +100,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
-        [Category(Categories.MacTODO.NeedsRenameOldPath)]
         public void RenameFolderTest()
         {
             string folderName = "folder4a";
@@ -141,7 +139,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(6)]
-        [Category(Categories.MacTODO.NeedsRenameOldPath)]
         public void CaseOnlyRenameOfNewFolderKeepsModifiedPathsEntries()
         {
             if (this.fileSystem is PowerShellRunner)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -392,7 +392,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
         [TestCase, Order(13)]
         [Category(Categories.GitCommands)]
-        [Category(Categories.MacTODO.M3)]
+        [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
         public void FolderContentsProjectedAfterFolderCreateAndCheckout()
         {
             string folderName = "GVFlt_MultiThreadTest";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -74,8 +74,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, fileSystem, "Temp/", "Temp/temp1.txt", "Temp/temp2.txt");
         }
 
-        [Category(Categories.MacTODO.NeedsRenameOldPath)]
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
+        [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
         public void ModifiedPathsSavedAfterRemount(FileSystemRunner fileSystem)
         {
             string fileToAdd = this.Enlistment.GetVirtualPathTo(FileToAdd);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -823,7 +823,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.M3)]
+        [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
         public void CreateAFolderThenCheckoutBranchWithFolder()
         {
             this.FolderShouldExistAndHaveFile("DeleteFileWithNameAheadOfDotAndSwitchCommits", "1");


### PR DESCRIPTION
We want to test the specific cases of
- rename within a virtualization root
- file moved outside a virtualization root to in
- file moved inside a virtualization root to out

The events sent by the OS are
- Predelete on the From location
- Rename with a from and to location

Since we receive the predelete, no work is necessary by the rename for the 'from' location.
**With this is mind we do not want to populate the 'from' portion for renames in the kext.  We do need to populate it for hard links.**