### PR TITLE
Update libgit2 native binaries and include .so for Linux

### DIFF
--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -47,7 +47,7 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.165" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.278" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.165" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.278" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.Commands" Version="4.9.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">

--- a/GVFS/LibGit2Sharp.NativeBinaries.props
+++ b/GVFS/LibGit2Sharp.NativeBinaries.props
@@ -1,11 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <None Condition="Exists('..\..\..\packages\libgit2sharp.nativebinaries\1.0.165\runtimes\win7-x64\native\git2-1196807.dll')" Include="..\..\..\packages\libgit2sharp.nativebinaries\1.0.165\runtimes\win7-x64\native\git2-1196807.dll">
+        <None Condition="Exists('..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\win-x64\native\git2-572e4d8.dll')" Include="..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\win-x64\native\git2-572e4d8.dll">
             <Link>git2.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Condition="Exists('..\..\..\packages\libgit2sharp.nativebinaries\1.0.165\runtimes\osx\native\libgit2-1196807.dylib')" Include="..\..\..\packages\libgit2sharp.nativebinaries\1.0.165\runtimes\osx\native\libgit2-1196807.dylib">
+        <None Condition="Exists('..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\linux-x64\native\libgit2-572e4d8.so')" Include="..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\linux-x64\native\libgit2-572e4d8.so">
+            <Link>git2.so</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Condition="Exists('..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\osx\native\libgit2-572e4d8.dylib')" Include="..\..\..\packages\libgit2sharp.nativebinaries\2.0.278\runtimes\osx\native\libgit2-572e4d8.dylib">
             <Link>git2.dylib</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
Upgrade the LibGit2Sharp.NativeBinaries NuGet package from v1.0.165 (containing LibGit2Sharp v0.23.1) to [v2.0.278](https://www.nuget.org/packages/LibGit2Sharp.NativeBinaries/2.0.278), which contains the latest [LibGit2Sharp release v0.26](https://github.com/libgit2/libgit2sharp/releases/tag/v0.26).

LibGit2Sharp version 0.26 eliminates most external library dependencies other than OpenSSL.  In particular, by removing the dependency on libcurl, there is no longer a link-time requirement for a version of libcurl with deprecated `CURL_OPENSSL_3` symbols and SSLv3 support.

This allows us to include the compiled `libgit2-*.so` from the LibGit2Sharp.NativeBinaries NuGet package when building on Linux; otherwise, builds on Linux are unsuccessful or else require old and insecure libcurl installations, so this is a prerequisite for a Linux platform build (along with PRs #1119 and #1123).

/cc @jrbriggs, @kivikakk