### PR TITLE
Refactor for easier conversion to sqlite

### DIFF
--- a/GVFS/GVFS.Common/Database/IPlaceholderData.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace GVFS.Common
+﻿namespace GVFS.Common.Database
 {
     public interface IPlaceholderData
     {

--- a/GVFS/GVFS.Common/Database/IPlaceholderDatabase.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderDatabase.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace GVFS.Common.Database
+{
+    public interface IPlaceholderDatabase
+    {
+        int Count { get; }
+
+        void GetAllEntries(out List<IPlaceholderData> filePlaceholders, out List<IPlaceholderData> folderPlaceholders);
+        HashSet<string> GetAllFilePaths();
+
+        void AddPartialFolder(string path);
+        void AddExpandedFolder(string path);
+        void AddPossibleTombstoneFolder(string path);
+
+        void AddFile(string path, string sha);
+
+        void Remove(string path);
+    }
+}

--- a/GVFS/GVFS.Common/IPlaceholderData.cs
+++ b/GVFS/GVFS.Common/IPlaceholderData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GVFS.Common
+{
+    public interface IPlaceholderData
+    {
+        string Path { get; }
+        string Sha { get; }
+        bool IsFolder { get; }
+        bool IsExpandedFolder { get; }
+        bool IsPossibleTombstoneFolder { get; }
+    }
+}

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.FileSystem;
+﻿using GVFS.Common.Database;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
@@ -6,7 +7,7 @@ using System.IO;
 
 namespace GVFS.Common
 {
-    public class PlaceholderListDatabase : FileBasedCollection
+    public class PlaceholderListDatabase : FileBasedCollection, IPlaceholderDatabase
     {
         // Special folder values must:
         // - Be 40 characters long
@@ -49,7 +50,7 @@ namespace GVFS.Common
         /// The EstimatedCount is "estimated" because it's simply (# adds - # deletes).  There is nothing to prevent
         /// multiple adds or deletes of the same path from being double counted
         /// </summary>
-        public int EstimatedCount { get; private set; }
+        public int Count { get; private set; }
 
         public static bool TryCreate(ITracer tracer, string dataFilePath, PhysicalFileSystem fileSystem, out PlaceholderListDatabase output, out string error)
         {
@@ -59,7 +60,7 @@ namespace GVFS.Common
             if (!temp.TryLoadFromDisk<string, string>(
                 temp.TryParseAddLine,
                 temp.TryParseRemoveLine,
-                (key, value) => temp.EstimatedCount++,
+                (key, value) => temp.Count++,
                 out error))
             {
                 temp = null;
@@ -72,22 +73,27 @@ namespace GVFS.Common
             return true;
         }
 
-        public void AddAndFlushFile(string path, string sha)
+        public void AddFile(string path, string sha)
         {
             this.AddAndFlush(path, sha);
         }
 
-        public void AddAndFlushFolder(string path, bool isExpanded)
+        public void AddPartialFolder(string path)
         {
-            this.AddAndFlush(path, isExpanded ? ExpandedFolderValue : PartialFolderValue);
+            this.AddAndFlush(path, PartialFolderValue);
         }
 
-        public void AddAndFlushPossibleTombstoneFolder(string path)
+        public void AddExpandedFolder(string path)
+        {
+            this.AddAndFlush(path, ExpandedFolderValue);
+        }
+
+        public void AddPossibleTombstoneFolder(string path)
         {
             this.AddAndFlush(path, PossibleTombstoneFolderValue);
         }
 
-        public void RemoveAndFlush(string path)
+        public void Remove(string path)
         {
             try
             {
@@ -95,7 +101,7 @@ namespace GVFS.Common
                     path,
                     () =>
                     {
-                        this.EstimatedCount--;
+                        this.Count--;
                         if (this.placeholderChangesWhileRebuildingList != null)
                         {
                             this.placeholderChangesWhileRebuildingList.Add(new PlaceholderDataEntry(path));
@@ -124,7 +130,7 @@ namespace GVFS.Common
         {
             try
             {
-                List<IPlaceholderData> placeholders = new List<IPlaceholderData>(Math.Max(1, this.EstimatedCount));
+                List<IPlaceholderData> placeholders = new List<IPlaceholderData>(Math.Max(1, this.Count));
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -165,12 +171,12 @@ namespace GVFS.Common
         ///     - If WriteAllEntriesAndFlush is *not* called entries that were added to the PlaceholderListDatabase after
         ///       calling GetAllEntriesAndPrepToWriteAllEntries will be lost
         /// </remarks>
-        public void GetAllEntriesAndPrepToWriteAllEntries(out List<IPlaceholderData> filePlaceholders, out List<IPlaceholderData> folderPlaceholders)
+        public void GetAllEntries(out List<IPlaceholderData> filePlaceholders, out List<IPlaceholderData> folderPlaceholders)
         {
             try
             {
-                List<IPlaceholderData> filePlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, this.EstimatedCount));
-                List<IPlaceholderData> folderPlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, (int)(this.EstimatedCount * .3)));
+                List<IPlaceholderData> filePlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, this.Count));
+                List<IPlaceholderData> folderPlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, (int)(this.Count * .3)));
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -210,12 +216,12 @@ namespace GVFS.Common
             }
         }
 
-        public Dictionary<string, IPlaceholderData> GetAllFileEntries()
+        public HashSet<string> GetAllFilePaths()
         {
             try
             {
-                Dictionary<string, IPlaceholderData> filePlaceholdersFromDiskByPath =
-                    new Dictionary<string, IPlaceholderData>(Math.Max(1, this.EstimatedCount), StringComparer.Ordinal);
+                HashSet<string> filePlaceholdersFromDiskByPath =
+                    new HashSet<string>(StringComparer.Ordinal);
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -225,7 +231,7 @@ namespace GVFS.Common
                     {
                         if (!PlaceholderData.IsShaAFolder(value))
                         {
-                            filePlaceholdersFromDiskByPath[key] = new PlaceholderData(path: key, fileShaOrFolderValue: value);
+                            filePlaceholdersFromDiskByPath.Add(key);
                         }
                     },
                     out error))
@@ -257,12 +263,12 @@ namespace GVFS.Common
         {
             HashSet<string> keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            this.EstimatedCount = 0;
+            this.Count = 0;
             foreach (IPlaceholderData updated in updatedPlaceholders)
             {
                 if (keys.Add(updated.Path))
                 {
-                    this.EstimatedCount++;
+                    this.Count++;
                 }
 
                 yield return this.FormatAddLine(updated.Path + PathTerminator + updated.Sha);
@@ -276,7 +282,7 @@ namespace GVFS.Common
                     {
                         if (keys.Remove(entry.Path))
                         {
-                            this.EstimatedCount--;
+                            this.Count--;
                             yield return this.FormatRemoveLine(entry.Path);
                         }
                     }
@@ -284,7 +290,7 @@ namespace GVFS.Common
                     {
                         if (keys.Add(entry.Path))
                         {
-                            this.EstimatedCount++;
+                            this.Count++;
                         }
 
                         yield return this.FormatAddLine(entry.Path + PathTerminator + entry.Sha);
@@ -303,7 +309,7 @@ namespace GVFS.Common
                     path + PathTerminator + sha,
                     () =>
                     {
-                        this.EstimatedCount++;
+                        this.Count++;
                         if (this.placeholderChangesWhileRebuildingList != null)
                         {
                             this.placeholderChangesWhileRebuildingList.Add(new PlaceholderDataEntry(path, sha));

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -47,7 +47,7 @@ namespace GVFS.Common
         }
 
         /// <summary>
-        /// The EstimatedCount is "estimated" because it's simply (# adds - # deletes).  There is nothing to prevent
+        /// The Count is "estimated" because it's simply (# adds - # deletes).  There is nothing to prevent
         /// multiple adds or deletes of the same path from being double counted
         /// </summary>
         public int Count { get; private set; }

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -220,8 +220,7 @@ namespace GVFS.Common
         {
             try
             {
-                HashSet<string> filePlaceholdersFromDiskByPath =
-                    new HashSet<string>(StringComparer.Ordinal);
+                HashSet<string> filePlaceholderPaths = new HashSet<string>(StringComparer.Ordinal);
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -231,7 +230,7 @@ namespace GVFS.Common
                     {
                         if (!PlaceholderData.IsShaAFolder(value))
                         {
-                            filePlaceholdersFromDiskByPath.Add(key);
+                            filePlaceholderPaths.Add(key);
                         }
                     },
                     out error))
@@ -239,7 +238,7 @@ namespace GVFS.Common
                     throw new InvalidDataException(error);
                 }
 
-                return filePlaceholdersFromDiskByPath;
+                return filePlaceholderPaths;
             }
             catch (Exception e)
             {

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -120,11 +120,11 @@ namespace GVFS.Common
         ///     - If WriteAllEntriesAndFlush is *not* called entries that were added to the PlaceholderListDatabase after
         ///       calling GetAllEntriesAndPrepToWriteAllEntries will be lost
         /// </remarks>
-        public List<PlaceholderData> GetAllEntriesAndPrepToWriteAllEntries()
+        public List<IPlaceholderData> GetAllEntriesAndPrepToWriteAllEntries()
         {
             try
             {
-                List<PlaceholderData> placeholders = new List<PlaceholderData>(Math.Max(1, this.EstimatedCount));
+                List<IPlaceholderData> placeholders = new List<IPlaceholderData>(Math.Max(1, this.EstimatedCount));
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -165,12 +165,12 @@ namespace GVFS.Common
         ///     - If WriteAllEntriesAndFlush is *not* called entries that were added to the PlaceholderListDatabase after
         ///       calling GetAllEntriesAndPrepToWriteAllEntries will be lost
         /// </remarks>
-        public void GetAllEntriesAndPrepToWriteAllEntries(out List<PlaceholderData> filePlaceholders, out List<PlaceholderData> folderPlaceholders)
+        public void GetAllEntriesAndPrepToWriteAllEntries(out List<IPlaceholderData> filePlaceholders, out List<IPlaceholderData> folderPlaceholders)
         {
             try
             {
-                List<PlaceholderData> filePlaceholdersFromDisk = new List<PlaceholderData>(Math.Max(1, this.EstimatedCount));
-                List<PlaceholderData> folderPlaceholdersFromDisk = new List<PlaceholderData>(Math.Max(1, (int)(this.EstimatedCount * .3)));
+                List<IPlaceholderData> filePlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, this.EstimatedCount));
+                List<IPlaceholderData> folderPlaceholdersFromDisk = new List<IPlaceholderData>(Math.Max(1, (int)(this.EstimatedCount * .3)));
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -210,12 +210,12 @@ namespace GVFS.Common
             }
         }
 
-        public Dictionary<string, PlaceholderListDatabase.PlaceholderData> GetAllFileEntries()
+        public Dictionary<string, IPlaceholderData> GetAllFileEntries()
         {
             try
             {
-                Dictionary<string, PlaceholderListDatabase.PlaceholderData> filePlaceholdersFromDiskByPath =
-                    new Dictionary<string, PlaceholderListDatabase.PlaceholderData>(Math.Max(1, this.EstimatedCount), StringComparer.Ordinal);
+                Dictionary<string, IPlaceholderData> filePlaceholdersFromDiskByPath =
+                    new Dictionary<string, IPlaceholderData>(Math.Max(1, this.EstimatedCount), StringComparer.Ordinal);
 
                 string error;
                 if (!this.TryLoadFromDisk<string, string>(
@@ -241,7 +241,7 @@ namespace GVFS.Common
             }
         }
 
-        public void WriteAllEntriesAndFlush(IEnumerable<PlaceholderData> updatedPlaceholders)
+        public void WriteAllEntriesAndFlush(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
             try
             {
@@ -253,12 +253,12 @@ namespace GVFS.Common
             }
         }
 
-        private IEnumerable<string> GenerateDataLines(IEnumerable<PlaceholderData> updatedPlaceholders)
+        private IEnumerable<string> GenerateDataLines(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
             HashSet<string> keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             this.EstimatedCount = 0;
-            foreach (PlaceholderData updated in updatedPlaceholders)
+            foreach (IPlaceholderData updated in updatedPlaceholders)
             {
                 if (keys.Add(updated.Path))
                 {

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -118,15 +118,15 @@ namespace GVFS.Common
         /// Gets all entries and prepares the PlaceholderListDatabase for a call to WriteAllEntriesAndFlush.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// GetAllEntriesAndPrepToWriteAllEntries was called (a second time) without first calling WriteAllEntriesAndFlush.
+        /// GetAllEntries was called (a second time) without first calling WriteAllEntriesAndFlush.
         /// </exception>
         /// <remarks>
         /// Usage notes:
-        ///     - All calls to GetAllEntriesAndPrepToWriteAllEntries must be paired with a subsequent call to WriteAllEntriesAndFlush
+        ///     - All calls to GetAllEntries must be paired with a subsequent call to WriteAllEntriesAndFlush
         ///     - If WriteAllEntriesAndFlush is *not* called entries that were added to the PlaceholderListDatabase after
-        ///       calling GetAllEntriesAndPrepToWriteAllEntries will be lost
+        ///       calling GetAllEntries will be lost
         /// </remarks>
-        public List<IPlaceholderData> GetAllEntriesAndPrepToWriteAllEntries()
+        public List<IPlaceholderData> GetAllEntries()
         {
             try
             {
@@ -142,7 +142,7 @@ namespace GVFS.Common
                     {
                         if (this.placeholderChangesWhileRebuildingList != null)
                         {
-                        throw new InvalidOperationException($"PlaceholderListDatabase should always flush queue placeholders using WriteAllEntriesAndFlush before calling {nameof(this.GetAllEntriesAndPrepToWriteAllEntries)} again.");
+                        throw new InvalidOperationException($"PlaceholderListDatabase should always flush queue placeholders using WriteAllEntriesAndFlush before calling {nameof(this.GetAllEntries)} again.");
                         }
 
                         this.placeholderChangesWhileRebuildingList = new List<PlaceholderDataEntry>();
@@ -198,7 +198,7 @@ namespace GVFS.Common
                     {
                         if (this.placeholderChangesWhileRebuildingList != null)
                         {
-                            throw new InvalidOperationException($"PlaceholderListDatabase should always flush queue placeholders using WriteAllEntriesAndFlush before calling {(nameof(this.GetAllEntriesAndPrepToWriteAllEntries))} again.");
+                            throw new InvalidOperationException($"PlaceholderListDatabase should always flush queue placeholders using WriteAllEntriesAndFlush before calling {(nameof(this.GetAllEntries))} again.");
                         }
 
                         this.placeholderChangesWhileRebuildingList = new List<PlaceholderDataEntry>();

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -351,7 +351,7 @@ namespace GVFS.Common
             return true;
         }
 
-        public class PlaceholderData
+        public class PlaceholderData : IPlaceholderData
         {
             public PlaceholderData(string path, string fileShaOrFolderValue)
             {

--- a/GVFS/GVFS.Common/PlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/PlaceholderListDatabase.cs
@@ -19,13 +19,13 @@ namespace GVFS.Common
         private const char PathTerminator = '\0';
 
         // This list holds placeholder entries that are created between calls to
-        // GetAllEntriesAndPrepToWriteAllEntries and WriteAllEntriesAndFlush.
+        // GetAllEntries and WriteAllEntriesAndFlush.
         //
         //    Example:
         //
         //       1) VFS4G parses the updated index (as part of a projection change)
         //       2) VFS4G starts the work to update placeholders
-        //       3) VFS4G calls GetAllEntriesAndPrepToWriteAllEntries
+        //       3) VFS4G calls GetAllEntries
         //       4) VFS4G starts updating placeholders
         //       5) Some application reads a pure-virtual file (creating a new placeholder) while VFS4G is updating existing placeholders.
         //          That new placeholder is added to placeholderChangesWhileRebuildingList.
@@ -35,7 +35,7 @@ namespace GVFS.Common
         //
         // This scenario is covered in the unit test PlaceholderDatabaseTests.HandlesRaceBetweenAddAndWriteAllEntries
         //
-        // Because of this list, callers must always call WriteAllEntries after calling GetAllEntriesAndPrepToWriteAllEntries.
+        // Because of this list, callers must always call WriteAllEntries after calling GetAllEntries.
         //
         // This list must always be accessed from inside one of FileBasedCollection's synchronizedAction callbacks because
         // there is race potential between creating the queue, adding to the queue, and writing to the data file.
@@ -163,13 +163,13 @@ namespace GVFS.Common
         /// Gets all entries and prepares the PlaceholderListDatabase for a call to WriteAllEntriesAndFlush.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// GetAllEntriesAndPrepToWriteAllEntries was called (a second time) without first calling WriteAllEntriesAndFlush.
+        /// GetAllEntries was called (a second time) without first calling WriteAllEntriesAndFlush.
         /// </exception>
         /// <remarks>
         /// Usage notes:
-        ///     - All calls to GetAllEntriesAndPrepToWriteAllEntries must be paired with a subsequent call to WriteAllEntriesAndFlush
+        ///     - All calls to GetAllEntries must be paired with a subsequent call to WriteAllEntriesAndFlush
         ///     - If WriteAllEntriesAndFlush is *not* called entries that were added to the PlaceholderListDatabase after
-        ///       calling GetAllEntriesAndPrepToWriteAllEntries will be lost
+        ///       calling GetAllEntries will be lost
         /// </remarks>
         public void GetAllEntries(out List<IPlaceholderData> filePlaceholders, out List<IPlaceholderData> folderPlaceholders)
         {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.DiskLayoutUpgrades;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
@@ -49,7 +49,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                         .Select(x => x.Substring(workingDirectoryRoot.Length + 1))
                         .Select(x => new PlaceholderListDatabase.PlaceholderData(x, GVFSConstants.AllZeroSha));
 
-                    List<IPlaceholderData> placeholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
+                    List<IPlaceholderData> placeholderEntries = placeholders.GetAllEntries();
                     placeholderEntries.AddRange(folderPlaceholderPaths);
 
                     placeholders.WriteAllEntriesAndFlush(placeholderEntries);

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout12to13Upgrade_FolderPlaceholder.cs
@@ -43,12 +43,12 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
                     string workingDirectoryRoot = Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName);
 
                     // Run through the folder placeholders adding to the placeholder list
-                    IEnumerable<PlaceholderListDatabase.PlaceholderData> folderPlaceholderPaths =
+                    IEnumerable<IPlaceholderData> folderPlaceholderPaths =
                         GetFolderPlaceholdersFromDisk(tracer, new PhysicalFileSystem(), workingDirectoryRoot)
                         .Select(x => x.Substring(workingDirectoryRoot.Length + 1))
                         .Select(x => new PlaceholderListDatabase.PlaceholderData(x, GVFSConstants.AllZeroSha));
 
-                    List<PlaceholderListDatabase.PlaceholderData> placeholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
+                    List<IPlaceholderData> placeholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
                     placeholderEntries.AddRange(folderPlaceholderPaths);
 
                     placeholders.WriteAllEntriesAndFlush(placeholderEntries);

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.DiskLayoutUpgrades;

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
@@ -35,10 +35,10 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
                 using (placeholders)
                 {
-                    List<PlaceholderListDatabase.PlaceholderData> oldPlaceholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
-                    List<PlaceholderListDatabase.PlaceholderData> newPlaceholderEntries = new List<PlaceholderListDatabase.PlaceholderData>();
+                    List<IPlaceholderData> oldPlaceholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
+                    List<IPlaceholderData> newPlaceholderEntries = new List<IPlaceholderData>();
 
-                    foreach (PlaceholderListDatabase.PlaceholderData entry in oldPlaceholderEntries)
+                    foreach (IPlaceholderData entry in oldPlaceholderEntries)
                     {
                         if (entry.Sha == GVFSConstants.AllZeroSha)
                         {

--- a/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
+++ b/GVFS/GVFS.Platform.Windows/DiskLayoutUpgrades/DiskLayout16to17Upgrade_FolderPlaceholderValues.cs
@@ -36,7 +36,7 @@ namespace GVFS.Platform.Windows.DiskLayoutUpgrades
 
                 using (placeholders)
                 {
-                    List<IPlaceholderData> oldPlaceholderEntries = placeholders.GetAllEntriesAndPrepToWriteAllEntries();
+                    List<IPlaceholderData> oldPlaceholderEntries = placeholders.GetAllEntries();
                     List<IPlaceholderData> newPlaceholderEntries = new List<IPlaceholderData>();
 
                     foreach (IPlaceholderData entry in oldPlaceholderEntries)

--- a/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock;
 using GVFS.UnitTests.Mock.FileSystem;
@@ -43,7 +44,7 @@ namespace GVFS.UnitTests.Common
                 "D Test_EPF_UpdatePlaceholderTests\\LockToPreventUpdate\\test.txt\r\n" +
                 "D Test_EPF_UpdatePlaceholderTests\\LockToPreventUpdate\\test.txt\r\n" +
                 "D Test_EPF_UpdatePlaceholderTests\\LockToPreventUpdate\\test.txt\r\n");
-            dut.EstimatedCount.ShouldEqual(5);
+            dut.Count.ShouldEqual(5);
         }
 
         [TestCase]
@@ -51,11 +52,11 @@ namespace GVFS.UnitTests.Common
         {
             ConfigurableFileSystem fs = new ConfigurableFileSystem();
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, string.Empty);
-            dut.AddAndFlushFile(InputGitIgnorePath, InputGitIgnoreSHA);
+            dut.AddFile(InputGitIgnorePath, InputGitIgnoreSHA);
 
             fs.ExpectedFiles[MockEntryFileName].ReadAsString().ShouldEqual(ExpectedGitIgnoreEntry);
 
-            dut.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
+            dut.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
 
             fs.ExpectedFiles[MockEntryFileName].ReadAsString().ShouldEqual(ExpectedTwoEntries);
         }
@@ -66,10 +67,10 @@ namespace GVFS.UnitTests.Common
             ConfigurableFileSystem fs = new ConfigurableFileSystem();
             using (PlaceholderListDatabase dut1 = CreatePlaceholderListDatabase(fs, string.Empty))
             {
-                dut1.AddAndFlushFile(InputGitIgnorePath, InputGitIgnoreSHA);
-                dut1.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
-                dut1.AddAndFlushFile(InputThirdFilePath, InputThirdFileSHA);
-                dut1.RemoveAndFlush(InputThirdFilePath);
+                dut1.AddFile(InputGitIgnorePath, InputGitIgnoreSHA);
+                dut1.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
+                dut1.AddFile(InputThirdFilePath, InputThirdFileSHA);
+                dut1.Remove(InputThirdFilePath);
             }
 
             string error;
@@ -85,13 +86,13 @@ namespace GVFS.UnitTests.Common
             ConfigurableFileSystem fs = new ConfigurableFileSystem();
             using (PlaceholderListDatabase dut1 = CreatePlaceholderListDatabase(fs, string.Empty))
             {
-                dut1.AddAndFlushFile(InputGitIgnorePath, InputGitIgnoreSHA);
-                dut1.AddAndFlushFolder("partialFolder", isExpanded: false);
-                dut1.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
-                dut1.AddAndFlushFolder("expandedFolder", isExpanded: true);
-                dut1.AddAndFlushFile(InputThirdFilePath, InputThirdFileSHA);
-                dut1.AddAndFlushPossibleTombstoneFolder("tombstone");
-                dut1.RemoveAndFlush(InputThirdFilePath);
+                dut1.AddFile(InputGitIgnorePath, InputGitIgnoreSHA);
+                dut1.AddPartialFolder("partialFolder");
+                dut1.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
+                dut1.AddExpandedFolder("expandedFolder");
+                dut1.AddFile(InputThirdFilePath, InputThirdFileSHA);
+                dut1.AddPossibleTombstoneFolder("tombstone");
+                dut1.Remove(InputThirdFilePath);
             }
 
             string error;
@@ -99,7 +100,7 @@ namespace GVFS.UnitTests.Common
             PlaceholderListDatabase.TryCreate(null, MockEntryFileName, fs, out dut2, out error).ShouldEqual(true, error);
             List<IPlaceholderData> fileData;
             List<IPlaceholderData> folderData;
-            dut2.GetAllEntriesAndPrepToWriteAllEntries(out fileData, out folderData);
+            dut2.GetAllEntries(out fileData, out folderData);
             fileData.Count.ShouldEqual(2);
             folderData.Count.ShouldEqual(3);
             folderData.ShouldContain(
@@ -140,7 +141,7 @@ namespace GVFS.UnitTests.Common
 
             List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
 
-            dut.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
+            dut.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
 
             dut.WriteAllEntriesAndFlush(existingEntries);
             fs.ExpectedFiles[MockEntryFileName].ReadAsString().ShouldEqual(ExpectedTwoEntries);
@@ -158,7 +159,7 @@ namespace GVFS.UnitTests.Common
 
             List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
 
-            dut.RemoveAndFlush(InputGitAttributesPath);
+            dut.Remove(InputGitAttributesPath);
 
             dut.WriteAllEntriesAndFlush(existingEntries);
             fs.ExpectedFiles[MockEntryFileName].ReadAsString().ShouldEqual(ExpectedTwoEntries + DeleteGitAttributesEntry);

--- a/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
@@ -75,7 +75,7 @@ namespace GVFS.UnitTests.Common
             string error;
             PlaceholderListDatabase dut2;
             PlaceholderListDatabase.TryCreate(null, MockEntryFileName, fs, out dut2, out error).ShouldEqual(true, error);
-            List<PlaceholderListDatabase.PlaceholderData> allData = dut2.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> allData = dut2.GetAllEntriesAndPrepToWriteAllEntries();
             allData.Count.ShouldEqual(2);
         }
 
@@ -97,8 +97,8 @@ namespace GVFS.UnitTests.Common
             string error;
             PlaceholderListDatabase dut2;
             PlaceholderListDatabase.TryCreate(null, MockEntryFileName, fs, out dut2, out error).ShouldEqual(true, error);
-            List<PlaceholderListDatabase.PlaceholderData> fileData;
-            List<PlaceholderListDatabase.PlaceholderData> folderData;
+            List<IPlaceholderData> fileData;
+            List<IPlaceholderData> folderData;
             dut2.GetAllEntriesAndPrepToWriteAllEntries(out fileData, out folderData);
             fileData.Count.ShouldEqual(2);
             folderData.Count.ShouldEqual(3);
@@ -138,7 +138,7 @@ namespace GVFS.UnitTests.Common
 
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedGitIgnoreEntry);
 
-            List<PlaceholderListDatabase.PlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
 
             dut.AddAndFlushFile(InputGitAttributesPath, InputGitAttributesSHA);
 
@@ -156,7 +156,7 @@ namespace GVFS.UnitTests.Common
 
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedTwoEntries);
 
-            List<PlaceholderListDatabase.PlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
 
             dut.RemoveAndFlush(InputGitAttributesPath);
 

--- a/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PlaceholderDatabaseTests.cs
@@ -62,7 +62,7 @@ namespace GVFS.UnitTests.Common
         }
 
         [TestCase]
-        public void GetAllEntriesAndPrepToWriteAllEntriesReturnsCorrectEntries()
+        public void GetAllEntriesReturnsCorrectEntries()
         {
             ConfigurableFileSystem fs = new ConfigurableFileSystem();
             using (PlaceholderListDatabase dut1 = CreatePlaceholderListDatabase(fs, string.Empty))
@@ -76,12 +76,12 @@ namespace GVFS.UnitTests.Common
             string error;
             PlaceholderListDatabase dut2;
             PlaceholderListDatabase.TryCreate(null, MockEntryFileName, fs, out dut2, out error).ShouldEqual(true, error);
-            List<IPlaceholderData> allData = dut2.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> allData = dut2.GetAllEntries();
             allData.Count.ShouldEqual(2);
         }
 
         [TestCase]
-        public void GetAllEntriesAndPrepToWriteAllEntriesSplitsFilesAndFoldersCorrectly()
+        public void GetAllEntriesSplitsFilesAndFoldersCorrectly()
         {
             ConfigurableFileSystem fs = new ConfigurableFileSystem();
             using (PlaceholderListDatabase dut1 = CreatePlaceholderListDatabase(fs, string.Empty))
@@ -139,7 +139,7 @@ namespace GVFS.UnitTests.Common
 
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedGitIgnoreEntry);
 
-            List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> existingEntries = dut.GetAllEntries();
 
             dut.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
 
@@ -157,7 +157,7 @@ namespace GVFS.UnitTests.Common
 
             PlaceholderListDatabase dut = CreatePlaceholderListDatabase(fs, ExpectedTwoEntries);
 
-            List<IPlaceholderData> existingEntries = dut.GetAllEntriesAndPrepToWriteAllEntries();
+            List<IPlaceholderData> existingEntries = dut.GetAllEntries();
 
             dut.Remove(InputGitAttributesPath);
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -133,7 +133,7 @@ namespace GVFS.Virtualization
             this.logsHeadPath = Path.Combine(this.context.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Logs.Head);
 
             EventMetadata metadata = new EventMetadata();
-            metadata.Add("placeholders.Count", placeholders.EstimatedCount);
+            metadata.Add("placeholders.Count", placeholders.Count);
             metadata.Add("background.Count", this.backgroundFileSystemTaskRunner.Count);
             metadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(FileSystemCallbacks)} created");
             this.context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(FileSystemCallbacks)}_Constructor", metadata);

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -295,7 +295,7 @@ namespace GVFS.Virtualization
             }
 
             metadata.Add("ModifiedPathsCount", this.modifiedPaths.Count);
-            metadata.Add("PlaceholderCount", this.GitIndexProjection.EstimatedPlaceholderCount);
+            metadata.Add("PlaceholderCount", this.GitIndexProjection.PlaceholderCount);
             if (this.gitStatusCache.WriteTelemetryandReset(metadata))
             {
                 eventLevel = EventLevel.Informational;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
@@ -89,7 +89,7 @@ namespace GVFS.Virtualization.Projection
                     throw new InvalidOperationException($"{nameof(this.projection)} cannot be null when calling {nameof(this.AddMissingModifiedFilesAndRemoveThemFromPlaceholderList)}");
                 }
 
-                Dictionary<string, PlaceholderListDatabase.PlaceholderData> filePlaceholders =
+                Dictionary<string, IPlaceholderData> filePlaceholders =
                     this.projection.placeholderList.GetAllFileEntries();
 
                 tracer.RelatedEvent(
@@ -165,7 +165,7 @@ namespace GVFS.Virtualization.Projection
             /// </param>
             private FileSystemTaskResult AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded(
                 GitIndexEntry gitIndexEntry,
-                Dictionary<string, PlaceholderListDatabase.PlaceholderData> filePlaceholders)
+                Dictionary<string, IPlaceholderData> filePlaceholders)
             {
                 gitIndexEntry.BackgroundTask_ParsePath();
                 string placeholderRelativePath = gitIndexEntry.BackgroundTask_GetPlatformRelativePath();

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Common.Tracing;
 using GVFS.Virtualization.Background;
 using System;
@@ -89,8 +90,7 @@ namespace GVFS.Virtualization.Projection
                     throw new InvalidOperationException($"{nameof(this.projection)} cannot be null when calling {nameof(this.AddMissingModifiedFilesAndRemoveThemFromPlaceholderList)}");
                 }
 
-                Dictionary<string, IPlaceholderData> filePlaceholders =
-                    this.projection.placeholderList.GetAllFileEntries();
+                HashSet<string> filePlaceholders = this.projection.placeholderList.GetAllFilePaths();
 
                 tracer.RelatedEvent(
                     EventLevel.Informational,
@@ -113,7 +113,7 @@ namespace GVFS.Virtualization.Projection
 
                 // Any paths that were not found in the index need to be added to ModifiedPaths
                 // and removed from the placeholder list
-                foreach (string path in filePlaceholders.Keys)
+                foreach (string path in filePlaceholders)
                 {
                     result = this.projection.AddModifiedPath(path);
                     if (result != FileSystemTaskResult.Success)
@@ -165,7 +165,7 @@ namespace GVFS.Virtualization.Projection
             /// </param>
             private FileSystemTaskResult AddEntryToModifiedPathsAndRemoveFromPlaceholdersIfNeeded(
                 GitIndexEntry gitIndexEntry,
-                Dictionary<string, IPlaceholderData> filePlaceholders)
+                HashSet<string> filePlaceholders)
             {
                 gitIndexEntry.BackgroundTask_ParsePath();
                 string placeholderRelativePath = gitIndexEntry.BackgroundTask_GetPlatformRelativePath();

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -124,7 +124,7 @@ namespace GVFS.Virtualization.Projection
             GitLink,
         }
 
-        public int EstimatedPlaceholderCount
+        public int PlaceholderCount
         {
             get
             {

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.NamedPipes;
@@ -127,7 +128,7 @@ namespace GVFS.Virtualization.Projection
         {
             get
             {
-                return this.placeholderList.EstimatedCount;
+                return this.placeholderList.Count;
             }
         }
 
@@ -320,22 +321,22 @@ namespace GVFS.Virtualization.Projection
 
         public void OnPlaceholderFolderCreated(string virtualPath)
         {
-            this.placeholderList.AddAndFlushFolder(virtualPath, isExpanded: false);
+            this.placeholderList.AddPartialFolder(virtualPath);
         }
 
         public void OnPossibleTombstoneFolderCreated(string virtualPath)
         {
-            this.placeholderList.AddAndFlushPossibleTombstoneFolder(virtualPath);
+            this.placeholderList.AddPossibleTombstoneFolder(virtualPath);
         }
 
         public virtual void OnPlaceholderFolderExpanded(string relativePath)
         {
-            this.placeholderList.AddAndFlushFolder(relativePath, isExpanded: true);
+            this.placeholderList.AddExpandedFolder(relativePath);
         }
 
         public virtual void OnPlaceholderFileCreated(string virtualPath, string sha)
         {
-            this.placeholderList.AddAndFlushFile(virtualPath, sha);
+            this.placeholderList.AddFile(virtualPath, sha);
         }
 
         public virtual bool TryGetProjectedItemsFromMemory(string folderPath, out List<ProjectedFileInfo> projectedItems)
@@ -563,7 +564,7 @@ namespace GVFS.Virtualization.Projection
 
         public void RemoveFromPlaceholderList(string fileOrFolderPath)
         {
-            this.placeholderList.RemoveAndFlush(fileOrFolderPath);
+            this.placeholderList.Remove(fileOrFolderPath);
         }
 
         public void Dispose()
@@ -1097,7 +1098,7 @@ namespace GVFS.Virtualization.Projection
             Stopwatch stopwatch = new Stopwatch();
             List<IPlaceholderData> placeholderFilesListCopy;
             List<IPlaceholderData> placeholderFoldersListCopy;
-            this.placeholderList.GetAllEntriesAndPrepToWriteAllEntries(out placeholderFilesListCopy, out placeholderFoldersListCopy);
+            this.placeholderList.GetAllEntries(out placeholderFilesListCopy, out placeholderFoldersListCopy);
 
             EventMetadata metadata = new EventMetadata();
             metadata.Add("File placeholder count", placeholderFilesListCopy.Count);


### PR DESCRIPTION
This is only a refactoring to prepare for using SQLite and shouldn't contain any functional changes.  Started putting the code in a Database directory of GVFS.Common

It creates a couple of interfaces.  One for the placeholder data and one for the placeholder database.

Renamed some of the methods to be a little more generic like removing `AndFlush` and `AndPrepToWriteAllEntries` since SQLite will not have these.
  
Also replaced a `Dictionary<string, PlaceholderListDatabase.PlaceholderData>` with a `HashSet<string>` since it was never using the value of the dictionary.
