### PR TITLE
LooseObjectStepTests: Be more flexible with loose object count

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
 
-            this.GetLooseObjectFiles().Count.ShouldEqual(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
             this.CountPackFiles().ShouldEqual(1);
 
             // Running the step a second time should remove the loose obects and keep the pack file
@@ -107,7 +107,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.fileSystem.FileExists(fakeBlob).ShouldBeFalse(
                    "Step failed to delete corrupt blob");
             this.CountPackFiles().ShouldEqual(0, "Incorrect number of packs after first loose object step");
-            this.GetLooseObjectFiles().Count.ShouldEqual(
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(
                 looseObjectCount,
                 "unexpected number of loose objects after step");
 
@@ -115,7 +115,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.Enlistment.LooseObjectStep();
 
             this.CountPackFiles().ShouldEqual(1, "Incorrect number of packs after second loose object step");
-            this.GetLooseObjectFiles().Count.ShouldEqual(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
 
             // This step should delete the loose objects
             this.Enlistment.LooseObjectStep();


### PR DESCRIPTION
It appears that sometimes we are getting an extra loose object
after some of the steps, and it is probably because we are deleting
pack-files from the object store so we download a "missing" commit
or something.

Use ShouldBeAtLeast() to demonstrate that the loose objects we
expect to remain are still there.

Thanks, @jeschu1 for pointing out that this caused pain in a functional test build.