### PR TITLE
Rename WorkingDirectoryBackingRootPath constants

### DIFF
--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
         protected Enlistment(
             string enlistmentRoot,
             string workingDirectoryRoot,
-            string localStorageRoot,
+            string workingDirectoryBackingRoot,
             string repoUrl,
             string gitBinPath,
             string gvfsHooksRoot,
@@ -24,7 +24,7 @@ namespace GVFS.Common
 
             this.EnlistmentRoot = enlistmentRoot;
             this.WorkingDirectoryRoot = workingDirectoryRoot;
-            this.WorkingDirectoryBackingRoot = localStorageRoot;
+            this.WorkingDirectoryBackingRoot = workingDirectoryBackingRoot;
             this.DotGitRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Root);
             this.GitBinPath = gitBinPath;
             this.GVFSHooksRoot = gvfsHooksRoot;

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -23,7 +23,7 @@ namespace GVFS.Common
             : base(
                   enlistmentRoot,
                   Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName),
-                  Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.WorkingDirectoryBackingRootName),
+                  Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.WorkingDirectoryBackingRootPath),
                   repoUrl,
                   gitBinPath,
                   gvfsHooksRoot,

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -92,7 +92,7 @@ namespace GVFS.Common
             public static readonly char PathSeparator = Path.DirectorySeparatorChar;
             public abstract string ExecutableExtension { get; }
             public abstract string InstallerExtension { get; }
-            public abstract string WorkingDirectoryBackingRootName { get; }
+            public abstract string WorkingDirectoryBackingRootPath { get; }
 
             public abstract string GVFSBinDirectoryPath { get; }
 

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.Mac
                 get { return ".dmg"; }
             }
 
-            public override string WorkingDirectoryBackingRootName
+            public override string WorkingDirectoryBackingRootPath
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -406,7 +406,7 @@ namespace GVFS.Platform.Windows
                 get { return ".exe"; }
             }
 
-            public override string WorkingDirectoryBackingRootName
+            public override string WorkingDirectoryBackingRootPath
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -165,7 +165,7 @@ namespace GVFS.UnitTests.Mock.Common
                 get { return ".mockexe"; }
             }
 
-            public override string WorkingDirectoryBackingRootName
+            public override string WorkingDirectoryBackingRootPath
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }
             }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -662,6 +662,7 @@ namespace GVFS.CommandLine
             return new Result(true);
         }
 
+        // TODO(Linux), TODO(Mac): either adjust to "git" or remove entirely
         private void CreateGitScript(GVFSEnlistment enlistment)
         {
             FileInfo gitCmd = new FileInfo(Path.Combine(enlistment.EnlistmentRoot, "git.cmd"));


### PR DESCRIPTION
This PR primarily is a followup to #1102 to accommodate the fact that on Linux, the relative location of the working directory backing store will be a short path (i.e., `.gvfs/lower`) and not a single filename like `src`.  Hence we rename the `WorkingDirectoryBackingRootName` constants to `WorkingDirectoryBackingRootPath`, akin to how other short relative path constants are constructed in [`GVFS.Common.GVFSConstants.DotGVFS`](https://github.com/microsoft/VFSForGit/blob/7cc1786fcb2ca5d9be9ce7a40158eec8dacf1f4d/GVFS/GVFS.Common/GVFSConstants.cs#L107).

We also fix up the internal name of the `workingDirectoryBackingRoot` argument to the `GVFS.Common.Enlistment` class; it was possibly missed in #1102 because of the lowercase `l` in `localStorageRoot`.

And we add a `TODO` comment regarding the `git.cmd` script, which is presumably unused on non-Windows platforms and would be ignored even if renamed `git` as it's unlikely to be in the user's `PATH`.

These housekeeping changes are all in preparation, along with ~#1104~ (DONE), #1123, and #1128 (still WIP) for #1125, which adds the `GVFS.Platform.Linux` classes and related build tooling.

/cc @jrbriggs, @kivikakk