### PR TITLE
[POSIX, Mac] Refactor BSD-specific values out of POSIXFileSystem

### DIFF
--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -1,0 +1,157 @@
+﻿using GVFS.Common;
+using GVFS.Platform.POSIX;
+using System;
+using System.Runtime.InteropServices;
+
+namespace GVFS.Platform.Mac
+{
+    public class MacFileSystem : POSIXFileSystem
+    {
+        public override void ChangeMode(string path, ushort mode)
+        {
+            Chmod(path, mode);
+        }
+
+        public override bool HydrateFile(string fileName, byte[] buffer)
+        {
+            return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
+        }
+
+        public override bool IsExecutable(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsExecutable(statBuffer.Mode);
+        }
+
+        public override bool IsSocket(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsSock(statBuffer.Mode);
+        }
+
+        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int Chmod(string pathname, ushort mode);
+
+        private NativeStat.StatBuffer StatFile(string fileName)
+        {
+            if (NativeStat.Stat(fileName, out NativeStat.StatBuffer statBuffer) != 0)
+            {
+                NativeMethods.ThrowLastWin32Exception($"Failed to stat {fileName}");
+            }
+
+            return statBuffer;
+        }
+
+        private static class NativeStat
+        {
+            // #define  S_IFMT      0170000     /* [XSI] type of file mask */
+            private static readonly ushort IFMT = Convert.ToUInt16("170000", 8);
+
+            // #define  S_IFSOCK    0140000     /* [XSI] socket */
+            private static readonly ushort IFSOCK = Convert.ToUInt16("0140000", 8);
+
+            // #define S_IXUSR     0000100     /* [XSI] X for owner */
+            private static readonly ushort IXUSR = Convert.ToUInt16("100", 8);
+
+            // #define S_IXGRP     0000010     /* [XSI] X for group */
+            private static readonly ushort IXGRP = Convert.ToUInt16("10", 8);
+
+            // #define S_IXOTH     0000001     /* [XSI] X for other */
+            private static readonly ushort IXOTH = Convert.ToUInt16("1", 8);
+
+            public static bool IsSock(ushort mode)
+            {
+                // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
+                return (mode & IFMT) == IFSOCK;
+            }
+
+            public static bool IsExecutable(ushort mode)
+            {
+                return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
+            }
+
+            [DllImport("libc", EntryPoint = "stat$INODE64", SetLastError = true)]
+            public static extern int Stat(string path, [Out] out StatBuffer statBuffer);
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct TimeSpec
+            {
+                public long Sec;
+                public long Nsec;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct StatBuffer
+            {
+                public int Dev;              /* ID of device containing file */
+                public ushort Mode;          /* Mode of file (see below) */
+                public ushort NLink;         /* Number of hard links */
+                public ulong Ino;            /* File serial number */
+                public uint UID;             /* User ID of the file */
+                public uint GID;             /* Group ID of the file */
+                public int RDev;             /* Device ID */
+
+                public TimeSpec ATimespec;     /* time of last access */
+                public TimeSpec MTimespec;     /* time of last data modification */
+                public TimeSpec CTimespec;     /* time of last status change */
+                public TimeSpec BirthTimespec; /* time of file creation(birth) */
+
+                public long Size;          /* file size, in bytes */
+                public long Blocks;        /* blocks allocated for file */
+                public int BlkSize;        /* optimal blocksize for I/O */
+                public uint Glags;         /* user defined flags for file */
+                public uint Gen;           /* file generation number */
+                public int LSpare;         /* RESERVED: DO NOT USE! */
+
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+                public long[] QSpare;     /* RESERVED: DO NOT USE! */
+            }
+        }
+
+        private static class NativeFileReader
+        {
+            private const int ReadOnly = 0x0000;
+
+            internal static bool TryReadFirstByteOfFile(string fileName, byte[] buffer)
+            {
+                int fileDescriptor = -1;
+                bool readStatus = false;
+                try
+                {
+                    fileDescriptor = Open(fileName, ReadOnly);
+                    if (fileDescriptor != -1)
+                    {
+                        readStatus = TryReadOneByte(fileDescriptor, buffer);
+                    }
+                }
+                finally
+                {
+                    Close(fileDescriptor);
+                }
+
+                return readStatus;
+            }
+
+            [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+            private static extern int Open(string path, int flag);
+
+            [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+            private static extern int Close(int fd);
+
+            [DllImport("libc", EntryPoint = "read", SetLastError = true)]
+            private static extern int Read(int fd, [Out] byte[] buf, int count);
+
+            private static bool TryReadOneByte(int fileDescriptor, byte[] buffer)
+            {
+                int numBytes = Read(fileDescriptor, buffer, 1);
+
+                if (numBytes == -1)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -110,6 +110,7 @@ namespace GVFS.Platform.Mac
 
         private static class NativeFileReader
         {
+            // #define O_RDONLY 0x0000     /* open for reading only */
             private const int ReadOnly = 0x0000;
 
             internal static bool TryReadFirstByteOfFile(string fileName, byte[] buffer)

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -16,6 +16,8 @@ namespace GVFS.Platform.Mac
         public override IKernelDriver KernelDriver { get; } = new ProjFSKext();
         public override string Name { get => "macOS"; }
         public override GVFSPlatformConstants Constants { get; } = new MacPlatformConstants();
+        public override IPlatformFileSystem FileSystem { get; } = new MacFileSystem();
+
         public override string GetOSVersionInformation()
         {
             ProcessResult result = ProcessHelper.Run("sw_vers", args: string.Empty, redirectOutput: true);

--- a/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace GVFS.Platform.POSIX
 {
-    public partial class POSIXFileSystem : IPlatformFileSystem
+    public abstract partial class POSIXFileSystem : IPlatformFileSystem
     {
         public bool SupportsFileMode { get; } = true;
 
@@ -30,32 +30,18 @@ namespace GVFS.Platform.POSIX
             File.Copy(existingFileName, newFileName);
         }
 
-        public void ChangeMode(string path, ushort mode)
-        {
-            Chmod(path, mode);
-        }
+        public abstract void ChangeMode(string path, ushort mode);
 
         public bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage)
         {
             return POSIXFileSystem.TryGetNormalizedPathImplementation(path, out normalizedPath, out errorMessage);
         }
 
-        public bool HydrateFile(string fileName, byte[] buffer)
-        {
-            return NativeFileReader.TryReadFirstByteOfFile(fileName, buffer);
-        }
+        public abstract bool HydrateFile(string fileName, byte[] buffer);
 
-        public bool IsExecutable(string fileName)
-        {
-            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
-            return NativeStat.IsExecutable(statBuffer.Mode);
-        }
+        public abstract bool IsExecutable(string fileName);
 
-        public bool IsSocket(string fileName)
-        {
-            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
-            return NativeStat.IsSock(statBuffer.Mode);
-        }
+        public abstract bool IsSocket(string fileName);
 
         public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
         {
@@ -67,136 +53,7 @@ namespace GVFS.Platform.POSIX
             throw new NotImplementedException();
         }
 
-        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
-        private static extern int Chmod(string pathname, ushort mode);
-
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
         private static extern int Rename(string oldPath, string newPath);
-
-        private NativeStat.StatBuffer StatFile(string fileName)
-        {
-            NativeStat.StatBuffer statBuffer = new NativeStat.StatBuffer();
-            if (NativeStat.Stat(fileName, out statBuffer) != 0)
-            {
-                NativeMethods.ThrowLastWin32Exception($"Failed to stat {fileName}");
-            }
-
-            return statBuffer;
-        }
-
-        private static class NativeStat
-        {
-            // #define  S_IFMT      0170000     /* [XSI] type of file mask */
-            private static readonly ushort IFMT = Convert.ToUInt16("170000", 8);
-
-            // #define  S_IFSOCK    0140000     /* [XSI] socket */
-            private static readonly ushort IFSOCK = Convert.ToUInt16("0140000", 8);
-
-            // #define S_IXUSR     0000100     /* [XSI] X for owner */
-            private static readonly ushort IXUSR = Convert.ToUInt16("100", 8);
-
-            // #define S_IXGRP     0000010     /* [XSI] X for group */
-            private static readonly ushort IXGRP = Convert.ToUInt16("10", 8);
-
-            // #define S_IXOTH     0000001     /* [XSI] X for other */
-            private static readonly ushort IXOTH = Convert.ToUInt16("1", 8);
-
-            public static bool IsSock(ushort mode)
-            {
-                // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
-                return (mode & IFMT) == IFSOCK;
-            }
-
-            public static bool IsExecutable(ushort mode)
-            {
-                return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
-            }
-
-            [DllImport("libc", EntryPoint = "stat$INODE64", SetLastError = true)]
-            public static extern int Stat(string path, [Out] out StatBuffer statBuffer);
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct TimeSpec
-            {
-                public long Sec;
-                public long Nsec;
-            }
-
-            [StructLayout(LayoutKind.Sequential)]
-            public struct StatBuffer
-            {
-                public int Dev;              /* ID of device containing file */
-                public ushort Mode;          /* Mode of file (see below) */
-                public ushort NLink;         /* Number of hard links */
-                public ulong Ino;            /* File serial number */
-                public uint UID;             /* User ID of the file */
-                public uint GID;             /* Group ID of the file */
-                public int RDev;             /* Device ID */
-
-                public TimeSpec ATimespec;     /* time of last access */
-                public TimeSpec MTimespec;     /* time of last data modification */
-                public TimeSpec CTimespec;     /* time of last status change */
-                public TimeSpec BirthTimespec; /* time of file creation(birth) */
-
-                public long Size;          /* file size, in bytes */
-                public long Blocks;        /* blocks allocated for file */
-                public int BlkSize;        /* optimal blocksize for I/O */
-                public uint Glags;         /* user defined flags for file */
-                public uint Gen;           /* file generation number */
-                public int LSpare;         /* RESERVED: DO NOT USE! */
-
-                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
-                public long[] QSpare;     /* RESERVED: DO NOT USE! */
-            }
-        }
-
-        private class NativeFileReader
-        {
-            public const int ReadOnly = 0x0000;
-            public const int WriteOnly = 0x0001;
-
-            public const int Create = 0x0200;
-
-            public static bool TryReadFirstByteOfFile(string fileName, byte[] buffer)
-            {
-                int fileDescriptor = -1;
-                bool readStatus = false;
-                try
-                {
-                    fileDescriptor = Open(fileName, ReadOnly);
-                    if (fileDescriptor != -1)
-                    {
-                        readStatus = TryReadOneByte(fileDescriptor, buffer);
-                    }
-                }
-                finally
-                {
-                    Close(fileDescriptor);
-                }
-
-                return readStatus;
-            }
-
-            [DllImport("libc", EntryPoint = "open", SetLastError = true)]
-            public static extern int Open(string path, int flag);
-
-            [DllImport("libc", EntryPoint = "close", SetLastError = true)]
-            public static extern int Close(int fd);
-
-            [DllImport("libc", EntryPoint = "read", SetLastError = true)]
-            public static extern int Read(int fd, [Out] byte[] buf, int count);
-
-            private static bool TryReadOneByte(int fileDescriptor, byte[] buffer)
-            {
-                int numBytes = Read(fileDescriptor, buffer, 1);
-
-                if (numBytes == -1)
-                {
-                    return false;
-                }
-
-                return true;
-            }
-        }
     }
 }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -183,7 +183,7 @@ namespace GVFS.Platform.POSIX
         }
 
         [DllImport("libc", EntryPoint = "getuid", SetLastError = true)]
-        private static extern int Getuid();
+        private static extern uint Getuid();
 
         public abstract class POSIXPlatformConstants : GVFSPlatformConstants
         {

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -21,7 +21,7 @@ namespace GVFS.Platform.POSIX
         }
 
         public override IGitInstallation GitInstallation { get; } = new POSIXGitInstallation();
-        public override IPlatformFileSystem FileSystem { get; } = new POSIXFileSystem();
+
         public override void ConfigureVisualStudio(string gitBinPath, ITracer tracer)
         {
         }


### PR DESCRIPTION
Along with ~#1104~ (DONE), ~#1119~ (DONE), and #1128, this PR is a prerequisite to the addition of a `GVFS.Platform.Linux` set of classes in #1125.

In particular, we convert `POSIXFileSystem` into an abstract class and move the majority of its implementation into `MacFileSystem`, due to the fact that many of the syscall function signatures and flag values, plus the layout of the `struct stat` fields, differ between BSD/Darwin and Linux.  So we need to separate these out from the POSIX-level commonalities between the two.

The visibility of the members of the `NativeFileReader` subclass is also adjusted, and we remove some of its unused constants such as `Create` (for the `O_CREAT` flag, which isn't used here).

And we correct the return value of `getuid(2)` in `POSIXPlatform` to a 32-bit `uint`.  Note that on both Linux and BSD/Darwin, the `uid_t` `typedef` can be checked with the following:
```
gcc -E -xc -include 'sys/types.h' - </dev/null | grep [^u]uid_t | grep ^typedef
```

/cc @jrbriggs