### PR TITLE
[Linux] Implement update methods on Linux for placeholder files/dirs

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/Program.cs
+++ b/MirrorProvider/MirrorProvider.Linux/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace MirrorProvider.Linux
+namespace MirrorProvider.Linux
 {
     class Program
     {

--- a/MirrorProvider/Scripts/Linux/Build.sh
+++ b/MirrorProvider/Scripts/Linux/Build.sh
@@ -30,6 +30,11 @@ fi
 # Build the ProjFS library interface
 $SRCDIR/ProjFS.Linux/Scripts/Build.sh $CONFIGURATION || exit 1
 
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
 # Build the MirrorProvider
 dotnet restore $SLN /p:Configuration="$CONFIGURATION.Linux" --packages $ROOTDIR/packages
 dotnet build $SLN --configuration $CONFIGURATION.Linux

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -188,7 +188,7 @@ namespace PrjFSLib.Linux.Interop
         private static extern int _GetProjAttrs(
             IntPtr fs,
             string relativePath,
-            Attr[] attrs,
+            [In, Out] Attr[] attrs,
             uint nattrs);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -9,9 +9,11 @@ namespace PrjFSLib.Linux.Interop
 
         private const string ProviderIdAttrName = "vfsforgit.providerid";
         private const string ContentIdAttrName = "vfsforgit.contentid";
+        private const string StateAttrName = "empty";
 
         private readonly IntPtr providerIdAttrNamePtr = Marshal.StringToHGlobalAnsi(ProviderIdAttrName);
         private readonly IntPtr contentIdAttrNamePtr = Marshal.StringToHGlobalAnsi(ContentIdAttrName);
+        private readonly IntPtr stateAttrNamePtr = Marshal.StringToHGlobalAnsi(StateAttrName);
 
         private readonly IntPtr handle;
 
@@ -142,6 +144,58 @@ namespace PrjFSLib.Linux.Interop
                         attrs,
                         (uint)attrs.Length).ToResult();
                 }
+            }
+        }
+
+        public Result GetProjState(
+            string relativePath,
+            out ProjectionState state)
+        {
+            unsafe
+            {
+                byte stateAttr;
+                Attr[] attrs = new[]
+                {
+                    new Attr
+                    {
+                        Name = (byte*)this.stateAttrNamePtr,
+                        Value = &stateAttr,
+                        Size = 1
+                    }
+                };
+
+                Result result = _GetProjAttrs(
+                    this.handle,
+                    relativePath,
+                    attrs,
+                    (uint)attrs.Length).ToResult();
+
+                if (result == Result.Success)
+                {
+                    if (attrs[0].Size == -1)
+                    {
+                        state = ProjectionState.Full;
+                    }
+                    else if (stateAttr == 'n')
+                    {
+                        state = ProjectionState.Hydrated;
+                    }
+                    else if (stateAttr == 'y')
+                    {
+                        state = ProjectionState.Empty;
+                    }
+                    else
+                    {
+                        state = ProjectionState.Invalid;
+                        result = Result.Invalid;
+                    }
+                }
+                else
+                {
+                    state = ProjectionState.Invalid;
+                }
+
+                return result;
             }
         }
 

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/Interop/ProjFS.cs
@@ -164,11 +164,12 @@ namespace PrjFSLib.Linux.Interop
                     }
                 };
 
-                Result result = _GetProjAttrs(
+                int res = _GetProjAttrs(
                     this.handle,
                     relativePath,
                     attrs,
-                    (uint)attrs.Length).ToResult();
+                    (uint)attrs.Length);
+                Result result = res.ToResult();
 
                 if (result == Result.Success)
                 {
@@ -189,6 +190,12 @@ namespace PrjFSLib.Linux.Interop
                         state = ProjectionState.Invalid;
                         result = Result.Invalid;
                     }
+                }
+                else if (res == Errno.Constants.EPERM)
+                {
+                    // EPERM returned when inode is neither file nor directory
+                    state = ProjectionState.Unknown;
+                    result = Result.Invalid;
                 }
                 else
                 {

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationType.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/NotificationType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PrjFSLib.Linux
 {

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/ProjectionState.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/ProjectionState.cs
@@ -5,6 +5,7 @@ namespace PrjFSLib.Linux
     public enum ProjectionState
     {
         Invalid             = 0x00000000,
+        Unknown,
 
         Empty,
         Hydrated,

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/ProjectionState.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/ProjectionState.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace PrjFSLib.Linux
+{
+    public enum ProjectionState
+    {
+        Invalid             = 0x00000000,
+
+        Empty,
+        Hydrated,
+        Full
+    }
+}

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateFailureCause.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateFailureCause.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PrjFSLib.Linux
 {

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateType.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/UpdateType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PrjFSLib.Linux
 {

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -100,62 +100,47 @@ namespace PrjFSLib.Linux
             out UpdateFailureCause failureCause)
         {
             failureCause = UpdateFailureCause.NoFailure;
-            if (relativePath == string.Empty)
+            if (string.IsNullOrEmpty(relativePath))
             {
-                // mount point directory can not be deleted, so ignore
-                return Result.Success;
+                /* Our mount point directory can not be deleted; we would
+                 * receive an EBUSY error.  Therefore we just return
+                 * EDirectoryNotEmpty because that error is silently handled
+                 * by our caller in GitIndexProjection, and this is the
+                 * expected behavior (corresponding to the Mac implementation).
+                 */
+                return Result.EDirectoryNotEmpty;
             }
 
             string fullPath = Path.Combine(this.virtualizationRoot, relativePath);
-            try
+            bool isDirectory = Directory.Exists(fullPath);
+            Result result = Result.Success;
+            if (!isDirectory)
             {
-                if (Directory.Exists(fullPath))
-                {
-                    Directory.Delete(fullPath);
-                }
-                else
-                {
-                    // TODO(Linux): try to handle races with hydration?
-                    ProjectionState state;
-                    Result result = this.projfs.GetProjState(relativePath, out state);
+                // TODO(Linux): try to handle races with hydration?
+                ProjectionState state;
+                result = this.projfs.GetProjState(relativePath, out state);
 
-                    if (result == Result.EPathNotFound)
-                    {
-                        return Result.Success;
-                    }
-                    else if (result == Result.EAccessDenied || (result == Result.Success && state == ProjectionState.Full))
-                    {
-                        /* TODO(Linux): return EAccessDenied unless EPERM
-                         * (EPERM is returned when path is not a file or dir,
-                         *  which we want to treat as a full file)
-                         */
-                        failureCause = UpdateFailureCause.DirtyData;
-                        return Result.EVirtualizationInvalidOperation;
-                    }
-                    else if (result != Result.Success)
-                    {
-                        return result;
-                    }
-
-                    File.Delete(fullPath);
+                // treat unknown state (i.e., a special file) as a full file
+                if ((result == Result.Success && state == ProjectionState.Full) ||
+                    (result == Result.Invalid && state == ProjectionState.Unknown))
+                {
+                    failureCause = UpdateFailureCause.DirtyData;
+                    return Result.EVirtualizationInvalidOperation;
                 }
             }
-            catch (IOException ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+
+            if (result == Result.Success)
+            {
+                // TODO(Linux): set UpdateFailureCause.ReadOnly on EACCES?
+                result = NativeMethods.Remove(fullPath, isDirectory);
+            }
+
+            if (result == Result.EPathNotFound)
             {
                 return Result.Success;
             }
-            catch (IOException)
-            {
-                // TODO(Linux): return EDirectoryNotEmpty on ENOTEMPTY
-                return Result.EIOError;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // TODO(Linux): set UpdateFailureCause.ReadOnly on EACCES
-                return Result.EAccessDenied;
-            }
 
-            return Result.Success;
+            return result;
         }
 
         public virtual Result WritePlaceholderDirectory(
@@ -469,6 +454,26 @@ namespace PrjFSLib.Linux
             }
 
             return Result.ENotYetImplemented;
+        }
+
+        private static class NativeMethods
+        {
+            public static Result Remove(string path, bool isDirectory)
+            {
+                int res = isDirectory ? Rmdir(path) : Unlink(path);
+                if (res == -1)
+                {
+                    return Marshal.GetLastWin32Error().ToResult();
+                }
+
+                return Result.Success;
+            }
+
+            [DllImport("libc", EntryPoint = "rmdir", SetLastError = true)]
+            private static extern int Rmdir(string path);
+
+            [DllImport("libc", EntryPoint = "unlink", SetLastError = true)]
+            private static extern int Unlink(string path);
         }
 
         private static unsafe class NativeFileWriter

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -13,6 +13,7 @@ namespace PrjFSLib.Linux
 
         private ProjFS projfs;
         private int currentProcessId = Process.GetCurrentProcess().Id;
+        private string virtualizationRoot;
 
         // We must hold a reference to the delegates to prevent garbage collection
         private ProjFS.EventHandler preventGCOnProjEventDelegate;
@@ -65,6 +66,7 @@ namespace PrjFSLib.Linux
             }
 
             this.projfs = fs;
+            this.virtualizationRoot = virtualizationRootFullPath;
             return Result.Success;
         }
 
@@ -97,18 +99,63 @@ namespace PrjFSLib.Linux
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
-            /*
-            UpdateFailureCause deleteFailureCause = UpdateFailureCause.NoFailure;
-            Result result = ProjFS.DeleteFile(
-                relativePath,
-                updateFlags,
-                ref deleteFailureCause);
-
-            failureCause = deleteFailureCause;
-            return result;
-            */
             failureCause = UpdateFailureCause.NoFailure;
-            return Result.ENotYetImplemented;
+            if (relativePath == string.Empty)
+            {
+                // mount point directory can not be deleted, so ignore
+                return Result.Success;
+            }
+
+            string fullPath = Path.Combine(this.virtualizationRoot, relativePath);
+            try
+            {
+                if (Directory.Exists(fullPath))
+                {
+                    Directory.Delete(fullPath);
+                }
+                else
+                {
+                    // TODO(Linux): try to handle races with hydration?
+                    ProjectionState state;
+                    Result result = this.projfs.GetProjState(relativePath, out state);
+
+                    if (result == Result.EPathNotFound)
+                    {
+                        return Result.Success;
+                    }
+                    else if (result == Result.EAccessDenied || (result == Result.Success && state == ProjectionState.Full))
+                    {
+                        /* TODO(Linux): return EAccessDenied unless EPERM
+                         * (EPERM is returned when path is not a file or dir,
+                         *  which we want to treat as a full file)
+                         */
+                        failureCause = UpdateFailureCause.DirtyData;
+                        return Result.EVirtualizationInvalidOperation;
+                    }
+                    else if (result != Result.Success)
+                    {
+                        return result;
+                    }
+
+                    File.Delete(fullPath);
+                }
+            }
+            catch (IOException ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+            {
+                return Result.Success;
+            }
+            catch (IOException)
+            {
+                // TODO(Linux): return EDirectoryNotEmpty on ENOTEMPTY
+                return Result.EIOError;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // TODO(Linux): set UpdateFailureCause.ReadOnly on EACCES
+                return Result.EAccessDenied;
+            }
+
+            return Result.Success;
         }
 
         public virtual Result WritePlaceholderDirectory(
@@ -156,13 +203,13 @@ namespace PrjFSLib.Linux
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
-            /*
-            if (providerId.Length != ProjFS.PlaceholderIdLength ||
-                contentId.Length != ProjFS.PlaceholderIdLength)
+            if (providerId.Length != PlaceholderIdLength ||
+                contentId.Length != PlaceholderIdLength)
             {
                 throw new ArgumentException();
             }
 
+            /*
             UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
             Result result = ProjFS.UpdatePlaceholderFileIfNeeded(
                 relativePath,

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -120,7 +120,7 @@ namespace PrjFSLib.Linux
                 ProjectionState state;
                 result = this.projfs.GetProjState(relativePath, out state);
 
-                // treat unknown state (i.e., a special file) as a full file
+                // also treat unknown state as full/dirty (e.g., for sockets)
                 if ((result == Result.Success && state == ProjectionState.Full) ||
                     (result == Result.Invalid && state == ProjectionState.Unknown))
                 {
@@ -131,11 +131,14 @@ namespace PrjFSLib.Linux
 
             if (result == Result.Success)
             {
-                // TODO(Linux): set UpdateFailureCause.ReadOnly on EACCES?
-                result = NativeMethods.Remove(fullPath, isDirectory);
+                result = RemoveFileOrDirectory(fullPath, isDirectory);
             }
 
-            if (result == Result.EPathNotFound)
+            if (result == Result.EAccessDenied)
+            {
+                failureCause = UpdateFailureCause.ReadOnly;
+            }
+            else if (result == Result.EFileNotFound || result == Result.EPathNotFound)
             {
                 return Result.Success;
             }
@@ -233,6 +236,50 @@ namespace PrjFSLib.Linux
             string relativeDirectoryPath)
         {
             throw new NotImplementedException();
+        }
+
+        private static Result RemoveFileOrDirectory(
+            string fullPath,
+            bool isDirectory)
+        {
+            try
+            {
+                if (isDirectory)
+                {
+                    Directory.Delete(fullPath);
+                }
+                else
+                {
+                    File.Delete(fullPath);
+                }
+            }
+            catch (IOException ex) when (ex is DirectoryNotFoundException)
+            {
+                return Result.EPathNotFound;
+            }
+            catch (IOException ex) when (ex is FileNotFoundException)
+            {
+                return Result.EFileNotFound;
+            }
+            catch (IOException ex)
+            {
+                if (ex.HResult == Errno.Constants.ENOTEMPTY)
+                {
+                    return Result.EDirectoryNotEmpty;
+                }
+
+                return Result.EIOError;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Result.EAccessDenied;
+            }
+            catch
+            {
+                return Result.Invalid;
+            }
+
+            return Result.Success;
         }
 
         private static string GetProcCmdline(int pid)
@@ -454,26 +501,6 @@ namespace PrjFSLib.Linux
             }
 
             return Result.ENotYetImplemented;
-        }
-
-        private static class NativeMethods
-        {
-            public static Result Remove(string path, bool isDirectory)
-            {
-                int res = isDirectory ? Rmdir(path) : Unlink(path);
-                if (res == -1)
-                {
-                    return Marshal.GetLastWin32Error().ToResult();
-                }
-
-                return Result.Success;
-            }
-
-            [DllImport("libc", EntryPoint = "rmdir", SetLastError = true)]
-            private static extern int Rmdir(string path);
-
-            [DllImport("libc", EntryPoint = "unlink", SetLastError = true)]
-            private static extern int Unlink(string path);
         }
 
         private static unsafe class NativeFileWriter

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -209,22 +209,15 @@ namespace PrjFSLib.Linux
                 throw new ArgumentException();
             }
 
-            /*
-            UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
-            Result result = ProjFS.UpdatePlaceholderFileIfNeeded(
-                relativePath,
-                providerId,
-                contentId,
-                fileSize,
-                fileMode,
-                updateFlags,
-                ref updateFailureCause);
+            Result result = this.DeleteFile(relativePath, updateFlags, out failureCause);
+            if (result != Result.Success)
+            {
+                return result;
+            }
 
-            failureCause = updateFailureCause;
-            return result;
-            */
+            // TODO(Linux): try to handle races with hydration?
             failureCause = UpdateFailureCause.NoFailure;
-            return Result.ENotYetImplemented;
+            return this.WritePlaceholderFile(relativePath, providerId, contentId, fileSize, fileMode);
         }
 
         public virtual Result ReplacePlaceholderFileWithSymLink(
@@ -233,19 +226,15 @@ namespace PrjFSLib.Linux
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
         {
-            /*
-            UpdateFailureCause updateFailureCause = UpdateFailureCause.NoFailure;
-            Result result = ProjFS.ReplacePlaceholderFileWithSymLink(
-                relativePath,
-                symLinkTarget,
-                updateFlags,
-                ref updateFailureCause);
+            Result result = this.DeleteFile(relativePath, updateFlags, out failureCause);
+            if (result != Result.Success)
+            {
+                return result;
+            }
 
-            failureCause = updateFailureCause;
-            return result;
-            */
+            // TODO(Linux): try to handle races with hydration?
             failureCause = UpdateFailureCause.NoFailure;
-            return Result.ENotYetImplemented;
+            return this.WriteSymLink(relativePath, symLinkTarget);
         }
 
         public virtual Result CompleteCommand(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -261,13 +261,12 @@ namespace PrjFSLib.Linux
             {
                 return Result.EFileNotFound;
             }
-            catch (IOException ex)
+            catch (IOException ex) when (ex.HResult == Errno.Constants.ENOTEMPTY)
             {
-                if (ex.HResult == Errno.Constants.ENOTEMPTY)
-                {
-                    return Result.EDirectoryNotEmpty;
-                }
-
+                return Result.EDirectoryNotEmpty;
+            }
+            catch (IOException)
+            {
                 return Result.EIOError;
             }
             catch (UnauthorizedAccessException)

--- a/ProjFS.Linux/Scripts/Build.sh
+++ b/ProjFS.Linux/Scripts/Build.sh
@@ -15,6 +15,11 @@ PROJFS=$SRCDIR/ProjFS.Linux
 echo "Generating ProjFS.Linux constants..."
 "$SCRIPTDIR"/GenerateConstants.sh || exit 1
 
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
 echo "Restoring and building ProjFS.Linux packages..."
 dotnet restore $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 --packages $PACKAGES || exit 1
 dotnet build $PROJFS/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj /p:Configuration=$CONFIGURATION /p:Platform=x64 || exit 1

--- a/ProjFS.Linux/Scripts/GenerateConstants.sh
+++ b/ProjFS.Linux/Scripts/GenerateConstants.sh
@@ -7,6 +7,10 @@ INTEROP_DIR="$SCRIPTDIR/../PrjFSLib.Linux.Managed/Interop"
 
 CC=${CC:-cc}
 
+for includedir in '/usr/local/include/projfs' '/usr/include/projfs'; do
+  CPPFLAGS="${CPPFLAGS:+$CPPFLAGS }-I$includedir"
+done
+
 TMPFILE=$(mktemp -t vfsforgit.tmp.XXXXXX) || exit 1
 trap "rm -f -- '$TMPFILE'" EXIT
 


### PR DESCRIPTION
For the Linux implementation of the equivalent of the [`PrjFSLib.Mac.DeleteFile()`](https://github.com/microsoft/VFSForGit/blob/29fd6a1746fabedea35ac920ef0a2f844aeacb3e/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs#L72) method (and [PrjFS_DeleteFile()](https://github.com/microsoft/VFSForGit/blob/29fd6a1746fabedea35ac920ef0a2f844aeacb3e/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp#L527) C++ function), we rely on the [`projfs_get_attrs()`](https://github.com/github/libprojfs/blob/9f36ea1b4a3a38d97fd865049fcf11fd9ffe7435/include/projfs.h#L171) function in our libprojfs library, which allows us to read the `user.projection.empty` xattr.  If this xattr exists, the file or directory is not fully local, and may be deleted; otherwise, we return an error.

Our implementation of these functions follows the logic in the Mac `PrjFSLib.cpp` code, including the [small races](https://github.com/microsoft/VFSForGit/blob/master/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp#L546) in the `DeleteFile()` method between performing a `stat(2)` to check the nature of the file/dir, then a `getxattr(2)` to look for our projection flag xattr, and finally an `unlink(2)` or `rmdir(2)`.  (Note that unlike the Mac C++ implementation, here these low-level syscalls are actually performed in either libprojfs or in the C# standard library; they are just wrapped inside our calls to `ProjFS.GetProjState()`, `File.Delete()`, etc.)

Although we could try for a "more atomic" implementation by moving the code into libprojfs and acquiring a `flock(2)`, after consultation with @wilbaker this seems excessive, given that Git itself performs stat-followed-by-delete when trying to avoid deleting locally modified files, which is all this code is doing too.

Separately, we ensure Linux platform CI builds succeed by ignoring the `Profiling(Release)` builds (as done for [Mac as well](https://github.com/microsoft/VFSForGit/blob/29fd6a1746fabedea35ac920ef0a2f844aeacb3e/ProjFS.Mac/Scripts/Build.sh#L93)) and searching the usual system locations for our libprojfs headers and library.

Along with ~#1104~, ~#1119~, and ~#1123~ (ALL DONE), this PR is a prerequisite for the `GVFS.Platform.Linux` implementation in #1125.

Will resolve github/VFSForGit#13.