### PR TITLE
Mac: Don't Fill Placeholders & Properly Remove Placeholder Flag

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -287,6 +287,23 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             Assert.Fail("Unlike the other runners, bash.exe does not check folder handle before recusively deleting");
         }
 
+        public override long FileSize(string path)
+        {
+            string bashPath = this.ConvertWinPathToBashPath(path);
+
+            string statCommand = null;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                statCommand = string.Format("-c \"stat -f \"%z\" {0}\"", bashPath);
+            }
+            else
+            {
+                statCommand = string.Format("-c \"stat --format \"%s\" {0}\"", bashPath);
+            }
+
+            return long.Parse(this.RunProcess(statCommand));
+        }
+
         public override void CreateFileWithoutClose(string path)
         {
             throw new NotImplementedException();

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -238,5 +238,10 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             throw new NotImplementedException();
         }
+
+        public override long FileSize(string path)
+        {
+            return long.Parse(this.RunProcess(string.Format("/C for %I in ({0}) do @echo %~zI", path)));
+        }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -105,6 +105,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public abstract void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath);
         public abstract void CreateDirectory(string path);
         public abstract string EnumerateDirectory(string path);
+        public abstract long FileSize(string path);
 
         /// <summary>
         /// A recursive delete of a directory

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -200,6 +200,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             this.DeleteDirectory(path).ShouldContain(fileUsedByAnotherProcessMessage);
         }
 
+        public override long FileSize(string path)
+        {
+            return long.Parse(this.RunProcess(string.Format("-Command \"&{{ (Get-Item {0}).length}}\"", path)));
+        }
+
         public override void ChangeMode(string path, ushort mode)
         {
             throw new System.NotSupportedException();

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -220,6 +220,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             }
         }
 
+        public override long FileSize(string path)
+        {
+            return new FileInfo(path).Length;
+        }
+
         [DllImport("kernel32", SetLastError = true)]
         private static extern bool MoveFileEx(string existingFileName, string newFileName, int flags);
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -569,6 +569,14 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             filePath.ShouldBeAFile(this.fileSystem).WithContents(fileContents);
         }
 
+        [TestCase, Order(20)]
+        public void VerifyFileSize()
+        {
+            string filePath = this.Enlistment.GetVirtualPathTo("Test_EPF_WorkingDirectoryTests", "ProjectedFileHasExpectedContents.cpp");
+            long fileSize = this.fileSystem.FileSize(filePath);
+            fileSize.ShouldEqual(536);
+        }
+
         private void FolderEnumerationShouldHaveSingleEntry(string folderVirtualPath, string expectedEntryName, string searchPatten)
         {
             IEnumerable<FileSystemInfo> folderEntries;

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -1060,7 +1060,7 @@ static PrjFS_Result HandleFileNotification(
         notificationType,
         nullptr /* destinationRelativePath */);
     
-    if (result == 0 && placeholderFile && PrjFS_NotificationType_PreConvertToFull == notificationType)
+    if (result == PrjFS_Result_Success && placeholderFile && PrjFS_NotificationType_PreConvertToFull == notificationType)
     {
         errno_t result = RemoveXAttrWithoutFollowingLinks(absolutePath, PrjFSFileXAttrName);
         if (0 != result)

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -389,13 +389,6 @@ PrjFS_Result PrjFS_WritePlaceholderFile(
         goto CleanupAndFail;
     }
     
-    // Expand the file to the desired size
-    if (ftruncate(fileno(file), fileSize))
-    {
-        result = PrjFS_Result_EIOError;
-        goto CleanupAndFail;
-    }
-    
     fclose(file);
     file = nullptr;
     


### PR DESCRIPTION
1. Don't fill placeholders with data to make size
  - Commands that create placeholders without hydration will receive a performance boost
  - In perf tests I saw a 4% overall drop for a million placeholders (123 second down to 118)


2. Properly remove placeholder flag when file is covered to full (KAUTH_VNODE_WRITE_DATA / KAUTH_VNODE_APPEND_DATA).
  - This will avoid calling PreConvertToFull again when the same Vnode Events are called.

resolves #1133