### PR TITLE
PostFetchStep: delete and rewrite commit-graph on write error

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -46,7 +46,12 @@ namespace GVFS.Common.Maintenance
                 string commitGraphLockPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", CommitGraphLock);
                 this.Context.FileSystem.TryDeleteFile(commitGraphLockPath);
 
-                this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
+                GitProcess.Result writeResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
+
+                if (writeResult.ExitCodeIsFailure)
+                {
+                    this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
+                }
 
                 // Turning off Verify for commit graph due to performance issues.
                 /*


### PR DESCRIPTION
We are no longer using 'verify' to check that our commit-graph
is valid, but we can still discover some errors during the 'write'
command. We currently never recover from this problem.

If we inspect the response from the 'write' command, then we can
delete and rewrite on failure. This will resolve some issues that
users are seeing right now.