### PR TITLE
netcore build: fix runtime patch selection issues

### DIFF
--- a/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
+++ b/GVFS/GVFS.Platform.Mac/GVFS.Platform.Mac.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/GVFS/GVFS.Platform.POSIX/GVFS.Platform.POSIX.csproj
+++ b/GVFS/GVFS.Platform.POSIX/GVFS.Platform.POSIX.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/GVFS/GVFS.Service/GVFS.Service.Mac.csproj
+++ b/GVFS/GVFS.Service/GVFS.Service.Mac.csproj
@@ -9,6 +9,7 @@
     <Platforms>x64</Platforms>
     <RunTimeIdentifiers>osx-x64</RunTimeIdentifiers>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/PrjFSLib.Mac.Managed.csproj
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/PrjFSLib.Mac.Managed.csproj
@@ -4,6 +4,7 @@
     <Platforms>x64</Platforms>
     <Configurations>Debug;Release</Configurations>
     <CodeAnalysisRuleSet>..\..\GVFS\GVFS.Build\GVFS.ruleset</CodeAnalysisRuleSet>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Issue:

When switching between command line and IDE builds, the build will often fail
with an error similar to:

  NETSDK1061: The project was restored using Microsoft.NETCore.App version
  2.1.9, but with current settings, version 2.1.0 would be used instead. To
  resolve this issue, make sure the same settings are used for restore and for
  subsequent operations such as build or publish. Typically this issue can occur
  if the RuntimeIdentifier property is set during build or publish but not during
  restore. For more information, see
  https://aka.ms/dotnet-runtime-patch-selection.

My understanding is that this can happen when the runtime used by the restore
operation does not match the runtime expected by the publish operation. As the
publish operation might not call restore itself, it will generate this error
when the runtime does not match the expected version.

To fix this, the BuildGVFSForMac.sh script will not include the runtime
identifier when calling restore. The projects that generate self-contained
applications will also set the `TargetLatestRuntimePatch` property to target
the latest runtime.