### PR TITLE
Upgrader: do not include Micrsoft.Diagnostic.Tracing.EventSource

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -36,7 +36,6 @@ namespace GVFS.Common
                 UpgraderToolConfigFile,
                 "GVFS.Common.dll",
                 "GVFS.Platform.Windows.dll",
-                "Microsoft.Diagnostics.Tracing.EventSource.dll",
                 "netstandard.dll",
                 "System.Net.Http.dll",
                 "Newtonsoft.Json.dll",

--- a/GVFS/GVFS.Mount/GVFS.Mount.Windows.csproj
+++ b/GVFS/GVFS.Mount/GVFS.Mount.Windows.csproj
@@ -41,10 +41,6 @@
     <Reference Include="Microsoft.Data.Sqlite, Version=2.2.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Data.Sqlite.Core.2.2.4\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
-      <HintPath>..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net46\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -107,12 +103,10 @@
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.12\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />

--- a/GVFS/GVFS.Mount/packages.config
+++ b/GVFS/GVFS.Mount/packages.config
@@ -3,9 +3,6 @@
   <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite" version="2.2.4" targetFramework="net461" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.2.4" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource" version="1.1.28" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.12" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.12" targetFramework="net461" />

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -122,10 +122,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
     <Error Condition="!Exists('..\ProjectedFSLib.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\ProjectedFSLib.NativeBinaries.props'))" />
   </Target>
-  <Import Project="..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/GVFS/GVFS.Platform.Windows/packages.config
+++ b/GVFS/GVFS.Platform.Windows/packages.config
@@ -3,9 +3,6 @@
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.Database.Collections.Generic" version="1.9.4" targetFramework="net461" />
   <package id="Microsoft.Database.Isam" version="1.9.4" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource" version="1.1.28" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net461" />
   <package id="Microsoft.Windows.ProjFS" version="1.0.19108.2" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
   <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net461" />


### PR DESCRIPTION
The upgrade verb attempts to copy
Microsoft.Diagnostic.Tracing.EventSource when copying the
ProductUpgrader to the temporary directory to run. However, this dll is
no longer needed or installed during installation.

Older installations will have copied this file into the install
directory will still have a copy for the upgrade verb to copy over.
However, clean installs, or if you uninstall VFS4G and re-install, will
not have this dll and upgrade will fail.

This is a quick fix - we will also see how to make this less fragile.
One option might be to install "upgrader app" into its own directory
under the VFS For Git installation directory, and then just copy the
directory to the temp location, instead of providing a list of files
that need to be kept in sync.