### PR TITLE
Add .vsconfig file to declare required VS components

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,13 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Workload.NativeDesktop"
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Workload.NetCoreTools",
+    "Microsoft.Net.Core.Component.SDK.2.1",
+    "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
+    "Microsoft.Net.Component.4.6.1.TargetingPack",
+    "Microsoft.Net.Component.4.6.1.SDK",
+  ]
+}

--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,8 @@ You can also use Visual Studio 2019. There are a couple of options for getting a
   * MSVC v141 VS 2017 C++ build tools via the optional components in the Visual Studio 2019 installer. It is under the "Desktop Development with C++" heading.
   * Windows 10 SDK (10.0.10240.0) via the archived SDK page: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive
 
+Visual Studio 2019 will [automatically prompt you to install these dependencies](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/) when you open the solution. The .vsconfig file that is present in the root of the repository specifies all required components _except_ the Windows 10 SDK (10.0.10240.0) as this component is no longer shipped with VS2019 - **you'll still need to install that separately**.
+
 The installer can now be found at `C:\Repos\VFSForGit\BuildOutput\GVFS.Installer\bin\x64\[Debug|Release]\SetupGVFS.<version>.exe`
 
 ## Building VFS for Git on Mac


### PR DESCRIPTION
Declare the following VS components as required for this solution to build:

 - Microsoft.Component.MSBuild
 - Microsoft.VisualStudio.Workload.NativeDesktop
 - Microsoft.VisualStudio.Workload.ManagedDesktop
 - Microsoft.VisualStudio.Workload.NetCoreTools
 - Microsoft.Net.Core.Component.SDK.2.1
 - Microsoft.VisualStudio.Component.VC.v141.x86.x64
 - Microsoft.Net.Component.4.6.1.TargetingPack
 - Microsoft.Net.Component.4.6.1.SDK

Note that the Windows 10 SDK 10240 is also required, but this component is no longer shipped with VS2019.

https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/