### PR TITLE
Upgrader: do not include Micrsoft.Diagnostic.Tracing.EventSource

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -33,7 +33,6 @@ namespace GVFS.Common
                 UpgraderToolConfigFile,
                 "GVFS.Common.dll",
                 "GVFS.Platform.Windows.dll",
-                "Microsoft.Diagnostics.Tracing.EventSource.dll",
                 "netstandard.dll",
                 "System.Net.Http.dll",
                 "Newtonsoft.Json.dll",


### PR DESCRIPTION
The upgrade verb attempts to copy
Microsoft.Diagnostic.Tracing.EventSource when copying the
ProductUpgrader to the temporary directory to run. If this file is not
present, then the upgrade verb will fail. This following commit removes
this file:

  cbe5787d ("Remove in-proc ETW trace event listener", 2019-02-18)

Clean installs of VFS4G that include this commit will no longer have
this file in the installation directory, and will not be able to
upgrade.

This dll is no longer needed or installed during installation, so we
remove it from the list of files copied over for upgrade.

This is a quick fix - we will also see how to make this less fragile.
One option might be to install "upgrader app" into its own directory
under the VFS For Git installation directory, and then just copy the
directory to the temp location, instead of providing a list of files
that need to be kept in sync.

(cherry picked from commit f107731840a41034946d904820be9b7105134b58)