### PR TITLE
Updated Service response to EnablePrjFS request

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -232,7 +232,7 @@ namespace GVFS.Common.NamedPipes
                 }
             }
 
-            public bool TrySendResponse(string message)
+            public virtual bool TrySendResponse(string message)
             {
                 try
                 {

--- a/GVFS/GVFS.Service/Handlers/RequestHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/RequestHandler.cs
@@ -96,7 +96,7 @@ namespace GVFS.Service.Handlers
                     NamedPipeMessages.EnableAndAttachProjFSRequest.Response response = new NamedPipeMessages.EnableAndAttachProjFSRequest.Response();
                     response.State = NamedPipeMessages.CompletionState.Success;
 
-                    this.TrySendResponse(tracer, response.ToString(), connection);
+                    this.TrySendResponse(tracer, response.ToMessage().ToString(), connection);
                     break;
 
                 default:

--- a/GVFS/GVFS.UnitTests/Service/Mac/MacServiceTests.cs
+++ b/GVFS/GVFS.UnitTests/Service/Mac/MacServiceTests.cs
@@ -1,7 +1,9 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using GVFS.Common.NamedPipes;
 using GVFS.Platform.Mac;
 using GVFS.Service;
+using GVFS.Service.Handlers;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.FileSystem;
 using Moq;
@@ -47,6 +49,26 @@ namespace GVFS.UnitTests.Service.Mac
             service.Run();
 
             repoRegistry.VerifyAll();
+        }
+
+        [TestCase]
+        public void ServiceHandlesEnablePrjfsRequest()
+        {
+            string expectedServiceResponse = "TRequestResponse|{\"State\":1,\"ErrorMessage\":null}";
+            Mock<NamedPipeServer.Connection> connectionMock = new Mock<NamedPipeServer.Connection>(
+                MockBehavior.Strict,
+                null, // serverStream
+                this.tracer, // tracer
+                null); // isStopping
+            connectionMock.Setup(mp => mp.TrySendResponse(expectedServiceResponse)).Returns(true);
+
+            NamedPipeMessages.EnableAndAttachProjFSRequest request = new NamedPipeMessages.EnableAndAttachProjFSRequest();
+            request.EnlistmentRoot = string.Empty;
+
+            RequestHandler serviceRequestHandler = new RequestHandler(this.tracer, etwArea: string.Empty, repoRegistry: null);
+            serviceRequestHandler.HandleRequest(this.tracer, request.ToMessage().ToString(), connectionMock.Object);
+
+            connectionMock.VerifyAll();
         }
 
         [TestCase]


### PR DESCRIPTION
Service (`RequestHandler.cs`) on the Mac, was sending responses to EnableProjFS requests in an incorrect format. This was causing `gvfs service --mount-all` to fail with “un-expected response message” error. Updated RequestHandler to first create a Message object from EnableProjFS Response and use it in its reply to client. This helps create a client parsable response with expected header and body.

Service response before the change -
`GVFS.Common.NamedPipes.NamedPipeMessages+EnableAndAttachProjFSRequest+Response`

Service response after the change -
`TRequestResponse|{\"State\":1,\"ErrorMessage\":null}”}`

Fixes #1053