### PR TITLE
ProjectedFSLib: do not copy into GVFS.Platform.Windows output dir

### DIFF
--- a/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
+++ b/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
@@ -189,10 +189,6 @@
       mkdir  $(TargetDir)\netcoreapp2.1
       xcopy /Y $(BuildOutputDir)\FastFetch\bin\$(Platform)\$(Configuration)\netcoreapp2.1\* $(TargetDir)\netcoreapp2.1
       xcopy /Y $(BuildOutputDir)\GVFS.FunctionalTests.LockHolder\bin\$(Platform)\$(Configuration)\netcoreapp2.1\* $(TargetDir)\netcoreapp2.1
-
-      REM If there is an inbox version of the ProjFS dll, we must use that one to guarantee compat with the sys, so delete whatever is in our TargetDir
-      if exist c:\Windows\System32\ProjectedFSLib.dll del $(TargetDir)\ProjectedFSLib.dll
-
 </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -48,9 +48,6 @@
 
   <Target Name="CopyWindowsTestDependencies" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT'">
     <Copy SourceFiles="@(WindowsBuildOutputs)" DestinationFolder="$(TargetDir)\%(RecursiveDir)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
-
-    <!-- If there is an inbox version of the ProjFS dll, we must use that one to guarantee compat with the sys, so delete whatever is in our TargetDir -->
-    <Delete Files="$(TargetDir)\ProjectedFSLib.dll" Condition="Exists('c:\Windows\System32\ProjectedFSLib.dll')" />
   </Target>
   
 </Project>

--- a/GVFS/GVFS.Installer.Windows/Setup.iss
+++ b/GVFS/GVFS.Installer.Windows/Setup.iss
@@ -4,6 +4,7 @@
 ; General documentation on how to use InnoSetup scripts: http://www.jrsoftware.org/ishelp/index.php
 
 #define PrjFltDir PackagesDir + "\" + ProjFSNativePackage + "\filter" 
+#define ProjFSNativeLibDir PackagesDir + "\" + ProjFSNativePackage + "\lib" 
 #define VCRuntimeDir PackagesDir + "\GVFS.VCRuntime.0.2.0-build\lib\x64"
 #define GVFSDir BuildOutputDir + "\GVFS.Windows\bin\" + PlatformAndConfiguration
 #define GVFSCommonDir BuildOutputDir + "\GVFS.Common\bin\" + PlatformAndConfiguration + "\netstandard2.0"
@@ -75,7 +76,7 @@ DestDir: "{app}\Filter"; Flags: ignoreversion; Source:"{#PrjFltDir}\PrjFlt.sys"
 DestDir : "{app}\Filter"; Flags: ignoreversion; Source: "{#PrjFltDir}\prjflt.inf"
 
 ; PrjFlt Native Library Files, the GVFS.Service will copy these files into the {app} directory if needed
-DestDir: "{app}\ProjFS"; Flags: ignoreversion; Source:"{#GVFSDir}\ProjectedFSLib.dll"
+DestDir: "{app}\ProjFS"; Flags: ignoreversion; Source:"{#ProjFSNativeLibDir}\ProjectedFSLib.dll"
 
 ; PrjFlt Managed Assembly Files
 DestDir: "{app}"; Flags: ignoreversion; Source:"{#GVFSDir}\ProjectedFSLib.Managed.dll"

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -3,7 +3,6 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\ProjFS.props" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\GVFS.cs.props" />
-  <Import Project="..\ProjectedFSLib.NativeBinaries.props" Condition="Exists('..\ProjectedFSLib.NativeBinaries.props')" />
   <PropertyGroup>
     <ProjectGuid>{4CE404E7-D3FC-471C-993C-64615861EA63}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -122,7 +121,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\ProjectedFSLib.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\ProjectedFSLib.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\ProjFS.props" />
+  <Import Project="..\ProjectedFSLib.NativeBinaries.props" />
   <Import Project="$(SolutionDir)\GVFS\GVFS.Build\GVFS.cs.props" />
   <PropertyGroup>
     <ProjectGuid>{8E0D0989-21F6-4DD8-946C-39F992523CC6}</ProjectGuid>

--- a/GVFS/GVFS.UnitTests.Windows/packages.config
+++ b/GVFS/GVFS.UnitTests.Windows/packages.config
@@ -16,6 +16,7 @@
   <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net461" />
   <package id="NUnitLite" version="3.10.1" targetFramework="net461" />
+  <package id="GVFS.ProjFS" version="2019.411.1" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.12" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.12" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.12" targetFramework="net461" />

--- a/GVFS/ProjectedFSLib.NativeBinaries.props
+++ b/GVFS/ProjectedFSLib.NativeBinaries.props
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
         <None Condition="Exists('$(PackagesDir)\$(ProjFSNativePackage)\lib\ProjectedFSLib.dll')" Include="$(PackagesDir)\$(ProjFSNativePackage)\lib\ProjectedFSLib.dll">
+            <Link>ProjectedFSLib.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>


### PR DESCRIPTION
Currently, ProjectedFSLib.dll is expected to be copied into the GVFS.Platform.Windows
output directory during a build, and from there is copied into the installer. Due to
how this is included in the project, it is not consistently copied into
the GVFS.Platform.Windows output directory, and this can cause a build
failure simiar to:

```
Error on line in C:\Sources\Vfs4Git\src\GVFS\GVFS.Installer.Windows\Setup.iss: Source file "C:\Sources\Vfs4Git\src\..\BuildOutput\GVFS.Windows\bin\x64\Debug\ProjectedFSLib.dll" does not exist.
```

To fix this, we could fix the project setup to have the file copied over
consistently. However, this file is not needed by the
GVFS.Platform.Windows project. Post RS4, ProjectedFSLib.dll should be
provided by the operating system and not copied over the product.
Previously, the product had to bring over its own copy of
ProjectedFSLib.dll, as it was not providided by the OS. By now, we
expect developers to have moved to a version of Windows that includes
this the ProjectedFSLib.dll component in box.

This also means we can remove logic for deleting this file as part of a
post build step on systems where this file should not be provided by the
product.