### PR TITLE
GVFSService: platforms should use appropriate pipe name

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -40,6 +40,7 @@ namespace GVFS.Common
         public abstract bool IsProcessActive(int processId);
         public abstract void IsServiceInstalledAndRunning(string name, out bool installed, out bool running);
         public abstract string GetNamedPipeName(string enlistmentRoot);
+        public abstract string GetGVFSServiceNamedPipeName(string serviceName);
         public abstract NamedPipeServerStream CreatePipeByName(string pipeName);
 
         public abstract string GetOSVersionInformation();

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -117,6 +117,13 @@ namespace GVFS.Platform.POSIX
             return POSIXPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
         }
 
+        public override string GetGVFSServiceNamedPipeName(string serviceName)
+        {
+            // Pipes are stored as files on POSIX, use a rooted pipe name
+            // in the same location as the service to keep full control of the location of the file
+            return this.GetDataRootForGVFSComponent(serviceName) + ".pipe";
+        }
+
         public override bool IsConsoleOutputRedirectedToFile()
         {
             return POSIXPlatform.IsConsoleOutputRedirectedToFileImplementation();

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -199,6 +199,11 @@ namespace GVFS.Platform.Windows
             return WindowsPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
         }
 
+        public override string GetGVFSServiceNamedPipeName(string serviceName)
+        {
+            return serviceName + ".pipe";
+        }
+
         public override void ConfigureVisualStudio(string gitBinPath, ITracer tracer)
         {
             try

--- a/GVFS/GVFS.Service/GVFSService.Mac.cs
+++ b/GVFS/GVFS.Service/GVFSService.Mac.cs
@@ -42,7 +42,7 @@ namespace GVFS.Service
 
                 if (!string.IsNullOrEmpty(this.serviceName))
                 {
-                    string pipeName = this.serviceName + ".Pipe";
+                    string pipeName = GVFSPlatform.Instance.GetGVFSServiceNamedPipeName(this.serviceName);
                     this.tracer.RelatedInfo("Starting pipe server with name: " + pipeName);
 
                     using (NamedPipeServer pipeServer = NamedPipeServer.StartNewServer(

--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -52,7 +52,7 @@ namespace GVFS.Service
                 this.repoRegistry.Upgrade();
                 this.requestHandler = new WindowsRequestHandler(this.tracer, EtwArea, this.repoRegistry);
 
-                string pipeName = this.serviceName + ".Pipe";
+                string pipeName = GVFSPlatform.Instance.GetGVFSServiceNamedPipeName(this.serviceName);
                 this.tracer.RelatedInfo("Starting pipe server with name: " + pipeName);
 
                 using (NamedPipeServer pipeServer = NamedPipeServer.StartNewServer(

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -58,6 +58,11 @@ namespace GVFS.UnitTests.Mock.Common
             return "GVFS_Mock_PipeName";
         }
 
+        public override string GetGVFSServiceNamedPipeName(string serviceName)
+        {
+            return Path.Combine("GVFS_Mock_ServicePipeName", serviceName);
+        }
+
         public override NamedPipeServerStream CreatePipeByName(string pipeName)
         {
             throw new NotSupportedException();

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -86,7 +86,7 @@ namespace GVFS.CommandLine
         {
             get
             {
-                return this.ServiceName + ".Pipe";
+                return GVFSPlatform.Instance.GetGVFSServiceNamedPipeName(this.ServiceName);
             }
         }
 


### PR DESCRIPTION
On POSIX platforms the pipe name should be a rooted path so that we have
full control over the pipe path. If a relative path is used, then the
pipe is created in a temporary dictory, which can be a different
location depending on the user's context (i.e. running as root vs normal
user). This can result in an process running as root not being able to
communicate with the GVFS Service.

This change enables the different platforms to create a pipe path that
is suitable for the platform, and encapsulates the logic for creating
the pipe name for client / server in a single location.