### PR TITLE
Clone and mount in unattended mode for loose object functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -18,7 +18,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
         // the cache
         public LooseObjectStepTests()
-            : base(forcePerRepoObjectCache: true)
+            : base(forcePerRepoObjectCache: true, unattended: true)
         {
             this.fileSystem = new SystemIORunner();
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/TestsWithEnlistmentPerTestCase.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/TestsWithEnlistmentPerTestCase.cs
@@ -7,10 +7,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
     public abstract class TestsWithEnlistmentPerTestCase
     {
         private readonly bool forcePerRepoObjectCache;
+        private readonly bool unattended;
 
-        public TestsWithEnlistmentPerTestCase(bool forcePerRepoObjectCache = false)
+        public TestsWithEnlistmentPerTestCase(bool forcePerRepoObjectCache = false, bool unattended = false)
         {
             this.forcePerRepoObjectCache = forcePerRepoObjectCache;
+            this.unattended = unattended;
         }
 
         public GVFSFunctionalTestEnlistment Enlistment
@@ -23,11 +25,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             if (this.forcePerRepoObjectCache)
             {
-                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMountWithPerRepoCache(GVFSTestConfig.PathToGVFS, skipPrefetch: false);
+                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMountWithPerRepoCache(GVFSTestConfig.PathToGVFS, skipPrefetch: false, unattended: this.unattended);
             }
             else
             {
-                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMount(GVFSTestConfig.PathToGVFS);
+                this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMount(GVFSTestConfig.PathToGVFS, unattended: this.unattended);
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -84,21 +84,22 @@ namespace GVFS.FunctionalTests.Tools
             get; private set;
         }
 
-        public static GVFSFunctionalTestEnlistment CloneAndMountWithPerRepoCache(string pathToGvfs, bool skipPrefetch)
+        public static GVFSFunctionalTestEnlistment CloneAndMountWithPerRepoCache(string pathToGvfs, bool skipPrefetch, bool unattended = false)
         {
             string enlistmentRoot = GVFSFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
             string localCache = GVFSFunctionalTestEnlistment.GetRepoSpecificLocalCacheRoot(enlistmentRoot);
-            return CloneAndMount(pathToGvfs, enlistmentRoot, null, localCache, skipPrefetch);
+            return CloneAndMount(pathToGvfs, enlistmentRoot, null, localCache, skipPrefetch, unattended);
         }
 
         public static GVFSFunctionalTestEnlistment CloneAndMount(
             string pathToGvfs,
             string commitish = null,
             string localCacheRoot = null,
-            bool skipPrefetch = false)
+            bool skipPrefetch = false,
+            bool unattended = false)
         {
             string enlistmentRoot = GVFSFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
-            return CloneAndMount(pathToGvfs, enlistmentRoot, commitish, localCacheRoot, skipPrefetch);
+            return CloneAndMount(pathToGvfs, enlistmentRoot, commitish, localCacheRoot, skipPrefetch, unattended);
         }
 
         public static GVFSFunctionalTestEnlistment CloneAndMountEnlistmentWithSpacesInPath(string pathToGvfs, string commitish = null)
@@ -168,9 +169,9 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
-        public void CloneAndMount(bool skipPrefetch)
+        public void CloneAndMount(bool skipPrefetch, bool unattended = false)
         {
-            this.gvfsProcess.Clone(this.RepoUrl, this.Commitish, skipPrefetch);
+            this.gvfsProcess.Clone(this.RepoUrl, this.Commitish, skipPrefetch, unattended: unattended);
 
             GitProcess.Invoke(this.RepoRoot, "checkout " + this.Commitish);
             GitProcess.Invoke(this.RepoRoot, "branch --unset-upstream");
@@ -289,7 +290,13 @@ namespace GVFS.FunctionalTests.Tools
                 objectHash.Substring(2));
         }
 
-        private static GVFSFunctionalTestEnlistment CloneAndMount(string pathToGvfs, string enlistmentRoot, string commitish, string localCacheRoot, bool skipPrefetch = false)
+        private static GVFSFunctionalTestEnlistment CloneAndMount(
+            string pathToGvfs,
+            string enlistmentRoot,
+            string commitish,
+            string localCacheRoot,
+            bool skipPrefetch = false,
+            bool unattended = false)
         {
             GVFSFunctionalTestEnlistment enlistment = new GVFSFunctionalTestEnlistment(
                 pathToGvfs,

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -16,7 +16,7 @@ namespace GVFS.FunctionalTests.Tools
             this.localCacheRoot = localCacheRoot;
         }
 
-        public void Clone(string repositorySource, string branchToCheckout, bool skipPrefetch)
+        public void Clone(string repositorySource, string branchToCheckout, bool skipPrefetch, bool unattended = false)
         {
             string args = string.Format(
                 "clone \"{0}\" \"{1}\" --branch \"{2}\" --local-cache-path \"{3}\" {4}",
@@ -25,7 +25,7 @@ namespace GVFS.FunctionalTests.Tools
                 branchToCheckout,
                 this.localCacheRoot,
                 skipPrefetch ? "--no-prefetch" : string.Empty);
-            this.CallGVFS(args, failOnError: true);
+            this.CallGVFS(args, failOnError: true, unattended: unattended);
         }
 
         public void Mount()
@@ -123,7 +123,13 @@ namespace GVFS.FunctionalTests.Tools
             this.CallGVFS($"config --delete {key}", failOnError: true);
         }
 
-        private string CallGVFS(string args, bool failOnError = false, string trace = null, string standardInput = null, string internalParameter = null)
+        private string CallGVFS(
+            string args,
+            bool failOnError = false,
+            string trace = null,
+            string standardInput = null,
+            string internalParameter = null,
+            bool unattended = false)
         {
             ProcessStartInfo processInfo = null;
             processInfo = new ProcessStartInfo(this.pathToGVFS);
@@ -146,6 +152,11 @@ namespace GVFS.FunctionalTests.Tools
             if (trace != null)
             {
                 processInfo.EnvironmentVariables["GIT_TRACE"] = trace;
+            }
+
+            if (unattended)
+            {
+                processInfo.EnvironmentVariables["GVFS_UNATTENDED"] = "1";
             }
 
             using (Process process = Process.Start(processInfo))


### PR DESCRIPTION
The functional tests for loose objects seem to be a bit flaky. One reason may be that some background operations are interfering at some points. Clone in unattended mode to ensure no background operations are happening during our test runs.

I'll run the functional tests a few times with this to try and catch the flakiness. If this doesn't work, then we will need to relax the conditions on the tests.