### PR TITLE
GitProcess: Enable lower ProcessPriorityClass

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -83,6 +83,8 @@ namespace GVFS.Common.Git
             }
         }
 
+        public bool ForBackground { get; set; }
+
         public static Result Init(Enlistment enlistment)
         {
             return new GitProcess(enlistment).InvokeGitOutsideEnlistment("init \"" + enlistment.WorkingDirectoryBackingRoot + "\"");
@@ -688,6 +690,7 @@ namespace GVFS.Common.Git
 
             Process executingProcess = new Process();
             executingProcess.StartInfo = processInfo;
+
             return executingProcess;
         }
 
@@ -748,6 +751,11 @@ namespace GVFS.Common.Git
                             }
 
                             this.executingProcess.Start();
+
+                            if (this.ForBackground)
+                            {
+                                this.executingProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
+                            }
                         }
 
                         writeStdIn?.Invoke(this.executingProcess.StandardInput);

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -83,7 +83,7 @@ namespace GVFS.Common.Git
             }
         }
 
-        public bool ForBackground { get; set; }
+        public bool LowerPriority { get; set; }
 
         public static Result Init(Enlistment enlistment)
         {
@@ -752,7 +752,7 @@ namespace GVFS.Common.Git
 
                             this.executingProcess.Start();
 
-                            if (this.ForBackground)
+                            if (this.LowerPriority)
                             {
                                 this.executingProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
                             }

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -237,7 +237,7 @@ namespace GVFS.Common.Maintenance
                 }
 
                 this.MaintenanceGitProcess = this.Context.Enlistment.CreateGitProcess();
-                this.MaintenanceGitProcess.ForBackground = true;
+                this.MaintenanceGitProcess.LowerPriority = true;
             }
 
             try

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -237,6 +237,7 @@ namespace GVFS.Common.Maintenance
                 }
 
                 this.MaintenanceGitProcess = this.Context.Enlistment.CreateGitProcess();
+                this.MaintenanceGitProcess.ForBackground = true;
             }
 
             try


### PR DESCRIPTION
In an effort to have fewer complaints for running things in the background, give background Git commands a lower process priority.

See [ProcessPriorityClass enum documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processpriorityclass?view=netframework-4.8) for details of how this should work. By specifying "BelowNormal", we are allowing the process to run while a user is at the machine, but the process should not keep them from doing their work. The only lower priority is `Idle` which implies that the user is not using the machine, such as with a screensaver. I'm not sure if we want to go that low.

/cc @jrbriggs as he had an idea of what to do here, and this is the only kind of priority I could find.