### PR TITLE
Add repo root dir to retention list before projection updates

### DIFF
--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1111,7 +1111,10 @@ namespace GVFS.Virtualization.Projection
                 numThreads = Math.Min(numThreads, placeholderFilesListCopy.Count / minItemsPerThread);
                 numThreads = Math.Max(numThreads, 1);
 
+                // folderPlaceholdersToKeep always contains the empty path so as to avoid unnecessary attempts
+                // to remove the repository's root folder.
                 ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>();
+                folderPlaceholdersToKeep.Add(string.Empty);
 
                 // updatedPlaceholderDictionary and updatedPlaceholderBag are mutually exclusive.
                 //  - On platforms that expand on enumeration: updatedPlaceholderDictionary is used (required for ReExpandFolder)


### PR DESCRIPTION
The `GitIndexProjection.UpdatePlaceholders()` method, after processing the list of placeholder files, iterates over the list of placeholder folders and tries to remove any which are actually files, or not in the projection, or a possible tombstone.

The last placeholder folder in the ordered list appears to always correspond to the root of the repository; this placeholder has an empty path string, and `IsPathProjected()` returns `false` for both the `isProjected` and `isFolder` flags for this entry.

Because both flags are `false`, `RemoveFolderPlaceholderIfEmpty()` is called, which then results in a call to `DeleteFile()` in the lower-level `ProjFS` layer.  This always fails, because the root folder is never empty (it contains, among other things, the `.git` folder), but since `RemoveFolderPlaceholderIfEmpty()` handles the `FSResult.DirectoryNotEmpty` error code, no exception is propagated.

We can avoid these unnecessary attempts to remove the repository's root folder on `git checkout` operations by adding the empty path to the `folderPlaceholdersToKeep` list.

This behaviour was noted while testing #1128, which implements the underlying `DeleteFile()` method on Linux, where the use of a true filesystem mount point for the root of the VFSForGit repository means that an attempt to `rmdir(2)` the repository's root directory does not return `ENOTEMPTY` but rather `EBUSY` (`Device or resource busy`).  This is not silently handled by `RemoveFolderPlaceholderIfEmpty()` but instead logs an error.

/cc @jrbriggs, @kivikakk