### PR TITLE
Relax LooseObjectStepTests from exact object counts

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
 
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(1);
             this.CountPackFiles().ShouldEqual(1);
 
             // Running the step a second time should remove the loose obects and keep the pack file
@@ -115,7 +115,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.Enlistment.LooseObjectStep();
 
             this.CountPackFiles().ShouldEqual(1, "Incorrect number of packs after second loose object step");
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(1);
 
             // This step should delete the loose objects
             this.Enlistment.LooseObjectStep();


### PR DESCRIPTION
We are having some flaky tests because _somtimes_ we get one too many or one too few loose objects in our `LooseObjectStepTests`. The only reason this can happen (as I see it) is that we are downloading a loose object due to the virtualization layer, and that file exists in a pack somehow. This causes us to delete or add an object during the `LooseObjectsStep` and have off-by-one errors. Instead of seeing 160 objects (for example) we see 159 or 161.

Relax the test conditions to verify that we did not delete all of the loose objects during the steps instead of requiring the count is exact. (We already relaxed this in one direction in #1116.)