### PR TITLE
Fix handling of >>

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -345,10 +345,13 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         }
 
         [TestCase, Order(9)]
-        public void WriteToHydratedFileAfterRemount()
+        public void AppendToHydratedFileAfterRemount()
         {
-            string virtualFilePath = this.Enlistment.GetVirtualPathTo("Test_EPF_WorkingDirectoryTests", "WriteToHydratedFileAfterRemount.cpp");
+            string fileToAppendEntry = "Test_EPF_WorkingDirectoryTests/WriteToHydratedFileAfterRemount.cpp";
+            string virtualFilePath = this.Enlistment.GetVirtualPathTo(fileToAppendEntry);
             string fileContents = virtualFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileToAppendEntry);
 
             // Remount
             this.Enlistment.UnmountGVFS();
@@ -356,6 +359,8 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
             string appendedText = "Text to append";
             this.fileSystem.AppendAllText(virtualFilePath, appendedText);
+            this.Enlistment.WaitForBackgroundOperations();
+            GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, fileToAppendEntry);
             virtualFilePath.ShouldBeAFile(this.fileSystem).WithContents(fileContents + appendedText);
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -133,6 +133,14 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("status");
         }
 
+        [TestCase]
+        public void AppendFile()
+        {
+            this.AppendAllText(@"Readme.md", "More Data");
+
+            this.ValidateGitCommand("status");
+        }
+
         private void RepositoryIgnoreTestSetup()
         {
             this.WaitForUpToDateStatusCache();

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -436,13 +436,20 @@ namespace GVFS.Platform.Mac
             this.Context.Tracer.RelatedError($"{nameof(MacFileSystemVirtualizer)}::{nameof(this.OnLogError)}: {errorMessage}");
         }
 
-        private void OnFileModified(string relativePath)
+        private void OnFileModified(string relativePath, bool isPlaceholderFile)
         {
             try
             {
                 if (Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath))
                 {
                     this.OnDotGitFileOrFolderChanged(relativePath);
+                }
+                else if (isPlaceholderFile == true)
+                {
+                    // The '>>' bash command does not send a KAUTH_VNODE_WRITE data event
+                    // To handle this, PrjFSLib checks if a file is a placeholder in the Modifed event and converts the file to
+                    // full after delivering this callback
+                    this.NotifyFilePreConvertToFull(relativePath);
                 }
             }
             catch (Exception e)

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -182,9 +182,9 @@ namespace MirrorProvider.Mac
             Console.WriteLine($"OnLogError: {errorMessage}");
         }
 
-        private void OnFileModified(string relativePath)
+        private void OnFileModified(string relativePath, bool isPlaceholderFile)
         {
-            Console.WriteLine($"OnFileModified: {relativePath}");
+            Console.WriteLine($"OnFileModified: {relativePath} isPlaceholderFile: {isPlaceholderFile}");
         }
 
         private Result OnPreDelete(string relativePath, bool isDirectory)

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/CallbackDelegates.cs
@@ -31,6 +31,7 @@ namespace PrjFSLib.Mac
         int triggeringProcessId,
         string triggeringProcessName,
         bool isDirectory,
+        bool isPlaceholderFile,
         NotificationType notificationType);
 
     public delegate void LogErrorCallback(
@@ -60,7 +61,8 @@ namespace PrjFSLib.Mac
         string relativeNewLinkPath);
 
     public delegate void NotifyFileModified(
-        string relativePath);
+        string relativePath,
+        bool isPlaceholderFile);
 
     public delegate void NotifyFileDeleted(
         string relativePath,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -185,6 +185,7 @@ namespace PrjFSLib.Mac
             int triggeringProcessId,
             string triggeringProcessName,
             bool isDirectory,
+            bool isPlaceholderFile,
             NotificationType notificationType)
         {
             switch (notificationType)
@@ -193,7 +194,7 @@ namespace PrjFSLib.Mac
                     return this.OnPreDelete(relativePath, isDirectory);
 
                 case NotificationType.FileModified:
-                    this.OnFileModified(relativePath);
+                    this.OnFileModified(relativePath, isPlaceholderFile);
                     return Result.Success;
 
                 case NotificationType.NewFileCreated:

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -1057,10 +1057,13 @@ static PrjFS_Result HandleFileNotification(
         request->pid,
         request->procname,
         isDirectory,
+        placeholderFile,
         notificationType,
         nullptr /* destinationRelativePath */);
     
-    if (result == 0 && placeholderFile && PrjFS_NotificationType_PreConvertToFull == notificationType)
+    if ((result == PrjFS_Result_Success) &&
+        placeholderFile &&
+        (PrjFS_NotificationType_PreConvertToFull == notificationType || PrjFS_NotificationType_FileModified == notificationType))
     {
         errno_t result = RemoveXAttrWithoutFollowingLinks(absolutePath, PrjFSFileXAttrName);
         if (0 != result)

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -172,6 +172,7 @@ typedef PrjFS_Result (PrjFS_NotifyOperationCallback)(
     _In_    const char*                             triggeringProcessName,
                                                      
     _In_    bool                                    isDirectory,
+    _In_    bool                                    isPlaceholderFile,
     _In_    PrjFS_NotificationType                  notificationType,
     _In_    const char*                             destinationRelativePath);
 


### PR DESCRIPTION
- This will not call PreConvertToFull
- If we get a modified event for a file that is a placeholder, call PreConvertToFull unders the covers
  This will add it to ModifedPaths.dat