### PR TITLE
Do not take GVFSLock for git submodule commands

### DIFF
--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -417,6 +417,18 @@ namespace GVFS.Hooks
                 case "version":
                 case "web--browse":
                     return false;
+
+                /*
+                 * There are several git commands that are "unsupoorted" in virtualized (VFS4G)
+                 * enlistments that are blocked by git. Usually, these are blocked before they acquire
+                 * a GVFSLock, but the submodule command is different, and is blocked after acquiring the
+                 * GVFS lock. This can cause issues if another action is attempting to create placeholders.
+                 * As we know the submodule command is a no-op, allow it to proceed without acquiring the
+                 * GVFSLock. I have filed issue #1164 to track having git block all unsupported commands
+                 * before calling the pre-command hook.
+                 */
+                case "submodule":
+                    return false;
             }
 
             if (gitCommand == "reset" && args.Contains("--soft"))


### PR DESCRIPTION
Some git commands are unsupported in virtualized (VFS4G) repositories,
and git will return an error when they are run inside of a virtualized
repository. Depending on the type of command, git might block execution
before or after calling the pre-command hook. If this command results in
the GVFSLock being acquired, this can affect other actions, such as
placeholder creation.

The git submodule command in particular is causing an issue in an
environment that we would like to unblock. Make the change in VFS4G
until we can investigate making a deeper fix in git (see issue #1164).

(cherry picked from commit 9fc41d7e342ef1fceb764d65ea46c68c5a019af0)