### PR TITLE
refactor ReadLink into MirrorProvider.POSIX

### DIFF
--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -228,10 +228,10 @@ namespace MirrorProvider.Linux
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
             string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-            symLinkTarget = POSIXNative.ReadLink(fullPathInMirror);
+            symLinkTarget = LinuxNative.ReadLink(fullPathInMirror, out int error);
             if (symLinkTarget == null)
             {
-                Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
+                Console.WriteLine($"GetSymLinkTarget failed: {error}");
                 return false;
             }
 

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -1,8 +1,8 @@
+using MirrorProvider.POSIX;
 using PrjFSLib.Linux;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace MirrorProvider.Linux
 {
@@ -227,20 +227,13 @@ namespace MirrorProvider.Linux
 
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
-            symLinkTarget = null;
             string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-
-            const ulong BufSize = 4096;
-            byte[] targetBuffer = new byte[BufSize];
-            long bytesRead = ReadLink(fullPathInMirror, targetBuffer, BufSize);
-            if (bytesRead < 0)
+            symLinkTarget = POSIXNative.ReadLink(fullPathInMirror);
+            if (symLinkTarget == null)
             {
                 Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
                 return false;
             }
-
-            targetBuffer[bytesRead] = 0;
-            symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
             if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
             {

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -299,11 +299,5 @@ namespace MirrorProvider.Linux
             [DllImport("libc", EntryPoint = "__lxstat64", SetLastError = true)]
             private static extern int __LXStat64(int vers, string pathname, [Out] out StatBuffer buf);
         }
-
-        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
-        private static extern long ReadLink(
-            string path,
-            byte[] buf,
-            ulong bufsize);
     }
 }

--- a/MirrorProvider/MirrorProvider.Linux/LinuxNative.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxNative.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using MirrorProvider.POSIX;
+
+namespace MirrorProvider.Linux
+{
+    public static class LinuxNative
+    {
+        public const int ENAMETOOLONG = 36;
+
+        public static string ReadLink(string path, out int error)
+        {
+            return POSIXNative.ReadLink(path, ENAMETOOLONG, out error);
+        }
+    }
+}

--- a/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
+++ b/MirrorProvider/MirrorProvider.Linux/MirrorProvider.Linux.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\ProjFS.Linux\PrjFSLib.Linux.Managed\PrjFSLib.Linux.Managed.csproj" />
+    <ProjectReference Include="..\MirrorProvider.POSIX\MirrorProvider.POSIX.csproj" />
     <ProjectReference Include="..\MirrorProvider\MirrorProvider.csproj" />
   </ItemGroup>
 

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -1,5 +1,4 @@
-﻿using MirrorProvider.POSIX;
-using PrjFSLib.Mac;
+﻿using PrjFSLib.Mac;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -217,10 +216,10 @@ namespace MirrorProvider.Mac
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
             string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-            symLinkTarget = POSIXNative.ReadLink(fullPathInMirror);
+            symLinkTarget = MacNative.ReadLink(fullPathInMirror, out int error);
             if (symLinkTarget == null)
             {
-                Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
+                Console.WriteLine($"GetSymLinkTarget failed: {error}");
                 return false;
             }
 

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -1,8 +1,8 @@
-﻿using PrjFSLib.Mac;
+﻿using MirrorProvider.POSIX;
+using PrjFSLib.Mac;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace MirrorProvider.Mac
 {
@@ -216,20 +216,13 @@ namespace MirrorProvider.Mac
 
         private bool TryGetSymLinkTarget(string relativePath, out string symLinkTarget)
         {
-            symLinkTarget = null;
             string fullPathInMirror = this.GetFullPathInMirror(relativePath);
-
-            const ulong BufSize = 4096;
-            byte[] targetBuffer = new byte[BufSize];
-            long bytesRead = ReadLink(fullPathInMirror, targetBuffer, BufSize);
-            if (bytesRead < 0)
+            symLinkTarget = POSIXNative.ReadLink(fullPathInMirror);
+            if (symLinkTarget == null)
             {
                 Console.WriteLine($"GetSymLinkTarget failed: {Marshal.GetLastWin32Error()}");
                 return false;
             }
-
-            targetBuffer[bytesRead] = 0;
-            symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
             if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
             {
@@ -250,11 +243,5 @@ namespace MirrorProvider.Mac
 
             return bytes;
         }
-
-        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
-        private static extern long ReadLink(
-            string path,
-            byte[] buf,
-            ulong bufsize);
     }
 }

--- a/MirrorProvider/MirrorProvider.Mac/MacNative.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacNative.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using MirrorProvider.POSIX;
+
+namespace MirrorProvider.Mac
+{
+    public static class MacNative
+    {
+        public const int ENAMETOOLONG = 63;
+
+        public static string ReadLink(string path, out int error)
+        {
+            return POSIXNative.ReadLink(path, ENAMETOOLONG, out error);
+        }
+    }
+}

--- a/MirrorProvider/MirrorProvider.Mac/MirrorProvider.Mac.csproj
+++ b/MirrorProvider/MirrorProvider.Mac/MirrorProvider.Mac.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\ProjFS.Mac\PrjFSLib.Mac.Managed\PrjFSLib.Mac.Managed.csproj" />
+    <ProjectReference Include="..\MirrorProvider.POSIX\MirrorProvider.POSIX.csproj" />
     <ProjectReference Include="..\MirrorProvider\MirrorProvider.csproj" />
   </ItemGroup>
 

--- a/MirrorProvider/MirrorProvider.POSIX/MirrorProvider.POSIX.csproj
+++ b/MirrorProvider/MirrorProvider.POSIX/MirrorProvider.POSIX.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <Platforms>x64</Platforms>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildOutputDir>..\..\..\BuildOutput</BuildOutputDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IntermediateOutputPath>$(BuildOutputDir)\MirrorProvider.POSIX\obj\$(Configuration)\$(Platform)</IntermediateOutputPath>
+    <OutputPath>$(BuildOutputDir)\MirrorProvider.POSIX\bin\$(Configuration)\$(Platform)</OutputPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType></DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
+++ b/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MirrorProvider.POSIX
+{
+    public static class POSIXNative
+    {
+        public static string ReadLink(string path)
+        {
+            const ulong BufSize = 4096;
+            byte[] targetBuffer = new byte[BufSize];
+            long bytesRead = __ReadLink(path, targetBuffer, BufSize);
+            if (bytesRead < 0)
+            {
+                return null;
+            }
+
+            targetBuffer[bytesRead] = 0;
+            return Encoding.UTF8.GetString(targetBuffer);
+        }
+
+        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+        public static extern long __ReadLink(
+            string path,
+            byte[] buf,
+            ulong bufsize);
+    }
+}

--- a/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
+++ b/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
@@ -10,7 +10,8 @@ namespace MirrorProvider.POSIX
             const long BufSize = 4096;
             byte[] targetBuffer = new byte[BufSize];
             long bytesRead = __ReadLink(path, targetBuffer, BufSize);
-            if (bytesRead < 0) {
+            if (bytesRead < 0)
+            {
                 error = Marshal.GetLastWin32Error();
                 return null;
             }

--- a/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
+++ b/MirrorProvider/MirrorProvider.POSIX/POSIXNative.cs
@@ -5,18 +5,23 @@ namespace MirrorProvider.POSIX
 {
     public static class POSIXNative
     {
-        public static string ReadLink(string path)
+        public static string ReadLink(string path, int enametoolong, out int error)
         {
-            const ulong BufSize = 4096;
+            const long BufSize = 4096;
             byte[] targetBuffer = new byte[BufSize];
             long bytesRead = __ReadLink(path, targetBuffer, BufSize);
-            if (bytesRead < 0)
+            if (bytesRead < 0) {
+                error = Marshal.GetLastWin32Error();
+                return null;
+            }
+            if (bytesRead == BufSize)
             {
+                error = enametoolong;
                 return null;
             }
 
-            targetBuffer[bytesRead] = 0;
-            return Encoding.UTF8.GetString(targetBuffer);
+            error = 0;
+            return Encoding.UTF8.GetString(targetBuffer, 0, (int)bytesRead);
         }
 
         [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]

--- a/MirrorProvider/MirrorProvider.sln
+++ b/MirrorProvider/MirrorProvider.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider.Mac", "Mirro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider", "MirrorProvider\MirrorProvider.csproj", "{128451A2-7598-4142-BA2A-9B963D91CCBC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MirrorProvider.POSIX", "MirrorProvider.POSIX\MirrorProvider.POSIX.csproj", "{17B5B14E-A785-41B9-9258-D37F4433C8F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug.Linux|x64 = Debug.Linux|x64
@@ -76,6 +78,16 @@ Global
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Mac|x64.Build.0 = Release|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Windows|x64.ActiveCfg = Release|x64
 		{128451A2-7598-4142-BA2A-9B963D91CCBC}.Release.Windows|x64.Build.0 = Release|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Debug.Linux|x64.ActiveCfg = Debug|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Debug.Linux|x64.Build.0 = Debug|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Debug.Mac|x64.ActiveCfg = Debug|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Debug.Mac|x64.Build.0 = Debug|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Debug.Windows|x64.ActiveCfg = Debug|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Release.Linux|x64.ActiveCfg = Release|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Release.Linux|x64.Build.0 = Release|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Release.Mac|x64.ActiveCfg = Release|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Release.Mac|x64.Build.0 = Release|x64
+		{17B5B14E-A785-41B9-9258-D37F4433C8F4}.Release.Windows|x64.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Refactor our uses of libc's `readlink` in the MirrorProvider for Mac and Linux.

From @chrisd8088's suggestion at https://github.com/github/VFSForGit/pull/21#discussion_r284493927.

/cc @derrickstolee @wilbaker 