### PR TITLE
Fixed typo in Windows install directions in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ You can also use Visual Studio 2019. There are a couple of options for getting a
 
 Visual Studio 2019 will [automatically prompt you to install these dependencies](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/) when you open the solution. The .vsconfig file that is present in the root of the repository specifies all required components _except_ the Windows 10 SDK (10.0.10240.0) as this component is no longer shipped with VS2019 - **you'll still need to install that separately**.
 
-The installer can now be found at `C:\Repos\VFSForGit\BuildOutput\GVFS.Installer\bin\x64\[Debug|Release]\SetupGVFS.<version>.exe`
+The installer can now be found at `C:\Repos\VFSForGit\BuildOutput\GVFS.Installer.Windows\bin\x64\[Debug|Release]\SetupGVFS.<version>.exe`
 
 ## Building VFS for Git on Mac
 


### PR DESCRIPTION
In the Readme document, there was an typo in the Windows installation
directions. The document had the path for the installer as
...\BuildOutput\GVFS.Installer\...
Where it should have been
...\BuildOutput\GVFS.Installer.Windows\...
For installation on a windows machine.