### PR TITLE
Improve Linux event-handling robustness and allow provider-generated events

### DIFF
--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -411,11 +411,7 @@ namespace PrjFSLib.Linux
                 if (nt == NotificationType.FileRenamed || nt == NotificationType.HardLinkCreated)
                 {
                     currentRelativePath = PtrToStringUTF8(ev.TargetPath);
-
-                    if (nt == NotificationType.HardLinkCreated)
-                    {
-                        relativePath = currentRelativePath;
-                    }
+                    relativePath = currentRelativePath;
                 }
 
                 result = this.projfs.GetProjAttrs(

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -397,41 +397,22 @@ namespace PrjFSLib.Linux
             }
 
             bool isDirectory = (ev.Mask & ProjFS.Constants.PROJFS_ONDIR) != 0;
-            string triggeringProcessName = GetProcCmdline(ev.Pid);
-            byte[] providerId = new byte[PlaceholderIdLength];
-            byte[] contentId = new byte[PlaceholderIdLength];
-            string relativePath = PtrToStringUTF8(ev.Path);
-            Result result = Result.Success;
+            string relativePath;
 
-            if (!isDirectory)
+            if (nt == NotificationType.FileRenamed ||
+                nt == NotificationType.HardLinkCreated)
             {
-                string currentRelativePath = relativePath;
-
-                // TODO(Linux): can other intermediate file ops race us here?
-                if (nt == NotificationType.FileRenamed || nt == NotificationType.HardLinkCreated)
-                {
-                    currentRelativePath = PtrToStringUTF8(ev.TargetPath);
-                    relativePath = currentRelativePath;
-                }
-
-                result = this.projfs.GetProjAttrs(
-                    currentRelativePath,
-                    providerId,
-                    contentId);
+                relativePath = PtrToStringUTF8(ev.TargetPath);
+            }
+            else
+            {
+                relativePath = PtrToStringUTF8(ev.Path);
             }
 
-            if (result == Result.Success)
-            {
-                result = this.OnNotifyOperation(
-                    commandId: 0,
-                    relativePath: relativePath,
-                    providerId: providerId,
-                    contentId: contentId,
-                    triggeringProcessId: ev.Pid,
-                    triggeringProcessName: triggeringProcessName,
-                    isDirectory: isDirectory,
-                    notificationType: nt);
-            }
+            Result result = this.OnNotifyOperation(
+                relativePath: relativePath,
+                isDirectory: isDirectory,
+                notificationType: nt);
 
             int ret = -result.ToErrno();
 
@@ -461,12 +442,7 @@ namespace PrjFSLib.Linux
         }
 
         private Result OnNotifyOperation(
-            ulong commandId,
             string relativePath,
-            byte[] providerId,
-            byte[] contentId,
-            int triggeringProcessId,
-            string triggeringProcessName,
             bool isDirectory,
             NotificationType notificationType)
         {

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -291,7 +291,7 @@ namespace PrjFSLib.Linux
                     return parts.Length > 0 ? parts[0] : string.Empty;
                 }
             }
-            catch (IOException ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+            catch
             {
                 // process with given pid may have exited; nothing to be done
                 return string.Empty;

--- a/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Linux/PrjFSLib.Linux.Managed/VirtualizationInstance.cs
@@ -361,7 +361,7 @@ namespace PrjFSLib.Linux
             // ignore events triggered by own process to prevent deadlocks
             if (this.IsProviderEvent(ev))
             {
-                return 0;
+                return perm ? (int)ProjFS.Constants.PROJFS_ALLOW : 0;
             }
 
             bool isLink = (ev.Mask & ProjFS.Constants.PROJFS_ONLINK) != 0;


### PR DESCRIPTION
When the provider process generates a permission request event (e.g., by deleting a file in order to conform the working directory during a `git checkout`), this event is then delivered back to the provider itself for validation.

We want to always allow those provider-generated permission-request events to succeed, so we return `PROJFS_ALLOW` for them, which we were previously failing to do.

Separately, we may fail to read the `/proc/{pid}/cmdline` file on Linux for a variety of reasons, not solely that it does not exist.

In all cases, we should catch the exception and simply return an empty string; otherwise, the unhandled exception will unexpectedly halt the provider process.

Thirdly, we've been sending the incorrect path on `OnFileRenamed` events; it is [expected](https://github.com/microsoft/VFSForGit/blob/ceaaa10d19aa587e5eb2cac63dfce74d70f43749/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs#L543) to be the destination (a.k.a. target) path.

And lastly, we can remove a chunk of unnecessary overhead and code when handling non-projection events, because our `OnNotifyOperation()` method (which was derived from the [Mac version](https://github.com/microsoft/VFSForGit/blob/ceaaa10d19aa587e5eb2cac63dfce74d70f43749/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs#L180)), doesn't need most of its arguments.  Neither does the Mac one, but its signature has to match [the one implemented](https://github.com/microsoft/VFSForGit/blob/ceaaa10d19aa587e5eb2cac63dfce74d70f43749/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp#L1091) in its corresponding C++ library.

/cc @kivikakk