### PR TITLE
build GVFS.Upgrader on Linux

### DIFF
--- a/GVFS.sln
+++ b/GVFS.sln
@@ -427,9 +427,13 @@ Global
 		{4CC2A90D-D240-4382-B4BF-5E175515E492}.Release.Mac|x64.Build.0 = Release|x64
 		{4CC2A90D-D240-4382-B4BF-5E175515E492}.Release.Windows|x64.ActiveCfg = Release|x64
 		{4CC2A90D-D240-4382-B4BF-5E175515E492}.Release.Windows|x64.Build.0 = Release|x64
+		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Debug.Linux|x64.ActiveCfg = Debug|x64
+		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Debug.Linux|x64.Build.0 = Debug|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Debug.Mac|x64.ActiveCfg = Debug|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Debug.Windows|x64.ActiveCfg = Debug|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Debug.Windows|x64.Build.0 = Debug|x64
+		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Release.Linux|x64.ActiveCfg = Release|x64
+		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Release.Linux|x64.Build.0 = Release|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Release.Mac|x64.ActiveCfg = Release|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Release.Windows|x64.ActiveCfg = Release|x64
 		{AECEC217-2499-403D-B0BB-2962B9BE5970}.Release.Windows|x64.Build.0 = Release|x64

--- a/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
+++ b/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
@@ -20,6 +20,11 @@
     <Version>$(GVFSVersion)</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+  </PropertyGroup>
+
   <!-- ItemGroup Conditions are not supported on VS for Mac and Choose/When must be
        Used instead, see https://github.com/mono/monodevelop/issues/7417 -->
   <Choose>
@@ -34,7 +39,19 @@
         </Compile>
       </ItemGroup>
     </When>
-    <Otherwise>
+    <When Condition="'$(IsLinux)' == 'true'">
+      <PropertyGroup>
+        <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+        <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+      </PropertyGroup>
+      <ItemGroup>
+        <ProjectReference Include="..\GVFS.Platform.Linux\GVFS.Platform.Linux.csproj" />
+        <Compile Include="..\GVFS.PlatformLoader\PlatformLoader.Linux.cs">
+          <Link>PlatformLoader.Linux.cs</Link>
+        </Compile>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(IsOSX)' == 'true'">
       <PropertyGroup>
         <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
         <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
@@ -45,7 +62,7 @@
           <Link>PlatformLoader.Mac.cs</Link>
         </Compile>
       </ItemGroup>
-    </Otherwise>
+    </When>
   </Choose>
 
   <ItemGroup>


### PR DESCRIPTION
Build GVFS.Upgrader on Linux. Fixes the following build errors:

```
Upgrader/UpgradeOrchestratorTests.cs(35,17): error CS0246: The type or namespace name 'UpgradeOrchestrator' could not be found (are you missing a using directive or an assembly reference?) [/home/kivikakk/microsoft/VFSForGit/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj]
Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs(13,17): error CS0246: The type or namespace name 'UpgradeOrchestrator' could not be found (are you missing a using directive or an assembly reference?) [/home/kivikakk/microsoft/VFSForGit/GVFS/GVFS.UnitTests/GVFS.UnitTests.csproj]
```

Also include the Linux platform loader in GVFS.Upgrader.

See https://github.com/microsoft/VFSForGit/pull/1059 for some vaguely related prior work.

/cc @chrisd8088 fyi
/cc @derrickstolee @wilbaker 