### PR TITLE
Mac ProjFS: Only hydrate/expand when deleting due to rename

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -376,19 +376,23 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(17)]
         public void FileMovedFromInsideRepoToOutside()
         {
-            string fileName = "InsideRepoToOutside.txt";
-            string fileInsideRepo = this.Enlistment.GetVirtualPathTo(fileName);
-            this.fileSystem.WriteAllText(fileInsideRepo, "Contents for the new file");
-            fileInsideRepo.ShouldBeAFile(this.fileSystem);
-            this.Enlistment.WaitForBackgroundOperations();
-            GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, fileName);
+            string fileInsideRepoEntry = "GitCommandsTests/RenameFileTests/1/#test";
+            string fileNameFullPath = Path.Combine("GitCommandsTests", "RenameFileTests", "1", "#test");
+            string fileInsideRepo = this.Enlistment.GetVirtualPathTo(fileNameFullPath);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileInsideRepoEntry);
 
-            string fileMovedOutsideRepo = Path.Combine(this.Enlistment.EnlistmentRoot, fileName);
+            string fileNameOutsideRepo = "FileNameOutSideRepo";
+            string fileMovedOutsideRepo = Path.Combine(this.Enlistment.EnlistmentRoot, fileNameOutsideRepo);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileNameOutsideRepo);
+
             this.fileSystem.MoveFile(fileInsideRepo, fileMovedOutsideRepo);
+
             fileInsideRepo.ShouldNotExistOnDisk(this.fileSystem);
             fileMovedOutsideRepo.ShouldBeAFile(this.fileSystem);
+            this.fileSystem.ReadAllText(fileMovedOutsideRepo).ShouldContain("test");
             this.Enlistment.WaitForBackgroundOperations();
-            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileName);
+            GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, fileInsideRepoEntry);
+            GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileNameOutsideRepo);
         }
 
         [TestCase, Order(18)]

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -283,6 +283,8 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A2A699B2295AA7800ACAAAF /* ArrayUtilities.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ArrayUtilities.hpp; sourceTree = "<group>"; };
+		4A2A699D2296BACE00ACAAAF /* KauthHandlerPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KauthHandlerPrivate.hpp; sourceTree = "<group>"; };
 		4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KextAssertIntegration.m; sourceTree = "<group>"; };
 		4A2A69A12297375A00ACAAAF /* KextAssertIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KextAssertIntegration.h; sourceTree = "<group>"; };
 		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
@@ -439,9 +441,11 @@
 		4391F88D21E42AA70008103C /* PrjFSKext */ = {
 			isa = PBXGroup;
 			children = (
+				4A2A699B2295AA7800ACAAAF /* ArrayUtilities.hpp */,
 				4391F88F21E42AC40008103C /* Info.plist */,
 				4391F89321E42AC40008103C /* KauthHandler.cpp */,
 				4391F8A421E42AC50008103C /* KauthHandler.hpp */,
+				4A2A699D2296BACE00ACAAAF /* KauthHandlerPrivate.hpp */,
 				F5E39C8121F11556006D65C2 /* KauthHandlerTestable.hpp */,
 				4391F89021E42AC40008103C /* kernel-header-wrappers */,
 				4391F89121E42AC40008103C /* KextLog.cpp */,

--- a/ProjFS.Mac/PrjFSKext/ArrayUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/ArrayUtilities.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+template<typename T, size_t size>
+    constexpr size_t Array_Size(T (&array)[size])
+{
+    return size;
+}
+
+template <typename T> void Array_CopyElements(T* destination, const T* source, size_t count)
+{
+    for (size_t i = 0; i < count; ++i)
+    {
+        destination[i] = source[i];
+    }
+}
+
+template <typename T> void Array_DefaultInit(T* array, size_t count)
+{
+    for (size_t i = 0; i < count; ++i)
+    {
+        array[i] = T();
+    }
+}
+

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -248,6 +248,14 @@ KEXT_STATIC int HandleVnodeOperation(
     bool isDeleteAction = false;
     bool isDirectory = false;
 
+    {
+        PerfSample considerVnodeSample(&perfTracer, PrjFSPerfCounter_VnodeOp_BasicVnodeChecks);
+        if (!VnodeIsEligibleForEventHandling(currentVnode))
+        {
+            goto CleanupAndReturn;
+        }
+    }
+
     if (!ShouldHandleVnodeOpEvent(
             &perfTracer,
             context,
@@ -818,15 +826,6 @@ KEXT_STATIC bool ShouldHandleVnodeOpEvent(
             //    request in progress is advisory, rather than authoritative.  Listeners
             //    performing consequential work (i.e. not strictly checking authorisation)
             //    may test this flag to avoid performing unnecessary work."
-            *kauthResult = KAUTH_RESULT_DEFER;
-            return false;
-        }
-    }
-    
-    {
-        PerfSample considerVnodeSample(perfTracer, PrjFSPerfCounter_VnodeOp_ShouldHandle_BasicVnodeChecks);
-        if (!VnodeIsEligibleForEventHandling(vnode))
-        {
             *kauthResult = KAUTH_RESULT_DEFER;
             return false;
         }

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -623,7 +623,7 @@ KEXT_STATIC int HandleVnodeOperation(
                 root,
                 isDirectory ?
                 MessageType_KtoU_NotifyDirectoryPreDelete :
-                MessageType_KtoU_NotifyFilePreDelete,
+                isRename ? MessageType_KtoU_NotifyFilePreDeleteFromRename : MessageType_KtoU_NotifyFilePreDelete,
                 currentVnode,
                 vnodeFsidInode,
                 nullptr, // path not needed, use fsid/inode

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerPrivate.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerPrivate.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "kernel-header-wrappers/kauth.h"
+
+// Define missing symbol when building with 10.13 SDK/Xcode 9
+#ifndef KAUTH_FILEOP_WILL_RENAME
+#define KAUTH_FILEOP_WILL_RENAME 8
+#endif

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
@@ -5,6 +5,7 @@
 #include "../PrjFSKext/PerformanceTracing.hpp"
 #include "../PrjFSKext/VirtualizationRoots.hpp"
 #include "KauthHandler.hpp"
+#include "KauthHandlerPrivate.hpp"
 
 #ifndef __cplusplus
 #error None of the kext code is set up for being called from C or Objective-C; change the including file to C++ or Objective-C++
@@ -15,6 +16,9 @@
 #endif
 
 struct FsidInode;
+
+extern uint32_t s_maxPendingRenames;
+extern uint32_t s_pendingRenameCount;
 
 KEXT_STATIC_INLINE bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
@@ -64,3 +68,9 @@ KEXT_STATIC bool ShouldHandleFileOpEvent(
     int* pid);
 KEXT_STATIC void UseMainForkIfNamedStream(vnode_t& vnode, bool& putVnodeWhenDone);
 KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser();
+KEXT_STATIC bool InitPendingRenames();
+KEXT_STATIC void CleanupPendingRenames();
+KEXT_STATIC void ResizePendingRenames(uint32_t newMaxPendingRenames);
+KEXT_STATIC void RecordPendingRenameOperation(vnode_t vnode);
+KEXT_STATIC bool DeleteOpIsForRename(vnode_t vnode);
+

--- a/ProjFS.Mac/PrjFSKext/Locks.cpp
+++ b/ProjFS.Mac/PrjFSKext/Locks.cpp
@@ -180,3 +180,30 @@ void RWLock_DropExclusiveToShared(RWLock& rwLock)
 #endif
 }
 
+
+SpinLock SpinLock_Alloc()
+{
+    return SpinLock { lck_spin_alloc_init(s_lockGroup, LCK_ATTR_NULL) };
+}
+
+void SpinLock_FreeMemory(SpinLock* lock)
+{
+    assert(lock->p != nullptr);
+    lck_spin_free(lock->p, s_lockGroup);
+    lock->p = nullptr;
+}
+
+bool SpinLock_IsValid(SpinLock lock)
+{
+    return lock.p != nullptr;
+}
+
+void SpinLock_Acquire(SpinLock lock)
+{
+    lck_spin_lock(lock.p);
+}
+
+void SpinLock_Release(SpinLock lock)
+{
+    lck_spin_unlock(lock.p);
+}

--- a/ProjFS.Mac/PrjFSKext/Locks.hpp
+++ b/ProjFS.Mac/PrjFSKext/Locks.hpp
@@ -49,6 +49,17 @@ void RWLock_ReleaseExclusive(RWLock& rwLock);
 void RWLock_DropExclusiveToShared(RWLock& rwLock);
 bool RWLock_AcquireSharedToExclusive(RWLock& rwLock);
 
+typedef struct __lck_spin_t__ lck_spin_t;
 
+struct SpinLock
+{
+    lck_spin_t* p;
+};
+
+SpinLock SpinLock_Alloc();
+void SpinLock_FreeMemory(SpinLock* lock);
+bool SpinLock_IsValid(SpinLock lock);
+void SpinLock_Acquire(SpinLock lock);
+void SpinLock_Release(SpinLock lock);
 
 #endif /* Locks_h */

--- a/ProjFS.Mac/PrjFSKext/Message_Kernel.cpp
+++ b/ProjFS.Mac/PrjFSKext/Message_Kernel.cpp
@@ -1,12 +1,7 @@
 #include "Message_Kernel.hpp"
+#include "ArrayUtilities.hpp"
 #include <kern/debug.h>
 #include <kern/assert.h>
-
-template<typename T, size_t size>
-    constexpr size_t Array_Size(T (&array)[size])
-{
-    return size;
-}
 
 void Message_Init(
     Message* spec,

--- a/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
+++ b/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
@@ -92,6 +92,7 @@ void ProviderMessaging_HandleKernelMessageResponse(VirtualizationRootHandle prov
         case MessageType_KtoU_HydrateFile:
         case MessageType_KtoU_NotifyFileModified:
         case MessageType_KtoU_NotifyFilePreDelete:
+        case MessageType_KtoU_NotifyFilePreDeleteFromRename:
         case MessageType_KtoU_NotifyDirectoryPreDelete:
         case MessageType_KtoU_NotifyFileCreated:
         case MessageType_KtoU_NotifyFileRenamed:

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -16,6 +16,7 @@ typedef enum
     
     MessageType_KtoU_NotifyFileModified,
     MessageType_KtoU_NotifyFilePreDelete,
+    MessageType_KtoU_NotifyFilePreDeleteFromRename,
     MessageType_KtoU_NotifyDirectoryPreDelete,
     MessageType_KtoU_NotifyFileCreated,
     MessageType_KtoU_NotifyFileRenamed,

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -44,4 +44,14 @@ enum PrjFSServiceUserClientType
 #define KEXT_STATIC_INLINE static inline
 #endif
 
+namespace PrjFSDarwinMajorVersion
+{
+    enum
+    {
+        MacOS10_13_HighSierra = 17,
+        MacOS10_14_Mojave = 18,
+        MacOS10_15_Catalina = 19,
+    };
+}
+
 #endif /* PrjFSCommon_h */

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSPerfCounter.h
@@ -7,10 +7,10 @@ enum PrjFSPerfCounter : int32_t
     
     PrjFSPerfCounter_VnodeOp,
         PrjFSPerfCounter_VnodeOp_GetPath,
+        PrjFSPerfCounter_VnodeOp_BasicVnodeChecks,
         PrjFSPerfCounter_VnodeOp_ShouldHandle,
             PrjFSPerfCounter_VnodeOp_ShouldHandle_IsVnodeAccessCheck,
                 PrjFSPerfCounter_VnodeOp_ShouldHandle_IgnoredVnodeAccessCheck,
-            PrjFSPerfCounter_VnodeOp_ShouldHandle_BasicVnodeChecks,
             PrjFSPerfCounter_VnodeOp_ShouldHandle_ReadFileFlags,
                 PrjFSPerfCounter_VnodeOp_ShouldHandle_NotInAnyRoot,
             PrjFSPerfCounter_VnodeOp_ShouldHandle_CheckFileSystemCrawler,

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -853,5 +853,21 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
     XCTAssertTrue(MockCalls::CallCount(ProviderMessaging_TrySendRequestAndWaitForResponse) == 0);
 }
 
+- (void) testIneligibleFilesystemType
+{
+    shared_ptr<mount> testMountNone = mount::Create("msdos", fsid_t{}, 0);
+    shared_ptr<vnode> testVnodeNone = vnode::Create(testMountNone, "/Volumes/USBSTICK");
+    XCTAssertEqual(
+        KAUTH_RESULT_DEFER,
+        HandleVnodeOperation(
+            nullptr,
+            nullptr,
+            KAUTH_VNODE_ADD_FILE,
+            reinterpret_cast<uintptr_t>(context),
+            reinterpret_cast<uintptr_t>(testVnodeNone.get()),
+            0,
+            0));
+    XCTAssertFalse(MockCalls::DidCallFunction(ProviderMessaging_TrySendRequestAndWaitForResponse));
+}
 
 @end

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -430,7 +430,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
         ProviderMessaging_TrySendRequestAndWaitForResponse,
         make_tuple(
             _,
-            MessageType_KtoU_NotifyFilePreDelete,
+            MessageType_KtoU_NotifyFilePreDeleteFromRename,
             testFileVnode.get(),
             _,
             _,
@@ -550,7 +550,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
         ProviderMessaging_TrySendRequestAndWaitForResponse,
         make_tuple(
            _,
-            MessageType_KtoU_NotifyFilePreDelete,
+            MessageType_KtoU_NotifyFilePreDeleteFromRename,
             testFileVnode.get(),
             _,
             _,
@@ -574,7 +574,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
         ProviderMessaging_TrySendRequestAndWaitForResponse,
         make_tuple(
            _,
-            MessageType_KtoU_NotifyFilePreDelete,
+            MessageType_KtoU_NotifyFilePreDeleteFromRename,
             otherTestFileVnode.get(),
             _,
             _,

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -856,7 +856,8 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
 - (void) testIneligibleFilesystemType
 {
     shared_ptr<mount> testMountNone = mount::Create("msdos", fsid_t{}, 0);
-    shared_ptr<vnode> testVnodeNone = vnode::Create(testMountNone, "/Volumes/USBSTICK");
+    shared_ptr<vnode> testVnodeNone = testMountNone->CreateVnodeTree("/Volumes/USBSTICK", VDIR);
+    
     XCTAssertEqual(
         KAUTH_RESULT_DEFER,
         HandleVnodeOperation(

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
@@ -2,6 +2,10 @@
 #include <map>
 #include <string>
 
+struct thread
+{
+};
+
 using std::make_pair;
 using std::map;
 using std::string;
@@ -10,12 +14,15 @@ static map<uintptr_t /*credential ID*/, int /*UID*/> s_credentialMap;
 static map<vfs_context_t /*context*/, int /*pid*/> s_contextMap;
 static map<int /*process Id*/, proc> s_processMap;
 static int s_selfPid;
+static uint16_t s_currentThreadIndex = 0;
+static thread s_threadPool[MockProcess_ThreadPoolSize] = {};
 
 void MockProcess_Reset()
 {
     s_processMap.clear();
     s_credentialMap.clear();
     s_contextMap.clear();
+    MockProcess_SetCurrentThreadIndex(0);
 }
 
 void MockProcess_SetSelfPid(int selfPid)
@@ -156,4 +163,15 @@ void MockProcess_AddProcess(int pid, uintptr_t credentialId, int ppid, string na
 {
     proc process = proc {pid, credentialId, ppid, name};
     s_processMap.insert(make_pair(pid, process));
+}
+
+kernel_thread_t current_thread()
+{
+    return &s_threadPool[s_currentThreadIndex];
+}
+
+void MockProcess_SetCurrentThreadIndex(uint16_t threadIndex)
+{
+    assert(threadIndex < MockProcess_ThreadPoolSize);
+    s_currentThreadIndex = threadIndex;
 }

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
@@ -1,6 +1,10 @@
 #include "../PrjFSKext/kernel-header-wrappers/vnode.h"
 #include <string>
 
+// In the kernel/kext this type is "thread_t" but there already exists a
+// conflicting Mach type in user space hence the name change.
+typedef struct thread* kernel_thread_t;
+
 // Kernel functions that are being mocked
 extern "C"
 {
@@ -16,6 +20,7 @@ extern "C"
     proc_t proc_find(int pid);
     int proc_rele(proc_t p);
     int proc_selfpid(void);
+    kernel_thread_t current_thread(void);
 }
 
 struct proc {
@@ -30,3 +35,7 @@ void MockProcess_AddCredential(uintptr_t credentialId, uid_t UID);
 void MockProcess_AddContext(vfs_context_t context, int pid);
 void MockProcess_AddProcess(int pid, uintptr_t credentialId, int ppid, std::string procName);
 void MockProcess_Reset();
+
+// Tests will only need to simulate a small number of threads, so we provide an existing, indexed pool.
+constexpr uint16_t MockProcess_ThreadPoolSize = 2;
+void MockProcess_SetCurrentThreadIndex(uint16_t threadIndex);

--- a/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/TestLocks.cpp
@@ -39,3 +39,25 @@ void RWLock_FreeMemory(RWLock* rwLock)
     delete rwLock->p;
     rwLock->p = nullptr;
 }
+
+void SpinLock_Acquire(SpinLock lock)
+{
+}
+
+void SpinLock_Release(SpinLock lock)
+{
+}
+
+SpinLock SpinLock_Alloc()
+{
+    return SpinLock{};
+}
+
+void SpinLock_FreeMemory(SpinLock* lock)
+{
+}
+
+bool SpinLock_IsValid(SpinLock lock)
+{
+    return true;
+}

--- a/ProjFS.Mac/PrjFSKextTests/TestMemory.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/TestMemory.cpp
@@ -1,11 +1,22 @@
 #include "../PrjFSKext/Memory.hpp"
+#include <cstddef>
+
+struct TrackedKextMemoryAllocation
+{
+    uint32_t size;
+    uint8_t data[];
+};
 
 void Memory_Free(void* memory, uint32_t sizeBytes)
 {
-    free(memory);
+    TrackedKextMemoryAllocation* memoryObject = reinterpret_cast<TrackedKextMemoryAllocation*>(static_cast<uint8_t*>(memory) - offsetof(TrackedKextMemoryAllocation, data));
+    assert(memoryObject->size == sizeBytes);
+    free(memoryObject);
 }
 
 void* Memory_Alloc(uint32_t sizeBytes)
 {
-    return malloc(sizeBytes);
+    TrackedKextMemoryAllocation* memoryObject = static_cast<TrackedKextMemoryAllocation*>(malloc(sizeBytes + sizeof(TrackedKextMemoryAllocation)));
+    memoryObject->size = sizeBytes;
+    return memoryObject->data;
 }

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationType.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/NotificationType.cs
@@ -10,6 +10,7 @@ namespace PrjFSLib.Mac
         None                = 0x00000001,
         NewFileCreated      = 0x00000004,
         PreDelete           = 0x00000010,
+        PreDeleteFromRename = 0x00000011,
         FileRenamed         = 0x00000080,
         HardLinkCreated     = 0x00000100,
         PreConvertToFull    = 0x00001000,

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -191,6 +191,7 @@ namespace PrjFSLib.Mac
             switch (notificationType)
             {
                 case NotificationType.PreDelete:
+                case NotificationType.PreDeleteFromRename:
                     return this.OnPreDelete(relativePath, isDirectory);
 
                 case NotificationType.FileModified:

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -47,6 +47,7 @@ typedef enum
     PrjFS_NotificationType_None                     = 0x00000001,
     PrjFS_NotificationType_NewFileCreated           = 0x00000004,
     PrjFS_NotificationType_PreDelete                = 0x00000010,
+    PrjFS_NotificationType_PreDeleteFromRename      = 0x00000011,
     PrjFS_NotificationType_FileRenamed              = 0x00000080,
     PrjFS_NotificationType_HardLinkCreated          = 0x00000100,
     PrjFS_NotificationType_PreConvertToFull         = 0x00001000,

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
@@ -335,8 +335,8 @@ static void InitDataQueueFunctions()
         return;
     }
     
-    if ((osVersion.major == 17 && osVersion.minor >= 7) // macOS 10.13.6+
-        || (osVersion.major == 18 && osVersion.minor == 0)) // macOS 10.14(.0) exactly
+    if ((osVersion.major == PrjFSDarwinMajorVersion::MacOS10_13_HighSierra && osVersion.minor >= 7) // macOS 10.13.6+
+        || (osVersion.major == PrjFSDarwinMajorVersion::MacOS10_14_Mojave && osVersion.minor == 0)) // macOS 10.14(.0) exactly
     {
         void* dataQueueLibrary = dlopen("libSharedDataQueue.dylib", RTLD_LAZY);
         if (nullptr == dataQueueLibrary)

--- a/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
+++ b/ProjFS.Mac/PrjFSLib/prjfs-log/kext-perf-tracing.cpp
@@ -31,10 +31,10 @@ static constexpr const char* const PerfCounterNames[PrjFSPerfCounter_Count] =
 {
     [PrjFSPerfCounter_VnodeOp]                                              = "HandleVnodeOperation",
     [PrjFSPerfCounter_VnodeOp_GetPath]                                      = " |--GetPath",
+    [PrjFSPerfCounter_VnodeOp_BasicVnodeChecks]                             = " |--BasicVnodeChecks",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle]                                 = " |--ShouldHandleVnodeOpEvent",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle_IsVnodeAccessCheck]              = " |  |--IsVnodeAccessCheck",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle_IgnoredVnodeAccessCheck]         = " |  |  |--IgnoredVnodeAccessCheck",
-    [PrjFSPerfCounter_VnodeOp_ShouldHandle_BasicVnodeChecks]                = " |  |--BasicVnodeChecks",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle_ReadFileFlags]                   = " |  |--TryReadVNodeFileFlags",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle_NotInAnyRoot]                    = " |  |  |--NotInAnyRoot",
     [PrjFSPerfCounter_VnodeOp_ShouldHandle_CheckFileSystemCrawler]          = " |  |--IsFileSystemCrawler",

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -59,7 +59,8 @@ while read line; do
 	 # PrjFSKext exclusions
 	 [[ $line != *"AllArrayElementsInitialized"* ]] &&              #Function is used for compile time checks only
 	 [[ $line != *"KauthHandler_Init"* ]] && 
-	 [[ $line != *"KauthHandler_Cleanup"* ]] && 
+	 [[ $line != *"KauthHandler_Cleanup"* ]] &&
+	 [[ $line != *"InitPendingRenames"* ]] &&
 	 [[ $line != *"HandleFileOpOperation"* ]] &&                     #SHOULD ADD COVERAGE
 	 [[ $line != *"TryGetVirtualizationRoot"* ]] &&                  #SHOULD ADD COVERAGE
 	 [[ $line != *"WaitForListenerCompletion"* ]] && 


### PR DESCRIPTION
This change utilises the KAUTH_FILEOP_WILL_RENAME event which was introduced with Mojave/10.14 to determine if a KAUTH_VNODE_DELETE authorisation check is due to a rename() operation. In this case, the file or directory genuinely needs hydrating, otherwise hydration can be skipped.

This change also adds unit tests for the new rename operation tracking code, and adapts existing unit tests so hydration is not expected when a KAUTH_VNODE_DELETE check occurs outside of a rename() operation.

This implements #526.