### PR TITLE
Remove all reference to looseObjectCount in LooseObjectStepTests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -53,8 +53,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             // Expand one pack, and verify we have loose objects
             this.ExpandOneTempPack(copyPackBackToPackDirectory: false);
-            int looseObjectCount = this.GetLooseObjectFiles().Count();
-            looseObjectCount.ShouldBeAtLeast(1);
+            this.GetLooseObjectFiles()
+                .Count()
+                .ShouldBeAtLeast(1);
 
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
@@ -89,8 +90,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             // Expand one pack, and verify we have loose objects
             this.ExpandOneTempPack(copyPackBackToPackDirectory: false);
-            int looseObjectCount = this.GetLooseObjectFiles().Count();
-            looseObjectCount.ShouldBeAtLeast(1, "Too few loose objects");
+            this.GetLooseObjectFiles()
+                .Count()
+                .ShouldBeAtLeast(1, "Too few loose objects");
 
             // Create an invalid loose object
             string fakeBlobFolder = Path.Combine(this.GitObjectRoot, "00");
@@ -108,7 +110,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
                    "Step failed to delete corrupt blob");
             this.CountPackFiles().ShouldEqual(0, "Incorrect number of packs after first loose object step");
             this.GetLooseObjectFiles().Count.ShouldBeAtLeast(
-                looseObjectCount,
+                1,
                 "unexpected number of loose objects after step");
 
             // This step should create a pack.


### PR DESCRIPTION
When making the tests more flexible in #1162, I missed one instance. To
be sure I didn't miss any more, I removed all use of the
exact loose object count.