### PR TITLE
Mac kext testing: assert() integration

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
 		4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */; };
+		4A2A69A02297339A00ACAAAF /* KextAssertIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */; };
 		4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
 		4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
 		4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
@@ -280,6 +281,8 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KextAssertIntegration.m; sourceTree = "<group>"; };
+		4A2A69A12297375A00ACAAAF /* KextAssertIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KextAssertIntegration.h; sourceTree = "<group>"; };
 		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
 		4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessaging.hpp; sourceTree = "<group>"; };
 		4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualizationRootsTests.mm; sourceTree = "<group>"; };
@@ -516,6 +519,8 @@
 				F5E39C7B21F1118D006D65C2 /* Info.plist */,
 				F5E39C7921F1118D006D65C2 /* KauthHandlerTests.mm */,
 				4A781DAF2223391A00DB7733 /* KextLogMock.cpp */,
+				4A2A69A12297375A00ACAAAF /* KextAssertIntegration.h */,
+				4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */,
 				F557623E22009F0E005DE35E /* KextLogMock.h */,
 				4A781DAA222330F700DB7733 /* KextMockUtilities.cpp */,
 				4A781DA92223305C00DB7733 /* KextMockUtilities.hpp */,
@@ -913,6 +918,7 @@
 				4A82C45C228086F800276002 /* MessageTests.mm in Sources */,
 				265504D0224ADE11005FAD74 /* MockPerfTracing.cpp in Sources */,
 				4A781DA52220946000DB7733 /* VirtualizationRootsTests.mm in Sources */,
+				4A2A69A02297339A00ACAAAF /* KextAssertIntegration.m in Sources */,
 				4A781DAE2223374200DB7733 /* MockVnodeAndMount.cpp in Sources */,
 				4AAE3FCA22832340002673FA /* HandleFileOpOperationTests.mm in Sources */,
 				F5554F422239883B00B31D19 /* MockProc.cpp in Sources */,
@@ -1493,6 +1499,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					TESTABLE_KEXT_TARGET,
 					KEXT_UNIT_TESTING,
+					"MACH_ASSERT=1",
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = NO;
@@ -1515,6 +1522,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					TESTABLE_KEXT_TARGET,
 					KEXT_UNIT_TESTING,
+					"MACH_ASSERT=1",
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = NO;
@@ -1537,6 +1545,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					TESTABLE_KEXT_TARGET,
 					KEXT_UNIT_TESTING,
+					"MACH_ASSERT=1",
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = NO;

--- a/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
@@ -9,7 +9,7 @@
 #include "../PrjFSKext/ProviderMessaging.hpp"
 #include "../PrjFSKext/public/PrjFSXattrs.h"
 #include "../PrjFSKext/kernel-header-wrappers/kauth.h"
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #import <sys/stat.h>
 #include "KextMockUtilities.hpp"
 #include "MockVnodeAndMount.hpp"
@@ -27,7 +27,7 @@ class PrjFSProviderUserClient
 {
 };
 
-@interface HandleFileOpOperationTests : XCTestCase
+@interface HandleFileOpOperationTests : PFSKextTestCase
 @end
 
 @implementation HandleFileOpOperationTests
@@ -58,6 +58,8 @@ class PrjFSProviderUserClient
 
 - (void) setUp
 {
+    [super setUp];
+
     kern_return_t initResult = VirtualizationRoots_Init();
     XCTAssertEqual(initResult, KERN_SUCCESS);
     context = vfs_context_create(NULL);
@@ -133,6 +135,8 @@ class PrjFSProviderUserClient
     MockVnodes_CheckAndClear();
     MockCalls::Clear();
     MockProcess_Reset();
+
+    [super tearDown];
 }
 
 - (void) testOpen {

--- a/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
@@ -100,7 +100,6 @@ class PrjFSProviderUserClient
     ProvidermessageMock_ResetResultCount();
     ProviderMessageMock_SetDefaultRequestResult(true);
     ProviderMessageMock_SetSecondRequestResult(true);
-    ProviderMessageMock_SetCleanupRootsAfterRequest(false);
 }
 
 - (void) tearDownProviders

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -85,7 +85,6 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
     ProvidermessageMock_ResetResultCount();
     ProviderMessageMock_SetDefaultRequestResult(true);
     ProviderMessageMock_SetSecondRequestResult(true);
-    ProviderMessageMock_SetCleanupRootsAfterRequest(false);
 }
 
 - (void) tearDown
@@ -659,7 +658,11 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
 }
 
 - (void) testDeleteDirectoryWithDisappearingVirtualizationRoot {
-    ProviderMessageMock_SetCleanupRootsAfterRequest(true);
+    ProviderMessageMock_SetRequestSideEffect(
+        [&]()
+        {
+            ActiveProvider_Disconnect(self->dummyRepoHandle, &self->dummyClient);
+        });
     testDirVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
     XCTAssertTrue(HandleVnodeOperation(
         nullptr,
@@ -750,7 +753,11 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
 }
 
 - (void) testWriteWithDisappearingVirtualizationRoot {
-    ProviderMessageMock_SetCleanupRootsAfterRequest(true);
+    ProviderMessageMock_SetRequestSideEffect(
+        [&]()
+        {
+            ActiveProvider_Disconnect(self->dummyRepoHandle, &self->dummyClient);
+        });
     testFileVnode->attrValues.va_flags = FileFlags_IsEmpty | FileFlags_IsInVirtualizationRoot;
     XCTAssertTrue(HandleVnodeOperation(
         nullptr,

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -9,7 +9,7 @@
 #include "../PrjFSKext/ProviderMessaging.hpp"
 #include "../PrjFSKext/public/PrjFSXattrs.h"
 #include "../PrjFSKext/kernel-header-wrappers/kauth.h"
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #import <sys/stat.h>
 #include "KextMockUtilities.hpp"
 #include "MockVnodeAndMount.hpp"
@@ -35,7 +35,7 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
     vnode->xattrs.insert(make_pair(PrjFSFileXAttrName, rootXattrData));
 }
 
-@interface HandleVnodeOperationTests : XCTestCase
+@interface HandleVnodeOperationTests : PFSKextTestCase
 @end
 
 @implementation HandleVnodeOperationTests
@@ -55,6 +55,8 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
 
 - (void) setUp
 {
+    [super setUp];
+    
     kern_return_t initResult = VirtualizationRoots_Init();
     XCTAssertEqual(initResult, KERN_SUCCESS);
     context = vfs_context_create(NULL);
@@ -99,6 +101,8 @@ static void SetPrjFSFileXattrData(const shared_ptr<vnode>& vnode)
     MockVnodes_CheckAndClear();
     MockCalls::Clear();
     MockProcess_Reset();
+
+    [super tearDown];
 }
 
 - (void) testEmptyFileHydrates {

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -391,6 +391,12 @@ class org_vfsforgit_PrjFSProviderUserClient
             true, // isDirectory,
             &testRootHandle,
             &pid));
+
+    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    {
+        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
+        ActiveProvider_Disconnect(testRootHandle, &userClient);
+    }
 }
 
 - (void)testShouldHandleFileOpEvent_UnsupportedFileSystem {
@@ -421,15 +427,16 @@ class org_vfsforgit_PrjFSProviderUserClient
     shared_ptr<vnode> testVnodeUnsupportedType = vnode::Create(testMount, "/foo", VNON);
 
     org_vfsforgit_PrjFSProviderUserClient userClient;
-    VirtualizationRootHandle testRootHandle = InsertVirtualizationRoot_Locked(
+    VirtualizationRootHandle testRepoHandle = InsertVirtualizationRoot_Locked(
         &userClient,
         0,
         repoRootVnode.get(),
         repoRootVnode->GetVid(),
         FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() },
         repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootHandle));
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRepoHandle));
 
+    VirtualizationRootHandle testRootHandle;
     int pid;
     // Invalid Vnode Type should fail
     XCTAssertFalse(
@@ -442,6 +449,12 @@ class org_vfsforgit_PrjFSProviderUserClient
             true, // isDirectory,
             &testRootHandle,
             &pid));
+
+    if (VirtualizationRoot_IsValidRootHandle(testRepoHandle))
+    {
+        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
+        ActiveProvider_Disconnect(testRepoHandle, &userClient);
+    }
 }
 
 - (void)testShouldHandleFileOpEvent_ProviderOffline {
@@ -509,6 +522,12 @@ class org_vfsforgit_PrjFSProviderUserClient
             true, // isDirectory,
             &testRootHandle,
             &pid));
+    
+    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    {
+        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
+        ActiveProvider_Disconnect(testRootHandle, &userClient);
+    }
 }
 
 - (void)testShouldHandleFileOpEvent_VnodeCacheUpdated {
@@ -614,6 +633,12 @@ class org_vfsforgit_PrjFSProviderUserClient
             XCTAssertTrue(0 == self->cacheWrapper[index].vid);
             XCTAssertTrue(0 == self->cacheWrapper[index].virtualizationRoot);
         }
+    }
+
+    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    {
+        vnode_get(repoRootVnode.get());
+        ActiveProvider_Disconnect(testRootHandle, &userClient);
     }
 }
 

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -2,7 +2,7 @@
 #include "../PrjFSKext/KauthHandlerTestable.hpp"
 #include "../PrjFSKext/PerformanceTracing.hpp"
 #include "../PrjFSKext/VirtualizationRootsTestable.hpp"
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #import <sys/stat.h>
 #include "KextLogMock.h"
 #include "KextMockUtilities.hpp"
@@ -17,7 +17,7 @@ class org_vfsforgit_PrjFSProviderUserClient
 {
 };
 
-@interface KauthHandlerTests : XCTestCase
+@interface KauthHandlerTests : PFSKextTestCase
 @end
 
 @implementation KauthHandlerTests
@@ -27,6 +27,7 @@ class org_vfsforgit_PrjFSProviderUserClient
 }
 
 - (void) setUp {
+    [super setUp];
     kern_return_t initResult = VirtualizationRoots_Init();
     XCTAssertEqual(initResult, KERN_SUCCESS);
     self->cacheWrapper.AllocateCache();
@@ -41,6 +42,7 @@ class org_vfsforgit_PrjFSProviderUserClient
     self->cacheWrapper.FreeCache();
     MockVnodes_CheckAndClear();
     VirtualizationRoots_Cleanup();
+    [super tearDown];
 }
 
 - (void)testActionBitIsSet {

--- a/ProjFS.Mac/PrjFSKextTests/KextAssertIntegration.h
+++ b/ProjFS.Mac/PrjFSKextTests/KextAssertIntegration.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#import <XCTest/XCTest.h>
+
+// XCTestCase subclass that registers itself with the kext assert integration system
+@interface PFSKextTestCase : XCTestCase
+
+- (void) setUp;
+- (void) tearDown;
+
+- (void) setExpectedFailedKextAssertionCount:(uint32_t)failedAssertionCount;
+
+@end

--- a/ProjFS.Mac/PrjFSKextTests/KextAssertIntegration.m
+++ b/ProjFS.Mac/PrjFSKextTests/KextAssertIntegration.m
@@ -1,0 +1,90 @@
+#import "KextAssertIntegration.h"
+#include <pthread.h>
+
+extern void Assert(const char* file, unsigned line, const char* expression);
+
+static pthread_key_t s_currentTestCaseKey;
+
+static PFSKextTestCase* CurrentTestCase()
+{
+    return (__bridge PFSKextTestCase*)pthread_getspecific(s_currentTestCaseKey);
+}
+
+@implementation PFSKextTestCase
+{
+    uint32_t expectedKextAssertionFailures;
+}
+
++ (void) initialize
+{
+    pthread_key_create(&s_currentTestCaseKey, NULL);
+}
+
+- (void) setUp
+{
+    pthread_setspecific(s_currentTestCaseKey, (__bridge void*)self);
+}
+
+- (void) tearDown
+{
+    XCTAssertEqual(self->expectedKextAssertionFailures, 0, "Expected assertions apparently did not occur");
+    self->expectedKextAssertionFailures = 0;
+    pthread_setspecific(s_currentTestCaseKey, NULL);
+}
+
+- (void) setExpectedFailedKextAssertionCount:(uint32_t)failedAssertionCount
+{
+    self->expectedKextAssertionFailures = failedAssertionCount;
+}
+
+- (bool) isKextAssertionFailureExpected
+{
+    if (self->expectedKextAssertionFailures > 0)
+    {
+        --self->expectedKextAssertionFailures;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+@end
+
+// catches kext assert()
+void Assert(const char* file, unsigned line, const char* expression)
+{
+    PFSKextTestCase* test = CurrentTestCase();
+    bool expected = [test isKextAssertionFailureExpected];
+    if (expected)
+    {
+        return;
+    }
+
+    NSString* expressionString = [NSString stringWithCString:expression encoding:NSUTF8StringEncoding];
+    _XCTFailureHandler(test, YES, file, line, expressionString, @"");
+}
+
+// catches kext assertf() - currently no source file & line number support
+void panic(const char* format, ...)
+{
+    PFSKextTestCase* test = CurrentTestCase();
+    bool expected = [test isKextAssertionFailureExpected];
+    if (expected)
+    {
+        return;
+    }
+    
+    va_list arguments;
+    char* panicString = NULL;
+
+    va_start(arguments, format);
+    vasprintf(&panicString, format, arguments);
+    va_end(arguments);
+    
+    NSString* panicStringObj = [NSString stringWithUTF8String:panicString];
+    free(panicString);
+
+    _XCTFailureHandler(test, YES, "unknown file", 0, panicStringObj, @"");
+}

--- a/ProjFS.Mac/PrjFSKextTests/MemoryTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/MemoryTests.mm
@@ -1,7 +1,7 @@
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #include "../PrjFSKext/Memory.hpp"
 
-@interface MemoryTests : XCTestCase
+@interface MemoryTests : PFSKextTestCase
 
 @end
 

--- a/ProjFS.Mac/PrjFSKextTests/MessageTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/MessageTests.mm
@@ -1,8 +1,8 @@
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 
 #include "../PrjFSKext/Message_Kernel.hpp"
 
-@interface MessageTests : XCTestCase
+@interface MessageTests : PFSKextTestCase
 
 @end
 
@@ -10,10 +10,12 @@
 
 - (void)setUp
 {
+    [super setUp];
 }
 
 - (void)tearDown
 {
+    [super tearDown];
 }
 
 - (void)testMessageEncodedSize

--- a/ProjFS.Mac/PrjFSKextTests/ProviderMessagingMock.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/ProviderMessagingMock.hpp
@@ -1,4 +1,7 @@
+#include <functional>
+
 void ProvidermessageMock_ResetResultCount();
 void ProviderMessageMock_SetDefaultRequestResult(bool success);
-void ProviderMessageMock_SetCleanupRootsAfterRequest(bool cleanupRoots);
+
+void ProviderMessageMock_SetRequestSideEffect(std::function<void()> sideEffectFunction);
 void ProviderMessageMock_SetSecondRequestResult(bool secondRequestResult);

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -10,7 +10,7 @@
 #include "KextMockUtilities.hpp"
 #include "MockVnodeAndMount.hpp"
 
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #include <vector>
 #include <string>
 #include <tuple>
@@ -40,7 +40,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     vnode->xattrs.insert(make_pair(PrjFSVirtualizationRootXAttrName, rootXattrData));
 }
 
-@interface VirtualizationRootsTests : XCTestCase
+@interface VirtualizationRootsTests : PFSKextTestCase
 
 @end
 
@@ -55,6 +55,8 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
 
 - (void)setUp
 {
+    [super setUp];
+
     srand(0);
     self->dummyClientPid = 100;
     
@@ -79,6 +81,8 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
 
     MockVnodes_CheckAndClear();
     MockCalls::Clear();
+
+    [super tearDown];
 }
 
 

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -598,6 +598,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     // In production FindVnodeRootFromDiskAndUpdateCache would panic when it sees an
     // invalid UpdateCacheBehavior, but in user-mode the assertf if a no-op
     VirtualizationRootHandle rootHandle;
+    [self setExpectedFailedKextAssertionCount:1];
     FindVnodeRootFromDiskAndUpdateCache(
         &self->dummyPerfTracer,
         PrjFSPerfCounter_VnodeOp_Vnode_Cache_Hit,

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -1,4 +1,4 @@
-#import <XCTest/XCTest.h>
+#import "KextAssertIntegration.h"
 #include "MockVnodeAndMount.hpp"
 #include "KextLogMock.h"
 #include "KextMockUtilities.hpp"
@@ -11,7 +11,7 @@
 using KextMock::_;
 using std::shared_ptr;
 
-@interface VnodeCacheTests : XCTestCase
+@interface VnodeCacheTests : PFSKextTestCase
 @end
 
 @implementation VnodeCacheTests
@@ -32,6 +32,8 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 
 - (void)setUp
 {
+    [super setUp];
+
     kern_return_t initResult = VirtualizationRoots_Init();
     XCTAssertEqual(initResult, KERN_SUCCESS);
     
@@ -57,6 +59,8 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
     self->testMount.reset();
     MockCalls::Clear();
     VirtualizationRoots_Cleanup();
+
+    [super tearDown];
 }
 
 - (void)testInitCacheStats {

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -90,6 +90,11 @@ while read line; do
 	 [[ $line != *"RetainIOCount"* ]] && 
 	 [[ $line != *"ProviderMessaging_"* ]] && 
 	 [[ $line != *"RWLock_DropExclusiveToShared"* ]] && 
+      # Not going down the "unexpected" code path in isKextAssertionFailureExpected, Assert & panic is good!
+	 [[ $line != *"PFSKextTestCase isKextAssertionFailureExpected"* ]] &&
+	 [[ $line != *"Assert"* ]] &&
+	 [[ $line != *"panic"* ]] &&
+
 	 # PrjFSLib exclusions
 	 [[ $line != *"PrjFS_"* ]] &&                                     #SHOULD ADD COVERAGE
 	 [[ $line != *"FsidInodeCompare"* ]] &&                           #SHOULD ADD COVERAGE
@@ -127,6 +132,7 @@ while read line; do
 	 [[ $line != *".xctest"* ]] && 
 	 [[ $line != *".cpp"* ]] && 
 	 [[ $line != *".a"* ]] && 
+	 [[ $line != *".m"* ]] &&
 	 [[ $line != *".hpp"* ]]; then
        echo "Error: not at 100% Code Coverage $line"
        exit 1


### PR DESCRIPTION
This patch series enables `assert()` and `assertf()` in the "testable" kext build. This plus the supporting infrastructure are implemented in the first commit:

 * Enables assertions in the testable kext build by `#define`ing `MACH_ASSERT=1`.
 * Implements the back-end Assert() and panic() functions used by the assert() and assertf() macros, respectively. These back-end functions call into XCTest's test failure reporting mechanism, so failed kext assertions in unit tests are now reported as regular unit test failures.
 * To facilitate this, the current test case needs to be known outside the test's Objective-C class, so we track that in thread-local storage by subclassing XCTestCase and deriving all tests from the new class, and perform current test registration/deregistration during setUp/tearDown.
 * Some unit tests deliberately cause failed assertions, so a mechanism for ignoring a specific number of them in a test is provided.
 * Not having full coverage in panic/Assert/etc. is a good thing, so those have been added to the 100% test coverage exceptions

The remaining commits fix unit test breakage that is caused by this - mostly cases of `VirtualizationRoots_Cleanup()` calls in a state where mock providers haven't yet disconnected. There's also a test which deliberately causes a failed assertion, which now needs to explicitly declare this fact.

**Reviewer notes:**

 * Commit-by-commit review probably will make a lot more sense than viewing all changes in one go.
 * The lack of support for an `assert()` with teeth in the testable kext has been annoying me for a while, so although it's not explicitly listed in #900, I've gone ahead and done it now as I ran into a situation where it would have helped while working on #526/#1193.