### PR TITLE
Really really fix LooseObjectStepTests by unmounting

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -53,9 +53,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             // Expand one pack, and verify we have loose objects
             this.ExpandOneTempPack(copyPackBackToPackDirectory: false);
-            this.GetLooseObjectFiles()
-                .Count()
-                .ShouldBeAtLeast(1);
+            int looseObjectCount = this.GetLooseObjectFiles().Count();
+            looseObjectCount.ShouldBeAtLeast(1);
 
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
@@ -90,9 +89,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             // Expand one pack, and verify we have loose objects
             this.ExpandOneTempPack(copyPackBackToPackDirectory: false);
-            this.GetLooseObjectFiles()
-                .Count()
-                .ShouldBeAtLeast(1, "Too few loose objects");
+            int looseObjectCount = this.GetLooseObjectFiles().Count();
+            looseObjectCount.ShouldBeAtLeast(1, "Too few loose objects");
 
             // Create an invalid loose object
             string fakeBlobFolder = Path.Combine(this.GitObjectRoot, "00");
@@ -110,7 +108,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
                    "Step failed to delete corrupt blob");
             this.CountPackFiles().ShouldEqual(0, "Incorrect number of packs after first loose object step");
             this.GetLooseObjectFiles().Count.ShouldBeAtLeast(
-                1,
+                looseObjectCount,
                 "unexpected number of loose objects after step");
 
             // This step should create a pack.

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -125,6 +125,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
         private void ClearAllObjects()
         {
+            this.Enlistment.UnmountGVFS();
+
             // Delete/Move any starting loose objects and packfiles
             this.DeleteFiles(this.GetLooseObjectFiles());
             this.MovePackFilesToTemp();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
 
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldEqual(looseObjectCount);
             this.CountPackFiles().ShouldEqual(1);
 
             // Running the step a second time should remove the loose obects and keep the pack file
@@ -107,7 +107,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.fileSystem.FileExists(fakeBlob).ShouldBeFalse(
                    "Step failed to delete corrupt blob");
             this.CountPackFiles().ShouldEqual(0, "Incorrect number of packs after first loose object step");
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(
+            this.GetLooseObjectFiles().Count.ShouldEqual(
                 looseObjectCount,
                 "unexpected number of loose objects after step");
 
@@ -115,7 +115,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.Enlistment.LooseObjectStep();
 
             this.CountPackFiles().ShouldEqual(1, "Incorrect number of packs after second loose object step");
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
+            this.GetLooseObjectFiles().Count.ShouldEqual(looseObjectCount);
 
             // This step should delete the loose objects
             this.Enlistment.LooseObjectStep();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -59,7 +59,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             // This step should put the loose objects into a packfile
             this.Enlistment.LooseObjectStep();
 
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(1);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
             this.CountPackFiles().ShouldEqual(1);
 
             // Running the step a second time should remove the loose obects and keep the pack file
@@ -115,7 +115,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.Enlistment.LooseObjectStep();
 
             this.CountPackFiles().ShouldEqual(1, "Incorrect number of packs after second loose object step");
-            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(1);
+            this.GetLooseObjectFiles().Count.ShouldBeAtLeast(looseObjectCount);
 
             // This step should delete the loose objects
             this.Enlistment.LooseObjectStep();


### PR DESCRIPTION
These tests have been super-flaky and frustrating. After weakening the tests, but still finding places where the loose object count is not deterministic, I thought it was worth starting over with the full list of exact-count assertions. To avoid loose objects being added or dropped from the counts in unexpected ways, now we unmount the repo before counting the objects.

I ran the functional tests 20 times on this PR and only one failure, but it was in the `GVFS.FunctionalTests.Tests.EnlistmentPerFixture.GitReadAndGitLockTests.GitAliasNamedAfterKnownCommandAcquiresLock()` test, unrelated to this change.

Replaces #1162, #1198, #1116.

Fixes #1201.