### PR TITLE
Mac kext: Fix for potential vnode_put() race in VirtualizationRoot_RegisterProviderForPath

### DIFF
--- a/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
@@ -95,7 +95,6 @@ class PrjFSProviderUserClient
     
     if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
     {
-        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
         ActiveProvider_Disconnect(testRootHandle, &userClient);
     }
 }
@@ -146,7 +145,6 @@ class PrjFSProviderUserClient
     
     if (VirtualizationRoot_IsValidRootHandle(testRepoHandle))
     {
-        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
         ActiveProvider_Disconnect(testRepoHandle, &userClient);
     }
 }
@@ -163,7 +161,6 @@ class PrjFSProviderUserClient
 
     if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
     {
-        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
         ActiveProvider_Disconnect(testRootHandle, &userClient);
     }
 
@@ -210,7 +207,6 @@ class PrjFSProviderUserClient
     
     if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
     {
-        vnode_get(repoRootVnode.get()); // InsertVirtualizationRoot_Locked doesn't _get directly, but ActiveProvider_Disconnect does _put
         ActiveProvider_Disconnect(testRootHandle, &userClient);
     }
 }
@@ -316,7 +312,6 @@ class PrjFSProviderUserClient
     
     if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
     {
-        vnode_get(repoRootVnode.get());
         ActiveProvider_Disconnect(testRootHandle, &userClient);
     }
 }

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -164,9 +164,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl, _, 0));
     XCTAssertTrue(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty, &self->dummyClient, _));
     
-    s_virtualizationRoots[result.root].providerUserClient = nullptr;
-    vnode_put(s_virtualizationRoots[result.root].rootVNode);
-
+    ActiveProvider_Disconnect(result.root, &self->dummyClient);
 }
 
 - (void)testRegisterProviderForPath_ProviderExists
@@ -222,8 +220,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
         XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl));
         XCTAssertTrue(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty));
     
-        s_virtualizationRoots[result.root].providerUserClient = nullptr;
-        vnode_put(s_virtualizationRoots[result.root].rootVNode);
+        ActiveProvider_Disconnect(result.root, &self->dummyClient);
     }
 }
 
@@ -254,8 +251,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
         XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl, self->testMountPoint.get(), _));
         XCTAssertTrue(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty, &self->dummyClient, _));
     
-        s_virtualizationRoots[result.root].providerUserClient = nullptr;
-        vnode_put(s_virtualizationRoots[result.root].rootVNode);
+        ActiveProvider_Disconnect(result.root, &self->dummyClient);
     }
 
     if (VirtualizationRoot_IsValidRootHandle(result2.root))
@@ -265,8 +261,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
         XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl, secondMountPoint.get(), 0));
         XCTAssertTrue(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty, &dummyClient2, _));
     
-        s_virtualizationRoots[result2.root].providerUserClient = nullptr;
-        vnode_put(s_virtualizationRoots[result2.root].rootVNode);
+        ActiveProvider_Disconnect(result2.root, &dummyClient2);
     }
     
     XCTAssertTrue(MockCalls::DidCallFunctionsInOrder(
@@ -331,8 +326,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     XCTAssertTrue(MockCalls::DidCallFunction(vfs_setauthcache_ttl, self->testMountPoint.get(), 0));
     XCTAssertTrue(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty));
     
-    s_virtualizationRoots[result.root].providerUserClient = nullptr;
-    vnode_put(newVnode.get());
+    ActiveProvider_Disconnect(result.root, &self->dummyClient);
 }
 
 - (void)testVnodeIsOnAllowedFilesystem


### PR DESCRIPTION
Previously, VirtualizationRoot_RegisterProviderForPath() called vnode_mount() on a vnode that was not guaranteed to have a strong reference on it after the lock was dropped. This patch changes InsertVirtualizationRoot_Locked so it calls vnode_get() on the vnode in the case of an active provider rather than leaving the outer function to deal with it, and VirtualizationRoot_RegisterProviderForPath() now always retains the iocount until *after* disabling the auth cache, subsequently always dropping it with `vnode_put()`.

Due to the change, InsertVirtualizationRoot_Locked() now also pairs nicely with ActiveProvider_Disconnect(), which tidies up some unit tests a little.

**Notes:**

 * This change builds on #1200, this PR is only about the final commit.
 * This fix first appeared in #500 but as that still has not been merged and #1200 resurfaced the issue, I've submitted it in isolation.