### PR TITLE
Mac ProjFS: Deny I/O on offline roots, with exceptions, part 1

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -13,5 +13,6 @@ namespace GVFS.Common.FileSystem
         bool TryPrepareFolderForCallbacks(string folderPath, out string error, out Exception exception);
         bool IsReady(JsonTracer tracer, string enlistmentRoot, TextWriter output, out string error);
         bool IsGVFSUpgradeSupported();
+        bool RegisterForOfflineIO();
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
@@ -12,6 +13,26 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
     [Category(Categories.ExtraCoverage)]
     public class RepairTests : TestsWithEnlistmentPerTestCase
     {
+        private const string PrjFSLibPath = "libPrjFSLib.dylib";
+
+        [OneTimeSetUp]
+        public void TurnOfflineIOOn()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                 RegisterForOfflineIO();
+            }
+        }
+
+        [OneTimeTearDown]
+        public void TurnOfflineIOOff()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                UnregisterForOfflineIO();
+            }
+        }
+
         [TestCase]
         public void NoFixesNeeded()
         {
@@ -153,6 +174,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             result.ExitCode.ShouldEqual(0, result.Errors);
             this.Enlistment.MountGVFS();
         }
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_RegisterForOfflineIO")]
+        private static extern uint RegisterForOfflineIO();
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_UnregisterForOfflineIO")]
+        private static extern uint UnregisterForOfflineIO();
 
         private void CreateCorruptIndexAndRename(string indexPath, Action<FileStream, FileStream> corruptionAction)
         {

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -86,6 +86,11 @@ namespace GVFS.Platform.Mac
             return true;
         }
 
+        public bool RegisterForOfflineIO()
+        {
+            return PrjFSLib.Mac.Managed.OfflineIO.RegisterForOfflineIO();
+        }
+
         private bool TryLoad(ITracer tracer, TextWriter output, out string errorMessage)
         {
             output?.WriteLine("Driver not loaded.  Attempting to load. You may be prompted for sudo password...");

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -465,6 +465,11 @@ namespace GVFS.Platform.Windows
                 TryAttach(enlistmentRoot, out error);
         }
 
+        public bool RegisterForOfflineIO()
+        {
+            return true;
+        }
+
         private static bool IsInboxAndEnabled()
         {
             ProcessResult getOptionalFeatureResult = GetProjFSOptionalFeatureStatus();

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -13,6 +13,7 @@ namespace GVFS
         public static void Main(string[] args)
         {
             GVFSPlatformLoader.Initialize();
+            GVFSPlatform.Instance.KernelDriver.RegisterForOfflineIO();
 
             Type[] verbTypes = new Type[]
             {

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
 		4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
 		4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
+		4A5EC302229D5F12005E8D8F /* PrjFSOfflineIOUserClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A5EC300229D5F12005E8D8F /* PrjFSOfflineIOUserClient.cpp */; };
+		4A5EC303229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A5EC301229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp */; };
 		4A781DA52220946000DB7733 /* VirtualizationRootsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */; };
 		4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8A721E42AC50008103C /* VirtualizationRoots.cpp */; };
 		4A781DAB222330F700DB7733 /* KextMockUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A781DAA222330F700DB7733 /* KextMockUtilities.cpp */; };
@@ -290,6 +292,8 @@
 		4A2A69A12297375A00ACAAAF /* KextAssertIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KextAssertIntegration.h; sourceTree = "<group>"; };
 		4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessaging.cpp; sourceTree = "<group>"; };
 		4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessaging.hpp; sourceTree = "<group>"; };
+		4A5EC300229D5F12005E8D8F /* PrjFSOfflineIOUserClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSOfflineIOUserClient.cpp; sourceTree = "<group>"; };
+		4A5EC301229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSOfflineIOUserClient.hpp; sourceTree = "<group>"; };
 		4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualizationRootsTests.mm; sourceTree = "<group>"; };
 		4A781DA6222094C300DB7733 /* VirtualizationRootsPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VirtualizationRootsPrivate.hpp; sourceTree = "<group>"; };
 		4A781DA82222C6EA00DB7733 /* PrjFSProviderUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSProviderUserClient.hpp; sourceTree = "<group>"; };
@@ -465,6 +469,8 @@
 				4391F89C21E42AC40008103C /* PrjFSKext.cpp */,
 				4391F8A021E42AC50008103C /* PrjFSLogUserClient.cpp */,
 				4391F89E21E42AC50008103C /* PrjFSLogUserClient.hpp */,
+				4A5EC300229D5F12005E8D8F /* PrjFSOfflineIOUserClient.cpp */,
+				4A5EC301229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp */,
 				4391F89521E42AC40008103C /* PrjFSProviderUserClient.cpp */,
 				4391F89F21E42AC50008103C /* PrjFSProviderUserClientPrivate.hpp */,
 				4A781DA82222C6EA00DB7733 /* PrjFSProviderUserClient.hpp */,
@@ -561,6 +567,7 @@
 			files = (
 				4391F8A821E42AC50008103C /* Locks.hpp in Headers */,
 				4391F8B821E42AC50008103C /* PrjFSLogUserClient.hpp in Headers */,
+				4A5EC303229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp in Headers */,
 				4391F8B221E42AC50008103C /* Memory.hpp in Headers */,
 				4391F8AE21E42AC50008103C /* VirtualizationRoots.hpp in Headers */,
 				4391F8BE21E42AC50008103C /* KauthHandler.hpp in Headers */,
@@ -868,6 +875,7 @@
 				4391F8C121E42AC50008103C /* VirtualizationRoots.cpp in Sources */,
 				4391F8C021E42AC50008103C /* Locks.cpp in Sources */,
 				4391F8AD21E42AC50008103C /* KauthHandler.cpp in Sources */,
+				4A5EC302229D5F12005E8D8F /* PrjFSOfflineIOUserClient.cpp in Sources */,
 				4391F8AF21E42AC50008103C /* PrjFSProviderUserClient.cpp in Sources */,
 				4391F8BA21E42AC50008103C /* PrjFSLogUserClient.cpp in Sources */,
 				4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,

--- a/ProjFS.Mac/PrjFSKext/ArrayUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/ArrayUtilities.hpp
@@ -22,3 +22,8 @@ template <typename T> void Array_DefaultInit(T* array, size_t count)
     }
 }
 
+template <typename T, typename MIN_T, typename MAX_T>
+    auto clamp(const T& value, const MIN_T& min, const MAX_T& max)
+{
+    return value < min ? min : (value > max ? max : value);
+}

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -669,8 +669,8 @@ KEXT_STATIC int HandleVnodeOperation(
                 if (providerStatus == Provider_IsOffline)
                 {
                     assert(!shouldMessageProvider);
-                    // TODO(Mac): Write access to placeholder files in offline roots should be denied (#182)
-                    //kauthResult = KAUTH_RESULT_DENY;
+                    // Deny write access to placeholders in an offline root
+                    kauthResult = KAUTH_RESULT_DENY;
                     goto CleanupAndReturn;
                 }
                 

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -572,6 +572,12 @@ KEXT_STATIC int HandleVnodeOperation(
         {
             if (FileFlagsBitIsSet(currentVnodeFileFlags, FileFlags_IsEmpty))
             {
+                bool isWriteOperation = ActionBitIsSet(
+                    action,
+                    KAUTH_VNODE_WRITE_ATTRIBUTES |
+                    KAUTH_VNODE_WRITE_EXTATTRIBUTES |
+                    KAUTH_VNODE_WRITE_DATA |
+                    KAUTH_VNODE_APPEND_DATA);
                 if (!TryGetVirtualizationRoot(
                         &perfTracer,
                         context,
@@ -579,8 +585,8 @@ KEXT_STATIC int HandleVnodeOperation(
                         pid,
                         // Prevent system services from hydrating files as this tends to cause deadlocks with the kauth listeners for Antivirus software
                         CallbackPolicy_UserInitiatedOnly,
-                        // TODO(Mac): Access to empty files in an offline root should be denied except for deletions (#182)
-                        false, // denyIfOffline
+                        // Prevent write access to empty files in offline roots. For now allow reads, and always allow the user to delete files.
+                        isWriteOperation,
                         &root,
                         &vnodeFsidInode,
                         &kauthResult,

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -28,12 +28,6 @@
 #include "KauthHandlerTestable.hpp"
 #endif
 
-template <typename T, typename MIN_T, typename MAX_T>
-    auto clamp(const T& value, const MIN_T& min, const MAX_T& max)
-{
-    return value < min ? min : (value > max ? max : value);
-}
-
 enum ProviderCallbackPolicy
 {
     CallbackPolicy_AllowAny,
@@ -1132,6 +1126,10 @@ static bool TryGetVirtualizationRoot(
         perfTracer->IncrementCount(PrjFSPerfCounter_VnodeOp_GetVirtualizationRoot_ProviderOffline);
         
         *kauthResult = KAUTH_RESULT_DEFER;
+        if (!VirtualizationRoots_ProcessMayAccessOfflineRoots(pidMakingRequest))
+        {
+        }
+        
         return false;
     }
     

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -592,7 +592,7 @@ KEXT_STATIC int HandleVnodeOperation(
                         // Prevent system services from hydrating files as this tends to cause deadlocks with the kauth listeners for Antivirus software
                         CallbackPolicy_UserInitiatedOnly,
                         // Prevent write access to empty files in offline roots. For now allow reads, and always allow the user to delete files.
-                        isWriteOperation,
+                        isWriteOperation || (isRename && s_osSupportsRenameDetection),
                         &root,
                         &vnodeFsidInode,
                         &kauthResult,

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -110,7 +110,7 @@ template <typename... args>
 
 #define KextLog_VnodeOp(vnode, vnodeType, procname, action, message) \
     do { \
-        if (VDIR == vnodeType) \
+        if (VDIR == (vnodeType)) \
         { \
             KextLog_File( \
                 vnode, \

--- a/ProjFS.Mac/PrjFSKext/PrjFSClasses.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSClasses.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 // IOKit class naming convention is to use reverse DNS notation
-#define PrjFSService            org_vfsforgit_PrjFS
+#define PrjFSService                 org_vfsforgit_PrjFS
 class PrjFSService;
-#define PrjFSProviderUserClient org_vfsforgit_PrjFSProviderUserClient
+#define PrjFSProviderUserClient      org_vfsforgit_PrjFSProviderUserClient
 class PrjFSProviderUserClient;
-#define PrjFSLogUserClient      org_vfsforgit_PrjFSLogUserClient
+#define PrjFSLogUserClient           org_vfsforgit_PrjFSLogUserClient
 class PrjFSLogUserClient;
+#define PrjFSOfflineIOUserClient     org_vfsforgit_PrjFSOfflineIOUserClient
+class PrjFSOfflineIOUserClient;

--- a/ProjFS.Mac/PrjFSKext/PrjFSOfflineIOUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSOfflineIOUserClient.cpp
@@ -1,0 +1,41 @@
+#include "PrjFSOfflineIOUserClient.hpp"
+#include "VirtualizationRoots.hpp"
+#include <sys/proc.h>
+
+OSDefineMetaClassAndStructors(PrjFSOfflineIOUserClient, IOUserClient);
+
+bool PrjFSOfflineIOUserClient::initWithTask(
+    task_t owningTask, void* securityToken, UInt32 type, OSDictionary* properties)
+{
+    if (!this->super::initWithTask(owningTask, securityToken, type, properties))
+    {
+        return false;
+    }
+    
+    this->pid = proc_selfpid();
+    bool success = VirtualizationRoots_AddOfflineIOProcess(this->pid);
+    if (!success)
+    {
+        this->pid = 0;
+    }
+    
+    return success;
+}
+
+IOReturn PrjFSOfflineIOUserClient::clientClose()
+{
+    this->terminate(0);
+    return kIOReturnSuccess;
+}
+
+void PrjFSOfflineIOUserClient::stop(IOService* provider)
+{
+    if (this->pid != 0)
+    {
+        VirtualizationRoots_RemoveOfflineIOProcess(this->pid);
+        this->pid = 0;
+    }
+    
+    this->super::stop(provider);
+}
+

--- a/ProjFS.Mac/PrjFSKext/PrjFSOfflineIOUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSOfflineIOUserClient.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "PrjFSClasses.hpp"
+#include <IOKit/IOUserClient.h>
+
+class PrjFSOfflineIOUserClient : public IOUserClient
+{
+    OSDeclareDefaultStructors(PrjFSOfflineIOUserClient);
+private:
+    typedef IOUserClient super;
+    pid_t pid;
+
+public:
+    // IOUserClient methods:
+    virtual bool initWithTask(task_t owningTask, void* securityToken, UInt32 type, OSDictionary* properties) override;
+    virtual IOReturn clientClose() override;
+
+    // IOService methods:
+    virtual void stop(IOService* provider) override;
+};
+

--- a/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
@@ -3,6 +3,7 @@
 #include "PrjFSService.hpp"
 #include "PrjFSProviderUserClientPrivate.hpp"
 #include "PrjFSLogUserClient.hpp"
+#include "PrjFSOfflineIOUserClient.hpp"
 #include "KextLog.hpp"
 #include "VirtualizationRoots.hpp"
 
@@ -121,6 +122,16 @@ IOReturn PrjFSService::newUserClient(
                     StopDetachReleaseUserClient(this, log_client);
                     result = kIOReturnExclusiveAccess;
                 }
+            }
+        }
+        break;
+    case UserClientType_OfflineIO:
+        {
+            PrjFSOfflineIOUserClient* offline_io_client = new PrjFSOfflineIOUserClient();
+            if (InitAttachAndStartUserClient(this, offline_io_client, owningTask, securityID, type, properties))
+            {
+                *handler = offline_io_client;
+                result = kIOReturnSuccess;
             }
         }
         break;

--- a/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
+++ b/ProjFS.Mac/PrjFSKext/ProviderMessaging.cpp
@@ -179,14 +179,15 @@ bool ProviderMessaging_TrySendRequestAndWaitForResponse(
     {
         if (0 != sendError)
         {
-            // TODO: appropriately handle unresponsive providers
-            *kauthResult = KAUTH_RESULT_DEFER;
+            // If message delivery fails, block the operation to avoid missed messages in the provider.
+            *kauthResult = KAUTH_RESULT_DENY;
         }
         else
         {
             while (!message.receivedResult &&
                    !s_isShuttingDown)
             {
+                // TODO: appropriately handle unresponsive providers
                 Mutex_Sleep(5, &message, &s_outstandingMessagesMutex);
             }
         

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.hpp
@@ -52,3 +52,6 @@ errno_t ActiveProvider_SendMessage(VirtualizationRootHandle rootHandle, const Me
 bool VirtualizationRoot_VnodeIsOnAllowedFilesystem(vnode_t _Nonnull vnode);
 bool VirtualizationRoot_IsValidRootHandle(VirtualizationRootHandle rootHandle);
 ActiveProviderProperties VirtualizationRoot_GetActiveProvider(VirtualizationRootHandle rootHandle);
+bool VirtualizationRoots_ProcessMayAccessOfflineRoots(pid_t pid);
+bool VirtualizationRoots_AddOfflineIOProcess(pid_t pid);
+void VirtualizationRoots_RemoveOfflineIOProcess(pid_t pid);

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -32,6 +32,7 @@ enum PrjFSServiceUserClientType
     
     UserClientType_Provider,
     UserClientType_Log,
+    UserClientType_OfflineIO,
 };
 
 // When building the kext in user space for unit testing, we want some functions

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -450,6 +450,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
 {
     testFileVnode->attrValues.va_flags = FileFlags_IsEmpty | FileFlags_IsInVirtualizationRoot;
 
+    InitPendingRenames();
     XCTAssertTrue(HandleVnodeOperation(
         nullptr,
         nullptr,
@@ -484,10 +485,12 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
         _,
         _,
         nullptr));
+    CleanupPendingRenames();
 }
 
 - (void) testConcurrentRenameOperationRecording
 {
+    InitPendingRenames();
     self->testFileVnode->attrValues.va_flags = FileFlags_IsEmpty | FileFlags_IsInVirtualizationRoot;
 
     string otherFilePath = repoPath + "/otherFile";
@@ -588,6 +591,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
             nullptr))
     );
     XCTAssertTrue(MockCalls::CallCount(ProviderMessaging_TrySendRequestAndWaitForResponse) == 4);
+    CleanupPendingRenames();
 }
 
 
@@ -648,6 +652,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
     testDirVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
 
     TestForAllSupportedDarwinVersions(^{
+        InitPendingRenames();
         XCTAssertTrue(HandleVnodeOperation(
             nullptr,
             nullptr,
@@ -692,6 +697,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
         }
         
         MockCalls::Clear();
+        CleanupPendingRenames();
     });
 }
 

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -66,5 +66,11 @@ namespace PrjFSLib.Mac.Interop
             IntPtr fileHandle,
             IntPtr bytes,
             uint byteCount);
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_RegisterForOfflineIO")]
+        public static extern Result RegisterForOfflineIO();
+
+        [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_UnregisterForOfflineIO")]
+        public static extern Result UnregisterForOfflineIO();
     }
 }

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/OfflineIO.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/OfflineIO.cs
@@ -1,0 +1,16 @@
+﻿using System;
+namespace PrjFSLib.Mac.Managed
+{
+    public class OfflineIO
+    {
+        public static bool RegisterForOfflineIO()
+        {
+            return Result.Success == Interop.PrjFSLib.RegisterForOfflineIO();
+        }
+
+        public static bool UnregisterForOfflineIO()
+        {
+            return Result.Success == Interop.PrjFSLib.UnregisterForOfflineIO();
+        }
+    }
+}

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -91,6 +91,9 @@ extern "C" PrjFS_Result PrjFS_WriteSymLink(
     _In_    const char*                             relativePath,
     _In_    const char*                             symLinkTarget);
 
+extern "C" PrjFS_Result PrjFS_RegisterForOfflineIO();
+extern "C" PrjFS_Result PrjFS_UnregisterForOfflineIO();
+
 typedef enum
 {
     PrjFS_UpdateType_Invalid                        = 0x00000000,

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -82,7 +82,8 @@ while read line; do
 	 [[ $line != *"ActiveProvider_"* ]] && 
 	 [[ $line != *"GetRelativePath"* ]] && 
 	 [[ $line != *"VirtualizationRoot_GetRootRelativePath"* ]] && 
-	 [[ $line != *"MockCalls"* ]] && 
+	 [[ $line != *"VirtualizationRoots_AddOfflineIOProcess"* ]] &&   # The only branch not covered is one for dealing with a race. We can't yet provoke this in tests.
+	 [[ $line != *"MockCalls"* ]] &&
 	 [[ $line != *"VnodeCacheEntriesWrapper"* ]] &&
 	 [[ $line != *"PerfTracing_"* ]] && 
 	 [[ $line != *"proc_"* ]] && 


### PR DESCRIPTION
This is the first stage of implementing #182 - the kext now blocks write I/O to empty or placeholder files on offline roots.

I/O needs to be blocked when:

1. A message failed to deliver to the provider.
2. A process attempts to write to an empty file in an offline root (this file would subsequently be overwritten by a hydration event)
3. A process attempts to write to a placeholder (hydrated unmodified) file when the provider is offline. The file would not show up in git status and could be overwritten by a subsequent checkout/rebase/merge.
4. A process attempts to rename a file in an offline root.
5. A process attempts to read/execute an empty file in an offline root. The result of the read would be bad data, so failing with denied authorisation is preferable to letting the bad data propagate.
6. A process attempts to create files or directories in an offline root.

This change implements cases 1-4. Cases 5-6 will be covered in a future change.

At first glance this seems like it would be a very simple change, but in practice, some processes must be allowed unfettered access to files in offline roots. So a large part of this patch set is dedicated to implementing a system for allowing exceptions - there is a new type of IOKit user client for processes which need unrestricted access to offline roots, and this needed to be implemented all the way through from kext, via native lib, to (managed) VFS4G code proper.

Next, the vnode handler, which is in the actual business of denying or allowing file access, has been expanded to allow returning different results based on whether the root's provider is offline.

Finally, "deny" results are actually returned for a number of different cases - so far, this only includes writes. Even this caused some test failures, so the test process itself needs to register as an exception with unrestricted offline root access. This code was kindly provided by @jeschu1.

**Review Notes:**

This is a pretty big change set so I recommend reviewing commit-by-commit:

 1. **Minor macro tweak** - tiny bug fix to the `KextLog_VnodeOp` macro for an issue I ran into while working on this. The `vnodeType` argument can itself be the result of an expression, and so must be surrounded by parentheses to avoid operator precedence problems.
 2. **Adds system for registering processes for offline root I/O** - This implements the kext-side `IOUserClient` subclass for processes which need access to offline roots, code for maintaining the active list of these exceptions, plus some seeds of actual exception logic in `TryGetVirtualizationRoot`. (At this stage no exception is actually needed because no access is denied yet.) There are also unit tests for covering much of this new code.
 3. **User-space support for offline I/O process registration.** - This adds the ability to register and deregister as an offline root exception process to the native PrjFS library, along with calls to the new functions from the managed side from the `Main()` method of the `gvfs` tool.
 4. **Preparation for denying access to offline roots.** - This change identifies the various sites in the vnode handler where access will need to be denied, and prepares the code such that this behaviour can easily be enabled in a subsequent change. Doing so adds some new code paths, so new tests are provided to cover those paths.
 5. **Register/Unregister for offline I/O in functional tests** - This commit by @jeschu1 registers the functional test runner as a process which is allowed to perform I/O on offline roots. This is a requirement for the tests to pass once the subsequent commits are applied.
 6. **Denies access when provider does not respond** - If the provider process does not respond to a message from the vnode handler, we deny the operation, whatever it was. This is perhaps not ideal; a cleaner way to implement this would be to behave as if the provider was offline. That looks like it'll involve some refactoring of the vnode/fileop handlers, which I'll leave for #900.
 7. **Denies write access to empty files in offline root** - What it says on the tin. Writing to empty files makes no sense, when the provider comes online, it'll think the file is still empty and hydrate it, overwriting whatever the user stored there. Adds a test that verifies that such accesses are indeed denied by the vnode handler. 
 8. **Denies write access to placeholder files in offline root** - Placeholder (hydrated, non-full) files in an offline root must not be writable, or the provider will miss the PreConvertToFull/MileModified events and incorrectly track it as unmodified. This is prevented by this change; tests are updated to reflect the new expected behaviour.