### PR TITLE
Fix Mac installer issues

### DIFF
--- a/GVFS/GVFS.Installer.Mac/scripts/postinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/postinstall
@@ -1,4 +1,29 @@
 #!/bin/bash
+
+# Load PrjFSKext if it is not loaded already
+# PrjFSKext is an IOKit kext and should get automatically loaded 
+# by macOS after install. But the system does not seem to auto-load it
+# consistently after every install. The code below checks if it has
+# been auto-loaded. If not, it will attempt to load it.
+# The BundleID of the Kext(ProjFS.Mac/PrjFS.xcodeproj) is defined in
+# ProjFS.Mac/PrjFS.xcodeproj project.
+KEXTBUNDLEID="org.vfsforgit.PrjFSKext"
+KEXTPATH="/Library/Extensions/PrjFSKext.kext"
+kextstatCmd="/usr/sbin/kextstat -l -b $KEXTBUNDLEID"
+kextstatOutput=$(eval $kextstatCmd)
+if [[ -z "${kextstatOutput// }" ]]; then
+# load the kext using kextload command. Installer is run as the
+# admin user, so we already have required privileges. In case load
+# still fails, then exit 1. This will cause the installer to display
+# an installation failed error message.
+    loadCmd="/sbin/kextload \"$KEXTPATH\""
+    echo $loadCmd
+    eval $loadCmd || exit 1
+else
+    echo "$kextstatCmd returned non-zero output. This might possibly indicate an error."
+    echo "$kextstatOutput"
+fi
+
 loadCmd="sudo launchctl load -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
 echo "Loading PrjFSKextLogDaemon: '$loadCmd'..."
 eval $loadCmd || exit 1


### PR DESCRIPTION
#### Fix couple installer issues
1. Mac installer relies on GVFS.Service to do the auto-mount of registered repos. When GVFS.Service gets launched (post installation) it (Service) calls gvfs mount in the background (without user interaction). In this case if the kext is not loaded, then mount will fail. Updating the installer to load kext would help in scenario. Also updated postflight script to log output of kextstat command that is used to determine if macOS autoloaded kext or not. A non empty output means kext got autoloaded or there was an error running kextstat.

2. Don't install copy of "VFS For Git.app" in /usr/loca/vfsforgit directory.

Fixes #1210