### PR TITLE
Prefetch tests: Delete multi-pack-index before indexing a pack

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -71,6 +71,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteFile(idxPath);
             idxPath.ShouldNotExistOnDisk(this.fileSystem);
 
+            // Remove midx that contains references to the pack
+            string midxPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), "pack", "multi-pack-index");
+            File.SetAttributes(midxPath, FileAttributes.Normal);
+            this.fileSystem.DeleteFile(midxPath);
+            midxPath.ShouldNotExistOnDisk(this.fileSystem);
+
             // Prefetch should rebuild the missing idx
             this.Enlistment.Prefetch("--commits");
             this.PostFetchJobShouldComplete();


### PR DESCRIPTION
This test deletes an existing .idx file, and then checks that
VFS for Git calls `git index-pack` when scanning the pack-files.
When we take Git 2.22.0, this test starts to fail. The fix is to
delete the multi-pack-index before rebuilding the .idx. This is
a reasonable expectation because we won't have a pack covered by
the multi-pack-index without having the corresponding .idx file.

The reason this broke with Git 2.22.0 is a bit subtle:

When running `git index-pack`, Git looks for duplicate objects in
order to check for SHA-1 collisions. When the multi-pack-index
includes the objects in the pack, Git sees what it thinks are
the same object ids and goes to load the content to verify they
are equal.

In Git 2.22.0, we solved the "many packs" problem by adding the
pack-files from the multi-pack-index to the packed_git linked
list. Adding to this list will fail if there is no corresponding
.idx file. (The multi-pack-index prevents any reads into this
.idx file, but existence is required.) This means that the content
lookup fails and Git complains with "fatal: cannot read existing
object info"

This will unblock taking Git 2.22.0 after the release. See
microsoft/git#140 for details on that update.