### PR TITLE
Upgrader - platform specific directory creation

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -73,6 +73,10 @@ namespace GVFS.Common
             ITracer tracer,
             string lockPath);
 
+        public abstract ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer);
+
         public bool TryGetNormalizedPathRoot(string path, out string pathRoot, out string errorMessage)
         {
             pathRoot = null;

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -138,16 +138,19 @@ namespace GVFS.Common
             public UnderConstructionFlags(
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool requiresDeprecatedGitHooksLoader = false)
+                bool requiresDeprecatedGitHooksLoader = false,
+                bool supportsNuGetEncryption = true)
             {
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
                 this.RequiresDeprecatedGitHooksLoader = requiresDeprecatedGitHooksLoader;
+                this.SupportsNuGetEncryption = supportsNuGetEncryption;
             }
 
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
             public bool RequiresDeprecatedGitHooksLoader { get; }
+            public bool SupportsNuGetEncryption { get; }
         }
     }
 }

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +26,7 @@ namespace GVFS.Common.NuGetUpgrade
         private readonly string feedUrl;
         private readonly string feedName;
         private readonly string downloadFolder;
+        private readonly bool platformSupportsEncryption;
 
         private SourceRepository sourceRepository;
         private string personalAccessToken;
@@ -38,6 +38,7 @@ namespace GVFS.Common.NuGetUpgrade
             string feedName,
             string downloadFolder,
             string personalAccessToken,
+            bool platformSupportsEncryption,
             ITracer tracer)
         {
             this.feedUrl = feedUrl;
@@ -52,6 +53,7 @@ namespace GVFS.Common.NuGetUpgrade
             // - NoCache - Do not cache package version lists
             this.sourceCacheContext = NullSourceCacheContext.Instance.Clone();
             this.sourceCacheContext.NoCache = true;
+            this.platformSupportsEncryption = platformSupportsEncryption;
 
             this.nuGetLogger = new Logger(this.tracer);
             this.SetSourceRepository();
@@ -153,7 +155,7 @@ namespace GVFS.Common.NuGetUpgrade
             return metadata;
         }
 
-        private static PackageSourceCredential BuildCredentialsFromPAT(string personalAccessToken)
+        private static PackageSourceCredential BuildCredentialsFromPAT(string personalAccessToken, bool storePasswordInClearText)
         {
             // The storePasswordInClearText property is used to control whether the password
             // is written to NuGet config files in clear text or not. It also controls whether the
@@ -163,7 +165,6 @@ namespace GVFS.Common.NuGetUpgrade
             // usage of NuGet functionality we do not write out config files, it is OK to not set this property
             // (with the tradeoff being the password is not encrypted in memory, and we need to make sure that new code
             // does not start to write out config files).
-            bool storePasswordInClearText = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             return PackageSourceCredential.FromUserInput(
                 "VfsForGitNugetUpgrader",
                 "PersonalAccessToken",
@@ -176,7 +177,7 @@ namespace GVFS.Common.NuGetUpgrade
             this.sourceRepository = Repository.Factory.GetCoreV3(this.feedUrl);
             if (!string.IsNullOrEmpty(this.personalAccessToken))
             {
-                this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken);
+                this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken, !this.platformSupportsEncryption);
             }
         }
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -48,6 +48,7 @@ namespace GVFS.Common.NuGetUpgrade
                     config.PackageFeedName,
                     downloadFolder,
                     null,
+                    GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                     tracer),
                 credentialStore)
         {

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -50,7 +50,8 @@ namespace GVFS.Common.NuGetUpgrade
                     null,
                     GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                     tracer),
-                credentialStore)
+                credentialStore,
+                GVFSPlatform.Instance.CreateProductUpgraderPlatformInteractions(fileSystem, tracer))
         {
         }
 
@@ -62,13 +63,15 @@ namespace GVFS.Common.NuGetUpgrade
             PhysicalFileSystem fileSystem,
             NuGetUpgraderConfig config,
             NuGetFeed nuGetFeed,
-            ICredentialStore credentialStore)
+            ICredentialStore credentialStore,
+            ProductUpgraderPlatformStrategy productUpgraderPlatformStrategy)
             : base(
                 currentVersion,
                 tracer,
                 dryRun,
                 noVerify,
-                fileSystem)
+                fileSystem,
+                productUpgraderPlatformStrategy)
         {
             this.nuGetUpgraderConfig = config;
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/OrgNuGetUpgrader.cs
@@ -58,7 +58,8 @@ namespace GVFS.Common.NuGetUpgrade
                fileSystem,
                config,
                nuGetFeed,
-               credentialStore)
+               credentialStore,
+               GVFSPlatform.Instance.CreateProductUpgraderPlatformInteractions(fileSystem, tracer))
         {
             this.httpClient = httpClient;
             this.platform = platform;

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -20,6 +20,7 @@ namespace GVFS.Common
 
     public abstract class ProductUpgrader : IDisposable
     {
+        public const string ToolsDirectory = "Tools";
         protected readonly Version installedVersion;
         protected readonly ITracer tracer;
         protected readonly PhysicalFileSystem fileSystem;
@@ -27,7 +28,6 @@ namespace GVFS.Common
         protected bool noVerify;
         protected bool dryRun;
 
-        private const string ToolsDirectory = "Tools";
         private static readonly string UpgraderToolName = GVFSPlatform.Instance.Constants.GVFSUpgraderExecutableName;
 
         public ProductUpgrader(

--- a/GVFS/GVFS.Common/ProductUpgraderPlatformStrategy.cs
+++ b/GVFS/GVFS.Common/ProductUpgraderPlatformStrategy.cs
@@ -1,0 +1,38 @@
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System;
+using System.IO;
+
+namespace GVFS.Common
+{
+    public abstract class ProductUpgraderPlatformStrategy
+    {
+        public ProductUpgraderPlatformStrategy(PhysicalFileSystem fileSystem, ITracer tracer)
+        {
+            this.FileSystem = fileSystem;
+            this.Tracer = tracer;
+        }
+
+        protected PhysicalFileSystem FileSystem { get; }
+        protected ITracer Tracer { get; }
+
+        public abstract bool TryPrepareLogDirectory(out string error);
+
+        public abstract bool TryPrepareApplicationDirectory(out string error);
+
+        public abstract bool TryPrepareDownloadDirectory(out string error);
+
+        protected void TraceException(Exception exception, string method, string message)
+        {
+            this.TraceException(this.Tracer, exception, method, message);
+        }
+
+        protected void TraceException(ITracer tracer, Exception exception, string method, string message)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("Method", method);
+            metadata.Add("Exception", exception.ToString());
+            tracer.RelatedError(metadata, message);
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -82,6 +82,13 @@ namespace GVFS.Platform.Mac
             return result;
         }
 
+        public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer)
+        {
+            return new MacProductUpgraderPlatformStrategy(fileSystem, tracer);
+        }
+
         public class MacPlatformConstants : POSIXPlatformConstants
         {
             public override string InstallerExtension

--- a/GVFS/GVFS.Platform.Mac/MacProductUpgraderPlatformStrategy.cs
+++ b/GVFS/GVFS.Platform.Mac/MacProductUpgraderPlatformStrategy.cs
@@ -1,0 +1,63 @@
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System;
+using System.IO;
+
+namespace GVFS.Platform.Mac
+{
+    public class MacProductUpgraderPlatformStrategy : ProductUpgraderPlatformStrategy
+    {
+        public MacProductUpgraderPlatformStrategy(PhysicalFileSystem fileSystem, ITracer tracer)
+        : base(fileSystem, tracer)
+        {
+        }
+
+        public override bool TryPrepareLogDirectory(out string error)
+        {
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareApplicationDirectory(out string error)
+        {
+            string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
+            string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ProductUpgrader.ToolsDirectory);
+
+            Exception deleteDirectoryException;
+            if (this.FileSystem.DirectoryExists(toolsDirectoryPath) &&
+                !this.FileSystem.TryDeleteDirectory(toolsDirectoryPath, out deleteDirectoryException))
+            {
+                error = $"Failed to delete {toolsDirectoryPath} - {deleteDirectoryException.Message}";
+
+                this.TraceException(deleteDirectoryException, nameof(this.TryPrepareApplicationDirectory), $"Error deleting {toolsDirectoryPath}.");
+                return false;
+            }
+
+            this.FileSystem.CreateDirectory(toolsDirectoryPath);
+
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareDownloadDirectory(out string error)
+        {
+            string directory = ProductUpgraderInfo.GetAssetDownloadsPath();
+
+            Exception deleteDirectoryException;
+            if (this.FileSystem.DirectoryExists(directory) &&
+                !this.FileSystem.TryDeleteDirectory(directory, out deleteDirectoryException))
+            {
+                error = $"Failed to delete {directory} - {deleteDirectoryException.Message}";
+
+                this.TraceException(deleteDirectoryException, nameof(this.TryPrepareDownloadDirectory), $"Error deleting {directory}.");
+                return false;
+            }
+
+            this.FileSystem.CreateDirectory(directory);
+
+            error = null;
+            return true;
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -16,7 +16,8 @@ namespace GVFS.Platform.POSIX
         protected POSIXPlatform() : this(
             underConstruction: new UnderConstructionFlags(
                 supportsGVFSUpgrade: false,
-                supportsGVFSConfig: false))
+                supportsGVFSConfig: false,
+                supportsNuGetEncryption: false))
         {
         }
 

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -92,6 +92,7 @@
     <Compile Include="WindowsPhysicalDiskInfo.cs" />
     <Compile Include="WindowsPlatform.cs" />
     <Compile Include="WindowsPlatform.Shared.cs" />
+    <Compile Include="WindowsProductUpgraderPlatformStrategy.cs" />
     <Compile Include="WindowsFileSystem.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -341,6 +341,13 @@ namespace GVFS.Platform.Windows
             return new WindowsFileBasedLock(fileSystem, tracer, lockPath);
         }
 
+        public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer)
+        {
+            return new WindowsProductUpgraderPlatformStrategy(fileSystem, tracer);
+        }
+
         public override bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
         {
             return WindowsPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);

--- a/GVFS/GVFS.Platform.Windows/WindowsProductUpgraderPlatformStrategy.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsProductUpgraderPlatformStrategy.cs
@@ -1,0 +1,76 @@
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System;
+using System.IO;
+
+namespace GVFS.Platform.Windows
+{
+    public class WindowsProductUpgraderPlatformStrategy : ProductUpgraderPlatformStrategy
+    {
+        public WindowsProductUpgraderPlatformStrategy(PhysicalFileSystem fileSystem, ITracer tracer)
+        : base(fileSystem, tracer)
+        {
+        }
+
+        public override bool TryPrepareLogDirectory(out string error)
+        {
+            // Under normal circumstances
+            // ProductUpgraderInfo.GetLogDirectoryPath will have
+            // already been created by GVFS.Service.  If for some
+            // reason it does not (e.g. the service failed to start),
+            // we need to create
+            // ProductUpgraderInfo.GetLogDirectoryPath() explicity to
+            // ensure that it has the correct ACLs (so that both admin
+            // and non-admin users can create log files).  If the logs
+            // directory does not already exist, this call could fail
+            // when running as a non-elevated user.
+            string createDirectoryError;
+            if (!this.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(ProductUpgraderInfo.GetLogDirectoryPath(), out createDirectoryError))
+            {
+                error = $"ERROR: Unable to create directory `{ProductUpgraderInfo.GetLogDirectoryPath()}`";
+                error += $"\n{createDirectoryError}";
+                error += $"\n\nTry running {GVFSConstants.UpgradeVerbMessages.GVFSUpgrade} from an elevated command prompt.";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareApplicationDirectory(out string error)
+        {
+            string rootDirectoryPath = ProductUpgraderInfo.GetUpgradesDirectoryPath();
+            string toolsDirectoryPath = Path.Combine(rootDirectoryPath, ProductUpgrader.ToolsDirectory);
+
+            Exception deleteDirectoryException;
+            if (this.FileSystem.DirectoryExists(toolsDirectoryPath) &&
+                !this.FileSystem.TryDeleteDirectory(toolsDirectoryPath, out deleteDirectoryException))
+            {
+                error = $"Failed to delete {toolsDirectoryPath} - {deleteDirectoryException.Message}";
+
+                this.TraceException(deleteDirectoryException, nameof(this.TryPrepareApplicationDirectory), $"Error deleting {toolsDirectoryPath}.");
+                return false;
+            }
+
+            if (!this.FileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissions(
+                    this.Tracer,
+                    toolsDirectoryPath,
+                    out error))
+            {
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareDownloadDirectory(out string error)
+        {
+            return this.FileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissions(
+                this.Tracer,
+                ProductUpgraderInfo.GetAssetDownloadsPath(),
+                out error);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -114,6 +114,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Windows\Upgrader\WindowsNuGetUpgraderTests.cs" />
     <Compile Include="Windows\Mock\MockProcessLauncher.cs" />
     <Compile Include="Windows\Mock\MockVirtualizationInstance.cs" />
     <Compile Include="Windows\Mock\MockWriteBuffer.cs" />

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/WindowsNuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Upgrader/WindowsNuGetUpgraderTests.cs
@@ -1,0 +1,60 @@
+﻿using GVFS.Common;
+using GVFS.Platform.Windows;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Common.NuGetUpgrade;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.UnitTests.Windows.Common.Upgrader
+{
+    [TestFixture]
+    public class WindowsNuGetUpgraderTests : NuGetUpgraderTests
+    {
+        public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformStrategy()
+        {
+            return new WindowsProductUpgraderPlatformStrategy(this.mockFileSystem, this.tracer);
+        }
+
+        [TestCase]
+        public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
+        {
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
+            this.upgrader.TrySetupToolsDirectory(out string _, out string _).ShouldBeFalse();
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
+        }
+
+        [TestCase]
+        public void CanDownloadNewestVersionFailsIfDownloadDirectoryCreationFails()
+        {
+            Version actualNewestVersion;
+            string message;
+            List<IPackageSearchMetadata> availablePackages = new List<IPackageSearchMetadata>()
+            {
+                this.GeneratePackageSeachMetadata(new Version(CurrentVersion)),
+                this.GeneratePackageSeachMetadata(new Version(NewerVersion)),
+            };
+
+            string testDownloadPath = Path.Combine(this.downloadDirectoryPath, "testNuget.zip");
+            IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
+            this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
+            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(testDownloadPath);
+
+            bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
+
+            // Assert that no new version was returned
+            success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
+            actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
+
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
+            bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
+            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
+            downloadSuccessful.ShouldBeFalse();
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -20,38 +20,44 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
     [TestFixture]
     public class NuGetUpgraderTests
     {
-        private const string OlderVersion = "1.0.1185.0";
-        private const string CurrentVersion = "1.5.1185.0";
-        private const string NewerVersion = "1.6.1185.0";
-        private const string NewerVersion2 = "1.7.1185.0";
+        protected const string OlderVersion = "1.0.1185.0";
+        protected const string CurrentVersion = "1.5.1185.0";
+        protected const string NewerVersion = "1.6.1185.0";
+        protected const string NewerVersion2 = "1.7.1185.0";
 
-        private const string NuGetFeedUrl = "https://pkgs.dev.azure.com/contoso/packages";
-        private const string NuGetFeedName = "feedNameValue";
+        protected const string NuGetFeedUrl = "https://pkgs.dev.azure.com/contoso/packages";
+        protected const string NuGetFeedName = "feedNameValue";
 
-        private static Exception httpRequestAuthException = new System.Net.Http.HttpRequestException("Response status code does not indicate success: 401 (Unauthorized).");
-        private static Exception fatalProtocolAuthException = new FatalProtocolException("Unable to load the service index for source.", httpRequestAuthException);
+        protected static Exception httpRequestAuthException = new System.Net.Http.HttpRequestException("Response status code does not indicate success: 401 (Unauthorized).");
+        protected static Exception fatalProtocolAuthException = new FatalProtocolException("Unable to load the service index for source.", httpRequestAuthException);
 
-        private static Exception[] networkAuthFailures =
+        protected static Exception[] networkAuthFailures =
         {
             httpRequestAuthException,
             fatalProtocolAuthException
         };
 
-        private NuGetUpgrader upgrader;
-        private MockTracer tracer;
+        protected NuGetUpgrader upgrader;
+        protected MockTracer tracer;
 
-        private NuGetUpgrader.NuGetUpgraderConfig upgraderConfig;
+        protected NuGetUpgrader.NuGetUpgraderConfig upgraderConfig;
 
-        private Mock<NuGetFeed> mockNuGetFeed;
-        private MockFileSystem mockFileSystem;
-        private Mock<ICredentialStore> mockCredentialManager;
+        protected Mock<NuGetFeed> mockNuGetFeed;
+        protected MockFileSystem mockFileSystem;
+        protected Mock<ICredentialStore> mockCredentialManager;
+        protected ProductUpgraderPlatformStrategy productUpgraderPlatformStrategy;
 
-        private string downloadDirectoryPath = Path.Combine(
+        protected string downloadDirectoryPath = Path.Combine(
             $"mock:{Path.DirectorySeparatorChar}",
             ProductUpgraderInfo.UpgradeDirectoryName,
             ProductUpgraderInfo.DownloadDirectory);
 
-        private delegate void DownloadPackageAsyncCallback(PackageIdentity packageIdentity);
+        protected delegate void DownloadPackageAsyncCallback(PackageIdentity packageIdentity);
+
+        public virtual ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformStrategy()
+        {
+            return new MockProductUpgraderPlatformStrategy(this.mockFileSystem, this.tracer);
+        }
 
         [SetUp]
         public void SetUp()
@@ -80,6 +86,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             string emptyString = string.Empty;
             this.mockCredentialManager.Setup(foo => foo.TryGetCredential(It.IsAny<ITracer>(), It.IsAny<string>(), out credentialManagerString, out credentialManagerString, out credentialManagerString)).Returns(true);
 
+            this.productUpgraderPlatformStrategy = this.CreateProductUpgraderPlatformStrategy();
+
             this.upgrader = new NuGetUpgrader(
                 CurrentVersion,
                 this.tracer,
@@ -88,7 +96,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.mockFileSystem,
                 this.upgraderConfig,
                 this.mockNuGetFeed.Object,
-                this.mockCredentialManager.Object);
+                this.mockCredentialManager.Object,
+                this.productUpgraderPlatformStrategy);
         }
 
         [TearDown]
@@ -216,34 +225,6 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
         }
 
         [TestCase]
-        public void CanDownloadNewestVersionFailsIfDownloadDirectoryCreationFails()
-        {
-            Version actualNewestVersion;
-            string message;
-            List<IPackageSearchMetadata> availablePackages = new List<IPackageSearchMetadata>()
-            {
-                this.GeneratePackageSeachMetadata(new Version(CurrentVersion)),
-                this.GeneratePackageSeachMetadata(new Version(NewerVersion)),
-            };
-
-            string testDownloadPath = Path.Combine(this.downloadDirectoryPath, "testNuget.zip");
-            IPackageSearchMetadata newestAvailableVersion = availablePackages.Last();
-            this.mockNuGetFeed.Setup(foo => foo.QueryFeedAsync(NuGetFeedName)).ReturnsAsync(availablePackages);
-            this.mockNuGetFeed.Setup(foo => foo.DownloadPackageAsync(It.Is<PackageIdentity>(packageIdentity => packageIdentity == newestAvailableVersion.Identity))).ReturnsAsync(testDownloadPath);
-
-            bool success = this.upgrader.TryQueryNewestVersion(out actualNewestVersion, out message);
-
-            // Assert that no new version was returned
-            success.ShouldBeTrue($"Expecting TryQueryNewestVersion to have completed sucessfully. Error: {message}");
-            actualNewestVersion.ShouldEqual(newestAvailableVersion.Identity.Version.Version, "Actual new version does not match expected new version.");
-
-            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
-            bool downloadSuccessful = this.upgrader.TryDownloadNewestVersion(out message);
-            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
-            downloadSuccessful.ShouldBeFalse();
-        }
-
-        [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void DownloadNewestVersion_HandleException()
         {
@@ -303,7 +284,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object,
-                this.mockCredentialManager.Object);
+                this.mockCredentialManager.Object,
+                this.productUpgraderPlatformStrategy);
 
             nuGetUpgrader.UpgradeAllowed(out _).ShouldBeTrue("NuGetUpgrader config is complete: upgrade should be allowed.");
 
@@ -319,7 +301,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object,
-                this.mockCredentialManager.Object);
+                this.mockCredentialManager.Object,
+                this.productUpgraderPlatformStrategy);
 
             nuGetUpgrader.UpgradeAllowed(out string _).ShouldBeFalse("Upgrade without FeedURL configured should not be allowed.");
 
@@ -336,7 +319,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object,
-                this.mockCredentialManager.Object);
+                this.mockCredentialManager.Object,
+                this.productUpgraderPlatformStrategy);
 
             nuGetUpgrader.UpgradeAllowed(out string _).ShouldBeFalse("Upgrade without FeedName configured should not be allowed.");
         }
@@ -388,14 +372,6 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
         }
 
         [TestCase]
-        public void TrySetupToolsDirectoryFailsIfCreateToolsDirectoryFails()
-        {
-            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = false;
-            this.upgrader.TrySetupToolsDirectory(out string upgraderToolsPath, out string error).ShouldBeFalse();
-            this.mockFileSystem.TryCreateOrUpdateDirectoryToAdminModifyPermissionsShouldSucceed = true;
-        }
-
-        [TestCase]
         public void DownloadFailsOnNuGetPackageVerificationFailure()
         {
             Version actualNewestVersion;
@@ -440,7 +416,8 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 this.mockFileSystem,
                 nuGetUpgraderConfig,
                 this.mockNuGetFeed.Object,
-                this.mockCredentialManager.Object);
+                this.mockCredentialManager.Object,
+                this.productUpgraderPlatformStrategy);
 
             Version actualNewestVersion;
             string message;
@@ -466,7 +443,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
             downloadSuccessful.ShouldBeTrue("Should be able to download package with verification issues when noVerify is specified");
         }
 
-        private IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)
+        protected IPackageSearchMetadata GeneratePackageSeachMetadata(Version version)
         {
             Mock<IPackageSearchMetadata> mockPackageSearchMetaData = new Mock<IPackageSearchMetadata>();
             NuGet.Versioning.NuGetVersion nuGetVersion = new NuGet.Versioning.NuGetVersion(version);

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -65,6 +65,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 NuGetFeedName,
                 this.downloadDirectoryPath,
                 null,
+                GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                 this.tracer);
             this.mockNuGetFeed.Setup(feed => feed.SetCredentials(It.IsAny<string>()));
 

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
@@ -84,6 +84,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 DefaultUpgradeFeedPackageName,
                 this.downloadDirectoryPath,
                 null,
+                GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                 this.tracer);
 
             this.mockFileSystem = new MockFileSystem(

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -151,6 +151,13 @@ namespace GVFS.UnitTests.Mock.Common
             return new MockFileBasedLock(fileSystem, tracer, lockPath);
         }
 
+        public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer)
+        {
+            return new MockProductUpgraderPlatformStrategy(fileSystem, tracer);
+        }
+
         public override bool TryKillProcessTree(int processId, out int exitCode, out string error)
         {
             error = null;

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockProductUpgraderPlatformStrategy.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockProductUpgraderPlatformStrategy.cs
@@ -1,0 +1,32 @@
+using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+
+namespace GVFS.UnitTests.Mock.Common
+{
+    public class MockProductUpgraderPlatformStrategy : ProductUpgraderPlatformStrategy
+    {
+        public MockProductUpgraderPlatformStrategy(PhysicalFileSystem fileSystem, ITracer tracer)
+        : base(fileSystem, tracer)
+        {
+        }
+
+        public override bool TryPrepareLogDirectory(out string error)
+        {
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareApplicationDirectory(out string error)
+        {
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareDownloadDirectory(out string error)
+        {
+            error = null;
+            return true;
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Upgrader/UpgradeOrchestratorTests.cs
+++ b/GVFS/GVFS.UnitTests/Upgrader/UpgradeOrchestratorTests.cs
@@ -43,7 +43,7 @@ namespace GVFS.UnitTests.Upgrader
             this.PreRunChecker = new MockInstallerPrerunChecker(this.Tracer);
             this.PreRunChecker.Reset();
             this.MoqUpgrader = this.DefaultUpgrader();
-            this.orchestrator = new UpgradeOrchestrator(
+            this.orchestrator = new WindowsUpgradeOrchestrator(
                 this.MoqUpgrader.Object,
                 this.Tracer,
                 this.FileSystem,

--- a/GVFS/GVFS.UnitTests/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -17,7 +17,7 @@ namespace GVFS.UnitTests.Upgrader
         {
             base.Setup();
 
-            this.orchestrator = new UpgradeOrchestrator(
+            this.orchestrator = new WindowsUpgradeOrchestrator(
                 this.Upgrader,
                 this.Tracer,
                 this.FileSystem,

--- a/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
+++ b/GVFS/GVFS.Upgrader/GVFS.Upgrader.csproj
@@ -26,6 +26,7 @@
     <When Condition="'$(OS)' == 'Windows_NT'">
       <PropertyGroup>
         <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+	<DefineConstants>$(DefineConstants);WINDOWS_BUILD</DefineConstants>
       </PropertyGroup>
       <ItemGroup>
         <ProjectReference Include="..\GVFS.Platform.Windows\GVFS.Platform.Windows.csproj" />
@@ -38,6 +39,7 @@
       <PropertyGroup>
         <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
         <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
+	<DefineConstants>$(DefineConstants);MACOS_BUILD</DefineConstants>
       </PropertyGroup>
       <ItemGroup>
         <ProjectReference Include="..\GVFS.Platform.Mac\GVFS.Platform.Mac.csproj" />

--- a/GVFS/GVFS.Upgrader/MacUpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/MacUpgradeOrchestrator.cs
@@ -1,0 +1,17 @@
+namespace GVFS.Upgrader
+{
+    public class MacUpgradeOrchestrator : UpgradeOrchestrator
+    {
+        public MacUpgradeOrchestrator(UpgradeOptions options)
+        : base(options)
+        {
+        }
+
+        protected override bool TryMountRepositories(out string consoleError)
+        {
+            // Mac upgrader does not mount repositories
+            consoleError = null;
+            return true;
+        }
+    }
+}

--- a/GVFS/GVFS.Upgrader/Program.cs
+++ b/GVFS/GVFS.Upgrader/Program.cs
@@ -9,8 +9,8 @@ namespace GVFS.Upgrader
         {
             GVFSPlatformLoader.Initialize();
 
-            Parser.Default.ParseArguments<UpgradeOrchestrator>(args)
-                    .WithParsed(upgrader => upgrader.Execute());
+            Parser.Default.ParseArguments<UpgradeOptions>(args)
+                .WithParsed(options =>  UpgradeOrchestratorFactory.Create(options).Execute());
         }
     }
 }

--- a/GVFS/GVFS.Upgrader/UpgradeOptions.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOptions.cs
@@ -1,0 +1,22 @@
+using CommandLine;
+
+namespace GVFS.Upgrader
+{
+    [Verb("UpgradeOrchestrator", HelpText = "Upgrade VFS for Git.")]
+    public class UpgradeOptions
+    {
+        [Option(
+            "dry-run",
+            Default = false,
+            Required = false,
+            HelpText = "Display progress and errors, but don't install GVFS")]
+        public bool DryRun { get; set; }
+
+        [Option(
+            "no-verify",
+            Default = false,
+            Required = false,
+            HelpText = "Don't verify authenticode signature of installers")]
+        public bool NoVerify { get; set; }
+    }
+}

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestratorFactory.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestratorFactory.cs
@@ -1,0 +1,16 @@
+namespace GVFS.Upgrader
+{
+    public static class UpgradeOrchestratorFactory
+    {
+        public static UpgradeOrchestrator Create(UpgradeOptions options)
+        {
+#if MACOS_BUILD
+            return new MacUpgradeOrchestrator(options);
+#elif WINDOWS_BUILD
+            return new WindowsUpgradeOrchestrator(options);
+#else
+            throw new NotImplementedException();
+#endif
+            }
+    }
+}

--- a/GVFS/GVFS.Upgrader/WindowsUpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/WindowsUpgradeOrchestrator.cs
@@ -1,0 +1,55 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System.IO;
+
+namespace GVFS.Upgrader
+{
+    public class WindowsUpgradeOrchestrator : UpgradeOrchestrator
+    {
+        public WindowsUpgradeOrchestrator(
+            ProductUpgrader upgrader,
+            ITracer tracer,
+            PhysicalFileSystem fileSystem,
+            InstallerPreRunChecker preRunChecker,
+            TextReader input,
+            TextWriter output)
+            : base(upgrader, tracer, fileSystem, preRunChecker, input, output)
+        {
+        }
+
+        public WindowsUpgradeOrchestrator(UpgradeOptions options)
+            : base(options)
+        {
+        }
+
+        protected override bool TryMountRepositories(out string consoleError)
+        {
+            string errorMessage = string.Empty;
+            if (this.mount && !this.LaunchInsideSpinner(
+                () =>
+                {
+                    string mountError;
+                    if (!this.preRunChecker.TryMountAllGVFSRepos(out mountError))
+                    {
+                        EventMetadata metadata = new EventMetadata();
+                        metadata.Add("Upgrade Step", nameof(this.TryMountRepositories));
+                        metadata.Add("Mount Error", mountError);
+                        this.tracer.RelatedError(metadata, $"{nameof(this.preRunChecker.TryMountAllGVFSRepos)} failed.");
+                        errorMessage += mountError;
+                        return false;
+                    }
+
+                    return true;
+                },
+                "Mounting repositories"))
+            {
+                consoleError = errorMessage;
+                return false;
+            }
+
+            consoleError = null;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
The upgrade logic between the different platforms has some high level differences that need to be accounted for:

1) Creation of directories with the correct ACLs
    - On Mac, the directories will be created with the expected ACLs, and we will not need to re-acl the directories.

There are other ways to handle the platform differences, but including:

  - performing the re-ACLing of directories on non-windows platforms. We could re-use more of the top level logic, but then we would be doing extra work with ACLs that is not needed.

  - Do no re-ACL on non-windows platforms. I did not want to cause confusion with the methods not doing what they advertise (especially around ACLs), in case someone misses this subtlety in the future. This would be hard from a maintainability standpoint...


2) Whether the Upgrader is responsible for remounting or not
    - On Windows, the upgrader itself is responsible for re-mounting after upgrade, while on Mac, the GVFS.Service will auto remount when the service starts up.

There is still some further work I need to do here to get this into shape, but I wanted to put this up for initial feedback on the general direction.