### PR TITLE
Upgrader: copy entire application directory

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -39,6 +39,26 @@ namespace GVFS.Common.FileSystem
             directory.Delete();
         }
 
+        public virtual void CopyDirectoryRecursive(string srcDirectoryPath, string dstDirectoryPath)
+        {
+            DirectoryInfo srcDirectory = new DirectoryInfo(srcDirectoryPath);
+
+            if (!this.DirectoryExists(dstDirectoryPath))
+            {
+                this.CreateDirectory(dstDirectoryPath);
+            }
+
+            foreach (FileInfo file in srcDirectory.EnumerateFiles())
+            {
+                this.CopyFile(file.FullName, Path.Combine(dstDirectoryPath, file.Name), overwrite: true);
+            }
+
+            foreach (DirectoryInfo subDirectory in srcDirectory.EnumerateDirectories())
+            {
+                this.CopyDirectoryRecursive(subDirectory.FullName, Path.Combine(dstDirectoryPath, subDirectory.Name));
+            }
+        }
+
         public virtual bool FileExists(string path)
         {
             return File.Exists(path);


### PR DESCRIPTION
When upgrading VFS for Git via the built-in upgrade logic, the upgrade verb will copy the upgrader application to a temporary directory, and run the upgrade app from the temporary directory. The main reason for this is so that the upgrade application can update the original application without open file handles getting in the way (and preventing the deletion of the application that is being updated).

The upgrade verb currently has a hard coded list of dependencies (files) required for the upgrader application to run. This can be fragile as we need to keep this list in sync with the actual dependencies, across multiple platforms. This can easily break if the dependencies change, and we update the list of files included with the installer, but not with the upgrader application. A specific occurrence of this happened in #1144.

Instead, just copy over the whole VFS for Git application directory when creating a temporary copy of the upgrader application to run. We might copy over a few additional files, but this should not cause any noticeable downsides.

#### TODO:
- ~~[ ] Tests~~ copied to backlog in #1129 