### PR TITLE
 Upgrader: add command install action

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/InstallActionInfo.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/InstallActionInfo.cs
@@ -7,13 +7,15 @@ namespace GVFS.Common.NuGetUpgrade
         /// </summary>
         public const string ManifestEntryInstallationIdToken = "installation_id";
         public const string ManifestEntryLogDirectoryToken = "log_directory";
+        public const string ManifestEntryInstallerBaseDirectoryToken = "installer_base_path";
 
-        public InstallActionInfo(string name, string version, string args, string installerRelativePath)
+        public InstallActionInfo(string name, string version, string args, string installerRelativePath, string command)
         {
             this.Name = name;
             this.Version = version;
             this.Args = args;
             this.InstallerRelativePath = installerRelativePath;
+            this.Command = command;
         }
 
         /// <summary>
@@ -27,8 +29,8 @@ namespace GVFS.Common.NuGetUpgrade
         public string Name { get; }
 
         /// <summary>
-        /// The path to the installer, relative to the
-        /// content directory of the NuGet package.
+        /// The path to the application or document to start. The path
+        /// is relative to the content directory of the NuGet package.
         /// </summary>
         public string InstallerRelativePath { get; }
 
@@ -36,5 +38,12 @@ namespace GVFS.Common.NuGetUpgrade
         /// The version of the component that this entry installs
         /// </summary>
         public string Version { get; }
+
+        /// <summary>
+        /// The command to run. If this is present, the command is run
+        /// directly (with the processed args), and the
+        /// InstallerRelativePath property is ignored.
+        /// </summary>
+        public string Command { get; }
     }
 }

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -488,7 +488,6 @@ namespace GVFS.Common.NuGetUpgrade
 
         private bool TryGetPersonalAccessToken(string credentialUrl, ITracer tracer, out string token, out string error)
         {
-            error = null;
             return this.credentialStore.TryGetCredential(this.tracer, credentialUrl, out string username, out token, out error);
         }
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -157,9 +157,9 @@ namespace GVFS.Common.NuGetUpgrade
         public static string ReplaceArgTokens(string src, string installationId, string logsDirectory, string installerBaseDirectory)
         {
             string dst = src
-                .Replace(NuGetUpgrader.replacementToken(InstallActionInfo.ManifestEntryLogDirectoryToken), logsDirectory)
-                .Replace(NuGetUpgrader.replacementToken(InstallActionInfo.ManifestEntryInstallationIdToken), installationId)
-                .Replace(NuGetUpgrader.replacementToken(InstallActionInfo.ManifestEntryInstallerBaseDirectoryToken), installerBaseDirectory);
+                .Replace(NuGetUpgrader.ReplacementToken(InstallActionInfo.ManifestEntryLogDirectoryToken), logsDirectory)
+                .Replace(NuGetUpgrader.ReplacementToken(InstallActionInfo.ManifestEntryInstallationIdToken), installationId)
+                .Replace(NuGetUpgrader.ReplacementToken(InstallActionInfo.ManifestEntryInstallerBaseDirectoryToken), installerBaseDirectory);
             return dst;
         }
 
@@ -464,7 +464,7 @@ namespace GVFS.Common.NuGetUpgrade
             return metadata;
         }
 
-        private static string replacementToken(string tokenString)
+        private static string ReplacementToken(string tokenString)
         {
             return "{" + tokenString + "}";
         }

--- a/GVFS/GVFS.UnitTests/Common/InstallManifestTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/InstallManifestTests.cs
@@ -97,7 +97,8 @@ namespace GVFS.UnitTests.Common
                 name: $"Installer{entrySuffix}",
                 version: $"1.{entrySuffix}.1.2",
                 args: $"/nodowngrade{entrySuffix}",
-                installerRelativePath: $"installers/installer1{entrySuffix}");
+                installerRelativePath: $"installers/installer1{entrySuffix}",
+                command: string.Empty);
         }
 
         private void VerifyInstallManifestsAreEqual(InstallManifest expected, InstallManifest actual)

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -364,11 +364,11 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
         {
             string logDirectory = "mock:\\test_log_directory";
             string noTokenSourceString = "/arg no_token log_directory installation_id";
-            NuGetUpgrader.ReplaceArgTokens(noTokenSourceString, "unique_id", logDirectory).ShouldEqual(noTokenSourceString, "String with no tokens should not be modifed");
+            NuGetUpgrader.ReplaceArgTokens(noTokenSourceString, "unique_id", logDirectory, "installerBase").ShouldEqual(noTokenSourceString, "String with no tokens should not be modifed");
 
-            string sourceStringWithTokens = "/arg /log {log_directory}_{installation_id}";
-            string expectedProcessedString = "/arg /log " + logDirectory + "_" + "unique_id";
-            NuGetUpgrader.ReplaceArgTokens(sourceStringWithTokens, "unique_id", logDirectory).ShouldEqual(expectedProcessedString, "expected tokens have not been replaced");
+            string sourceStringWithTokens = "/arg /log {log_directory}_{installation_id}_{installer_base_path}";
+            string expectedProcessedString = "/arg /log " + logDirectory + "_unique_id_installerBase";
+            NuGetUpgrader.ReplaceArgTokens(sourceStringWithTokens, "unique_id", logDirectory, "installerBase").ShouldEqual(expectedProcessedString, "expected tokens have not been replaced");
         }
 
         [TestCase]


### PR DESCRIPTION
When the upgrader runs install actions defined in the installer manifest, it previously only supported starting an application or document contained in the installer package. The installer author might
want to run instead a command that is provided by the host operating
system / environment. For example, on macOS the installer author might want to run bash
or the "installer" binary directly as one of the install actions defined in the installer payload.

As any command can be included as an installer action, there is not any additional verification we can make about the command, except for validating the integrity of the containing NuGet package, and enforcing that the package contents have not been tampered with before we run the command.

This does not currently include a mechanism to define an environment variable.