### PR TITLE
Perform case-sensitive path comparisons on Linux

### DIFF
--- a/GVFS/FastFetch/WorkingTree.cs
+++ b/GVFS/FastFetch/WorkingTree.cs
@@ -26,7 +26,7 @@ namespace FastFetch
 
             Parallel.ForEach(
                 dir.EnumerateDirectories().Where(subdir =>
-                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, StringComparison.OrdinalIgnoreCase) &&
+                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, GVFSPlatform.Instance.Constants.PathComparison) &&
                      !subdir.Attributes.HasFlag(FileAttributes.ReparsePoint))),
                 subdir => { ForAllDirectories(subdir, asyncParallelCallback); });
         }

--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common.FileSystem
         {
             IEnumerable<string> valuableHooksLines = defaultHooksLines.Where(line => !string.IsNullOrEmpty(line.Trim()));
 
-            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, StringComparer.OrdinalIgnoreCase))
+            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, GVFSPlatform.Instance.Constants.PathComparer))
             {
                 throw new HooksConfigurationException(
                     $"{GVFSPlatform.Instance.Constants.GVFSHooksExecutableName} should not be specified in the configuration for "

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -102,6 +102,28 @@ namespace GVFS.Common
 
             public abstract string GVFSExecutableName { get; }
 
+            public abstract bool CaseSensitiveFileSystem { get; }
+
+            public StringComparison PathComparison
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparison.Ordinal :
+                        StringComparison.OrdinalIgnoreCase;
+                }
+            }
+
+            public StringComparer PathComparer
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparer.Ordinal :
+                        StringComparer.OrdinalIgnoreCase;
+                }
+            }
+
             public string GVFSHooksExecutableName
             {
                 get { return "GVFS.Hooks" + this.ExecutableExtension; }

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -58,12 +58,12 @@ namespace GVFS.Common.Maintenance
             {
                 string extension = Path.GetExtension(info.Name);
 
-                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(extension, ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     count++;
                     size += info.Length;
                 }
-                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(extension, ".keep", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     hasKeep = true;
                 }
@@ -88,7 +88,7 @@ namespace GVFS.Common.Maintenance
 
             foreach (DirectoryItemInfo info in packDirContents)
             {
-                if (string.Equals(Path.GetExtension(info.Name), ".idx", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(info.Name), ".idx", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string pairedPack = Path.ChangeExtension(info.FullName, ".pack");
 

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -316,7 +316,7 @@ namespace GVFS.Common.Maintenance
                                          .FileSystem
                                          .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
                                          .Where(item => item.Name.StartsWith(prefix)
-                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", StringComparison.OrdinalIgnoreCase))
+                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                                          .FirstOrDefault();
             if (info == null)
             {

--- a/GVFS/GVFS.Common/RepoMetadata.cs
+++ b/GVFS/GVFS.Common/RepoMetadata.cs
@@ -48,7 +48,7 @@ namespace GVFS.Common
             string dictionaryPath = Path.Combine(dotGVFSPath, GVFSConstants.DotGVFS.Databases.RepoMetadata);
             if (Instance != null)
             {
-                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, StringComparison.OrdinalIgnoreCase))
+                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     throw new InvalidOperationException(
                         string.Format(

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -445,11 +445,6 @@ namespace GVFS.Hooks
             return true;
         }
 
-        private static bool ContainsArg(string[] actualArgs, string expectedArg)
-        {
-            return actualArgs.Contains(expectedArg, StringComparer.OrdinalIgnoreCase);
-        }
-
         private static string GetHookType(string[] args)
         {
             return args[0].ToLowerInvariant();

--- a/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
@@ -494,7 +494,7 @@ namespace GVFS.Platform.Linux
                 bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
                 if (pathInsideDotGit)
                 {
-                    if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+                    if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.Ordinal))
                     {
                         string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
                         if (string.IsNullOrEmpty(lockedGitCommand))

--- a/GVFS/GVFS.Platform.Linux/LinuxPlatform.cs
+++ b/GVFS/GVFS.Platform.Linux/LinuxPlatform.cs
@@ -89,6 +89,8 @@ namespace GVFS.Platform.Linux
             {
                 get { return Path.GetFileName(this.GVFSBinDirectoryPath); }
             }
+
+            public override bool CaseSensitiveFileSystem => true;
         }
     }
 }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -78,6 +78,8 @@ namespace GVFS.Platform.Mac
             {
                 get { return "vfsforgit"; }
             }
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -440,6 +440,8 @@ namespace GVFS.Platform.Windows
             {
                 get { return "GVFS" + this.ExecutableExtension; }
             }
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Service/Linux/GVFSService.cs
+++ b/GVFS/GVFS.Service/Linux/GVFSService.cs
@@ -27,7 +27,7 @@ namespace GVFS.Service.Linux
 
         public void RunWithArgs(string[] args)
         {
-            string nameArg = args.FirstOrDefault(arg => arg.StartsWith(ServiceNameArgPrefix, StringComparison.OrdinalIgnoreCase));
+            string nameArg = args.FirstOrDefault(arg => arg.StartsWith(ServiceNameArgPrefix, StringComparison.Ordinal));
             if (!string.IsNullOrEmpty(nameArg))
             {
                 this.serviceName = nameArg.Substring(ServiceNameArgPrefix.Length);

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -197,7 +197,7 @@ namespace GVFS.Service
 
         public Dictionary<string, RepoRegistration> ReadRegistry()
         {
-            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
 
             using (Stream stream = this.fileSystem.OpenFileStream(
                     Path.Combine(this.registryParentFolderPath, RegistryName),
@@ -238,7 +238,7 @@ namespace GVFS.Service
                                 string normalizedEnlistmentRootPath = registration.EnlistmentRoot;
                                 if (this.fileSystem.TryGetNormalizedPath(registration.EnlistmentRoot, out normalizedEnlistmentRootPath, out errorMessage))
                                 {
-                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, StringComparison.OrdinalIgnoreCase))
+                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                     {
                                         EventMetadata metadata = new EventMetadata();
                                         metadata.Add("registration.EnlistmentRoot", registration.EnlistmentRoot);

--- a/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
+++ b/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
@@ -3,5 +3,6 @@
     public static class CategoryConstants
     {
         public const string ExceptionExpected = "ExceptionExpected";
+        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
@@ -329,7 +329,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxFileExistsFailures > 0)
                 {
                     if (this.fileExistsFailureCount < this.maxFileExistsFailures &&
-                        string.Equals(path, this.fileExistsFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.fileExistsFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -342,7 +342,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 1 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -391,7 +391,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxOpenFileStreamFailures > 0)
                 {
                     if (this.openFileStreamFailureCount < this.maxOpenFileStreamFailures &&
-                        string.Equals(path, this.openFileStreamFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.openFileStreamFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.openFileStreamFailureCount;
 
@@ -408,7 +408,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 0 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.failuresAcrossOpenExistsAndOverwriteCount;
                         throw new IOException();

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests.Mock.Common
 {
@@ -194,6 +195,8 @@ namespace GVFS.UnitTests.Mock.Common
             {
                 get { return "MockGVFS" + this.ExecutableExtension; }
             }
+
+            public override bool CaseSensitiveFileSystem => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -231,7 +231,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
                 // if it's called for one of those paths remap the paths to be inside the mock: root
                 string mockDirectoryPath = directoryPath;
                 string gvfsProgramData = @"C:\ProgramData\GVFS";
-                if (directoryPath.StartsWith(gvfsProgramData, StringComparison.OrdinalIgnoreCase))
+                if (directoryPath.StartsWith(gvfsProgramData, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     mockDirectoryPath = mockDirectoryPath.Substring(gvfsProgramData.Length);
                     mockDirectoryPath = "mock:" + mockDirectoryPath;

--- a/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
@@ -124,7 +124,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
         protected override bool TryDownloadAsset(Asset asset, out string errorMessage)
         {
             bool validAsset = true;
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSDownload))
                 {
@@ -132,7 +132,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                     return false;
                 }
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitDownload))
                 {
@@ -161,7 +161,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
 
         protected override bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSCleanup))
                 {
@@ -172,7 +172,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 exception = null;
                 return true;
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitCleanup))
                 {
@@ -215,7 +215,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
             exitCode = 0;
             error = null;
 
-            if (fileName.Equals(this.expectedGitAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGitAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("Git", installationInfo);
                 this.InstallerExeLaunched = true;
@@ -234,7 +234,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 return;
             }
 
-            if (fileName.Equals(this.expectedGVFSAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGVFSAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("GVFS", installationInfo);
                 this.InstallerExeLaunched = true;

--- a/GVFS/GVFS.UnitTests/Platform.Linux/LinuxFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Linux/LinuxFileSystemVirtualizerTests.cs
@@ -309,7 +309,7 @@ namespace GVFS.UnitTests.Platform.Linux
                 gitIndexProjection.EnumerationInMemory = false;
                 mockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 mockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFilePath, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFilePath, StringComparison.Ordinal) && kvp.Value == GitIndexProjection.FileMode644);
                 fileSystemCallbacks.Stop();
             }
         }
@@ -347,7 +347,7 @@ namespace GVFS.UnitTests.Platform.Linux
                 gitIndexProjection.EnumerationInMemory = true;
                 mockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 mockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFilePath, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFilePath, StringComparison.Ordinal) && kvp.Value == GitIndexProjection.FileMode644);
                 gitIndexProjection.ExpandedFolders.ShouldMatchInOrder(TestFolderName);
                 fileSystemCallbacks.Stop();
             }
@@ -396,11 +396,11 @@ namespace GVFS.UnitTests.Platform.Linux
                 gitIndexProjection.EnumerationInMemory = true;
                 mockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 mockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile644Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFile644Path, StringComparison.Ordinal) && kvp.Value == GitIndexProjection.FileMode644);
                 mockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile664Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode664);
+                    kvp => kvp.Key.Equals(testFile664Path, StringComparison.Ordinal) && kvp.Value == GitIndexProjection.FileMode664);
                 mockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile755Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode755);
+                    kvp => kvp.Key.Equals(testFile755Path, StringComparison.Ordinal) && kvp.Value == GitIndexProjection.FileMode755);
                 fileSystemCallbacks.Stop();
             }
         }

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Common.Prefetch.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
 using NUnit.Framework;
@@ -102,6 +103,7 @@ namespace GVFS.UnitTests.Prefetch
         // Delete a folder with two sub folders each with a single file
         // Readd it with a different casing and same contents
         [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
         public void ParsesCaseChangesAsAdds()
         {
             MockTracer tracer = new MockTracer();

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -3,6 +3,7 @@ using GVFS.UnitTests.Category;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests
 {
@@ -17,6 +18,11 @@ namespace GVFS.UnitTests
             if (Debugger.IsAttached)
             {
                 excludeCategories.Add(CategoryConstants.ExceptionExpected);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                excludeCategories.Add(CategoryConstants.CaseInsensitiveFileSystemOnly);
             }
 
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Virtualization.Background;
 using GVFS.UnitTests.Mock.Virtualization.BlobSize;
@@ -29,10 +30,16 @@ namespace GVFS.UnitTests.Virtualization
         public void IsPathInsideDotGitIsTrueForDotGitPath()
         {
             FileSystemCallbacks.IsPathInsideDotGit(@".git" + Path.DirectorySeparatorChar).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_file.txt")).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_folder", "test_file.txt")).ShouldEqual(true);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
+        public void IsPathInsideDotGitIsTrueForDifferentCaseDotGitPath()
+        {
+            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
+            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_folder", "test_file.txt")).ShouldEqual(true);
         }
 

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
@@ -123,7 +123,7 @@ namespace GVFS.Virtualization.Background
         private bool TryParseAddLine(string line, out long key, out FileSystemTask value, out string error)
         {
             // Expected: <ID>\0<Background Update>
-            int idx = line.IndexOf(ValueTerminator, StringComparison.OrdinalIgnoreCase);
+            int idx = line.IndexOf(ValueTerminator, StringComparison.Ordinal);
             if (idx < 0)
             {
                 key = 0;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -150,17 +150,17 @@ namespace GVFS.Virtualization.FileSystem
         protected bool IsSpecialGitFile(string fileName)
         {
             return
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, StringComparison.OrdinalIgnoreCase) ||
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, StringComparison.OrdinalIgnoreCase);
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, GVFSPlatform.Instance.Constants.PathComparison) ||
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         protected void OnDotGitFileOrFolderChanged(string relativePath)
         {
-            if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+            if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnIndexFileChange();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnLogsHeadChange();
             }
@@ -168,7 +168,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -180,7 +180,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -365,9 +365,9 @@ namespace GVFS.Virtualization.FileSystem
 
         private static bool IsPathHeadOrLocalBranch(string relativePath)
         {
-            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, StringComparison.OrdinalIgnoreCase) &&
-                (relativePath.Equals(GVFSConstants.DotGit.Head, StringComparison.OrdinalIgnoreCase) ||
-                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, StringComparison.OrdinalIgnoreCase)))
+            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, GVFSPlatform.Instance.Constants.PathComparison) &&
+                (relativePath.Equals(GVFSConstants.DotGit.Head, GVFSPlatform.Instance.Constants.PathComparison) ||
+                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -69,7 +69,7 @@ namespace GVFS.Virtualization
             this.context = context;
             this.fileSystemVirtualizer = fileSystemVirtualizer;
 
-            this.placeHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
+            this.placeHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             string error;
@@ -165,7 +165,7 @@ namespace GVFS.Virtualization
         /// </summary>
         public static bool IsPathInsideDotGit(string relativePath)
         {
-            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public bool TryStart(out string error)
@@ -282,7 +282,7 @@ namespace GVFS.Virtualization
             if (this.placeHolderCreationCount.Count > 0)
             {
                 ConcurrentDictionary<string, PlaceHolderCreateCounter> collectedData = this.placeHolderCreationCount;
-                this.placeHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
+                this.placeHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
 
                 int count = 0;
                 foreach (KeyValuePair<string, PlaceHolderCreateCounter> processCount in

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -101,7 +101,7 @@ namespace GVFS.CommandLine
 
                 if (normalizedLocalCacheRootPath.StartsWith(
                     Path.Combine(normalizedEnlistmentRootPath, GVFSConstants.WorkingDirectoryRootName),
-                    StringComparison.OrdinalIgnoreCase))
+                    GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.ReportErrorAndExit("'--local-cache-path' cannot be inside the src folder");
                 }
@@ -291,7 +291,7 @@ namespace GVFS.CommandLine
             // LogFileEventListener will create a file in EnlistmentRootPath
             if (Directory.Exists(normalizedEnlistementRootPath) && Directory.EnumerateFileSystemEntries(normalizedEnlistementRootPath).Any())
             {
-                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, StringComparison.OrdinalIgnoreCase))
+                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     return new Result($"Clone directory '{fullEnlistmentRootPathParameter}' exists and is not empty");
                 }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -359,7 +359,7 @@ of your enlistment's src folder.
             foreach (string file in Directory.GetFiles(folderPath, searchPattern))
             {
                 string fileName = Path.GetFileName(file);
-                if (!filenamesToSkip.Any(x => x.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+                if (!filenamesToSkip.Any(x => x.Equals(fileName, GVFSPlatform.Instance.Constants.PathComparison)))
                 {
                     if (!this.TryIO(
                         tracer,

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -553,7 +553,7 @@ namespace GVFS.CommandLine
                 DriveInfo enlistmentDrive = new DriveInfo(enlistmentNormalizedPathRoot);
                 string enlistmentDriveDiskSpace = this.FormatByteCount(enlistmentDrive.AvailableFreeSpace);
 
-                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.WriteMessage("Available space on " + enlistmentDrive.Name + " drive(enlistment and local cache): " + enlistmentDriveDiskSpace);
                 }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -964,7 +964,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                                     while (!reader.EndOfStream)
                                     {
                                         string alternatesLine = reader.ReadLine();
-                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, StringComparison.OrdinalIgnoreCase))
+                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                         {
                                             gitObjectsRootInAlternates = true;
                                         }

--- a/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Linux/LinuxFileSystemVirtualizer.cs
@@ -11,6 +11,8 @@ namespace MirrorProvider.Linux
     {
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
 
+        protected override StringComparison PathComparison => StringComparison.Ordinal;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             error = null;
@@ -242,7 +244,7 @@ namespace MirrorProvider.Linux
                 return false;
             }
 
-            if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
+            if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.Ordinal))
             {
                 // Link target is an absolute path inside the MirrorRoot.
                 // The target needs to be adjusted to point inside the src root

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -9,6 +9,8 @@ namespace MirrorProvider.Mac
     {
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(directory);

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -12,6 +12,8 @@ namespace MirrorProvider.Windows
         private VirtualizationInstance virtualizationInstance;
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations = new ConcurrentDictionary<Guid, ActiveEnumeration>();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             error = string.Empty;

--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -9,6 +9,8 @@ namespace MirrorProvider
     {
         protected Enlistment Enlistment { get; private set; }
 
+        protected abstract StringComparison PathComparison { get; }
+
         public abstract bool TryConvertVirtualizationRoot(string directory, out string error);
         public virtual bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)
         {
@@ -151,7 +153,7 @@ namespace MirrorProvider
             FileSystemInfo fileSystemInfo = 
                 dirInfo
                 .GetFileSystemInfos()
-                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, PathComparison));
 
             if (fileSystemInfo == null)
             {


### PR DESCRIPTION
On Windows and Mac, path comparisons are case-insensitive, as the filesystems are case-insensitive -- `.git` and `.GIT` are the same path name, and you can't have two different files or directories with names that only differ in case.

On Linux, filesystems (usually) are case-sensitive -- it is possible to have `.git`, `.GIT` and `.Git` entries in the one directory, all referring to different things. Accordingly, we need to do all path comparisons in a case-sensitive fashion.

This change should be a no-op for Windows and Mac, inasmuch as no different values will result after the change. This change does mean `GVFSPlatform.Instance` is being relied on in more places, and it's difficult to audit if a given piece of code could be called without `GVFSPlatform.Instance` already being initialised. (This bit me when working on #1084, where I tried to use `GVFSPlatform.Instance` in `GVFS.FunctionalTests.LockHolder`, which silently died with NRE because it wasn't initialised.)

Nonetheless, unit and (Windows) functional tests pass, so it might be fine.

Fixes github#29.
/cc @chrisd8088