### PR TITLE
Upgrader: implement cross platform functionality

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -106,6 +106,8 @@ namespace GVFS.Common
 
             public abstract string GVFSExecutableName { get; }
 
+            public abstract string ProgramLocaterCommand { get; }
+
             public string GVFSHooksExecutableName
             {
                 get { return "GVFS.Hooks" + this.ExecutableExtension; }

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -108,6 +108,18 @@ namespace GVFS.Common
 
             public abstract string ProgramLocaterCommand { get; }
 
+            /// <summary>
+            /// Different platforms can have different requirements
+            /// around which processes can block upgrade. For example,
+            /// on Windows, we will block upgrade if any GVFS commands
+            /// are running, but on POSIX platforms, we relax this
+            /// constraint to allow upgrade to run while the upgrade
+            /// command is running. Another example is that
+            /// Non-windows platforms do not block upgrade when bash
+            /// is running.
+            /// </summary>
+            public abstract HashSet<string> UpgradeBlockingProcesses { get; }
+
             public string GVFSHooksExecutableName
             {
                 get { return "GVFS.Hooks" + this.ExecutableExtension; }

--- a/GVFS/GVFS.Common/IProcessRunner.cs
+++ b/GVFS/GVFS.Common/IProcessRunner.cs
@@ -1,0 +1,12 @@
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Interface around process helper methods. This is to enable
+    /// testing of components that interact with the ProcessHelper
+    /// static class.
+    /// </summary>
+    public interface IProcessRunner
+    {
+        ProcessResult Run(string programName, string args, bool redirectOutput);
+    }
+}

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -12,8 +12,6 @@ namespace GVFS.Upgrader
 {
     public class InstallerPreRunChecker
     {
-        private static readonly HashSet<string> BlockingProcessSet = new HashSet<string> { "GVFS", "GVFS.Mount", "git", "ssh-agent", "bash", "wish", "git-bash" };
-
         private ITracer tracer;
 
         public InstallerPreRunChecker(ITracer tracer, string commandToRerun)
@@ -139,7 +137,7 @@ namespace GVFS.Upgrader
 
             foreach (Process process in allProcesses)
             {
-                if (process.Id == currentProcessId || !BlockingProcessSet.Contains(process.ProcessName))
+                if (process.Id == currentProcessId || !GVFSPlatform.Instance.Constants.UpgradeBlockingProcesses.Contains(process.ProcessName))
                 {
                     continue;
                 }

--- a/GVFS/GVFS.Common/InstallerPreRunChecker.cs
+++ b/GVFS/GVFS.Common/InstallerPreRunChecker.cs
@@ -153,7 +153,7 @@ namespace GVFS.Upgrader
 
         protected virtual bool TryRunGVFSWithArgs(string args, out string consoleError)
         {
-            string gvfsDirectory = ProcessHelper.WhereDirectory(GVFSPlatform.Instance.Constants.GVFSExecutableName);
+            string gvfsDirectory = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSExecutableName);
             if (!string.IsNullOrEmpty(gvfsDirectory))
             {
                 string gvfsPath = Path.Combine(gvfsDirectory, GVFSPlatform.Instance.Constants.GVFSExecutableName);

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -62,9 +62,9 @@ namespace GVFS.Common
             return currentVersion.Major == 0;
         }
 
-        public static string WhereDirectory(string processName)
+        public static string GetProgramLocation(string programLocaterCommand, string processName)
         {
-            ProcessResult result = ProcessHelper.Run("where", processName);
+            ProcessResult result = ProcessHelper.Run(programLocaterCommand, processName);
             if (result.ExitCode != 0)
             {
                 return null;

--- a/GVFS/GVFS.Common/ProcessRunnerImpl.cs
+++ b/GVFS/GVFS.Common/ProcessRunnerImpl.cs
@@ -1,0 +1,16 @@
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Default product implementation of IProcessRunner
+    /// interface. Delegates calls to static ProcessHelper class. This
+    /// class can be used to enable testing of components that call
+    /// into the ProcessHelper functionality.
+    /// </summary>
+    public class ProcessRunnerImpl : IProcessRunner
+    {
+        public ProcessResult Run(string programName, string args, bool redirectOutput)
+        {
+            return ProcessHelper.Run(programName, args, redirectOutput);
+        }
+    }
+}

--- a/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
+++ b/GVFS/GVFS.Installer.Mac/scripts/Distribution.xml
@@ -34,7 +34,7 @@
         
         function GetBlockingProcesses()
         {
-            var watchList = [ "gvfs", "GVFS.Mount", "git", "gitk", "Wish" ];
+            var watchList = [ "GVFS.Mount", "git", "gitk", "Wish" ];
             var blockingProcesses = new Array();
             for (var process of watchList)
             {

--- a/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
+++ b/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
@@ -26,7 +26,7 @@ namespace GVFS.PerfProfiling
         private GVFSEnlistment CreateEnlistment(string enlistmentRootPath)
         {
             string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            string hooksPath = ProcessHelper.WhereDirectory(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            string hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
 
             return GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, hooksPath, authentication: null);
         }

--- a/GVFS/GVFS.Platform.Mac/MacDaemonController.cs
+++ b/GVFS/GVFS.Platform.Mac/MacDaemonController.cs
@@ -1,0 +1,74 @@
+using GVFS.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.Platform.Mac
+{
+    /// <summary>
+    /// Class to query the configured services on macOS
+    /// </summary>
+    public class MacDaemonController
+    {
+        private const string LaunchCtlPath = @"/bin/launchctl";
+        private const string LaunchCtlArg = @"list";
+
+        private IProcessRunner processRunner;
+
+        public MacDaemonController(IProcessRunner processRunner)
+        {
+            this.processRunner = processRunner;
+        }
+
+        public bool TryGetDaemons(string currentUser, out List<DaemonInfo> daemons, out string error)
+        {
+            // Consider for future improvement:
+            // Use Launchtl to run Launchctl as the "real" user, so we can get the process list from the user.
+            ProcessResult result = this.processRunner.Run(LaunchCtlPath, "asuser " + currentUser + " "  + LaunchCtlPath + " " + LaunchCtlArg, true);
+
+            if (result.ExitCode != 0)
+            {
+                error = result.Output;
+                daemons = null;
+                return false;
+            }
+
+            return this.TryParseOutput(result.Output, out daemons, out error);
+        }
+
+        private bool TryParseOutput(string output, out List<DaemonInfo> daemonInfos, out string error)
+        {
+            daemonInfos = new List<DaemonInfo>();
+
+            // 1st line is the header, skip it
+            foreach (string line in output.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Skip(1))
+            {
+                // The expected output is a list of tab delimited entried:
+                // PID\tSTATUS\tLABEL
+                string[] tokens = line.Split('\t');
+
+                if (tokens.Length != 3)
+                {
+                    daemonInfos = null;
+                    error = $"Unexpected number of tokens in line: {line}";
+                    return false;
+                }
+
+                string label = tokens[2];
+                bool isRunning = int.TryParse(tokens[0], out _);
+
+                daemonInfos.Add(new DaemonInfo() { Name = label, IsRunning = isRunning });
+            }
+
+            error = null;
+            return true;
+        }
+
+        public class DaemonInfo
+        {
+            public string Name { get; set; }
+            public bool IsRunning { get; set; }
+        }
+    }
+}

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -207,7 +207,7 @@ namespace GVFS.Platform.POSIX
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string> { "GVFS.Mount", "git", "wish" }; }
+                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS.Mount", "git", "wish" }; }
             }
         }
     }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -199,6 +199,12 @@ namespace GVFS.Platform.POSIX
             {
                 get { return "gvfs"; }
             }
+
+            public override string ProgramLocaterCommand
+            {
+                get { return "which"; }
+            }
+
         }
     }
 }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -205,6 +205,10 @@ namespace GVFS.Platform.POSIX
                 get { return "which"; }
             }
 
+            public override HashSet<string> UpgradeBlockingProcesses
+            {
+                get { return new HashSet<string> { "GVFS.Mount", "git", "wish" }; }
+            }
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsGitInstallation.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsGitInstallation.cs
@@ -19,7 +19,7 @@ namespace GVFS.Platform.Windows
                 return File.Exists(gitBinPath);
             }
 
-            return ProcessHelper.WhereDirectory(GitProcessName) != null;
+            return ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GitProcessName) != null;
         }
 
         public string GetInstalledGitBinPath()

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -455,7 +455,7 @@ namespace GVFS.Platform.Windows
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string> { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
+                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
             }
         }
     }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -452,6 +452,11 @@ namespace GVFS.Platform.Windows
             {
                 get { return "where"; }
             }
+
+            public override HashSet<string> UpgradeBlockingProcesses
+            {
+                get { return new HashSet<string> { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
+            }
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -244,7 +244,7 @@ namespace GVFS.Platform.Windows
         {
             error = null;
             hooksVersion = null;
-            hooksPath = ProcessHelper.WhereDirectory(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
             if (hooksPath == null)
             {
                 error = "Could not find " + GVFSPlatform.Instance.Constants.GVFSHooksExecutableName;
@@ -446,6 +446,11 @@ namespace GVFS.Platform.Windows
             public override string GVFSExecutableName
             {
                 get { return "GVFS" + this.ExecutableExtension; }
+            }
+
+            public override string ProgramLocaterCommand
+            {
+                get { return "where"; }
             }
         }
     }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -201,6 +201,11 @@ namespace GVFS.UnitTests.Mock.Common
             {
                 get { return "MockGVFS" + this.ExecutableExtension; }
             }
+
+            public override string ProgramLocaterCommand
+            {
+                get { return "MockWhere"; }
+            }
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -209,7 +209,7 @@ namespace GVFS.UnitTests.Mock.Common
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string> { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
+                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
             }
         }
     }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -206,6 +206,11 @@ namespace GVFS.UnitTests.Mock.Common
             {
                 get { return "MockWhere"; }
             }
+
+            public override HashSet<string> UpgradeBlockingProcesses
+            {
+                get { return new HashSet<string> { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
+            }
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacDaemonControllerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacDaemonControllerTests.cs
@@ -1,0 +1,41 @@
+using GVFS.Common;
+using GVFS.Platform.Mac;
+using GVFS.Tests.Should;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GVFS.UnitTests.Platform.Mac
+{
+    [TestFixture]
+    public class MacServiceProcessTests
+    {
+        [TestCase]
+        public void CanGetServices()
+        {
+            Mock<IProcessRunner> processHelperMock = new Mock<IProcessRunner>(MockBehavior.Strict);
+
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("PID\tStatus\tLabel");
+            sb.AppendLine("1\t0\tcom.apple.process1");
+            sb.AppendLine("2\t0\tcom.apple.process2");
+            sb.AppendLine("3\t0\tcom.apple.process3");
+            sb.AppendLine("-\t0\tcom.apple.process4");
+
+            ProcessResult processResult = new ProcessResult(sb.ToString(), string.Empty, 0);
+
+            processHelperMock.Setup(m => m.Run("/bin/launchctl", "asuser 521 /bin/launchctl list", true)).Returns(processResult);
+
+            MacDaemonController daemonController = new MacDaemonController(processHelperMock.Object);
+            bool success = daemonController.TryGetDaemons("521", out List<MacDaemonController.DaemonInfo> daemons, out string error);
+
+            success.ShouldBeTrue();
+            daemons.ShouldNotBeNull();
+            daemons.Count.ShouldEqual(4);
+            processHelperMock.VerifyAll();
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -1110,7 +1110,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                     // the .git/hooks folder, and once Windows does the same, this hooksPath can be removed (from here
                     // and all the classes that handle it on the way to GitProcess)
 
-                    hooksPath = ProcessHelper.WhereDirectory(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+                    hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
                     if (hooksPath == null)
                     {
                         this.ReportErrorAndExit("Could not find " + GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);


### PR DESCRIPTION
Includes the following changes to enable cross platform functionality required by the upgrade functionality:

 - Platform specific blocking process lists
 - Platform specific ability to locate programs
 - Implement IsServiceInstalledAndRunning for Mac platform

To see how these changes fit in with the larger Mac Upgrader work, please look at #1129 