### PR TITLE
Handle KAUTH_FILEOP_CLOSE_MODIFIED as a bit field

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -714,7 +714,7 @@ KEXT_STATIC int HandleFileOpOperation(
         
         UseMainForkIfNamedStream(currentVnode, putCurrentVnode);
         
-        if (KAUTH_FILEOP_CLOSE_MODIFIED != closeFlags)
+        if (!FileFlagsBitIsSet(closeFlags, KAUTH_FILEOP_CLOSE_MODIFIED))
         {
             goto CleanupAndReturn;
         }

--- a/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
@@ -206,6 +206,32 @@ class PrjFSProviderUserClient
             _));
 }
 
+- (void) testCloseWithModifedWithBitChange {
+    testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
+
+    HandleFileOpOperation(
+        nullptr,
+        nullptr,
+        KAUTH_FILEOP_CLOSE,
+        reinterpret_cast<uintptr_t>(testFileVnode.get()),
+        reinterpret_cast<uintptr_t>(filePath),
+        KAUTH_FILEOP_CLOSE_MODIFIED | 1<<2,
+        0);
+    
+    XCTAssertTrue(
+       MockCalls::DidCallFunction(
+            ProviderMessaging_TrySendRequestAndWaitForResponse,
+            _,
+            MessageType_KtoU_NotifyFileModified,
+            testFileVnode.get(),
+            _,
+            filePath,
+            _,
+            _,
+            _,
+            _));
+}
+
 - (void) testCloseWithModifedOnDirectory {
     testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
 


### PR DESCRIPTION
KAUTH_FILEOP_CLOSE_MODIFIED is in theory a bit field, but HandleFileOpOperation() tests for equality. There currently aren't any other possible flags, but if Apple were to add some in future, our code could break.

Adds a test illustrating the problem. 

resolves #971 
