### PR TITLE
NuGetFeed: only encrypt in memory credential  on supported platforms

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -154,11 +155,20 @@ namespace GVFS.Common.NuGetUpgrade
 
         private static PackageSourceCredential BuildCredentialsFromPAT(string personalAccessToken)
         {
+            // The storePasswordInClearText property is used to control whether the password
+            // is written to NuGet config files in clear text or not. It also controls whether the
+            // password is stored encrypted in memory or not. The ability to encrypt / decrypt the password
+            // is not supported in non-windows platforms at this point.
+            // We do not actually write out config files or store the password (except in memory). As in our
+            // usage of NuGet functionality we do not write out config files, it is OK to not set this property
+            // (with the tradeoff being the password is not encrypted in memory, and we need to make sure that new code
+            // does not start to write out config files).
+            bool storePasswordInClearText = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             return PackageSourceCredential.FromUserInput(
                 "VfsForGitNugetUpgrader",
                 "PersonalAccessToken",
                 personalAccessToken,
-                storePasswordInClearText: false);
+                storePasswordInClearText: storePasswordInClearText);
         }
 
         private void SetSourceRepository()


### PR DESCRIPTION
The NuGet Client API has flags to control whether a password is stored
in clear text or not. This flag controls:

  1) Whether the password is stored in clear text when persisted to a
  config file on disk.

  2) Whether the password is stored encrypted in memory

Encrypting the password is only supported on Windows (and Mono)
platforms, and not on netcore platfroms.

As VFS for Git does not actually update any configuration files, the
flag only controls how the password is stored in memory. For netcore
platforms, do not set this flag. As VFS for Git does not persist this
data to disk, the tradeoff is whether the process is encrypting the
password in memory or not. VFS for Git itself is working with the
plain text password, so this is not broading the risk in this aspect.