### PR TITLE
Simplify excluded categories in functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -85,15 +85,6 @@ namespace GVFS.FunctionalTests
                 includeCategories.Remove(Categories.ExtraCoverage);
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                excludeCategories.Add(Categories.WindowsOnly);
-            }
-            else
-            {
-                excludeCategories.Add(Categories.LinuxOnly);
-            }
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
@@ -105,9 +96,17 @@ namespace GVFS.FunctionalTests
                 excludeCategories.Add(Categories.MacTODO.NeedsCorruptObjectFix);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);
+                excludeCategories.Add(Categories.LinuxOnly);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                excludeCategories.Add(Categories.WindowsOnly);
+                excludeCategories.Add(Categories.MacOnly);
             }
             else
             {
+                // Windows excludes.
+                excludeCategories.Add(Categories.LinuxOnly);
                 excludeCategories.Add(Categories.MacOnly);
             }
 


### PR DESCRIPTION
The per-platform excluded test categories are somewhat difficult to parse with multiple sequential conditionals. Simplify per @wilbaker's suggestion at https://github.com/microsoft/VFSForGit/pull/1125#discussion_r290382941.