### PR TITLE
update Mac build steps to install Java first

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,8 +81,8 @@ Note that VFS for Git on Mac is under active development.
 
 * Prep your machine to use VFS for Git. The following are all done by the script below.
   * install [Homebrew](https://brew.sh/)
-  * install and setup the Git Credential Manager (with `brew`)
   * install/update Java (with `brew`)
+  * install and setup the Git Credential Manager (with `brew`)
   * install a VFS for Git aware version of Git
 
   ```


### PR DESCRIPTION
Moved the Java install step before the git-credential-manager install step.

The Mac build instructions currently instruct the user to install `git-credential-manager` via Homebrew first and then install Java, but doing that fails:

```
git-credential-manager: Java 1.6+ is required to install this formula.
Install AdoptOpenJDK with Homebrew Cask:
  brew cask install adoptopenjdk
```

