### PR TITLE
LooseObjectsStep: report full object cache size

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Git;
+﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
@@ -103,6 +104,29 @@ namespace GVFS.Common.Maintenance
                                 error),
                             metadata: null);
                     }
+                }
+            }
+        }
+
+        // public only for unit tests
+        public void GetPackFilesInfo(out int count, out long size, out bool hasKeep)
+        {
+            count = 0;
+            size = 0;
+            hasKeep = false;
+
+            foreach (DirectoryItemInfo info in this.Context.FileSystem.ItemsInDirectory(this.Context.Enlistment.GitPackRoot))
+            {
+                string extension = Path.GetExtension(info.Name);
+
+                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                {
+                    count++;
+                    size += info.Length;
+                }
+                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasKeep = true;
                 }
             }
         }

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -48,29 +48,6 @@ namespace GVFS.Common.Maintenance
         protected override TimeSpan TimeBetweenRuns => TimeSpan.FromDays(1);
 
         // public only for unit tests
-        public void GetPackFilesInfo(out int count, out long size, out bool hasKeep)
-        {
-            count = 0;
-            size = 0;
-            hasKeep = false;
-
-            foreach (DirectoryItemInfo info in this.Context.FileSystem.ItemsInDirectory(this.Context.Enlistment.GitPackRoot))
-            {
-                string extension = Path.GetExtension(info.Name);
-
-                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
-                {
-                    count++;
-                    size += info.Length;
-                }
-                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
-                {
-                    hasKeep = true;
-                }
-            }
-        }
-
-        // public only for unit tests
         public List<string> CleanStaleIdxFiles(out int numDeletionBlocked)
         {
             List<DirectoryItemInfo> packDirContents = this.Context

--- a/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
@@ -143,9 +143,10 @@ namespace GVFS.UnitTests.Maintenance
             this.TestSetup(DateTime.UtcNow.AddDays(-7));
 
             LooseObjectsStep step = new LooseObjectsStep(this.context, requireCacheLock: false, forceRun: false);
-            int count = step.CountLooseObjects();
+            step.CountLooseObjects(out int count, out long size);
 
             count.ShouldEqual(3);
+            size.ShouldEqual("one".Length + "two".Length + "three".Length);
         }
 
         [TestCase]
@@ -212,7 +213,7 @@ namespace GVFS.UnitTests.Maintenance
                 null,
                 new List<MockFile>()
                 {
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "AA", "1156f4f2b850673090c285289ea8475d629fe1"), string.Empty)
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "AA", "1156f4f2b850673090c285289ea8475d629fe1"), "one")
                 });
 
             // Create Hex Folder 2 with 2 Files
@@ -221,8 +222,8 @@ namespace GVFS.UnitTests.Maintenance
                 null,
                 new List<MockFile>()
                 {
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "1156f4f2b850673090c285289ea8475d629fe2"), string.Empty),
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "1156f4f2b850673090c285289ea8475d629fe3"), string.Empty)
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "1156f4f2b850673090c285289ea8475d629fe2"), "two"),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "F1", "1156f4f2b850673090c285289ea8475d629fe3"), "three")
                 });
 
             // Create NonHex Folder with 4 Files
@@ -231,14 +232,19 @@ namespace GVFS.UnitTests.Maintenance
                 null,
                 new List<MockFile>()
                 {
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe4"), string.Empty),
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe5"), string.Empty),
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe6"), string.Empty),
-                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe7"), string.Empty)
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe4"), "4"),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe5"), "5"),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe6"), "6"),
+                     new MockFile(Path.Combine(enlistment.GitObjectsRoot, "ZZ", "1156f4f2b850673090c285289ea8475d629fe7"), "7")
                 });
 
+            MockDirectory pack = new MockDirectory(
+                enlistment.GitPackRoot,
+                null,
+                new List<MockFile>());
+
             // Create git objects directory
-            MockDirectory gitObjectsRoot = new MockDirectory(enlistment.GitObjectsRoot, new List<MockDirectory>() { infoRoot, hex1, hex2, nonhex }, null);
+            MockDirectory gitObjectsRoot = new MockDirectory(enlistment.GitObjectsRoot, new List<MockDirectory>() { infoRoot, hex1, hex2, nonhex, pack }, null);
 
             // Add object directory to file System
             List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };


### PR DESCRIPTION
As the PackfileMaintenanceStep is now running in production, I noticed a user's repo was growing significantly between runs. It turns out this user had many loose objects and the packs created by the LooseObjectsStep were large.

Add extra object size checks and pack-size checks to the LooseObjectsStep so we can report the total effect on the object cache's contents.