### PR TITLE
Mac: Switch on the UTF8 tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -11,10 +11,6 @@
 
         public static class MacTODO
         {
-            // The FailsOnBuildAgent category is for tests that pass on dev
-            // machines but not on the build agents
-            public const string FailsOnBuildAgent = "FailsOnBuildAgent";
-
             // Tests that require #360 (detecting/handling new empty folders)
             public const string NeedsNewFolderCreateNotification = "NeedsNewFolderCreateNotification";
 

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -86,7 +86,6 @@ namespace GVFS.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                excludeCategories.Add(Categories.MacTODO.FailsOnBuildAgent);
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
                 excludeCategories.Add(Categories.MacTODO.NeedsDehydrate);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -452,7 +452,6 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         }
 
         [TestCase, Order(15)]
-        [Category(Categories.MacTODO.FailsOnBuildAgent)]
         public void FilterNonUTF8FileName()
         {
             string encodingFilename = "ريلٌأكتوبرûمارسأغسطسºٰٰۂْٗ۵ريلٌأك.txt";

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -987,7 +987,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.FailsOnBuildAgent)]
         public void EditFileNeedingUtf8Encoding()
         {
             this.ValidateGitCommand("checkout -b tests/functional/EditFileNeedingUtf8Encoding");


### PR DESCRIPTION
When we were standing up the Functional Tests on macOS, we saw failures in tests that involved UTF-8 strings on the Azure Pipelines hosted macOS agents which we could never repro locally. Now that they've moved to a newer image, these tests now pass on both our local dev machines, our dedicated functional test machines and the Azure Pipelines hosted machines. 

Let's enable the tests.