### PR TITLE
Update Git to v2.22.0

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190522.3</GitPackageVersion>
+    <GitPackageVersion>2.20190610.5</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -157,7 +157,7 @@ namespace GVFS.Common
                 public const string PostCommandHookName = "post-command";
                 public const string ReadObjectName = "read-object";
                 public const string VirtualFileSystemName = "virtual-filesystem";
-                public const string PostIndexChangedName = "post-indexchanged";
+                public const string PostIndexChangedName = "post-index-change";
                 public static readonly string Root = Path.Combine(DotGit.Root, "hooks");
                 public static readonly string PreCommandPath = Path.Combine(Hooks.Root, PreCommandHookName);
                 public static readonly string PostCommandPath = Path.Combine(Hooks.Root, PostCommandHookName);


### PR DESCRIPTION
Updates to v2.22.0.vfs.1 as discussed in  microsoft/git#140.

Includes these changes in microsoft/git:

* microsoft/git#133
* microsoft/git#139
* microsoft/git#141
* microsoft/git#143

Also, the `post-indexchanged` hook was renamed to `post-index-change` as it was upstreamed.