### PR TITLE
NuGetUpgrader: fix issue with upgrader using interop services

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -138,16 +138,19 @@ namespace GVFS.Common
             public UnderConstructionFlags(
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool requiresDeprecatedGitHooksLoader = false)
+                bool requiresDeprecatedGitHooksLoader = false,
+                bool supportsNuGetEncryption = true)
             {
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
                 this.RequiresDeprecatedGitHooksLoader = requiresDeprecatedGitHooksLoader;
+                this.SupportsNuGetEncryption = supportsNuGetEncryption;
             }
 
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
             public bool RequiresDeprecatedGitHooksLoader { get; }
+            public bool SupportsNuGetEncryption { get; }
         }
     }
 }

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +26,7 @@ namespace GVFS.Common.NuGetUpgrade
         private readonly string feedUrl;
         private readonly string feedName;
         private readonly string downloadFolder;
+        private readonly bool platformSupportsEncryption;
 
         private SourceRepository sourceRepository;
         private string personalAccessToken;
@@ -38,6 +38,7 @@ namespace GVFS.Common.NuGetUpgrade
             string feedName,
             string downloadFolder,
             string personalAccessToken,
+            bool platformSupportsEncryption,
             ITracer tracer)
         {
             this.feedUrl = feedUrl;
@@ -52,6 +53,7 @@ namespace GVFS.Common.NuGetUpgrade
             // - NoCache - Do not cache package version lists
             this.sourceCacheContext = NullSourceCacheContext.Instance.Clone();
             this.sourceCacheContext.NoCache = true;
+            this.platformSupportsEncryption = platformSupportsEncryption;
 
             this.nuGetLogger = new Logger(this.tracer);
             this.SetSourceRepository();
@@ -153,7 +155,7 @@ namespace GVFS.Common.NuGetUpgrade
             return metadata;
         }
 
-        private static PackageSourceCredential BuildCredentialsFromPAT(string personalAccessToken)
+        private static PackageSourceCredential BuildCredentialsFromPAT(string personalAccessToken, bool storePasswordInClearText)
         {
             // The storePasswordInClearText property is used to control whether the password
             // is written to NuGet config files in clear text or not. It also controls whether the
@@ -163,7 +165,6 @@ namespace GVFS.Common.NuGetUpgrade
             // usage of NuGet functionality we do not write out config files, it is OK to not set this property
             // (with the tradeoff being the password is not encrypted in memory, and we need to make sure that new code
             // does not start to write out config files).
-            bool storePasswordInClearText = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             return PackageSourceCredential.FromUserInput(
                 "VfsForGitNugetUpgrader",
                 "PersonalAccessToken",
@@ -176,7 +177,7 @@ namespace GVFS.Common.NuGetUpgrade
             this.sourceRepository = Repository.Factory.GetCoreV3(this.feedUrl);
             if (!string.IsNullOrEmpty(this.personalAccessToken))
             {
-                this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken);
+                this.sourceRepository.PackageSource.Credentials = BuildCredentialsFromPAT(this.personalAccessToken, !this.platformSupportsEncryption);
             }
         }
 

--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -48,6 +48,7 @@ namespace GVFS.Common.NuGetUpgrade
                     config.PackageFeedName,
                     downloadFolder,
                     null,
+                    GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                     tracer),
                 credentialStore)
         {

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -16,7 +16,8 @@ namespace GVFS.Platform.POSIX
         protected POSIXPlatform() : this(
             underConstruction: new UnderConstructionFlags(
                 supportsGVFSUpgrade: false,
-                supportsGVFSConfig: false))
+                supportsGVFSConfig: false,
+                supportsNuGetEncryption: false))
         {
         }
 

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -65,6 +65,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 NuGetFeedName,
                 this.downloadDirectoryPath,
                 null,
+                GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                 this.tracer);
             this.mockNuGetFeed.Setup(feed => feed.SetCredentials(It.IsAny<string>()));
 

--- a/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
@@ -84,6 +84,7 @@ namespace GVFS.UnitTests.Common.NuGetUpgrade
                 DefaultUpgradeFeedPackageName,
                 this.downloadDirectoryPath,
                 null,
+                GVFSPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
                 this.tracer);
 
             this.mockFileSystem = new MockFileSystem(


### PR DESCRIPTION
Instead of querying interop services at runtime (with a dll that is not
included with the windows install), determine this at compile time using the
under construction flags.

(cherry picked from commit fe04e7daf4705e2795157ccc11956d422d35c31b)