### PR TITLE
VFSForGit installer non-relocatable

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -45,6 +45,7 @@ INSTALLERPACKAGENAME="VFSForGit.$PACKAGEVERSION"
 INSTALLERPACKAGEID="com.vfsforgit.pkg"
 UNINSTALLERPATH="${SOURCEDIRECTORY}/uninstall_vfsforgit.sh"
 SCRIPTSPATH="${SOURCEDIRECTORY}/scripts"
+COMPONENTSPLISTPATH="${SOURCEDIRECTORY}/vfsforgit_components.plist"
 DIST_FILE_NAME="Distribution.updated.xml"
 
 function CheckBuildIsAvailable()
@@ -129,7 +130,7 @@ function CopyBinariesToInstall()
 
 function CreateVFSForGitInstaller()
 {
-    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --scripts \"${SCRIPTSPATH}\" --root \"${STAGINGDIR}\" \"${PACKAGESTAGINGDIR}/$INSTALLERPACKAGENAME.pkg\""
+    pkgBuildCommand="/usr/bin/pkgbuild --identifier $INSTALLERPACKAGEID --component-plist \"${COMPONENTSPLISTPATH}\" --scripts \"${SCRIPTSPATH}\" --root \"${STAGINGDIR}\" \"${PACKAGESTAGINGDIR}/$INSTALLERPACKAGENAME.pkg\""
     eval $pkgBuildCommand || exit 1
 }
 

--- a/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
+++ b/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>BundleHasStrictIdentifier</key>
+		<true/>
+		<key>BundleIsRelocatable</key>
+		<false/>
+		<key>BundleIsVersionChecked</key>
+		<true/>
+		<key>BundleOverwriteAction</key>
+		<string>upgrade</string>
+		<key>RootRelativeBundlePath</key>
+		<string>Library/Application Support/VFS For Git/VFS For Git.app</string>
+	</dict>
+	<dict>
+		<key>BundleIsVersionChecked</key>
+		<true/>
+		<key>BundleOverwriteAction</key>
+		<string>upgrade</string>
+		<key>RootRelativeBundlePath</key>
+		<string>Library/Extensions/PrjFSKext.kext</string>
+	</dict>
+</array>
+</plist>


### PR DESCRIPTION
- Added component-plist file for "VFS For Git" package. This is an xml file that contains specifications for how installer should handle installing bundles in VFSForGit package. 
 It is created using the command - 
 `pkgbuild --analyze --root ../BuildOutput/GVFS.Installer.Mac/bin/x64/Debug/netcoreapp2.1/osx-x64/Staging vfsforgit_components.plist`.
 The file has all default flags except `BundleIsRelocatable` which is set to false, for "VFS For Git.app". At install time, this flag stops the installer from searching the target disc for a copy of the app (on developer machines it often times picks the copy from BuildOutput directory), which it then upgrades. Now the installer will always fresh-install (or upgrade) the specific path - `/Library/Application\ Support/VFS For Git/VFS For Git.app` only. 
- Also updated CreateInstaller script to use the component-plist file.