### PR TITLE
Fix performance regression in LibGit2RepoInvoker

### DIFF
--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -44,12 +44,20 @@ namespace GVFS.Common.Git
             Unknown,
         }
 
-        public bool HasActiveLibGit2Repo => this.libgit2RepoInvoker?.IsActive == true;
-
         public GVFSLock GVFSLock
         {
             get;
             private set;
+        }
+
+        public void CloseActiveRepo()
+        {
+            this.libgit2RepoInvoker?.DisposeSharedRepo();
+        }
+
+        public void OpenRepo()
+        {
+            this.libgit2RepoInvoker?.InitializedSharedRepo();
         }
 
         public bool TryGetIsBlob(string sha, out bool isBlob)

--- a/GVFS/GVFS.Common/Git/LibGit2RepoInvoker.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2RepoInvoker.cs
@@ -19,7 +19,7 @@ namespace GVFS.Common.Git
             this.tracer = tracer;
             this.createRepo = createRepo;
 
-            this.sharedRepo = this.createRepo();
+            this.InitializedSharedRepo();
         }
 
         public void Dispose()
@@ -79,7 +79,9 @@ namespace GVFS.Common.Git
 
         public void InitializedSharedRepo()
         {
-            this.GetSharedRepo();
+            // Run a test on the shared repo to ensure the object store
+            // is loaded, as that is what takes a long time with many packs.
+            this.GetSharedRepo().ObjectExists(GVFSConstants.AllZeroSha);
         }
 
         private LibGit2Repo GetSharedRepo()

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -128,18 +128,6 @@ namespace GVFS.Common.Maintenance
                         activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to git pids {string.Join(",", processIds)}", Keywords.Telemetry);
                         return;
                     }
-
-                    // If a LibGit2Repo is active, then it may hold handles to the .idx and .pack files we want
-                    // to delete during the 'git multi-pack-index expire' step. If one starts during the step,
-                    // then it can still block those deletions, but we will clean them up in the next run. By
-                    // checking HasActiveLibGit2Repo here, we ensure that we do not run twice with the same
-                    // LibGit2Repo active across two calls. A "new" repo should not hold handles to .idx files
-                    // that do not have corresponding .pack files, so we will clean them up in CleanStaleIdxFiles().
-                    if (this.Context.Repository.HasActiveLibGit2Repo)
-                    {
-                        activity.RelatedWarning($"Skipping {nameof(PackfileMaintenanceStep)} due to active libgit2 repo", Keywords.Telemetry);
-                        return;
-                    }
                 }
 
                 this.GetPackFilesInfo(out int beforeCount, out long beforeSize, out bool hasKeep);
@@ -150,7 +138,23 @@ namespace GVFS.Common.Maintenance
                     return;
                 }
 
-                GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.MultiPackIndexExpire));
+                try
+                {
+                    // If a LibGit2Repo is active, then it may hold handles to the .idx and .pack files we want
+                    // to delete during the 'git multi-pack-index expire' step. If one starts during the step,
+                    // then it can still block those deletions, but we will clean them up in the next run. By
+                    // running CloseActiveRepos() here, we ensure that we do not run twice with the same
+                    // LibGit2Repo active across two calls. A "new" repo should not hold handles to .idx files
+                    // that do not have corresponding .pack files, so we will clean them up in CleanStaleIdxFiles().
+                    this.Context.Repository.CloseActiveRepo();
+
+                    GitProcess.Result expireResult = this.RunGitCommand((process) => process.MultiPackIndexExpire(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.MultiPackIndexExpire));
+                }
+                finally
+                {
+                    this.Context.Repository.OpenRepo();
+                }
+
                 List<string> staleIdxFiles = this.CleanStaleIdxFiles(out int numDeletionBlocked);
                 this.GetPackFilesInfo(out int expireCount, out long expireSize, out hasKeep);
 

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
@@ -183,6 +183,11 @@ namespace GVFS.UnitTests.Common
                 this.parent = parent;
             }
 
+            public override bool ObjectExists(string sha)
+            {
+                return false;
+            }
+
             protected override void Dispose(bool disposing)
             {
                 if (disposing)

--- a/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LibGit2RepoInvokerTests.cs
@@ -2,7 +2,6 @@
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using NUnit.Framework;
-using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -11,7 +10,6 @@ namespace GVFS.UnitTests.Common
     [TestFixture]
     public class LibGit2RepoInvokerTests
     {
-        private readonly TimeSpan disposalPeriod = TimeSpan.FromMilliseconds(1);
         private MockTracer tracer;
         private LibGit2RepoInvoker invoker;
         private int numConstructors;
@@ -25,32 +23,65 @@ namespace GVFS.UnitTests.Common
             this.invoker?.Dispose();
 
             this.tracer = new MockTracer();
-            this.invoker = new LibGit2RepoInvoker(this.tracer, this.CreateRepo, this.disposalPeriod);
             this.numConstructors = 0;
             this.numDisposals = 0;
             this.DisposalTriggers = new BlockingCollection<object>();
+
+            this.invoker = new LibGit2RepoInvoker(this.tracer, this.CreateRepo);
         }
 
         [TestCase]
-        public void DoesNotCreateRepoOnConstruction()
+        public void DoesCreateRepoOnConstruction()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
         }
 
         [TestCase]
-        public void CreatesRepoOnTryInvoke()
+        public void CreatesOnRequestAfterClosed()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
+
+            this.invoker.DisposeSharedRepo();
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(1);
+
+            this.invoker.InitializedSharedRepo();
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(2);
 
             this.invoker.TryInvoke(repo => { return true; }, out bool result);
-            result.ShouldEqual(true);
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(2);
+        }
+
+        [TestCase]
+        public void CreatesOnInvokeAfterClosed()
+        {
             this.numConstructors.ShouldEqual(1);
+
+            this.invoker.DisposeSharedRepo();
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(1);
+
+            this.invoker.TryInvoke(repo => { return true; }, out bool result);
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(2);
+
+            this.invoker.InitializedSharedRepo();
+
+            this.numDisposals.ShouldEqual(1);
+            this.numConstructors.ShouldEqual(2);
         }
 
         [TestCase]
         public void DoesNotCreateMultipleRepos()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
 
             this.invoker.TryInvoke(repo => { return true; }, out bool result);
             result.ShouldEqual(true);
@@ -60,25 +91,24 @@ namespace GVFS.UnitTests.Common
             result.ShouldEqual(true);
             this.numConstructors.ShouldEqual(1);
 
-            this.invoker.TryInvoke(repo => { return true; }, out result);
-            result.ShouldEqual(true);
+            this.invoker.InitializedSharedRepo();
             this.numConstructors.ShouldEqual(1);
         }
 
         [TestCase]
         public void DoesNotCreateRepoAfterDisposal()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
             this.invoker.Dispose();
             this.invoker.TryInvoke(repo => { return true; }, out bool result);
             result.ShouldEqual(false);
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
         }
 
         [TestCase]
         public void DisposesSharedRepo()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
             this.numDisposals.ShouldEqual(0);
 
             this.invoker.TryInvoke(repo => { return true; }, out bool result);
@@ -93,7 +123,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void UsesOnlyOneRepoMultipleThreads()
         {
-            this.numConstructors.ShouldEqual(0);
+            this.numConstructors.ShouldEqual(1);
 
             Thread[] threads = new Thread[10];
             BlockingCollection<object> threadStarted = new BlockingCollection<object>();
@@ -136,24 +166,6 @@ namespace GVFS.UnitTests.Common
             }
 
             this.numConstructors.ShouldEqual(1);
-        }
-
-        [TestCase]
-        public void AutomaticallyDisposesAfterNoUse()
-        {
-            this.numConstructors.ShouldEqual(0);
-
-            bool tryInvokeResult1 = this.invoker.TryInvoke(repo => { return true; }, out bool result);
-            result.ShouldEqual(true, string.Format("Unexcepted function result from first call to TryInvoke: {0} ReturnCode: {1}", result, tryInvokeResult1));
-            this.numConstructors.ShouldEqual(1);
-
-            this.DisposalTriggers.TryTake(out object _, (int)this.disposalPeriod.TotalMilliseconds * 500).ShouldBeTrue("Did not dispose object in time");
-            this.numDisposals.ShouldEqual(1);
-            this.numConstructors.ShouldEqual(1);
-
-            bool tryInvokeResult2 = this.invoker.TryInvoke(repo => { return true; }, out result);
-            result.ShouldEqual(true, string.Format("Unexcepted function result from second call to TryInvoke: {0} ReturnCode: {1}", result, tryInvokeResult2));
-            this.numConstructors.ShouldEqual(2);
         }
 
         private LibGit2Repo CreateRepo()


### PR DESCRIPTION
Today, we noticed a performance regression from 1.0.19074.2 to 1.0.19130.1 (M150).

In that release, we changed the way we allocate and refresh LibGit2Repo objects. In order to allow packfile deletions, we need to drop the handles that LibGit2 keeps open during the duration of the LibGit2Repo. The change was to share one repo object and to dispose of it after 15 minutes of inactivity. However, that doesn't take into account the startup time required to initialize the data. This can be a lot worse if the user has thousands of pack-files.

To fix this, change the model. With this change, the PackfileMaintenanceStep will request that the LibGit2Repos are closed before performing the expire command, and then will reinitialize the LibGit2 repo right after. This will keep the "warmup" time as part of the initial mount or as the background operation.

If the read-object hook or a file hydration comes in while the expire command is running, a LibGit2 repo will be initialized and it _may_ cause some .idx files to stick around until the next run. This was already the case, but then the warmup would happen during those operations. This will happen at most once a day.

Resolves #1277 