### PR TITLE
Mac kext: Drop lock for allocating virtualization root array memory

### DIFF
--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -15,6 +15,7 @@
 #include "kernel-header-wrappers/stdatomic.h"
 #include "VnodeUtilities.hpp"
 #include "PerformanceTracing.hpp"
+#include "ArrayUtilities.hpp"
 
 #ifdef KEXT_UNIT_TESTING
 #include "VirtualizationRootsTestable.hpp"
@@ -24,6 +25,7 @@ static RWLock s_virtualizationRootsLock = {};
 
 // Current length of the s_virtualizationRoots array
 KEXT_STATIC uint16_t s_maxVirtualizationRoots = 0;
+static const uint16_t MaxVirtualizationRootsLimit = INT16_MAX + 1u;
 KEXT_STATIC VirtualizationRoot* s_virtualizationRoots = nullptr;
 
 // Looks up the vnode/vid and fsid/inode pairs among the known roots
@@ -32,13 +34,15 @@ static VirtualizationRootHandle FindRootAtVnode_Locked(vnode_t vnode, uint32_t v
 static void RefreshRootVnodeIfNecessary_Locked(VirtualizationRootHandle rootHandle, vnode_t vnode, uint32_t vid, FsidInode fileId);
 static bool FsidsAreEqual(fsid_t a, fsid_t b);
 KEXT_STATIC bool PathInsideDirectory(const char* directoryPath, const char* path);
+static void GrowVirtualizationRootArrayWithMemory_Locked(VirtualizationRoot* newMemory, uint16_t newLength);
 
 // Looks up the vnode and fsid/inode pair among the known roots, and if not found,
 // detects if there is a hitherto-unknown root at vnode by checking attributes.
 static VirtualizationRootHandle FindOrDetectRootAtVnode(vnode_t vnode, const FsidInode& vnodeFsidInode);
 
 static VirtualizationRootHandle FindUnusedIndex_Locked();
-KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
+
+KEXT_STATIC VirtualizationRootHandle FindOrInsertVirtualizationRoot_LockedMayUnlock(vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
 
 ActiveProviderProperties VirtualizationRoot_GetActiveProvider(VirtualizationRootHandle rootHandle)
 {
@@ -83,7 +87,8 @@ kern_return_t VirtualizationRoots_Init()
         return KERN_FAILURE;
     }
     
-    s_maxVirtualizationRoots = 128;
+    // Start with a small size so the resizing logic is regularly tested
+    s_maxVirtualizationRoots = 4;
     s_virtualizationRoots = Memory_AllocArray<VirtualizationRoot>(s_maxVirtualizationRoots);
     if (nullptr == s_virtualizationRoots)
     {
@@ -227,18 +232,10 @@ static VirtualizationRootHandle FindOrDetectRootAtVnode(vnode_t _Nonnull vnode, 
  
             RWLock_AcquireExclusive(s_virtualizationRootsLock);
             {
-                // Vnode may already have been inserted as a root in the interim
-                rootIndex = FindRootAtVnode_Locked(vnode, vid, vnodeFsidInode);
+                rootIndex = FindOrInsertVirtualizationRoot_LockedMayUnlock(vnode, vid, vnodeFsidInode, path);
                 
-                if (RootHandle_None == rootIndex)
-                {
-                    // Insert new offline root
-                    rootIndex = InsertVirtualizationRoot_Locked(nullptr, 0, vnode, vid, vnodeFsidInode, path);
-                    
-                    // TODO: error handling
-                    assert(rootIndex >= 0);
-                }
-
+                // TODO: error handling
+                assert(rootIndex >= 0);
             }
             RWLock_ReleaseExclusive(s_virtualizationRootsLock);
         }
@@ -272,42 +269,16 @@ static VirtualizationRootHandle FindUnusedIndex_Locked()
     return RootHandle_None;
 }
 
-static VirtualizationRootHandle FindUnusedIndexOrGrow_Locked()
+static void GrowVirtualizationRootArrayWithMemory_Locked(VirtualizationRoot* newMemory, uint16_t newLength)
 {
-    VirtualizationRootHandle rootIndex = FindUnusedIndex_Locked();
-    
-    if (RootHandle_None == rootIndex)
-    {
-        // No space, resize array
-        uint16_t newLength = MIN(s_maxVirtualizationRoots * 2u, INT16_MAX + 1u);
-        if (newLength <= s_maxVirtualizationRoots)
-        {
-            assertf(newLength > 0, "s_maxVirtualizationRoot was likely not initialized");
-            // Already at max size, nothing to do.
-            return RootHandle_None;
-        }
+    uint32_t oldSizeBytes = sizeof(s_virtualizationRoots[0]) * s_maxVirtualizationRoots;
+    memcpy(newMemory, s_virtualizationRoots, oldSizeBytes);
+    Memory_FreeArray(s_virtualizationRoots, s_maxVirtualizationRoots);
+    s_virtualizationRoots = newMemory;
 
-        VirtualizationRoot* grownArray = Memory_AllocArray<VirtualizationRoot>(newLength);
-        if (nullptr == grownArray)
-        {
-            return RootHandle_None;
-        }
-        
-        uint32_t oldSizeBytes = sizeof(s_virtualizationRoots[0]) * s_maxVirtualizationRoots;
-        memcpy(grownArray, s_virtualizationRoots, oldSizeBytes);
-        Memory_Free(s_virtualizationRoots, oldSizeBytes);
-        s_virtualizationRoots = grownArray;
+    Array_DefaultInit(&s_virtualizationRoots[s_maxVirtualizationRoots], newLength - s_maxVirtualizationRoots);
 
-        for (uint16_t i = s_maxVirtualizationRoots; i < newLength; ++i)
-        {
-            s_virtualizationRoots[i] = VirtualizationRoot{ };
-        }
-        
-        rootIndex = s_maxVirtualizationRoots;
-        s_maxVirtualizationRoots = newLength;
-    }
-    
-    return rootIndex;
+    s_maxVirtualizationRoots = newLength;
 }
 
 static bool FsidsAreEqual(fsid_t a, fsid_t b)
@@ -380,43 +351,78 @@ static void RefreshRootVnodeIfNecessary_Locked(VirtualizationRootHandle rootHand
     rootEntry.rootVNodeVid = vid;
 }
 
-// Returns negative value if it failed, or inserted index on success
-KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path)
+KEXT_STATIC VirtualizationRootHandle FindOrInsertVirtualizationRoot_LockedMayUnlock(vnode_t virtualizationRootVNode, uint32_t rootVid, FsidInode persistentIds, const char* path)
 {
-    VirtualizationRootHandle rootIndex = FindUnusedIndexOrGrow_Locked();
-    
-    if (RootHandle_None != rootIndex)
+    VirtualizationRootHandle rootIndex;
+    bool allocFailed = false;
+    do
     {
-        assert(rootIndex < s_maxVirtualizationRoots);
-        assert(!s_virtualizationRoots[rootIndex].inUse);
-        
-        // Retain a strong reference to the vnode if we have an active provider on it
-        if (userClient != nullptr)
+        rootIndex = FindRootAtVnode_Locked(virtualizationRootVNode, rootVid, persistentIds);
+        if (rootIndex >= 0)
         {
-            errno_t error = vnode_get(vnode);
-            assertf(error == 0, "The calling code should already hold an iocount on vnode, so vnode_get should never fail. error = %d", error);
+            return rootIndex;
         }
         
-        VirtualizationRoot* root = &s_virtualizationRoots[rootIndex];
-        
-        root->providerUserClient = userClient;
-        root->providerPid = clientPID;
-        root->inUse = true;
-
-        root->rootVNode = vnode;
-        root->rootVNodeVid = vid;
-        KextLog_File(vnode, "InsertVirtualizationRoot_Locked: virtualization root inserted at index %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u, user client PID %d, IOUC %p.",
-            rootIndex, path, persistentIds.fsid.val[0], persistentIds.fsid.val[1], persistentIds.inode, KextLog_Unslide(vnode), vid, clientPID, KextLog_Unslide(userClient));
-        
-        root->rootFsid = persistentIds.fsid;
-        root->rootInode = persistentIds.inode;
-
-        if (path != nullptr)
+        rootIndex = FindUnusedIndex_Locked();
+        if (rootIndex < 0)
         {
-            strlcpy(root->path, path, sizeof(root->path));
+            // No space, resize array
+            uint16_t newLength = MIN(s_maxVirtualizationRoots * 2u, MaxVirtualizationRootsLimit);
+            if (newLength <= s_maxVirtualizationRoots || allocFailed)
+            {
+                KextLog_Error(
+                    "FindOrInsertVirtualizationRoot_LockedMayUnlock: growing virtualization root array for root at '%s' failed: %s, array has reached %u items, resize target %u items\n",
+                    path,
+                    allocFailed ? "memory allocation failed" : "out of valid indices",
+                    s_maxVirtualizationRoots,
+                    newLength);
+                return RootHandle_None;
+            }
+        
+            // Must drop lock to safely allocate memory with blocking alloc
+            RWLock_ReleaseExclusive(s_virtualizationRootsLock);
+            VirtualizationRoot* grownArray = Memory_AllocArray<VirtualizationRoot>(newLength);
+            RWLock_AcquireExclusive(s_virtualizationRootsLock);
+            
+            if (grownArray == nullptr)
+            {
+                // Allocation failed; recheck for space since relocking, and if that fails, give up.
+                allocFailed = true;
+                continue;
+            }
+            
+            uint16_t newLengthAgain = MIN(s_maxVirtualizationRoots * 2u, MaxVirtualizationRootsLimit);
+            if (newLengthAgain != newLength || s_maxVirtualizationRoots == MaxVirtualizationRootsLimit)
+            {
+                KextLog_Info("FindOrInsertVirtualizationRoot_LockedMayUnlock: Beaten to the resize (newLength = %u, newLengthAgain = %u) by another thread, starting over.", newLength, newLengthAgain);
+                // another thread already resized, start over.
+                Memory_FreeArray(grownArray, newLength);
+                continue;
+            }
+            
+            GrowVirtualizationRootArrayWithMemory_Locked(grownArray, newLength);
         }
-    }
+    } while (rootIndex < 0);
+
+    assert(rootIndex < s_maxVirtualizationRoots);
+    assert(!s_virtualizationRoots[rootIndex].inUse);
+
+    VirtualizationRoot* root = &s_virtualizationRoots[rootIndex];
     
+    root->inUse = true;
+
+    root->rootVNode = virtualizationRootVNode;
+    root->rootVNodeVid = rootVid;
+    root->rootFsid = persistentIds.fsid;
+    root->rootInode = persistentIds.inode;
+    if (path != nullptr)
+    {
+        strlcpy(root->path, path, sizeof(root->path));
+    }
+
+    KextLog_File(virtualizationRootVNode, "FindOrInsertVirtualizationRoot_LockedMayUnlock: virtualization root inserted at index %d: (path: \"%s\", fsid: 0x%x:%x, inode: 0x%llx) directory vnode %p:%u.",
+            rootIndex, path, persistentIds.fsid.val[0], persistentIds.fsid.val[1], persistentIds.inode, KextLog_Unslide(virtualizationRootVNode), rootVid);
+
     return rootIndex;
 }
 
@@ -465,13 +471,16 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                 
                 RWLock_AcquireExclusive(s_virtualizationRootsLock);
                 {
-                    rootIndex = FindRootAtVnode_Locked(virtualizationRootVNode, rootVid, vnodeIds);
+                    rootIndex = FindOrInsertVirtualizationRoot_LockedMayUnlock(virtualizationRootVNode, rootVid, vnodeIds, virtualizationRootCanonicalPath);
+                    
                     if (rootIndex >= 0)
                     {
                         RefreshRootVnodeIfNecessary_Locked(rootIndex, virtualizationRootVNode, rootVid, vnodeIds);
                         
-                        // Reattaching to existing root
-                        if (nullptr != s_virtualizationRoots[rootIndex].providerUserClient)
+                        VirtualizationRoot& root = s_virtualizationRoots[rootIndex];
+                        assert(root.rootVNode == virtualizationRootVNode);
+
+                        if (nullptr != root.providerUserClient)
                         {
                             // Only one provider per root
                             err = EBUSY;
@@ -479,8 +488,6 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                         }
                         else
                         {
-                            VirtualizationRoot& root = s_virtualizationRoots[rootIndex];
-                            assert(root.rootVNode == virtualizationRootVNode);
                             root.providerUserClient = userClient;
                             root.providerPid = clientPID;
                             strlcpy(root.path, virtualizationRootCanonicalPath, sizeof(root.path));
@@ -494,18 +501,8 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
                     }
                     else
                     {
-                        rootIndex = InsertVirtualizationRoot_Locked(userClient, clientPID, virtualizationRootVNode, rootVid, vnodeIds, virtualizationRootCanonicalPath);
-                        if (rootIndex >= 0)
-                        {
-                            assert(rootIndex < s_maxVirtualizationRoots);
-                            
-                            KextLog("VirtualizationRoot_RegisterProviderForPath: new root not found in offline roots, inserted as new root with index %d. path '%s'", rootIndex, virtualizationRootCanonicalPath);
-                        }
-                        else
-                        {
-                            KextLog_Error("VirtualizationRoot_RegisterProviderForPath: failed to insert new root");
-                            err = ENOMEM;
-                        }
+                        KextLog_Error("VirtualizationRoot_RegisterProviderForPath: failed to insert new root '%s' for provider with PID %u", virtualizationRootPath, clientPID);
+                        err = ENOMEM;
                     }
                 }
                 RWLock_ReleaseExclusive(s_virtualizationRootsLock);

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRootsPrivate.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRootsPrivate.hpp
@@ -18,3 +18,8 @@ struct VirtualizationRoot
     // Only contains a valid path for online roots (active provider)
     char                        path[PrjFSMaxPath];
 };
+
+#if defined(KEXT_UNIT_TESTING) && !defined(TESTABLE_KEXT_TARGET) // Building unit tests
+#include <type_traits>
+static_assert(std::is_trivially_copyable<VirtualizationRoot>::value, "The array of VirtualizationRoot objects is resized using memcpy");
+#endif

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRootsTestable.hpp
@@ -10,6 +10,6 @@
 extern uint16_t s_maxVirtualizationRoots;
 extern VirtualizationRoot* s_virtualizationRoots;
 
-KEXT_STATIC VirtualizationRootHandle InsertVirtualizationRoot_Locked(PrjFSProviderUserClient* userClient, pid_t clientPID, vnode_t vnode, uint32_t vid, FsidInode persistentIds, const char* path);
+KEXT_STATIC VirtualizationRootHandle FindOrInsertVirtualizationRoot_LockedMayUnlock(vnode_t virtualizationRootVNode, uint32_t rootVid, FsidInode persistentIds, const char* path);
 KEXT_STATIC bool PathInsideDirectory(const char* directoryPath, const char* path);
 

--- a/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
@@ -58,7 +58,8 @@ class PrjFSProviderUserClient
 
 - (void)testRootHandle {
     int pid;
-    VirtualizationRootHandle testRootHandle;
+    VirtualizationRootHandle testRootHandle = RootHandle_None;
+    VirtualizationRootResult testRootResult;
     
     // Invalid Root Handle Test
     XCTAssertFalse(
@@ -72,14 +73,13 @@ class PrjFSProviderUserClient
             &testRootHandle,
             &pid));
 
-    testRootHandle = InsertVirtualizationRoot_Locked(
+    
+    testRootResult = VirtualizationRoot_RegisterProviderForPath(
         &self->userClient,
         0,
-        self->repoRootVnode.get(),
-        self->repoRootVnode->GetVid(),
-        FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
         self->repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootHandle));
+    XCTAssertEqual(0, testRootResult.error);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootResult.root));
 
     // With Valid Root Handle we should pass
     XCTAssertTrue(
@@ -92,10 +92,11 @@ class PrjFSProviderUserClient
             true, // isDirectory,
             &testRootHandle,
             &pid));
+    XCTAssertEqual(testRootHandle, testRootResult.root);
     
-    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    if (VirtualizationRoot_IsValidRootHandle(testRootResult.root))
     {
-        ActiveProvider_Disconnect(testRootHandle, &userClient);
+        ActiveProvider_Disconnect(testRootResult.root, &userClient);
     }
 }
 
@@ -120,14 +121,12 @@ class PrjFSProviderUserClient
 - (void)testUnsupportedVnodeType {
     shared_ptr<vnode> testVnodeUnsupportedType = vnode::Create(self->testMount, "/foo", VNON);
 
-    VirtualizationRootHandle testRepoHandle = InsertVirtualizationRoot_Locked(
+    VirtualizationRootResult testRootResult = VirtualizationRoot_RegisterProviderForPath(
         &self->userClient,
         0,
-        self->repoRootVnode.get(),
-        self->repoRootVnode->GetVid(),
-        FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
         self->repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRepoHandle));
+    XCTAssertEqual(0, testRootResult.error);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootResult.root));
 
     VirtualizationRootHandle testRootHandle;
     int pid;
@@ -143,25 +142,24 @@ class PrjFSProviderUserClient
             &testRootHandle,
             &pid));
     
-    if (VirtualizationRoot_IsValidRootHandle(testRepoHandle))
+    if (VirtualizationRoot_IsValidRootHandle(testRootResult.root))
     {
-        ActiveProvider_Disconnect(testRepoHandle, &userClient);
+        ActiveProvider_Disconnect(testRootResult.root, &userClient);
     }
 }
 
 - (void)testProviderOffline {
-    VirtualizationRootHandle testRootHandle = InsertVirtualizationRoot_Locked(
+    VirtualizationRootHandle testRootHandle = RootHandle_None;
+    VirtualizationRootResult testRootResult = VirtualizationRoot_RegisterProviderForPath(
         &self->userClient,
         0,
-        self->repoRootVnode.get(),
-        self->repoRootVnode->GetVid(),
-        FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
         self->repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootHandle));
+    XCTAssertEqual(0, testRootResult.error);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootResult.root));
 
-    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    if (VirtualizationRoot_IsValidRootHandle(testRootResult.root))
     {
-        ActiveProvider_Disconnect(testRootHandle, &userClient);
+        ActiveProvider_Disconnect(testRootResult.root, &userClient);
     }
 
     int pid;
@@ -179,14 +177,13 @@ class PrjFSProviderUserClient
 }
 
 - (void)testProviderInitiatedIO {
-    VirtualizationRootHandle testRootHandle = InsertVirtualizationRoot_Locked(
+    VirtualizationRootHandle testRootHandle = RootHandle_None;
+    VirtualizationRootResult testRootResult = VirtualizationRoot_RegisterProviderForPath(
         &self->userClient,
         0,
-        self->repoRootVnode.get(),
-        self->repoRootVnode->GetVid(),
-        FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
         self->repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootHandle));
+    XCTAssertEqual(0, testRootResult.error);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootResult.root));
 
     // Fail when pid matches provider pid
     MockProcess_Reset();
@@ -205,9 +202,9 @@ class PrjFSProviderUserClient
             &testRootHandle,
             &pid));
     
-    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    if (VirtualizationRoot_IsValidRootHandle(testRootResult.root))
     {
-        ActiveProvider_Disconnect(testRootHandle, &userClient);
+        ActiveProvider_Disconnect(testRootResult.root, &userClient);
     }
 }
 
@@ -216,14 +213,12 @@ class PrjFSProviderUserClient
 
     VirtualizationRootHandle rootHandle;
     int pid;
-    VirtualizationRootHandle testRootHandle = InsertVirtualizationRoot_Locked(
+    VirtualizationRootResult testRootResult = VirtualizationRoot_RegisterProviderForPath(
         &self->userClient,
         0,
-        self->repoRootVnode.get(),
-        self->repoRootVnode->GetVid(),
-        FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
         self->repoPath.c_str());
-    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootHandle));
+    XCTAssertEqual(0, testRootResult.error);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(testRootResult.root));
 
     // KAUTH_FILEOP_OPEN
     XCTAssertTrue(
@@ -236,7 +231,7 @@ class PrjFSProviderUserClient
             false, // isDirectory,
             &rootHandle,
             &pid));
-    XCTAssertEqual(rootHandle, testRootHandle);
+    XCTAssertEqual(rootHandle, testRootResult.root);
     // Finding the root should have added testVnodeFile to the cache
     // IMPORTANT: This check assumes that the vnode cache is empty before the above call to ShouldHandleFileOpEvent
     XCTAssertEqual(self->testVnodeFile.get(), self->cacheWrapper[ComputeVnodeHashIndex(self->testVnodeFile.get())].vnode);
@@ -253,7 +248,7 @@ class PrjFSProviderUserClient
             false, // isDirectory,
             &rootHandle,
             &pid));
-    XCTAssertEqual(rootHandle, testRootHandle);
+    XCTAssertEqual(rootHandle, testRootResult.root);
     // KAUTH_FILEOP_LINK should invalidate the cache entry for testVnodeFile
     XCTAssertEqual(self->testVnodeFile.get(), self->cacheWrapper[ComputeVnodeHashIndex(self->testVnodeFile.get())].vnode);
     XCTAssertEqual(RootHandle_Indeterminate, self->cacheWrapper[ComputeVnodeHashIndex(self->testVnodeFile.get())].virtualizationRoot);
@@ -271,7 +266,7 @@ class PrjFSProviderUserClient
             false, // isDirectory,
             &rootHandle,
             &pid));
-    XCTAssertEqual(rootHandle, testRootHandle);
+    XCTAssertEqual(rootHandle, testRootResult.root);
     // The cache should have been refreshed for KAUTH_FILEOP_RENAME
     XCTAssertEqual(self->testVnodeFile.get(), self->cacheWrapper[ComputeVnodeHashIndex(self->testVnodeFile.get())].vnode);
     XCTAssertEqual(rootHandle, self->cacheWrapper[ComputeVnodeHashIndex(self->testVnodeFile.get())].virtualizationRoot);
@@ -290,7 +285,7 @@ class PrjFSProviderUserClient
             true, // isDirectory,
             &rootHandle,
             &pid));
-    XCTAssertEqual(rootHandle, testRootHandle);
+    XCTAssertEqual(rootHandle, testRootResult.root);
 
     // Validate the cache is empty except for the testVnodeDirectory entry
     uintptr_t directoryVnodeHash = ComputeVnodeHashIndex(testVnodeDirectory.get());
@@ -310,9 +305,9 @@ class PrjFSProviderUserClient
         }
     }
     
-    if (VirtualizationRoot_IsValidRootHandle(testRootHandle))
+    if (VirtualizationRoot_IsValidRootHandle(testRootResult.root))
     {
-        ActiveProvider_Disconnect(testRootHandle, &userClient);
+        ActiveProvider_Disconnect(testRootResult.root, &userClient);
     }
 }
 

--- a/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VirtualizationRootsTests.mm
@@ -295,6 +295,33 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     XCTAssertFalse(MockCalls::DidCallFunction(ProviderUserClient_UpdatePathProperty));
 }
 
+- (void)testRegisterProviderForPath_ResizeArray
+{
+    const char* path = "/Users/test/code/Repo";
+    
+    shared_ptr<vnode> vnode = vnode::Create(self->testMountPoint, path, VDIR);
+    
+    // Start with 4 "full" array items, forcing resize on next insertion
+    Memory_FreeArray(s_virtualizationRoots, s_maxVirtualizationRoots);
+    s_maxVirtualizationRoots = 4;
+    s_virtualizationRoots = Memory_AllocArray<VirtualizationRoot>(s_maxVirtualizationRoots);
+    memset(s_virtualizationRoots, 0, s_maxVirtualizationRoots * sizeof(s_virtualizationRoots[0]));
+    
+    for (uint32_t i = 0; i < s_maxVirtualizationRoots; ++i)
+    {
+        s_virtualizationRoots[i].inUse = true;
+    }
+    
+    VirtualizationRootResult result = VirtualizationRoot_RegisterProviderForPath(&self->dummyClient, self->dummyClientPid, path);
+    XCTAssertEqual(result.error, 0);
+    XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(result.root));
+    
+    if (VirtualizationRoot_IsValidRootHandle(result.root))
+    {
+        ActiveProvider_Disconnect(result.root, &self->dummyClient);
+    }
+}
+
 
 - (void)testRegisterProviderForPath_ExistingRecycledRoot
 {
@@ -366,7 +393,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
     shared_ptr<vnode> deepFileVnode = self->testMountPoint->CreateVnodeTree(deeplyNestedPath);
     
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
 
     VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);
@@ -386,7 +413,7 @@ static void SetRootXattrData(shared_ptr<vnode> vnode)
     shared_ptr<vnode> testFileVnode = self->testMountPoint->CreateVnodeTree(filePath);
     
     
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(nullptr /* no client */, 0, repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(repoRootVnode.get(), repoRootVnode->GetVid(), FsidInode{ repoRootVnode->GetMountPoint()->GetFsid(), repoRootVnode->GetInode() }, repoPath);
     XCTAssertTrue(VirtualizationRoot_IsValidRootHandle(repoRootHandle));
     
     VirtualizationRootHandle foundRoot = VirtualizationRoot_FindForVnode(&self->dummyTracer, PrjFSPerfCounter_VnodeOp_FindRoot, PrjFSPerfCounter_VnodeOp_FindRoot_Iteration, testFileVnode.get(), self->dummyVFSContext);

--- a/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeCacheTests.mm
@@ -108,9 +108,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testVnodeCache_FindRootForVnode_EmptyCache {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -139,9 +137,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testVnodeCache_FindRootForVnode_FullCache {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -177,9 +173,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testVnodeCache_FindRootForVnode_VnodeInCache {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -226,9 +220,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testVnodeCache_RefreshRootForVnode {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -286,9 +278,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testVnodeCache_InvalidateVnodeRootAndGetLatestRoot {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -446,9 +436,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testFindVnodeRootFromDiskAndUpdateCache_RefreshAndInvalidateEntry {
-    VirtualizationRootHandle onDiskRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle onDiskRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },
@@ -526,9 +514,7 @@ static const VirtualizationRootHandle DummyRootHandleTwo = 52;
 }
 
 - (void)testFindVnodeRootFromDiskAndUpdateCache_FullCache {
-    VirtualizationRootHandle repoRootHandle = InsertVirtualizationRoot_Locked(
-        nullptr /* no client */,
-        0,
+    VirtualizationRootHandle repoRootHandle = FindOrInsertVirtualizationRoot_LockedMayUnlock(
         self->repoRootVnode.get(),
         self->repoRootVnode->GetVid(),
         FsidInode{ self->repoRootVnode->GetMountPoint()->GetFsid(), self->repoRootVnode->GetInode() },

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -72,7 +72,8 @@ while read line; do
 	 [[ $line != *"PerfTracer"* ]] && 
 	 [[ $line != *"VirtualizationRoot_GetActiveProvider"* ]] &&      #SHOULD ADD COVERAGE
 	 [[ $line != *"VirtualizationRoots_Init"* ]] && 
-	 [[ $line != *"VirtualizationRoots_Cleanup"* ]] && 
+	 [[ $line != *"VirtualizationRoots_Cleanup"* ]] &&
+	 [[ $line != *"FindOrInsertVirtualizationRoot_LockedMayUnlock"* ]] && # Race compensation path not covered, currently can't provoke this in tests.
 	 [[ $line != *"VnodeCache_Init"* ]] && 
 	 [[ $line != *"VnodeCache_Cleanup"* ]] && 
 	 [[ $line != *"VnodeCache_ExportHealthData"* ]] &&               # IOKit related functions are not unit tested


### PR DESCRIPTION
This is an old fix from #500 which I've rebased/updated, isolated, and simplified a little.

Performing a blocking memory allocation while holding a lock in a vnode listener callback is not necessarily safe. (There is potential for a deadlock in low-memory situations.) When growing the virtualization root array, this was exactly what the existing code was doing. This change restructures the virtualization root insertion logic so that the lock can be dropped for allocating the larger memory block. Dropping the lock means it must be re-checked whether an insertion is still necessary, which was not readily possible with the old code structure.

A bunch of existing unit tests were calling `InsertVirtualizationRoot_Locked()` which no longer exists, these have been updated to call either `FindOrInsertVirtualizationRoot_LockedMayUnlock` or `VirtualizationRoot_RegisterProviderForPath` as appropriate.