### PR TITLE
PrefetchStep: don't send post-fetch request if no new packs

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -150,6 +150,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.WriteAllText(oldKeepFile, this.Enlistment.EnlistmentRoot);
 
             this.Enlistment.Prefetch("--commits");
+            this.Enlistment.PostFetchStep();
             oldGitTempFile.ShouldNotExistOnDisk(this.fileSystem);
             oldKeepFile.ShouldNotExistOnDisk(this.fileSystem);
 

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -221,6 +221,11 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.PackfileMaintenanceStep(batchSize);
         }
 
+        public string PostFetchStep()
+        {
+            return this.gvfsProcess.PostFetchStep();
+        }
+
         public string Status(string trace = null)
         {
             return this.gvfsProcess.Status(trace);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -73,6 +73,15 @@ namespace GVFS.FunctionalTests.Tools
                 internalParameter: internalParameter);
         }
 
+        public string PostFetchStep()
+        {
+            string internalParameter = GVFSHelpers.GetInternalParameter("\\\"PostFetch\\\"");
+            return this.CallGVFS(
+                "dehydrate \"" + this.enlistmentRoot + "\"",
+                failOnError: true,
+                internalParameter: internalParameter);
+        }
+
         public string Diagnose()
         {
             return this.CallGVFS("diagnose \"" + this.enlistmentRoot + "\"");

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -80,6 +80,10 @@ namespace GVFS.CommandLine
                                     batchSize: this.PackfileMaintenanceBatchSize ?? PackfileMaintenanceStep.DefaultBatchSize)).Execute();
                                 return;
 
+                            case "PostFetch":
+                                (new PostFetchStep(context, new System.Collections.Generic.List<string>(), requireObjectCacheLock: false)).Execute();
+                                return;
+
                             default:
                                 this.ReportErrorAndExit($"Unknown maintenance job requested: {this.MaintenanceJob}");
                                 break;


### PR DESCRIPTION
Every time the post-fetch step runs, we write a new multi-pack-index. This is important to catch any leftover packs that were added by `gvfs prefetch --files` or by the loose objects step.

However, for a normal `git fetch` that calls `gvfs prefetch --commits`, there are likely no new packs. This previously triggered a post-fetch step anyway, and now it will not make that request if there are no new packs. This can save about one minute of CPU time per "trivial" prefetch.