### PR TITLE
Remove requirement to run --no-renames

### DIFF
--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -135,41 +135,9 @@ namespace GVFS.Hooks
             string command = GetGitCommand(args);
             switch (command)
             {
-                case "status":
-                    VerifyRenameDetectionSettings(args);
-                    break;
-
                 case "gui":
                     ExitWithError("To access the 'git gui' in a GVFS repo, please invoke 'git-gui.exe' instead.");
                     break;
-            }
-        }
-
-        private static void VerifyRenameDetectionSettings(string[] args)
-        {
-            string srcRoot = Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName);
-            if (File.Exists(Path.Combine(srcRoot, GVFSConstants.DotGit.MergeHead)) ||
-                File.Exists(Path.Combine(srcRoot, GVFSConstants.DotGit.RevertHead)))
-            {
-                // If no-renames is specified, avoid reading config.
-                if (!args.Contains("--no-renames"))
-                {
-                    // To behave properly, this needs to check for the status.renames setting the same
-                    // way that git does including global and local config files, setting inheritance from
-                    // diff.renames, etc.  This is probably best accomplished by calling "git config --get status.renames"
-                    // to ensure we are getting the correct value and then checking for "true" (rather than
-                    // just existance like below).
-                    Dictionary<string, GitConfigSetting> statusConfig = GitConfigHelper.GetSettings(
-                        File.ReadAllLines(Path.Combine(srcRoot, GVFSConstants.DotGit.Config)),
-                        "test");
-
-                    if (!statusConfig.ContainsKey("renames"))
-                    {
-                        ExitWithError(
-                            "git status requires rename detection to be disabled during a merge or revert conflict.",
-                            "Run 'git status --no-renames'");
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
There have been many changes since this was added and it seems this is no longer required.  I have tested with the branches from the original bug report that indicated there were objects being downloaded during the `status` call and in my testing no objects were downloaded.  

The significant changes since this one are that VFSForGit is now running in O(modified) and they have made changes in the rename detection in git.

Resolves #989 