### PR TITLE
Incremental commit graph

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190626.2</GitPackageVersion>
+    <GitPackageVersion>2.20190701.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -529,7 +529,7 @@ namespace GVFS.Common.Git
         /// </summary>
         public Result WriteCommitGraph(string objectDir, List<string> packs)
         {
-            string command = "commit-graph write --stdin-packs --append --object-dir \"" + objectDir + "\"";
+            string command = "commit-graph write --stdin-packs --split --size-multiple=4 --object-dir \"" + objectDir + "\"";
             return this.InvokeGitInWorkingDirectoryRoot(
                 command,
                 useReadObjectHook: true,
@@ -547,7 +547,7 @@ namespace GVFS.Common.Git
 
         public Result VerifyCommitGraph(string objectDir)
         {
-            string command = "commit-graph verify --object-dir \"" + objectDir + "\"";
+            string command = "commit-graph verify --shallow --object-dir \"" + objectDir + "\"";
             return this.InvokeGitInWorkingDirectoryRoot(command, useReadObjectHook: true);
         }
 

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -1,7 +1,9 @@
-﻿using GVFS.Common.Git;
+﻿using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace GVFS.Common.Maintenance
 {
@@ -47,6 +49,20 @@ namespace GVFS.Common.Maintenance
                 this.Context.FileSystem.TryDeleteFile(commitGraphLockPath);
 
                 GitProcess.Result writeResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
+
+                StringBuilder sb = new StringBuilder();
+                string commitGraphsDir = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graphs");
+
+                if (this.Context.FileSystem.DirectoryExists(commitGraphsDir))
+                {
+                    foreach (DirectoryItemInfo info in this.Context.FileSystem.ItemsInDirectory(commitGraphsDir))
+                    {
+                        sb.Append(info.Name);
+                        sb.Append(";");
+                    }
+                }
+
+                activity.RelatedInfo($"commit-graph list after write: {sb}");
 
                 if (writeResult.ExitCodeIsFailure)
                 {

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -7,7 +7,7 @@ namespace GVFS.Common.Maintenance
 {
     public class PostFetchStep : GitMaintenanceStep
     {
-        private const string CommitGraphLock = "commit-graph.lock";
+        private const string CommitGraphChainLock = "commit-graph-chain.lock";
         private const string MultiPackIndexLock = "multi-pack-index.lock";
         private List<string> packIndexes;
 
@@ -43,7 +43,7 @@ namespace GVFS.Common.Maintenance
 
             using (ITracer activity = this.Context.Tracer.StartActivity("TryWriteGitCommitGraph", EventLevel.Informational))
             {
-                string commitGraphLockPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", CommitGraphLock);
+                string commitGraphLockPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graphs", CommitGraphChainLock);
                 this.Context.FileSystem.TryDeleteFile(commitGraphLockPath);
 
                 GitProcess.Result writeResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, this.packIndexes), nameof(GitProcess.WriteCommitGraph));
@@ -53,15 +53,12 @@ namespace GVFS.Common.Maintenance
                     this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
                 }
 
-                // Turning off Verify for commit graph due to performance issues.
-                /*
                 GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyCommitGraph(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyCommitGraph));
 
                 if (!this.Stopping && verifyResult.ExitCodeIsFailure)
                 {
                     this.LogErrorAndRewriteCommitGraph(activity, this.packIndexes);
                 }
-                */
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -240,11 +240,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             midxResult.ExitCode.ShouldEqual(0);
 
             // A commit graph is not always generated, but if it is, then we want to ensure it is in a good state
-            if (this.fileSystem.FileExists(Path.Combine(objectDir, "info", "commit-graph")))
+            if (this.fileSystem.FileExists(Path.Combine(objectDir, "info", "commit-graphs", "commit-graph-chain")))
             {
-                ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph read --object-dir=\"" + objectDir + "\"");
+                ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph verify --shallow --object-dir=\"" + objectDir + "\"");
                 graphResult.ExitCode.ShouldEqual(0);
-                graphResult.Output.ShouldContain("43475048"); // Header from commit-graph file.
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -299,7 +299,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // Multi-pack-index write happens even if the prefetch downloads nothing, while
             // the commit-graph write happens only when the prefetch downloads at least one pack
 
-            string graphPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), "info", "commit-graph");
+            string graphPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), "info", "commit-graphs", "commit-graph-chain");
             string graphLockPath = graphPath + ".lock";
             string midxPath = Path.Combine(this.PackRoot, "multi-pack-index");
             string midxLockPath = midxPath + ".lock";
@@ -409,9 +409,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             ProcessResult midxResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "multi-pack-index verify --object-dir=\"" + objectDir + "\"");
             midxResult.ExitCode.ShouldEqual(0);
 
-            ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph read --object-dir=\"" + objectDir + "\"");
+            ProcessResult graphResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "commit-graph verify --shallow --object-dir=\"" + objectDir + "\"");
             graphResult.ExitCode.ShouldEqual(0);
-            graphResult.Output.ShouldContain("43475048"); // Header from commit-graph file.
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
@@ -20,8 +20,8 @@ namespace GVFS.UnitTests.Maintenance
 
         private string MultiPackIndexWriteCommand => $"-c core.multiPackIndex=true multi-pack-index write --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
         private string MultiPackIndexVerifyCommand => $"-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
-        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --append --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
-        private string CommitGraphVerifyCommand => $"commit-graph verify --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --split --size-multiple=4 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphVerifyCommand => $"commit-graph verify --shallow --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
 
         [TestCase]
         public void WriteMultiPackIndexNoGraphOnEmptyPacks()
@@ -75,13 +75,11 @@ namespace GVFS.UnitTests.Maintenance
 
             List<string> commands = this.gitProcess.CommandsRun;
 
-            // Turning off Commit Graph Verify while we address performance issues
-            // commands.Count.ShouldEqual(4);
-            commands.Count.ShouldEqual(3);
+            commands.Count.ShouldEqual(4);
             commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
             commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
             commands[2].ShouldEqual(this.CommitGraphWriteCommand);
-            //// commands[3].ShouldEqual(this.CommitGraphVerifyCommand);
+            commands[3].ShouldEqual(this.CommitGraphVerifyCommand);
         }
 
         [TestCase]
@@ -110,18 +108,15 @@ namespace GVFS.UnitTests.Maintenance
 
             List<string> commands = this.gitProcess.CommandsRun;
 
-            // Turning off Commit Graph Verify, while we address performance issues
-            // commands.Count.ShouldEqual(5);
-            commands.Count.ShouldEqual(4);
+            commands.Count.ShouldEqual(5);
             commands[0].ShouldEqual(this.MultiPackIndexWriteCommand);
             commands[1].ShouldEqual(this.MultiPackIndexVerifyCommand);
             commands[2].ShouldEqual(this.MultiPackIndexWriteCommand);
             commands[3].ShouldEqual(this.CommitGraphWriteCommand);
-            //// commands[4].ShouldEqual(this.CommitGraphVerifyCommand);
+            commands[4].ShouldEqual(this.CommitGraphVerifyCommand);
         }
 
         [TestCase]
-        [Ignore("Turn off Commit Graph Verify, while we address performance issues")]
         public void RewriteCommitGraphOnBadVerify()
         {
             this.TestSetup();

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -328,6 +328,9 @@ namespace GVFS.CommandLine
                 {
                     this.LogDirectoryEnumeration(gitObjectsRoot, localCacheArchivePath, GVFSConstants.DotGit.Objects.Pack.Name, "packs-cached.txt");
                     this.LogLooseObjectCount(gitObjectsRoot, localCacheArchivePath, string.Empty, "objects-cached.txt");
+
+                    // Store all commit-graph files
+                    this.CopyAllFiles(gitObjectsRoot, localCacheArchivePath, GVFSConstants.DotGit.Objects.Info.Root, copySubFolders: true);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
The incremental commit-graph format is designed to speed up commit-graph writes, and especially to allow fast verification of the new data. At least, most of the time.

Uses the new feature in microsoft/git#156.

By only writing the new data to a small "tip" commit-graph file, we can write much less data and only verify the new tip file.

Current settings include `--size-multiple=4`: This guarantees each level of the chain is half the size of the level below. This means the chain length will be limited by log_4(N) where N is the number of commits. This means ~6 levels is the maximum theoretical chain length with 4,000,000 commits. We are not currently using the `--max-commits` setting.

With these settings, the `git commit-graph verify` command will be much faster on most new tip files. For example, a tip graph with 3,300 commits uses 183 KB of data and took 0.7 seconds to verify.