### PR TITLE
Enable mac upgrade MVP

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -140,6 +140,12 @@ namespace GVFS.Common
             public static readonly char PathSeparator = Path.DirectorySeparatorChar;
             public abstract string ExecutableExtension { get; }
             public abstract string InstallerExtension { get; }
+
+            /// <summary>
+            /// Indicates whether the platform supports running the upgrade application while
+            /// the upgrade verb is running.
+            /// </summary>
+            public abstract bool SupportsUpgradeWhileRunning { get; }
             public abstract string WorkingDirectoryBackingRootPath { get; }
             public abstract string DotGVFSRoot { get; }
 

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -16,7 +16,11 @@ namespace GVFS.Platform.Mac
     {
         private const string UpgradeProtectedDataDirectory = "/usr/local/vfsforgit_upgrader";
 
-        public MacPlatform()
+        public MacPlatform() : base(
+             underConstruction: new UnderConstructionFlags(
+                supportsGVFSUpgrade: true,
+                supportsGVFSConfig: true,
+                supportsNuGetEncryption: false))
         {
         }
 

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -30,7 +30,7 @@ namespace GVFS.Platform.Mac
 
         public bool IsGVFSUpgradeSupported()
         {
-            return false;
+            return true;
         }
 
         public bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error)

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -296,6 +296,8 @@ namespace GVFS.Platform.POSIX
             {
                 get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS.Mount", "git", "wish" }; }
             }
+
+            public override bool SupportsUpgradeWhileRunning => true;
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -449,6 +449,8 @@ namespace GVFS.Platform.Windows
                 get { return ".exe"; }
             }
 
+            public override bool SupportsUpgradeWhileRunning => false;
+
             public override string WorkingDirectoryBackingRootPath
             {
                 get { return GVFSConstants.WorkingDirectoryRootName; }

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProcessLauncher.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Mock/MockProcessLauncher.cs
@@ -32,7 +32,7 @@ namespace GVFS.UnitTests.Windows.Upgrader
             get { return this.exitCode; }
         }
 
-        public override bool TryStart(string path, string args, out Exception exception)
+        public override bool TryStart(string path, string args, bool useShellExecute, out Exception exception)
         {
             this.LaunchPath = path;
             this.IsLaunched = true;

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -233,6 +233,8 @@ namespace GVFS.UnitTests.Mock.Common
             {
                 get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
             }
+
+            public override bool SupportsUpgradeWhileRunning => false;
         }
     }
 }


### PR DESCRIPTION
Final changes to enable upgrade on Mac MVP. This includes:

- Run upgrade application inline on platforms that support this
- Updating flags on Mac platform to indicate it supports upgrade