### PR TITLE
Installer reliability

### DIFF
--- a/GVFS/GVFS.Installer.Mac/scripts/postinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/postinstall
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+function startOrRestartService()
+{
+	domain=$1
+	service=$2
+	if [[ $domain == system* ]]; then
+		plistPath="/Library/LaunchDaemons"
+	elif [[ $domain == gui/* ]]; then
+		plistPath="/Library/LaunchAgents"
+	fi
+	startCmd="/bin/launchctl bootstrap $domain $plistPath/$service.plist"
+	restartCmd="/bin/launchctl kickstart -k $domain/$service"
+	isLoaded=`/bin/launchctl print $domain/$service | wc -l`
+	if [ $isLoaded -gt "0" ]; then
+		echo "Restarting Service: '$restartCmd'"
+		eval $restartCmd || exit 1
+	else
+		echo "Starting Service: '$startCmd'"
+		eval $startCmd || exit 1
+	fi
+}
+
 # Load PrjFSKext if it is not loaded already
 # PrjFSKext is an IOKit kext and should get automatically loaded 
 # by macOS after install. But the system does not seem to auto-load it
@@ -24,9 +45,7 @@ else
     echo "$kextstatOutput"
 fi
 
-loadCmd="sudo launchctl load -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
-echo "Loading PrjFSKextLogDaemon: '$loadCmd'..."
-eval $loadCmd || exit 1
+startOrRestartService "system" "org.vfsforgit.prjfs.PrjFSKextLogDaemon"
 
 # Load Launch Agents in all active User sessions
 # There will be one loginwindow instance for each logged in user, 
@@ -34,13 +53,11 @@ eval $loadCmd || exit 1
 # Then use launchctl bootstrap gui/uid to auto load the Service 
 # for each user.
 declare -a launchAgents=(
-    "/Library/LaunchAgents/org.vfsforgit.usernotification.plist"
-    "/Library/LaunchAgents/org.vfsforgit.service.plist"
+    "org.vfsforgit.usernotification"
+    "org.vfsforgit.service"
 )
 for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
     for nextLaunchAgent in "${launchAgents[@]}"; do
-        loadCmd="launchctl bootstrap gui/$uid ${nextLaunchAgent}"
-        echo "Loading Service: '$loadCmd'..."
-        eval $loadCmd || exit 1
+        startOrRestartService "gui/$uid" $nextLaunchAgent
     done
 done 

--- a/GVFS/GVFS.Installer.Mac/scripts/preinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/preinstall
@@ -1,29 +1,4 @@
 #!/bin/bash
-if [ -f /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist ]; then
-    unloadCmd="sudo launchctl unload -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
-    echo "Unloading PrjFSKextLogDaemon: '$unloadCmd'..."
-    eval $unloadCmd || exit 1
-fi
-
-# Unload Service in all active User sessions
-# There will be one loginwindow instance for each logged in user, 
-# get its uid (this will correspond to the logged in user's id.) 
-# Then use launchctl bootstrap gui/uid to auto load the Service 
-# for each user.
-declare -a launchAgents=(
-    "org.vfsforgit.usernotification"
-    "org.vfsforgit.service"
-)
-for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
-    for nextLaunchAgent in "${launchAgents[@]}"; do
-        isLoaded=`sudo launchctl print gui/$uid/$nextLaunchAgent | wc -l`
-        if [ $isLoaded -gt "0" ]; then
-            unloadCmd="launchctl bootout gui/$uid /Library/LaunchAgents/$nextLaunchAgent.plist"
-            echo "Unloading Service: '$unloadCmd'..."
-            eval $unloadCmd || exit 1            
-        fi
-    done
-done
 
 KEXTBUNDLEID="org.vfsforgit.PrjFSKext"
 isKextLoadedCmd="/usr/sbin/kextstat -l -b $KEXTBUNDLEID | wc -l"

--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -31,16 +31,16 @@ function UnInstallVFSForGit()
         eval $rmCmd || { echo "Error: Could not delete ${PRJFSKEXTDIRECTORY}/$KEXTFILENAME. Delete it manually."; exit 1; }
     fi
     
-    if [ -f "${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME" ]; then
-        # Check if the daemon is loaded. Unload only if necessary.
-        isLoadedCmd="sudo launchctl kill SIGCONT system/org.vfsforgit.prjfs.PrjFSKextLogDaemon"
-        echo "$isLoadedCmd"
-        if $isLoadedCmd; then
-            unloadCmd="sudo launchctl unload -w ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
-            echo "$unloadCmd..."
-            eval $unloadCmd || { echo "Error: Could not unload ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME. Unload it manually (\"$unloadCmd\")."; exit 1; }
-        fi
+    # Check if the daemon is loaded. Unload only if necessary.
+	isLoadedCmd="sudo launchctl kill SIGCONT system/org.vfsforgit.prjfs.PrjFSKextLogDaemon"
+	echo "$isLoadedCmd"
+	if $isLoadedCmd; then
+		unloadCmd="sudo launchctl unload ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
+		echo "$unloadCmd..."
+		eval $unloadCmd || { echo "Error: Could not unload ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME. Unload it manually (\"$unloadCmd\")."; exit 1; }
+	fi
         
+    if [ -f "${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME" ]; then
         rmCmd="sudo /bin/rm -Rf ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME"
         echo "$rmCmd..."
         eval $rmCmd || { echo "Error: Could not delete ${LAUNCHDAEMONDIRECTORY}/$LOGDAEMONLAUNCHDFILENAME. Delete it manually."; exit 1; }
@@ -55,22 +55,22 @@ function UnInstallVFSForGit()
     "org.vfsforgit.usernotification"
     "org.vfsforgit.service"
     )
-    for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
-        for nextLaunchAgent in "${launchAgents[@]}"; do
-            isLoadedCmd="sudo launchctl kill SIGCONT gui/$uid/$nextLaunchAgent"
+    for nextLaunchAgent in "${launchAgents[@]}"; do
+    	for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+			isLoadedCmd="sudo launchctl kill SIGCONT gui/$uid/$nextLaunchAgent"
             echo "$isLoadedCmd"
             if $isLoadedCmd; then
                 unloadCmd="launchctl bootout gui/$uid /Library/LaunchAgents/$nextLaunchAgent.plist"
                 echo "Unloading Service: '$unloadCmd'..."
-                eval $unloadCmd || exit 1
-                
-                rmCmd="sudo /bin/rm -Rf ${LAUNCHAGENTDIRECTORY}/$nextLaunchAgent.plist"
-                echo "$rmCmd..."
-                eval $rmCmd || { echo "Error: Could not delete ${LAUNCHAGENTDIRECTORY}/$nextLaunchAgent.plist. Delete it manually."; exit 1; }
+                eval $unloadCmd || exit 1                
             fi
-        done
-    done
-    
+    	done
+    	
+		rmCmd="sudo /bin/rm -Rf ${LAUNCHAGENTDIRECTORY}/$nextLaunchAgent.plist"
+		echo "$rmCmd..."
+		eval $rmCmd || { echo "Error: Could not delete ${LAUNCHAGENTDIRECTORY}/$nextLaunchAgent.plist. Delete it manually."; exit 1; }
+	done
+        
     if [ -s "${GVFSCOMMANDPATH}" ]; then
         rmCmd="sudo /bin/rm -Rf ${GVFSCOMMANDPATH}"
         echo "$rmCmd..."


### PR DESCRIPTION
#### Change details
- No change in behavior for fresh install.
- Upgrade install - avoid un-necessary unloading of launchd agent plist files in preinstall script only to reload them later in postinstall. Use launchctl kickstart -k instead in postinstall. It restarts the  agent without needing to unload/reload its plist file.
- Uninstaller - removed usage of "-w" option from launchctl "unload" command.  "-w" disables the service after unload which is undesirable.
- Uninstaller - fixed a logic error, where the agent plists were getting un-installed only if they were un-loaded as well.

#### Installer script behavior in Catalina
`VFSForGit` Installer now works on Catalina.

- Old Installer log (without the changes in this PR). - 
```
installd[2383]: ./preinstall: Unloading PrjFSKextLogDaemon: 'sudo launchctl unload -w /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist'...
installd[2383]: ./preinstall: /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist: Operation now in progress
installd[2383]: ./preinstall: Unloading Service: 'launchctl bootout gui/502 /Library/LaunchAgents/org.vfsforgit.usernotification.plist'...
installd[2383]: ./preinstall: /Library/LaunchAgents/org.vfsforgit.usernotification.plist: Operation now in progress
```

- New Installer log with the changes (Fresh install) - Previously loaded instances of the launchd services will not be found. They get loaded using `launchctl bootstrap` command. Also notice that `preinstall` script is silent.
```
installd[2383]: ./postinstall: /sbin/kextload "/Library/Extensions/PrjFSKext.kext"
installd[2383]: ./postinstall: Could not find service "org.vfsforgit.prjfs.PrjFSKextLogDaemon" in domain for system
installd[2383]: ./postinstall: Starting Service: '/bin/launchctl bootstrap system /Library/LaunchDaemons/org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist'
installd[2383]: ./postinstall: Could not find service "org.vfsforgit.usernotification" in domain for login: 100006
installd[2383]: ./postinstall: Starting Service: '/bin/launchctl bootstrap gui/502 /Library/LaunchAgents/org.vfsforgit.usernotification.plist'
installd[2383]: ./postinstall: Could not find service "org.vfsforgit.service" in domain for login: 100006
installd[2383]: ./postinstall: Starting Service: '/bin/launchctl bootstrap gui/502 /Library/LaunchAgents/org.vfsforgit.service.plist'
```

- New Installer log with the changes (Upgrade install) - Previously loaded instances of the launchd services are found and they get restarted using `launchctl kickstart -p` command.
 ```
installd[2383]: ./preinstall: /sbin/kextunload -b org.vfsforgit.PrjFSKext
installd[2383]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/EA457DEA-44B7-4D30-807B-23333E7F9532.sandboxTrash for sandbox /Library/InstallerSandboxes/PKInstallSandboxManager/EA457DEA-44B7-4D30-807B-23333E7F9532.activeSandbox
installd[2383]: PackageKit: Shoving /Library/InstallerSandboxes/PKInstallSandboxManager/EA457DEA-44B7-4D30-807B-23333E7F9532.activeSandbox/Root (2 items) to /
installd[2383]: PackageKit: Executing script "./postinstall" in /private/tmp/PKInstallSandbox.M2h3et/Scripts/com.vfsforgit.pkg.2mOb2M
installd[2383]: ./postinstall: /sbin/kextload "/Library/Extensions/PrjFSKext.kext"
installd[2383]: ./postinstall: Restarting Service: '/bin/launchctl kickstart -k system/org.vfsforgit.prjfs.PrjFSKextLogDaemon'
installd[2383]: ./postinstall: Restarting Service: '/bin/launchctl kickstart -k gui/502/org.vfsforgit.usernotification'
installd[2383]: ./postinstall: Restarting Service: '/bin/launchctl kickstart -k gui/502/org.vfsforgit.service'
```