### PR TITLE
use repository relative paths in DiffTreeResult.TargetPath

### DIFF
--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -160,6 +160,8 @@ namespace FastFetch
             DiffTreeResult treeOp;
             while (this.diff.DirectoryOperations.TryDequeue(out treeOp))
             {
+                string absoluteTargetPath = Path.Combine(this.enlistment.WorkingDirectoryBackingRoot, treeOp.TargetPath);
+
                 if (this.HasFailures)
                 {
                     return;
@@ -171,13 +173,13 @@ namespace FastFetch
                     case DiffTreeResult.Operations.Add:
                         try
                         {
-                            Directory.CreateDirectory(treeOp.TargetPath);
+                            Directory.CreateDirectory(absoluteTargetPath);
                         }
                         catch (Exception ex)
                         {
                             EventMetadata metadata = new EventMetadata();
                             metadata.Add("Operation", "CreateDirectory");
-                            metadata.Add(nameof(treeOp.TargetPath), treeOp.TargetPath);
+                            metadata.Add(nameof(treeOp.TargetPath), absoluteTargetPath);
                             this.tracer.RelatedError(metadata, ex.Message);
                             this.HasFailures = true;
                         }
@@ -186,19 +188,19 @@ namespace FastFetch
                     case DiffTreeResult.Operations.Delete:
                         try
                         {
-                            if (Directory.Exists(treeOp.TargetPath))
+                            if (Directory.Exists(absoluteTargetPath))
                             {
-                                this.fileSystem.DeleteDirectory(treeOp.TargetPath);
+                                this.fileSystem.DeleteDirectory(absoluteTargetPath);
                             }
                         }
                         catch (Exception ex)
                         {
                             // We are deleting directories and subdirectories in parallel
-                            if (Directory.Exists(treeOp.TargetPath))
+                            if (Directory.Exists(absoluteTargetPath))
                             {
                                 EventMetadata metadata = new EventMetadata();
                                 metadata.Add("Operation", "DeleteDirectory");
-                                metadata.Add(nameof(treeOp.TargetPath), treeOp.TargetPath);
+                                metadata.Add(nameof(treeOp.TargetPath), absoluteTargetPath);
                                 this.tracer.RelatedError(metadata, ex.Message);
                                 this.HasFailures = true;
                             }
@@ -206,7 +208,7 @@ namespace FastFetch
 
                         break;
                     default:
-                        this.tracer.RelatedError("Ignoring unexpected Tree Operation {0}: {1}", treeOp.TargetPath, treeOp.Operation);
+                        this.tracer.RelatedError("Ignoring unexpected Tree Operation {0}: {1}", absoluteTargetPath, treeOp.Operation);
                         continue;
                 }
 

--- a/GVFS/FastFetch/Index.cs
+++ b/GVFS/FastFetch/Index.cs
@@ -213,7 +213,7 @@ namespace FastFetch
                     addedOrEditedLocalFiles,
                     (localPath) =>
                     {
-                        string gitPath = FromDotnetFullPathToGitRelativePath(localPath, this.repoRoot);
+                        string gitPath = localPath.Replace(Path.DirectorySeparatorChar, GVFSConstants.GitPathSeparator);
                         long offset;
                         if (this.indexEntryOffsets.TryGetValue(gitPath, out offset))
                         {

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -54,7 +54,7 @@ namespace GVFS.UnitTests.Prefetch
         {
             MockTracer tracer = new MockTracer();
             DiffHelper diffForwards = new DiffHelper(tracer, new MockGVFSEnlistment(), new List<string>(), new List<string>(), includeSymLinks: this.IncludeSymLinks);
-            diffForwards.ParseDiffFile(GetDataPath("forward.txt"), "xx:\\fakeRepo");
+            diffForwards.ParseDiffFile(GetDataPath("forward.txt"));
 
             // File added, file edited, file renamed, folder => file, edit-rename file, SymLink added (if applicable)
             // Children of: Add folder, Renamed folder, edited folder, file => folder
@@ -82,7 +82,7 @@ namespace GVFS.UnitTests.Prefetch
         {
             MockTracer tracer = new MockTracer();
             DiffHelper diffBackwards = new DiffHelper(tracer, new Mock.Common.MockGVFSEnlistment(), new List<string>(), new List<string>(), includeSymLinks: this.IncludeSymLinks);
-            diffBackwards.ParseDiffFile(GetDataPath("backward.txt"), "xx:\\fakeRepo");
+            diffBackwards.ParseDiffFile(GetDataPath("backward.txt"));
 
             // File > folder, deleted file, edited file, renamed file, rename-edit file
             // Children of file > folder, renamed folder, deleted folder, recursive delete file, edited folder
@@ -106,7 +106,7 @@ namespace GVFS.UnitTests.Prefetch
         {
             MockTracer tracer = new MockTracer();
             DiffHelper diffBackwards = new DiffHelper(tracer, new Mock.Common.MockGVFSEnlistment(), new List<string>(), new List<string>(), includeSymLinks: this.IncludeSymLinks);
-            diffBackwards.ParseDiffFile(GetDataPath("caseChange.txt"), "xx:\\fakeRepo");
+            diffBackwards.ParseDiffFile(GetDataPath("caseChange.txt"));
 
             diffBackwards.RequiredBlobs.Count.ShouldEqual(2);
             diffBackwards.FileAddOperations.Sum(list => list.Value.Count).ShouldEqual(2);

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffTreeResultTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffTreeResultTests.cs
@@ -18,7 +18,6 @@ namespace GVFS.UnitTests.Prefetch
         private const string TestTreePath2 = "Test/directory with blob and spaces";
         private const string TestBlobPath1 = "Test/file with spaces.txt";
         private const string TestBlobPath2 = "Test/file with tree and spaces.txt";
-        private static readonly string RepoRoot = Path.Combine("C:", "root");
 
         private static readonly string MissingColonLineFromDiffTree = $"040000 040000 {TestSha1} {Test2Sha1} M\t{TestTreePath1}";
         private static readonly string TooManyFieldsLineFromDiffTree = $":040000 040000 {TestSha1} {Test2Sha1} M BadData\t{TestTreePath1}";
@@ -43,21 +42,14 @@ namespace GVFS.UnitTests.Prefetch
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_NullLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(null, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(null));
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_EmptyLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(string.Empty, RepoRoot));
-        }
-
-        [TestCase]
-        [Category(CategoryConstants.ExceptionExpected)]
-        public void ParseFromDiffTreeLine_NullRepo()
-        {
-            Assert.Throws<ArgumentNullException>(() => DiffTreeResult.ParseFromDiffTreeLine(ModifyTreeLineFromDiffTree, null));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(string.Empty));
         }
 
         [TestCase]
@@ -74,7 +66,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = Test2Sha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyTreeLineFromDiffTree, string.Empty);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyTreeLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -82,21 +74,14 @@ namespace GVFS.UnitTests.Prefetch
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromLsTreeLine_NullLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromLsTreeLine(null, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromLsTreeLine(null));
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromLsTreeLine_EmptyLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromLsTreeLine(string.Empty, RepoRoot));
-        }
-
-        [TestCase]
-        [Category(CategoryConstants.ExceptionExpected)]
-        public void ParseFromLsTreeLine_NullRepoRoot()
-        {
-            Assert.Throws<ArgumentNullException>(() => DiffTreeResult.ParseFromLsTreeLine(BlobLineFromLsTree, null));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromLsTreeLine(string.Empty));
         }
 
         [TestCase]
@@ -112,7 +97,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = TestSha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineFromLsTree, string.Empty);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -124,12 +109,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Add,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestTreePath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestTreePath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = null,
                 TargetSha = TestSha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineFromLsTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -146,35 +131,35 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = null
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(TreeLineFromLsTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(TreeLineFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
         [TestCase]
         public void ParseFromLsTreeLine_InvalidLine()
         {
-            DiffTreeResult.ParseFromLsTreeLine(InvalidLineFromLsTree, RepoRoot).ShouldBeNull();
+            DiffTreeResult.ParseFromLsTreeLine(InvalidLineFromLsTree).ShouldBeNull();
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_NoColonLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(MissingColonLineFromDiffTree, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(MissingColonLineFromDiffTree));
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_TooManyFieldsLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(TooManyFieldsLineFromDiffTree, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(TooManyFieldsLineFromDiffTree));
         }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_NotEnoughFieldsLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(NotEnoughFieldsLineFromDiffTree, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(NotEnoughFieldsLineFromDiffTree));
         }
 
         [TestCase]
@@ -182,7 +167,7 @@ namespace GVFS.UnitTests.Prefetch
         [Category(CategoryConstants.ExceptionExpected)]
         public void ParseFromDiffTreeLine_TwoPathLine()
         {
-            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(TwoPathLineFromDiffTree, RepoRoot));
+            Assert.Throws<ArgumentException>(() => DiffTreeResult.ParseFromDiffTreeLine(TwoPathLineFromDiffTree));
         }
 
         [TestCase]
@@ -198,7 +183,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = Test2Sha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyTreeLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyTreeLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -215,7 +200,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = EmptySha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteTreeLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteTreeLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -232,7 +217,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = Test2Sha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(AddTreeLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(AddTreeLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -244,12 +229,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Add,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestBlobPath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestBlobPath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = EmptySha1,
                 TargetSha = Test2Sha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(AddBlobLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(AddBlobLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -261,12 +246,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Delete,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestBlobPath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestBlobPath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = TestSha1,
                 TargetSha = EmptySha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteBlobLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteBlobLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -278,12 +263,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Delete,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestBlobPath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestBlobPath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = TestSha1,
                 TargetSha = EmptySha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteBlobLineFromDiffTree2, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(DeleteBlobLineFromDiffTree2);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -295,12 +280,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Modify,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestBlobPath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestBlobPath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = TestSha1,
                 TargetSha = Test2Sha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyBlobLineFromDiffTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromDiffTreeLine(ModifyBlobLineFromDiffTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -313,12 +298,12 @@ namespace GVFS.UnitTests.Prefetch
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
                 TargetIsSymLink = true,
-                TargetPath = Path.Combine(RepoRoot, TestTreePath1.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestTreePath1.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = null,
                 TargetSha = TestSha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(SymLinkLineFromLsTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(SymLinkLineFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -335,7 +320,7 @@ namespace GVFS.UnitTests.Prefetch
                 TargetSha = null
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(TreeLineWithBlobPathFromLsTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(TreeLineWithBlobPathFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -347,12 +332,12 @@ namespace GVFS.UnitTests.Prefetch
                 Operation = DiffTreeResult.Operations.Add,
                 SourceIsDirectory = false,
                 TargetIsDirectory = false,
-                TargetPath = Path.Combine(RepoRoot, TestBlobPath2.Replace('/', Path.DirectorySeparatorChar)),
+                TargetPath = TestBlobPath2.Replace('/', Path.DirectorySeparatorChar),
                 SourceSha = null,
                 TargetSha = TestSha1
             };
 
-            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineWithTreePathFromLsTree, RepoRoot);
+            DiffTreeResult result = DiffTreeResult.ParseFromLsTreeLine(BlobLineWithTreePathFromLsTree);
             this.ValidateDiffTreeResult(expected, result);
         }
 
@@ -370,7 +355,7 @@ namespace GVFS.UnitTests.Prefetch
 
         private static string CreateTreePath(string testPath)
         {
-            return Path.Combine(RepoRoot, testPath.Replace('/', Path.DirectorySeparatorChar)) + Path.DirectorySeparatorChar;
+            return testPath.Replace('/', Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
         }
 
         private void ValidateDiffTreeResult(DiffTreeResult expected, DiffTreeResult actual)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -523,7 +523,7 @@ You can specify a URL, a name of a configured cache server, or the special names
             GitProcess git = new GitProcess(enlistment);
             GitProcess.Result result = git.LsTree(
                 GVFSConstants.DotGit.HeadName,
-                line => rootEntries.Add(DiffTreeResult.ParseFromLsTreeLine(line, repoRoot: string.Empty)),
+                line => rootEntries.Add(DiffTreeResult.ParseFromLsTreeLine(line)),
                 recursive: false);
 
             if (result.ExitCodeIsFailure)


### PR DESCRIPTION
We construct absolute paths at point of use -- some cases use the `Enlistment`'s `WorkingDirectoryRoot`, and others use the `WorkingDirectoryBackingRoot`.  (These are identical on Windows and Mac, but different on Linux.)

As a result of this change:

* `DiffTreeResult` only deals in <var title="N.B.! This is the opposite of the Sith.">relative, repository-internal paths</var>. These are not prefixed with the directory separator character.
* `HydrateFilesStage` takes the working directory root to trigger projections by the projected fs.
* `BlobPrefetcher` likewise deals in repository-internal paths. Note that `--folders /` now produces an empty string folder path, which **does** make it into the lists later used for determining whether to include a file. This is a bit awkward, but works in all the ways we want it to.
* `FastFetch.Index` no longer tries to convert between full paths and git relative paths.

This fixes all `GVFS.FunctionalTests.Tests.EnlistmentPerFixture.PrefetchVerbTests` tests on Linux.