### PR TITLE
Actionable notifications

### DIFF
--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -235,7 +235,8 @@ namespace GVFS.Common.NamedPipes
                 {
                     AutomountStart,
                     MountSuccess,
-                    MountFailure
+                    MountFailure,
+                    UpgradeAvailable
                 }
 
                 public Identifier Id { get; set; }
@@ -247,6 +248,8 @@ namespace GVFS.Common.NamedPipes
                 public string Enlistment { get; set; }
 
                 public int EnlistmentCount { get; set; }
+
+                public string NewVersion { get; set; }
 
                 public static Request FromMessage(Message message)
                 {

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/IPC/VFSForGitNotification.h
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/IPC/VFSForGitNotification.h
@@ -9,14 +9,18 @@ typedef NS_ENUM(NSInteger, Identifier)
     AutomountStart,
     MountSuccess,
     MountFailure,
+    UpgradeAvailable,
     UnknownMessage
 };
 
-@interface VFSForGitNotification : NSObject
+@interface VFSForGitNotification : NSObject <NSCoding>
 
 @property (assign, readonly) Identifier identifier;
 @property (copy, readonly) NSString *title;
+@property (copy, readonly) NSString *actionTitle;
 @property (copy, readonly) NSString *message;
+@property (copy, readonly) NSString *gvfsCommand;
+@property (assign, readonly) BOOL actionable;
 
 + (BOOL)tryValidateMessage:(NSDictionary *)jsonMessage
          buildNotification:(VFSForGitNotification *_Nullable *_Nonnull)notification

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/IPC/VFSForGitNotification.m
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/IPC/VFSForGitNotification.m
@@ -4,18 +4,33 @@
 NSString * const IdentifierKey = @"Id";
 NSString * const EnlistmentKey = @"Enlistment";
 NSString * const EnlistmentCountKey = @"EnlistmentCount";
+NSString * const NewUpgradeVersionKey = @"NewVersion";
 NSString * const TitleKey = @"Title";
+NSString * const ActionTitleKey = @"ActionTitle";
+NSString * const IsActionableKey = @"IsActionable";
 NSString * const MessageKey = @"Message";
+NSString * const GVFSCommandKey = @"GVFSCommand";
 
 NSString * const AutomountTitle = @"GVFS AutoMount";
+NSString * const MountGVFSCommandFormat = @"gvfs mount %@";
+NSString * const MountActionTitle = @"Retry";
 NSString * const AutomountStartMessageFormat = @"Attempting to mount %lu GVFS repos(s)";
 NSString * const AutomountSuccessMessageFormat = @"The following GVFS repo is now mounted: \n%@";
 NSString * const AutomountFailureMessageFormat = @"The following GVFS repo failed to mount: \n%@";
 
+NSString * const UpgradeAvailableTitleFormat = @"New version %@ is available";
+NSString * const UpgradeAvailableMessage = @"Upgrade will unmount and remount gvfs repos, ensure you are at a stopping point.\nWhen ready, click Upgrade button to run upgrade.";
+NSString * const UpgradeActionTitle = @"Upgrade";
+NSString * const UpgradeGVFSCommandFormat = @"sudo gvfs upgrade --confirm";
+
 @interface VFSForGitNotification()
 
+@property (readwrite) Identifier identifier;
 @property (readwrite) NSString *title;
 @property (readwrite) NSString *message;
+@property (readwrite) NSString *actionTitle;
+@property (readwrite) NSString *gvfsCommand;
+@property (readwrite) BOOL actionable;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,8 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype _Nullable)initAsMountWithMessage:(NSDictionary *)messageDict
                                            title:(NSString *)title
                                    messageFormat:(NSString *)messageFormat
+                                    actionFormat:(NSString * _Nullable)commandFormat
                                            error:(NSError *__autoreleasing *)error;
 
+- (instancetype)initAsUpgradeAvailableWithMessage:(NSDictionary *)messageDict
+                                            error:(NSError *__autoreleasing *)error;
 NS_ASSUME_NONNULL_END
 
 @end
@@ -83,6 +101,14 @@ NS_ASSUME_NONNULL_END
                              error:&initError];
             break;
         }
+        
+        case UpgradeAvailable:
+        {
+            *notification = [[VFSForGitNotification alloc]
+                             initAsUpgradeAvailableWithMessage:jsonMessage
+                             error:&initError];
+            break;
+        }
             
         default:
         {
@@ -110,21 +136,22 @@ NS_ASSUME_NONNULL_END
     if (self = [super init])
     {
         id repoCount = messageDict[EnlistmentCountKey];
-        if (repoCount && [repoCount isKindOfClass:[NSNumber class]])
+        if ((repoCount != nil) && [repoCount isKindOfClass:[NSNumber class]])
         {
             _title = [AutomountTitle copy];
             _message = [[NSString stringWithFormat:AutomountStartMessageFormat, [repoCount unsignedIntegerValue]] copy];
-            return self;
         }
-        
-        if (error != nil)
+        else
         {
-            *error = [NSError errorWithDomain:VFSForGitNotificationErrorDomain
-                                         code:VFSForGitMissingRepoCountError
-                                     userInfo:@{ NSLocalizedDescriptionKey : @"Missing repos count in AutomountStart message" }];
+            if (error != nil)
+            {
+                *error = [NSError errorWithDomain:VFSForGitNotificationErrorDomain
+                                             code:VFSForGitMissingRepoCountError
+                                         userInfo:@{ NSLocalizedDescriptionKey : @"Missing repos count in AutomountStart message" }];
+            }
+            
+            self = nil;
         }
-        
-        self = nil;
     }
     
     return self;
@@ -136,6 +163,7 @@ NS_ASSUME_NONNULL_END
     return self = [self initAsMountWithMessage:messageDict
                                          title:(NSString *)AutomountTitle
                                  messageFormat:(NSString *)AutomountSuccessMessageFormat
+                                  actionFormat:nil
                                          error:error];
 }
 
@@ -145,12 +173,14 @@ NS_ASSUME_NONNULL_END
     return self = [self initAsMountWithMessage:messageDict
                                          title:(NSString *)AutomountTitle
                                  messageFormat:(NSString *)AutomountFailureMessageFormat
+                                  actionFormat:MountGVFSCommandFormat
                                          error:error];
 }
 
 - (instancetype)initAsMountWithMessage:(NSDictionary *)messageDict
                                  title:(NSString *)title
                          messageFormat:(NSString *)messageFormat
+                          actionFormat:(NSString *)commandFormat
                                  error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(title);
@@ -159,23 +189,89 @@ NS_ASSUME_NONNULL_END
     if (self = [super init])
     {
         id enlistment = messageDict[EnlistmentKey];
-        if (enlistment && [enlistment isKindOfClass:[NSString class]])
+        if ((enlistment != nil) && [enlistment isKindOfClass:[NSString class]])
         {
             _title = [title copy];
             _message = [[NSString stringWithFormat:
                          (NSString *)messageFormat,
                          enlistment] copy];
+            if (commandFormat != nil)
+            {
+                _gvfsCommand = [[NSString stringWithFormat:commandFormat, enlistment] copy];
+                _actionable = YES;
+                _actionTitle = MountActionTitle;
+            }
+            
             return self;
         }
-        
-        if (error != nil)
+        else
         {
-            *error = [NSError errorWithDomain:VFSForGitNotificationErrorDomain
-                                         code:VFSForGitMissingEntitlementInfoError
-                                     userInfo:@{ NSLocalizedDescriptionKey : @"ERROR: missing enlistment info." }];
+            if (error != nil)
+            {
+                *error = [NSError errorWithDomain:VFSForGitNotificationErrorDomain
+                                             code:VFSForGitMissingEntitlementInfoError
+                                         userInfo:@{ NSLocalizedDescriptionKey : @"ERROR: missing enlistment info." }];
+            }
+            
+            self = nil;
         }
-        
-        self = nil;
+    }
+    
+    return self;
+}
+
+- (instancetype)initAsUpgradeAvailableWithMessage:(NSDictionary *)messageDict
+                                            error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(messageDict);
+    
+    if (self = [super init])
+    {
+        id newVersion = messageDict[NewUpgradeVersionKey];
+        if ((newVersion != nil) && [newVersion isKindOfClass:[NSString class]])
+        {
+            _title = [[NSString stringWithFormat:UpgradeAvailableTitleFormat, newVersion] copy];
+            _message = [UpgradeAvailableMessage copy];
+            _actionTitle = [UpgradeActionTitle copy];
+            _actionable = YES;
+            _gvfsCommand = [UpgradeGVFSCommandFormat copy];
+        }
+        else
+        {
+            if (error != nil)
+            {
+                *error = [NSError errorWithDomain:VFSForGitNotificationErrorDomain
+                                             code:VFSForGitMissingEntitlementInfoError
+                                         userInfo:@{ NSLocalizedDescriptionKey : @"ERROR: missing new upgrade version info." }];
+            }
+            
+            self = nil;
+        }
+    }
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:[NSNumber numberWithInt:[self identifier]] forKey:IdentifierKey];
+    [aCoder encodeObject:[self title] forKey:TitleKey];
+    [aCoder encodeObject:[self message] forKey:MessageKey];
+    [aCoder encodeObject:[self actionTitle] forKey:ActionTitleKey];
+    [aCoder encodeObject:[self gvfsCommand] forKey:GVFSCommandKey];
+    [aCoder encodeObject:[NSNumber numberWithBool:[self actionable]] forKey:IsActionableKey];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    if (self = [super init])
+    {
+        _identifier = [[aDecoder decodeObjectForKey:IdentifierKey] integerValue];
+        _title = [[aDecoder decodeObjectForKey:TitleKey] copy];
+        _message = [[aDecoder decodeObjectForKey:MessageKey] copy];
+        _actionTitle = [[aDecoder decodeObjectForKey:ActionTitleKey] copy];
+        _gvfsCommand = [[aDecoder decodeObjectForKey:GVFSCommandKey] copy];
+        _actionable = [[aDecoder decodeObjectForKey:IsActionableKey] boolValue];
     }
     
     return self;

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Info.plist
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Info.plist
@@ -5,7 +5,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>`$(PRODUCT_NAME)` uses `Terminal` app to run `gvfs upgrade` and `gvfs mount` commands.</string>
+	<string>`$(PRODUCT_NAME)` uses `Terminal` app to run `gvfs` commands.</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Info.plist
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>`$(PRODUCT_NAME)` uses `Terminal` app to run `gvfs upgrade` and `gvfs mount` commands.</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/UI/VFSAppDelegate.m
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/UI/VFSAppDelegate.m
@@ -1,5 +1,6 @@
 #import "VFSAboutWindowController.h"
 #import "VFSAppDelegate.h"
+#import "VFSCommandRunner.h"
 #import "VFSMessageListener.h"
 #import "VFSNotificationDisplay.h"
 #import "VFSForGitNotification.h"
@@ -12,6 +13,7 @@
 @property (weak) IBOutlet NSWindow *Window;
 @property (strong) VFSStatusBarItem *StatusDisplay;
 @property (strong) VFSMessageListener *messageListener;
+@property (strong) VFSNotificationDisplay *notificationDisplay;
 
 - (void)displayNotification:(NSDictionary *_Nonnull)messageInfo;
 
@@ -42,6 +44,9 @@
                            initWithProductInfoFetcher:productInfoFetcher]];
     
     [self.StatusDisplay load];
+    
+    self.notificationDisplay = [[VFSNotificationDisplay alloc]
+                                initWithCommandRunner:[[VFSCommandRunner alloc] init]];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
@@ -63,10 +68,6 @@
         return;
     }
     
-    VFSNotificationDisplay *notificationDisplay =
-    [[VFSNotificationDisplay alloc] initWithTitle:notification.title
-                                          message:notification.message];
-    
-    [notificationDisplay display];
+    [self.notificationDisplay display:notification];
 }
 @end

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/UI/VFSNotificationDisplay.h
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/UI/VFSNotificationDisplay.h
@@ -1,10 +1,9 @@
 #import <Foundation/Foundation.h>
+#import "VFSForGitNotification.h"
 
-@interface VFSNotificationDisplay : NSObject
+@interface VFSNotificationDisplay : NSObject <NSUserNotificationCenterDelegate>
 
-- (instancetype _Nullable)initWithTitle:(NSString *)title message:(NSString *)message;
-- (instancetype _Nullable)initWithUserNotification:(NSUserNotification *)userNotification
-                                notificationCenter:(NSUserNotificationCenter *)notificationCenter;
-- (void) display;
+- (instancetype)initWithCommandRunner:(VFSCommandRunner *)commandRunner;
+- (void)display:(VFSForGitNotification *) notification;
 
 @end

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Utilities/VFSCommandRunner.h
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Utilities/VFSCommandRunner.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VFSCommandRunner : NSObject
+
+- (void) runCommand:(NSString *) command;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Utilities/VFSCommandRunner.m
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/StatusMenuItem/Utilities/VFSCommandRunner.m
@@ -1,0 +1,25 @@
+#import "VFSCommandRunner.h"
+
+NSString * const LaunchTerminalScriptFormat = @"\
+tell application \"Terminal\" \n\
+activate \n\
+do script (\"echo;echo Running gvfs command: %@;echo You might need to type Admin password;%@ \") \n\
+end tell";
+
+@implementation VFSCommandRunner
+
+- (void) runCommand:(NSString *) command
+{
+    NSString *scriptSource = [NSString stringWithFormat:LaunchTerminalScriptFormat, command, command];
+    NSAppleScript *scriptObject = [[NSAppleScript alloc] initWithSource:scriptSource];
+    NSDictionary *errorDict;
+    NSAppleEventDescriptor *returnDescriptor = NULL;
+    
+    returnDescriptor = [scriptObject executeAndReturnError: &errorDict];
+    if (returnDescriptor == nil)
+    {
+        NSLog(@"Error running %@. %@", command, [errorDict description]);
+    }
+}
+
+@end

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/VFSForGit.xcodeproj/project.pbxproj
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/VFSForGit.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		43AF0E0822B023F200E54D48 /* VFSMessageParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 43AF0E0622B023F200E54D48 /* VFSMessageParserTests.m */; };
 		43AF0E0922B023F200E54D48 /* VFSForGitNotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 43AF0E0722B023F200E54D48 /* VFSForGitNotificationTests.m */; };
 		43C021F022B18BDD00F868F2 /* VFSNotificationErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 43C021EF22B18BDD00F868F2 /* VFSNotificationErrors.m */; };
+		43C0221A22BBFA7A00F868F2 /* VFSCommandRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 43C0221822BBFA7A00F868F2 /* VFSCommandRunner.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,8 @@
 		43AF0E0722B023F200E54D48 /* VFSForGitNotificationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VFSForGitNotificationTests.m; sourceTree = "<group>"; };
 		43C021EE22B18BDD00F868F2 /* VFSNotificationErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VFSNotificationErrors.h; sourceTree = "<group>"; };
 		43C021EF22B18BDD00F868F2 /* VFSNotificationErrors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VFSNotificationErrors.m; sourceTree = "<group>"; };
+		43C0221822BBFA7A00F868F2 /* VFSCommandRunner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VFSCommandRunner.m; sourceTree = "<group>"; };
+		43C0221922BBFA7A00F868F2 /* VFSCommandRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VFSCommandRunner.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,6 +181,8 @@
 		435B1E04228C88E300E853F3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				43C0221922BBFA7A00F868F2 /* VFSCommandRunner.h */,
+				43C0221822BBFA7A00F868F2 /* VFSCommandRunner.m */,
 				433FE8582280E10F00488730 /* VFSProductInfoFetcher.h */,
 				433FE8592280E10F00488730 /* VFSProductInfoFetcher.m */,
 				435B1E0D228CC1E000E853F3 /* VFSProcessRunner.h */,
@@ -306,6 +311,7 @@
 				433FE8632281D06100488730 /* VFSAboutWindowController.m in Sources */,
 				43AF0DF822B01C9800E54D48 /* VFSForGitNotification.m in Sources */,
 				433FE821227B594300488730 /* main.m in Sources */,
+				43C0221A22BBFA7A00F868F2 /* VFSCommandRunner.m in Sources */,
 				43C021F022B18BDD00F868F2 /* VFSNotificationErrors.m in Sources */,
 				43AF0DFA22B01C9800E54D48 /* VFSMessageParser.m in Sources */,
 				433FE819227B593500488730 /* VFSAppDelegate.m in Sources */,


### PR DESCRIPTION
#### High level description
Native notifications can now have actions associated with them. When user clicks on the action button on a notification bubble, `VFSForGit.app` will run a Command in response.
Example: `Mount_Failure` notification can specifiy the `gvfs` command `gvfs mount <path>` as its associated action. Actionable notifications also have an `actionTitle`, which get displayed as text in a Button control on the Notification bubble.

#### More info
- Commands are run using `Terminal` app.
- Terminal is launched using `Applescript`.
- Only `UpgradeAvailable` and `Mount_Failure` notifications are actionable now.
- `VFSForGitNotification` class now confirms to `NSCoding` protocol. `VFSForGitNotification` object holds details of the notification including its associated commands. It is archived using `NSCoding` protocol and sent to the OS notification center. When user clicks the notification bubble, OS Notification Center calls `VFSForGit.app` with the specific notification UI object that user clicked. `VFSForGit.app` then retrieves the archived `VFSForGitNotification` object contained in the notification UI. `VFSForGit.app` then un-archives it, reads the command info contained in it and launches `Terminal` and executes the command.

#### Screenshots
- Upgrade available notification
<img width="358" alt="Screen Shot 2019-06-20 at 2 40 59 PM" src="https://user-images.githubusercontent.com/378580/59873325-b9d36980-9369-11e9-9c82-a99b12c46197.png">

- Clicking on `Upgrade` launches the following `Terminal` window - 

<img width="605" alt="Screen Shot 2019-06-20 at 2 41 19 PM" src="https://user-images.githubusercontent.com/378580/59873347-cce63980-9369-11e9-964e-9889e1a6d563.png">
