### PR TITLE
use correct checkout thread maximum in FastFetch

### DIFF
--- a/GVFS/FastFetch/CheckoutStage.cs
+++ b/GVFS/FastFetch/CheckoutStage.cs
@@ -91,7 +91,7 @@ namespace FastFetch
                 Keywords.Telemetry,
                 metadata: null))
             {
-                Parallel.For(1, this.maxParallel, (i) => { this.HandleAllFileDeleteOperations(); });
+                Parallel.For(0, this.maxParallel, (i) => { this.HandleAllFileDeleteOperations(); });
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("FilesDeleted", this.fileDeleteCount);
                 activity.Stop(metadata);
@@ -104,7 +104,7 @@ namespace FastFetch
                 Keywords.Telemetry,
                 metadata: null))
             {
-                Parallel.For(1, this.maxParallel, (i) => { this.HandleAllDirectoryOperations(); });
+                Parallel.For(0, this.maxParallel, (i) => { this.HandleAllDirectoryOperations(); });
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("DirectoryOperationsCompleted", this.directoryOpCount);
                 activity.Stop(metadata);
@@ -117,7 +117,7 @@ namespace FastFetch
                 Keywords.Telemetry,
                 metadata: null))
             {
-                Parallel.For(1, this.maxParallel, (i) => { this.HandleAllFileAddOperations(); });
+                Parallel.For(0, this.maxParallel, (i) => { this.HandleAllFileAddOperations(); });
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("FilesWritten", this.fileWriteCount);
                 activity.Stop(metadata);


### PR DESCRIPTION
The `--checkout-thread-count` parameter to `FastFetch`, when set to `1`, previously caused the program to fail because no executions of `HandleAll*Operations()` methods occurred.  This was due to the `Parallel.For()` method being called with equal `fromInclusive` and `toExclusive` parameters, both set to `1`, so the number of executions was zero.

We adjust the `fromInclusive` parameter to zero so that the number of parallel executions will be `this.maxParallel` (i.e., `toExclusive-fromInclusive == this.maxParallel-0`), which is the value from `CheckoutThreadCount`, as set by the `--checkout-thread-count` command line option.

Note that this failure condition could also be triggered when run in a single-core environment (e.g., a small VM), in which case `CheckoutThreadCount`, being constrained to a maximum of `Environment.ProcessorCount`, is always `1`.

/cc @kivikakk