### PR TITLE
Add include verb for allowing projection of only specific folders 

### DIFF
--- a/GVFS/GVFS.Common/Database/GVFSDatabase.cs
+++ b/GVFS/GVFS.Common/Database/GVFSDatabase.cs
@@ -118,6 +118,7 @@ namespace GVFS.Common.Database
                 }
 
                 PlaceholderTable.CreateTable(connection);
+                IncludedFolderTable.CreateTable(connection);
             }
         }
 

--- a/GVFS/GVFS.Common/Database/IIncludedFolderCollection.cs
+++ b/GVFS/GVFS.Common/Database/IIncludedFolderCollection.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GVFS.Common.Database
+{
+    public interface IIncludedFolderCollection
+    {
+        List<string> GetAll();
+
+        void Add(string directory);
+        void Remove(string directory);
+    }
+}

--- a/GVFS/GVFS.Common/Database/IncludedFolderTable.cs
+++ b/GVFS/GVFS.Common/Database/IncludedFolderTable.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Text;
+
+namespace GVFS.Common.Database
+{
+    public class IncludedFolderTable : IIncludedFolderCollection
+    {
+        private IGVFSConnectionPool connectionPool;
+
+        public IncludedFolderTable(IGVFSConnectionPool connectionPool)
+        {
+            this.connectionPool = connectionPool;
+        }
+
+        public static void CreateTable(IDbConnection connection)
+        {
+            using (IDbCommand command = connection.CreateCommand())
+            {
+                command.CommandText = "CREATE TABLE IF NOT EXISTS [IncludedFolder] (path TEXT PRIMARY KEY COLLATE NOCASE) WITHOUT ROWID;";
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public void Add(string directory)
+        {
+            try
+            {
+                using (IDbConnection connection = this.connectionPool.GetConnection())
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "INSERT OR REPLACE INTO IncludedFolder (path) VALUES (@path);";
+                    command.AddParameter("@path", DbType.String, directory);
+                    command.ExecuteNonQuery();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new GVFSDatabaseException($"{nameof(IncludedFolderTable)}.{nameof(this.Add)}({directory}) Exception: {ex.ToString()}", ex);
+            }
+        }
+
+        public List<string> GetAll()
+        {
+            try
+            {
+                using (IDbConnection connection = this.connectionPool.GetConnection())
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    List<string> directories = new List<string>();
+                    command.CommandText = $"SELECT path FROM IncludedFolder;";
+                    using (IDataReader reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            directories.Add(reader.GetString(0));
+                        }
+                    }
+
+                    return directories;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new GVFSDatabaseException($"{nameof(PlaceholderTable)}.{nameof(this.GetAll)} Exception: {ex.ToString()}", ex);
+            }
+        }
+
+        public void Remove(string directory)
+        {
+            try
+            {
+                using (IDbConnection connection = this.connectionPool.GetConnection())
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "DELETE FROM IncludedFolder WHERE path = @path;";
+                    command.AddParameter("@path", DbType.String, directory);
+                    command.ExecuteNonQuery();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new GVFSDatabaseException($"{nameof(IncludedFolderTable)}.{nameof(this.Remove)}({directory}) Exception: {ex.ToString()}", ex);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -89,6 +89,7 @@ namespace GVFS.Common
 
             public const string Clone = "clone";
             public const string Dehydrate = "dehydrate";
+            public const string Include = "include";
             public const string MountVerb = MountPrefix + "_verb";
             public const string MountProcess = MountPrefix + "_process";
             public const string MountUpgrade = MountPrefix + "_repoupgrade";

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -468,9 +468,19 @@ namespace GVFS.Common.Git
             return this.InvokeGitInWorkingDirectoryRoot("checkout -f " + target, useReadObjectHook: false);
         }
 
-        public Result Status(bool allowObjectDownloads, bool useStatusCache)
+        public Result Status(bool allowObjectDownloads, bool useStatusCache, bool showUntracked = false)
         {
-            string command = useStatusCache ? "status" : "status --no-deserialize";
+            string command = "status";
+            if (!useStatusCache)
+            {
+                command += " --no-deserialize";
+            }
+
+            if (showUntracked)
+            {
+                command += " -uall";
+            }
+
             return this.InvokeGitInWorkingDirectoryRoot(command, useReadObjectHook: allowObjectDownloads);
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
@@ -115,6 +115,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(5)]
+        [Category(Categories.WindowsOnly)]
         public void CreatingFolderShouldAddToIncludedListAndStartProjecting()
         {
             this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
@@ -126,6 +127,32 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             newFolderPath.ShouldBeADirectory(this.fileSystem);
             string[] fileSystemEntries = Directory.GetFileSystemEntries(newFolderPath);
             fileSystemEntries.Length.ShouldEqual(32);
+
+            string projectedFolder = Path.Combine(newFolderPath, "Git");
+            projectedFolder.ShouldBeADirectory(this.fileSystem);
+            fileSystemEntries = Directory.GetFileSystemEntries(projectedFolder);
+            fileSystemEntries.Length.ShouldEqual(13);
+
+            string projectedFile = Path.Combine(newFolderPath, "ReturnCode.cs");
+            projectedFile.ShouldBeAFile(this.fileSystem);
+        }
+
+        [TestCase, Order(5)]
+        [Category(Categories.MacOnly)]
+        public void CreateFolderThenFileShouldAddToIncludedListAndStartProjecting()
+        {
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
+
+            string newFolderPath = Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS.Common");
+            newFolderPath.ShouldNotExistOnDisk(this.fileSystem);
+            Directory.CreateDirectory(newFolderPath);
+            string newFilePath = Path.Combine(newFolderPath, "test.txt");
+            File.WriteAllText(newFilePath, "New file content");
+            newFolderPath.ShouldBeADirectory(this.fileSystem);
+            newFilePath.ShouldBeAFile(this.fileSystem);
+            string[] fileSystemEntries = Directory.GetFileSystemEntries(newFolderPath);
+            fileSystemEntries.Length.ShouldEqual(33);
 
             string projectedFolder = Path.Combine(newFolderPath, "Git");
             projectedFolder.ShouldBeADirectory(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
@@ -1,0 +1,79 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Should;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class IncludedFolderTests : TestsWithEnlistmentPerFixture
+    {
+        private FileSystemRunner fileSystem = new SystemIORunner();
+
+        [TestCase]
+        public void BasicTestsAddingAndRemoving()
+        {
+            // directories before limiting them
+            string[] allRootDirectories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            string[] directoriesForParentAdd = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
+
+            GVFSProcess gvfsProcess = new GVFSProcess(this.Enlistment);
+            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS"));
+
+            string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            directories.Length.ShouldEqual(2);
+            directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, ".git"));
+            directories[1].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
+
+            string folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS");
+            folder.ShouldBeADirectory(this.fileSystem);
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "CommandLine");
+            folder.ShouldBeADirectory(this.fileSystem);
+
+            folder = this.Enlistment.GetVirtualPathTo("Scripts");
+            folder.ShouldNotExistOnDisk(this.fileSystem);
+
+            // Remove the last directory should make all folders appear again
+            gvfsProcess.RemoveIncludedFolders(Path.Combine("GVFS", "GVFS"));
+            directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            directories.ShouldMatchInOrder(allRootDirectories);
+
+            // Add parent directory should make the parent recursive
+            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS", "CommandLine"));
+            directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
+            directories.Length.ShouldEqual(1);
+            directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS", "CommandLine"));
+
+            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS"));
+            directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
+            directories.ShouldMatchInOrder(directoriesForParentAdd);
+
+            // Add and remove folder
+            gvfsProcess.AddIncludedFolders("Scripts");
+            folder.ShouldBeADirectory(this.fileSystem);
+
+            gvfsProcess.RemoveIncludedFolders("Scripts");
+            folder.ShouldNotExistOnDisk(this.fileSystem);
+
+            // Add and remove sibling folder to GVFS/GVFS
+            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "FastFetch"));
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "FastFetch");
+            folder.ShouldBeADirectory(this.fileSystem);
+
+            gvfsProcess.RemoveIncludedFolders(Path.Combine("GVFS", "FastFetch"));
+            folder.ShouldNotExistOnDisk(this.fileSystem);
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS");
+            folder.ShouldBeADirectory(this.fileSystem);
+
+            // Add subfolder of GVFS/GVFS and make sure it stays recursive
+            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS", "Properties"));
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "Properties");
+            folder.ShouldBeADirectory(this.fileSystem);
+
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "CommandLine");
+            folder.ShouldBeADirectory(this.fileSystem);
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
@@ -177,7 +177,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string modifiedPath = Path.Combine(this.Enlistment.RepoRoot, "Scripts", "RunFunctionalTests.bat");
             this.fileSystem.WriteAllText(modifiedPath, "New Contents");
 
-            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            string output = this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            output.ShouldContain("Include was aborted");
             this.ValidateIncludedFolders(new string[0]);
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
@@ -3,6 +3,7 @@ using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
@@ -11,69 +12,138 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public class IncludedFolderTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem = new SystemIORunner();
+        private GVFSProcess gvfsProcess;
+        private string mainIncludedFolder = Path.Combine("GVFS", "GVFS");
+        private string[] allRootDirectories;
+        private string[] directoriesInMainFolder;
 
-        [TestCase]
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.gvfsProcess = new GVFSProcess(this.Enlistment);
+            this.allRootDirectories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            this.directoriesInMainFolder = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, this.mainIncludedFolder));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (string includedFolder in this.gvfsProcess.IncludedFoldersList())
+            {
+                this.gvfsProcess.RemoveIncludedFolders(includedFolder);
+            }
+
+            // Remove all included folders should make all folders appear again
+            string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            directories.ShouldMatchInOrder(this.allRootDirectories);
+            this.ValidateIncludedFolders(new string[0]);
+        }
+
+        [TestCase, Order(1)]
         public void BasicTestsAddingAndRemoving()
         {
-            // directories before limiting them
-            string[] allRootDirectories = Directory.GetDirectories(this.Enlistment.RepoRoot);
-            string[] directoriesForParentAdd = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
-
-            GVFSProcess gvfsProcess = new GVFSProcess(this.Enlistment);
-            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS"));
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
 
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
             directories.Length.ShouldEqual(2);
             directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, ".git"));
             directories[1].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
 
-            string folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS");
+            string folder = this.Enlistment.GetVirtualPathTo(this.mainIncludedFolder);
             folder.ShouldBeADirectory(this.fileSystem);
-            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "CommandLine");
+            folder = this.Enlistment.GetVirtualPathTo(this.mainIncludedFolder, "CommandLine");
             folder.ShouldBeADirectory(this.fileSystem);
 
             folder = this.Enlistment.GetVirtualPathTo("Scripts");
             folder.ShouldNotExistOnDisk(this.fileSystem);
+            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS.Common");
+            folder.ShouldNotExistOnDisk(this.fileSystem);
+        }
 
-            // Remove the last directory should make all folders appear again
-            gvfsProcess.RemoveIncludedFolders(Path.Combine("GVFS", "GVFS"));
-            directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
-            directories.ShouldMatchInOrder(allRootDirectories);
-
-            // Add parent directory should make the parent recursive
-            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS", "CommandLine"));
-            directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
+        [TestCase, Order(2)]
+        public void AddingParentDirectoryShouldMakeItRecursive()
+        {
+            string childPath = Path.Combine(this.mainIncludedFolder, "CommandLine");
+            this.gvfsProcess.AddIncludedFolders(childPath);
+            string[] directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, this.mainIncludedFolder));
             directories.Length.ShouldEqual(1);
-            directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS", "CommandLine"));
+            directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, childPath));
+            this.ValidateIncludedFolders(childPath);
 
-            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS"));
-            directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS"));
-            directories.ShouldMatchInOrder(directoriesForParentAdd);
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            directories = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, this.mainIncludedFolder));
+            directories.ShouldMatchInOrder(this.directoriesInMainFolder);
+            this.ValidateIncludedFolders(childPath, this.mainIncludedFolder);
+        }
 
-            // Add and remove folder
-            gvfsProcess.AddIncludedFolders("Scripts");
+        [TestCase, Order(3)]
+        public void AddingSiblingFolderShouldNotMakeParentRecursive()
+        {
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
+
+            // Add and remove sibling folder to main folder
+            string siblingPath = Path.Combine("GVFS", "FastFetch");
+            this.gvfsProcess.AddIncludedFolders(siblingPath);
+            string folder = this.Enlistment.GetVirtualPathTo(siblingPath);
             folder.ShouldBeADirectory(this.fileSystem);
+            this.ValidateIncludedFolders(this.mainIncludedFolder, siblingPath);
 
-            gvfsProcess.RemoveIncludedFolders("Scripts");
+            this.gvfsProcess.RemoveIncludedFolders(siblingPath);
             folder.ShouldNotExistOnDisk(this.fileSystem);
-
-            // Add and remove sibling folder to GVFS/GVFS
-            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "FastFetch"));
-            folder = this.Enlistment.GetVirtualPathTo("GVFS", "FastFetch");
+            folder = this.Enlistment.GetVirtualPathTo(this.mainIncludedFolder);
             folder.ShouldBeADirectory(this.fileSystem);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
+        }
 
-            gvfsProcess.RemoveIncludedFolders(Path.Combine("GVFS", "FastFetch"));
-            folder.ShouldNotExistOnDisk(this.fileSystem);
-            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS");
-            folder.ShouldBeADirectory(this.fileSystem);
+        [TestCase, Order(4)]
+        public void AddingSubfolderShouldKeepParentRecursive()
+        {
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
 
-            // Add subfolder of GVFS/GVFS and make sure it stays recursive
-            gvfsProcess.AddIncludedFolders(Path.Combine("GVFS", "GVFS", "Properties"));
-            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "Properties");
+            // Add subfolder of main folder and make sure it stays recursive
+            string subFolder = Path.Combine(this.mainIncludedFolder, "Properties");
+            this.gvfsProcess.AddIncludedFolders(subFolder);
+            string folder = this.Enlistment.GetVirtualPathTo(subFolder);
             folder.ShouldBeADirectory(this.fileSystem);
+            this.ValidateIncludedFolders(this.mainIncludedFolder, subFolder);
 
-            folder = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "CommandLine");
+            folder = this.Enlistment.GetVirtualPathTo(this.mainIncludedFolder, "CommandLine");
             folder.ShouldBeADirectory(this.fileSystem);
+        }
+
+        [TestCase, Order(5)]
+        public void CreatingFolderShouldAddToIncludedListAndStartProjecting()
+        {
+            this.gvfsProcess.AddIncludedFolders(this.mainIncludedFolder);
+            this.ValidateIncludedFolders(this.mainIncludedFolder);
+
+            string newFolderPath = Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS.Common");
+            newFolderPath.ShouldNotExistOnDisk(this.fileSystem);
+            Directory.CreateDirectory(newFolderPath);
+            newFolderPath.ShouldBeADirectory(this.fileSystem);
+            string[] fileSystemEntries = Directory.GetFileSystemEntries(newFolderPath);
+            fileSystemEntries.Length.ShouldEqual(32);
+
+            string projectedFolder = Path.Combine(newFolderPath, "Git");
+            projectedFolder.ShouldBeADirectory(this.fileSystem);
+            fileSystemEntries = Directory.GetFileSystemEntries(projectedFolder);
+            fileSystemEntries.Length.ShouldEqual(13);
+
+            string projectedFile = Path.Combine(newFolderPath, "ReturnCode.cs");
+            projectedFile.ShouldBeAFile(this.fileSystem);
+        }
+
+        private void ValidateIncludedFolders(params string[] folders)
+        {
+            HashSet<string> actualIncludedFolders = new HashSet<string>(this.gvfsProcess.IncludedFoldersList());
+            folders.Length.ShouldEqual(actualIncludedFolders.Count);
+            foreach (string expectedFolder in folders)
+            {
+                actualIncludedFolders.Contains(expectedFolder).ShouldBeTrue($"{expectedFolder} not found in actual folder list");
+            }
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/IncludedFolderTests.cs
@@ -28,6 +28,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TearDown]
         public void TearDown()
         {
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "clean -xdf");
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "reset --hard");
+
             foreach (string includedFolder in this.gvfsProcess.IncludedFoldersList())
             {
                 this.gvfsProcess.RemoveIncludedFolders(includedFolder);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -49,14 +49,14 @@ namespace GVFS.FunctionalTests.Tools
             return this.IsEnlistmentMounted();
         }
 
-        public void AddIncludedFolders(params string[] folders)
+        public string AddIncludedFolders(params string[] folders)
         {
-            this.CallGVFS($"include {this.enlistmentRoot} -a {string.Join(";", folders)}");
+            return this.CallGVFS($"include {this.enlistmentRoot} -a {string.Join(";", folders)}");
         }
 
-        public void RemoveIncludedFolders(params string[] folders)
+        public string RemoveIncludedFolders(params string[] folders)
         {
-            this.CallGVFS($" include {this.enlistmentRoot} -r {string.Join(";", folders)}");
+            return this.CallGVFS($" include {this.enlistmentRoot} -r {string.Join(";", folders)}");
         }
 
         public string[] IncludedFoldersList()

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Tests.Should;
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -56,6 +57,17 @@ namespace GVFS.FunctionalTests.Tools
         public void RemoveIncludedFolders(params string[] folders)
         {
             this.CallGVFS($" include {this.enlistmentRoot} -r {string.Join(";", folders)}");
+        }
+
+        public string[] IncludedFoldersList()
+        {
+            string output = this.CallGVFS($" include {this.enlistmentRoot} -l");
+            if (output.StartsWith("No folders in included list."))
+            {
+                return new string[0];
+            }
+
+            return output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public string Prefetch(string args, bool failOnError, string standardInput = null)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.Tests.Should;
 using System.Diagnostics;
+using System.IO;
 
 namespace GVFS.FunctionalTests.Tools
 {
@@ -8,6 +9,11 @@ namespace GVFS.FunctionalTests.Tools
         private readonly string pathToGVFS;
         private readonly string enlistmentRoot;
         private readonly string localCacheRoot;
+
+        public GVFSProcess(GVFSFunctionalTestEnlistment enlistment)
+            : this(GVFSTestConfig.PathToGVFS, enlistment.EnlistmentRoot, Path.Combine(enlistment.EnlistmentRoot, GVFSTestConfig.DotGVFSRoot))
+        {
+        }
 
         public GVFSProcess(string pathToGVFS, string enlistmentRoot, string localCacheRoot)
         {
@@ -40,6 +46,16 @@ namespace GVFS.FunctionalTests.Tools
             this.IsEnlistmentMounted().ShouldEqual(false, "GVFS is already mounted");
             output = this.CallGVFS("mount \"" + this.enlistmentRoot + "\"");
             return this.IsEnlistmentMounted();
+        }
+
+        public void AddIncludedFolders(params string[] folders)
+        {
+            this.CallGVFS($"include {this.enlistmentRoot} -a {string.Join(";", folders)}");
+        }
+
+        public void RemoveIncludedFolders(params string[] folders)
+        {
+            this.CallGVFS($" include {this.enlistmentRoot} -r {string.Join(";", folders)}");
         }
 
         public string Prefetch(string args, bool failOnError, string standardInput = null)

--- a/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace GVFS.FunctionalTests.Tools
 {
-    public class GitProcess
+    public static class GitProcess
     {
         public static string Invoke(string executionWorkingDirectory, string command)
         {

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -565,6 +565,7 @@ namespace GVFS.Mount
                         backgroundFileSystemTaskRunner: null,
                         fileSystemVirtualizer: virtualizer,
                         placeholderDatabase: new PlaceholderTable(this.gvfsDatabase),
+                        includedFolderCollection: new IncludedFolderTable(this.gvfsDatabase),
                         gitStatusCache: gitStatusCache);
                 }, "Failed to create src folder callback listener");
             this.maintenanceScheduler = this.CreateOrReportAndExit(() => new GitMaintenanceScheduler(this.context, this.gitObjects), "Failed to start maintenance scheduler");

--- a/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
+++ b/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
@@ -89,6 +89,7 @@ namespace GVFS.PerfProfiling
                 backgroundFileSystemTaskRunner: null,
                 fileSystemVirtualizer: null,
                 placeholderDatabase: new PlaceholderTable(this.gvfsDatabase),
+                includedFolderCollection: new IncludedFolderTable(this.gvfsDatabase),
                 gitStatusCache : null);
         }
     }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -526,6 +526,8 @@ namespace GVFS.Platform.Mac
                         {
                             if (this.FileSystemCallbacks.OnFolderCreated(relativePath))
                             {
+                                // Need to enumerate the directory to get and create placeholders
+                                // for all the directory items that are now included
                                 this.OnEnumerateDirectory(0, relativePath, -1, $"{nameof(this.OnNewFileCreated)}_FolderIncluded");
                             }
                         }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -524,7 +524,10 @@ namespace GVFS.Platform.Mac
                         }
                         else
                         {
-                            this.FileSystemCallbacks.OnFolderCreated(relativePath);
+                            if (this.FileSystemCallbacks.OnFolderCreated(relativePath))
+                            {
+                                this.OnEnumerateDirectory(0, relativePath, -1, $"{nameof(this.OnNewFileCreated)}_FolderIncluded");
+                            }
                         }
                     }
                     else

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -627,10 +627,18 @@ namespace GVFS.Platform.Mac
                     metadata.Add("fileInfo.Name", fileInfo.Name);
                     metadata.Add("fileInfo.Size", fileInfo.Size);
                     metadata.Add("fileInfo.IsFolder", fileInfo.IsFolder);
+                    metadata.Add(nameof(result), result.ToString());
                     metadata.Add(nameof(sha), sha);
                     this.Context.Tracer.RelatedError(metadata, $"{nameof(this.CreatePlaceholders)}: Write placeholder failed");
 
-                    return result;
+                    if (result == Result.EIOError)
+                    {
+                        this.FileSystemCallbacks.OnFileConvertedToFull(childRelativePath);
+                    }
+                    else
+                    {
+                        return result;
+                    }
                 }
                 else
                 {

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1003,9 +1003,18 @@ namespace GVFS.Platform.Windows
                     if (isDirectory)
                     {
                         GitCommandLineParser gitCommand = new GitCommandLineParser(this.Context.Repository.GVFSLock.GetLockedGitCommand());
-                        if (gitCommand.IsValidGitCommand || this.FileSystemCallbacks.OnFolderCreated(virtualPath))
+                        if (gitCommand.IsValidGitCommand)
                         {
                             this.MarkDirectoryAsPlaceholder(virtualPath, isDirectory, triggeringProcessId, triggeringProcessImageFileName);
+                        }
+                        else
+                        {
+                            if (this.FileSystemCallbacks.OnFolderCreated(virtualPath))
+                            {
+                                // When OnFolderCreated returns true it means the folder was previously excluded from the projection and was
+                                // included so it needs to be marked as a placeholder so that it will start projecting items in the folder
+                                this.MarkDirectoryAsPlaceholder(virtualPath, isDirectory, triggeringProcessId, triggeringProcessImageFileName);
+                            }
                         }
                     }
                     else

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
@@ -169,6 +169,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -181,7 +182,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -201,6 +203,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -208,6 +211,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test" }))
@@ -220,7 +224,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -239,6 +244,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -246,6 +252,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -258,7 +265,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -274,6 +282,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -281,6 +290,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -293,7 +303,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -312,6 +323,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -319,6 +331,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -331,7 +344,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -364,6 +378,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -371,6 +386,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -383,7 +399,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -410,6 +427,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -418,6 +436,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -430,7 +449,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -455,6 +475,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -462,6 +483,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -474,7 +496,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -504,6 +527,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -511,6 +535,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -523,7 +548,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -553,6 +579,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -560,6 +587,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -572,7 +600,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -632,6 +661,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -639,6 +669,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -651,7 +682,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -678,6 +710,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -685,6 +718,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -697,7 +731,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -738,6 +773,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -745,6 +781,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -757,7 +794,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -794,6 +832,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -802,6 +841,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -814,7 +854,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -852,6 +893,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -860,6 +902,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -872,7 +915,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
@@ -910,6 +954,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -918,6 +963,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -930,7 +976,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -969,6 +1016,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -977,6 +1025,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -989,7 +1038,8 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 try
                 {
@@ -1030,6 +1080,7 @@ namespace GVFS.UnitTests.Windows.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
@@ -87,11 +87,25 @@ namespace GVFS.UnitTests.Common.Database
 
             mockCommand2.Setup(x => x.Dispose());
 
+            Mock<IDbCommand> mockCommand3 = new Mock<IDbCommand>(MockBehavior.Strict);
+            mockCommand3.SetupSet(x => x.CommandText = "CREATE TABLE IF NOT EXISTS [IncludedFolder] (path TEXT PRIMARY KEY COLLATE NOCASE) WITHOUT ROWID;");
+            if (throwException)
+            {
+                mockCommand3.Setup(x => x.ExecuteNonQuery()).Throws(new Exception("Error"));
+            }
+            else
+            {
+                mockCommand3.Setup(x => x.ExecuteNonQuery()).Returns(1);
+            }
+
+            mockCommand3.Setup(x => x.Dispose());
+
             List<Mock<IDbConnection>> mockConnections = new List<Mock<IDbConnection>>();
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.SetupSequence(x => x.CreateCommand())
                           .Returns(mockCommand.Object)
-                          .Returns(mockCommand2.Object);
+                          .Returns(mockCommand2.Object)
+                          .Returns(mockCommand3.Object);
             mockConnection.Setup(x => x.Dispose());
             mockConnections.Add(mockConnection);
 

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemCallbacks.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemCallbacks.cs
@@ -19,8 +19,9 @@ namespace GVFS.UnitTests.Mock.FileSystem
             GitIndexProjection gitIndexProjection,
             BackgroundFileSystemTaskRunner backgroundFileSystemTaskRunner,
             FileSystemVirtualizer fileSystemVirtualizer,
-            IPlaceholderCollection placeholderDatabase)
-            : base(context, gitObjects, repoMetadata, blobSizes, gitIndexProjection, backgroundFileSystemTaskRunner, fileSystemVirtualizer, placeholderDatabase)
+            IPlaceholderCollection placeholderDatabase,
+            IIncludedFolderCollection includedFolderCollection)
+            : base(context, gitObjects, repoMetadata, blobSizes, gitIndexProjection, backgroundFileSystemTaskRunner, fileSystemVirtualizer, placeholderDatabase, includedFolderCollection)
         {
         }
 

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
@@ -67,6 +67,11 @@ namespace GVFS.UnitTests.Mock.Virtualization.Projection
             return this.ProjectionParseComplete;
         }
 
+        public override bool IsPathExcluded(string virtualPath)
+        {
+            return true;
+        }
+
         public void BlockGetProjectedItems(bool willWaitForRequest)
         {
             if (willWaitForRequest)

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/Projection/MockGitIndexProjection.cs
@@ -67,9 +67,9 @@ namespace GVFS.UnitTests.Mock.Virtualization.Projection
             return this.ProjectionParseComplete;
         }
 
-        public override bool IsPathExcluded(string virtualPath)
+        public override PathProjectionState GetPathProjectionState(string virtualPath)
         {
-            return true;
+            return PathProjectionState.Included;
         }
 
         public void BlockGetProjectedItems(bool willWaitForRequest)

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
@@ -90,6 +90,7 @@ namespace GVFS.UnitTests.Platform.Mac
             const string UpdatePlaceholderFileName = "testUpdatePlaceholder.txt";
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { UpdatePlaceholderFileName }))
@@ -102,7 +103,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     UpdatePlaceholderFileName,
@@ -172,6 +174,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -180,6 +183,7 @@ namespace GVFS.UnitTests.Platform.Mac
             const string WriteSymLinkFileName = "testWriteSymLink.txt";
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { WriteSymLinkFileName }))
@@ -192,7 +196,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     WriteSymLinkFileName,
@@ -219,6 +224,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -227,6 +233,7 @@ namespace GVFS.UnitTests.Platform.Mac
             const string PlaceholderToLinkFileName = "testUpdatePlaceholderToLink.txt";
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { PlaceholderToLinkFileName }))
@@ -239,7 +246,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     PlaceholderToLinkFileName,
@@ -279,6 +287,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -301,6 +310,7 @@ namespace GVFS.UnitTests.Platform.Mac
             string testFilePath = Path.Combine(TestFolderName, TestFileName);
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
 
@@ -316,7 +326,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     testFilePath,
@@ -334,6 +345,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -344,6 +356,7 @@ namespace GVFS.UnitTests.Platform.Mac
             string testFilePath = Path.Combine(TestFolderName, TestFileName);
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
 
@@ -359,7 +372,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     testFilePath,
@@ -378,6 +392,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -392,6 +407,7 @@ namespace GVFS.UnitTests.Platform.Mac
             string testFile755Path = Path.Combine(TestFolderName, TestFile755Name);
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
 
@@ -407,7 +423,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 gitIndexProjection.MockFileTypesAndModes.TryAdd(
                     testFile644Path,
@@ -435,6 +452,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -443,6 +461,7 @@ namespace GVFS.UnitTests.Platform.Mac
             const string TestFileName = "test.txt";
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { TestFileName }))
@@ -455,7 +474,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
@@ -483,6 +503,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -492,6 +513,7 @@ namespace GVFS.UnitTests.Platform.Mac
             const string TestFileName = "test.txt";
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { TestFileName }))
@@ -504,7 +526,8 @@ namespace GVFS.UnitTests.Platform.Mac
                 gitIndexProjection,
                 backgroundTaskRunner,
                 virtualizer,
-                mockPlaceholderDb.Object))
+                mockPlaceholderDb.Object,
+                mockIncludeDb.Object))
             {
                 string error;
                 fileSystemCallbacks.TryStart(out error).ShouldEqual(true);
@@ -530,6 +553,7 @@ namespace GVFS.UnitTests.Platform.Mac
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         private static ushort ConvertFileTypeAndModeToIndexFormat(GitIndexProjection.FileType fileType, ushort fileMode)

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -392,7 +392,7 @@ namespace GVFS.UnitTests.Virtualization
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFileDeleted, "OnFileDeleted.txt", FileSystemTask.OperationType.OnFileDeleted);
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFileOverwritten, "OnFileDeleted.txt", FileSystemTask.OperationType.OnFileOverwritten);
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFileSuperseded, "OnFileSuperseded.txt", FileSystemTask.OperationType.OnFileSuperseded);
-                this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFolderCreated, "OnFileSuperseded.txt", FileSystemTask.OperationType.OnFolderCreated);
+                this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, x => fileSystemCallbacks.OnFolderCreated(x), "OnFileSuperseded.txt", FileSystemTask.OperationType.OnFolderCreated);
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFolderDeleted, "OnFileSuperseded.txt", FileSystemTask.OperationType.OnFolderDeleted);
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFileConvertedToFull, "OnFileConvertedToFull.txt", FileSystemTask.OperationType.OnFileConvertedToFull);
             }

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -15,6 +15,7 @@ using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace GVFS.UnitTests.Virtualization
@@ -57,6 +58,8 @@ namespace GVFS.UnitTests.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
+            mockIncludeDb.Setup(x => x.GetAll()).Returns(new List<string>());
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -66,7 +69,8 @@ namespace GVFS.UnitTests.Virtualization
                 gitIndexProjection: null,
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: null,
-                placeholderDatabase: mockPlaceholderDb.Object))
+                placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object))
             {
                 fileSystemCallbacks.BackgroundOperationCount.ShouldEqual(backgroundTaskRunner.Count);
 
@@ -77,6 +81,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -86,6 +91,8 @@ namespace GVFS.UnitTests.Virtualization
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(0);
             mockPlaceholderDb.Setup(x => x.GetFilePlaceholdersCount()).Returns(() => 0);
             mockPlaceholderDb.Setup(x => x.GetFolderPlaceholdersCount()).Returns(() => 0);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
+            mockIncludeDb.Setup(x => x.GetAll()).Returns(new List<string>());
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -95,7 +102,8 @@ namespace GVFS.UnitTests.Virtualization
                 gitIndexProjection: null,
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: null,
-                placeholderDatabase: mockPlaceholderDb.Object))
+                placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object))
             {
                 EventMetadata metadata = fileSystemCallbacks.GetAndResetHeartBeatMetadata(out bool writeToLogFile);
                 EventLevel eventLevel = writeToLogFile ? EventLevel.Informational : EventLevel.Verbose;
@@ -108,6 +116,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -123,6 +132,8 @@ namespace GVFS.UnitTests.Virtualization
             mockPlaceholderDb.Setup(x => x.AddPartialFolder("foo")).Callback(() => ++folderPlaceholderCount);
             mockPlaceholderDb.Setup(x => x.GetFilePlaceholdersCount()).Returns(() => filePlaceholderCount);
             mockPlaceholderDb.Setup(x => x.GetFolderPlaceholdersCount()).Returns(() => folderPlaceholderCount);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
+            mockIncludeDb.Setup(x => x.GetAll()).Returns(new List<string>());
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -132,7 +143,8 @@ namespace GVFS.UnitTests.Virtualization
                 gitIndexProjection: null,
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: null,
-                placeholderDatabase: mockPlaceholderDb.Object))
+                placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object))
             {
                 fileSystemCallbacks.OnPlaceholderFileCreated("test.txt", "1111122222333334444455555666667777788888", "GVFS.UnitTests.exe");
 
@@ -187,6 +199,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -194,6 +207,7 @@ namespace GVFS.UnitTests.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockFileSystemVirtualizer fileSystemVirtualizer = new MockFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects))
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -205,7 +219,8 @@ namespace GVFS.UnitTests.Virtualization
                 gitIndexProjection: gitIndexProjection,
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: fileSystemVirtualizer,
-                placeholderDatabase: mockPlaceholderDb.Object))
+                placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object))
             {
                 string denyMessage;
                 fileSystemCallbacks.IsReadyForExternalAcquireLockRequests(
@@ -260,6 +275,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -267,6 +283,8 @@ namespace GVFS.UnitTests.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
+            mockIncludeDb.Setup(x => x.GetAll()).Returns(new List<string>());
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -276,7 +294,8 @@ namespace GVFS.UnitTests.Virtualization
                 gitIndexProjection: null,
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: null,
-                placeholderDatabase: mockPlaceholderDb.Object))
+                placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object))
             {
                 this.CallbackSchedulesBackgroundTask(
                     backgroundTaskRunner,
@@ -343,6 +362,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         [TestCase]
@@ -350,6 +370,7 @@ namespace GVFS.UnitTests.Virtualization
         {
             Mock<IPlaceholderCollection> mockPlaceholderDb = new Mock<IPlaceholderCollection>(MockBehavior.Strict);
             mockPlaceholderDb.Setup(x => x.GetCount()).Returns(1);
+            Mock<IIncludedFolderCollection> mockIncludeDb = new Mock<IIncludedFolderCollection>(MockBehavior.Strict);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (MockFileSystemVirtualizer fileSystemVirtualizer = new MockFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects))
             using (MockGitIndexProjection gitIndexProjection = new MockGitIndexProjection(new[] { "test.txt" }))
@@ -363,6 +384,7 @@ namespace GVFS.UnitTests.Virtualization
                 backgroundFileSystemTaskRunner: backgroundTaskRunner,
                 fileSystemVirtualizer: fileSystemVirtualizer,
                 placeholderDatabase: mockPlaceholderDb.Object,
+                includedFolderCollection: mockIncludeDb.Object,
                 gitStatusCache: gitStatusCache))
             {
                 this.ValidateActionInvalidatesStatusCache(backgroundTaskRunner, gitStatusCache, fileSystemCallbacks.OnFileConvertedToFull, "OnFileConvertedToFull.txt", FileSystemTask.OperationType.OnFileConvertedToFull);
@@ -376,6 +398,7 @@ namespace GVFS.UnitTests.Virtualization
             }
 
             mockPlaceholderDb.VerifyAll();
+            mockIncludeDb.VerifyAll();
         }
 
         private void ValidateActionInvalidatesStatusCache(

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
@@ -166,7 +166,7 @@ namespace GVFS.UnitTests.Virtualization.Git
             for (int i = 0; i < names.Length; i++)
             {
                 LazyUTF8String entryString = ConstructLazyUTF8String(names[i]);
-                entries.AddFile(entryString, new byte[20]);
+                entries.AddFile(entryString, new byte[20], isIncluded: true);
             }
         }
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -410,6 +410,14 @@ namespace GVFS.Virtualization
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFilePreDelete(relativePath));
         }
 
+        /// <summary>
+        /// Called to indicate a folder was created
+        /// </summary>
+        /// <param name="relativePath">The relative path to the newly created folder</param>
+        /// <returns>
+        /// true when the folder is successfully added to the include list because it is in the projection but currently excluded.
+        /// false when the folder was not excluded or there was a failure adding to the included list.
+        /// </returns>
         public bool OnFolderCreated(string relativePath)
         {
             GitIndexProjection.PathProjectionState pathProjectionState = this.GitIndexProjection.GetPathProjectionState(relativePath);

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -410,10 +410,17 @@ namespace GVFS.Virtualization
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFilePreDelete(relativePath));
         }
 
-        public void OnFolderCreated(string relativePath)
+        public bool OnFolderCreated(string relativePath)
         {
-            this.AddToNewlyCreatedList(relativePath, isFolder: true);
+            bool pathExcluded = this.GitIndexProjection.IsPathExcluded(relativePath);
+            if (!pathExcluded)
+            {
+                this.AddToNewlyCreatedList(relativePath, isFolder: true);
+            }
+
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFolderCreated(relativePath));
+
+            return pathExcluded;
         }
 
         public virtual void OnFolderRenamed(string oldRelativePath, string newRelativePath)
@@ -695,7 +702,16 @@ namespace GVFS.Virtualization
 
                 case FileSystemTask.OperationType.OnFolderCreated:
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
-                    result = this.TryAddModifiedPath(gitUpdate.VirtualPath, isFolder: true);
+                    if (this.GitIndexProjection.IsPathExcluded(gitUpdate.VirtualPath))
+                    {
+                        bool added = this.GitIndexProjection.TryAddIncludedFolder(gitUpdate.VirtualPath);
+                        result = added ? FileSystemTaskResult.Success : FileSystemTaskResult.RetryableError;
+                    }
+                    else
+                    {
+                        result = this.TryAddModifiedPath(gitUpdate.VirtualPath, isFolder: true);
+                    }
+
                     break;
 
                 case FileSystemTask.OperationType.OnFolderRenamed:

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -705,6 +705,7 @@ namespace GVFS.Virtualization
                     if (this.GitIndexProjection.IsPathExcluded(gitUpdate.VirtualPath))
                     {
                         bool added = this.GitIndexProjection.TryAddIncludedFolder(gitUpdate.VirtualPath);
+                        this.InvalidateGitStatusCache();
                         result = added ? FileSystemTaskResult.Success : FileSystemTaskResult.RetryableError;
                     }
                     else

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -54,6 +54,7 @@ namespace GVFS.Virtualization
             BackgroundFileSystemTaskRunner backgroundFileSystemTaskRunner,
             FileSystemVirtualizer fileSystemVirtualizer,
             IPlaceholderCollection placeholderDatabase,
+            IIncludedFolderCollection includedFolderCollection,
             GitStatusCache gitStatusCache = null)
         {
             this.logsHeadFileProperties = null;
@@ -88,6 +89,7 @@ namespace GVFS.Virtualization
                 repoMetadata,
                 fileSystemVirtualizer,
                 this.placeholderDatabase,
+                includedFolderCollection,
                 this.modifiedPaths);
 
             if (backgroundFileSystemTaskRunner != null)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -412,15 +412,15 @@ namespace GVFS.Virtualization
 
         public bool OnFolderCreated(string relativePath)
         {
-            bool pathExcluded = this.GitIndexProjection.IsPathExcluded(relativePath);
-            if (!pathExcluded)
+            GitIndexProjection.PathProjectionState pathProjectionState = this.GitIndexProjection.GetPathProjectionState(relativePath);
+            if (pathProjectionState == GitIndexProjection.PathProjectionState.NotFound)
             {
                 this.AddToNewlyCreatedList(relativePath, isFolder: true);
             }
 
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFolderCreated(relativePath));
 
-            return pathExcluded;
+            return pathProjectionState == GitIndexProjection.PathProjectionState.Excluded;
         }
 
         public virtual void OnFolderRenamed(string oldRelativePath, string newRelativePath)
@@ -702,7 +702,7 @@ namespace GVFS.Virtualization
 
                 case FileSystemTask.OperationType.OnFolderCreated:
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
-                    if (this.GitIndexProjection.IsPathExcluded(gitUpdate.VirtualPath))
+                    if (this.GitIndexProjection.GetPathProjectionState(gitUpdate.VirtualPath) == GitIndexProjection.PathProjectionState.Excluded)
                     {
                         bool added = this.GitIndexProjection.TryAddIncludedFolder(gitUpdate.VirtualPath);
                         this.InvalidateGitStatusCache();

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -423,8 +423,10 @@ namespace GVFS.Virtualization
             GitIndexProjection.PathProjectionState pathProjectionState = this.GitIndexProjection.GetPathProjectionState(relativePath);
             if (pathProjectionState == GitIndexProjection.PathProjectionState.Excluded)
             {
-                this.GitIndexProjection.TryAddIncludedFolder(relativePath);
-                return true;
+                if (this.GitIndexProjection.TryAddIncludedFolder(relativePath))
+                {
+                    return true;
+                }
             }
 
             this.AddToNewlyCreatedList(relativePath, isFolder: true);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FileData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FileData.cs
@@ -39,10 +39,11 @@ namespace GVFS.Virtualization.Projection
                 return this.Sha.ToString();
             }
 
-            public void ResetData(LazyUTF8String name, byte[] shaBytes)
+            public void ResetData(LazyUTF8String name, byte[] shaBytes, bool isIncluded)
             {
                 this.Name = name;
                 this.Size = InvalidSize;
+                this.IsIncluded = isIncluded;
                 Sha1Id.ShaBufferToParts(shaBytes, out this.shaBytes1through8, out this.shaBytes9Through16, out this.shaBytes17Through20);
             }
 

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
@@ -21,6 +21,7 @@ namespace GVFS.Virtualization.Projection
             {
                 this.Name = name;
                 this.ChildrenHaveSizes = false;
+                this.IsIncluded = true;
                 if (this.ChildEntries == null)
                 {
                     this.ChildEntries = new SortedFolderEntries();
@@ -37,6 +38,15 @@ namespace GVFS.Virtualization.Projection
             public FileData AddChildFile(LazyUTF8String name, byte[] shaBytes)
             {
                 return this.ChildEntries.AddFile(name, shaBytes);
+            }
+
+            public override void Include()
+            {
+                base.Include();
+                for (int i = 0; i < this.ChildEntries.Count; i++)
+                {
+                    this.ChildEntries[i].Include();
+                }
             }
 
             public void PopulateSizes(

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
@@ -37,7 +37,7 @@ namespace GVFS.Virtualization.Projection
 
             public FileData AddChildFile(LazyUTF8String name, byte[] shaBytes)
             {
-                return this.ChildEntries.AddFile(name, shaBytes);
+                return this.ChildEntries.AddFile(name, shaBytes, this.IsIncluded);
             }
 
             public override void Include()

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderEntryData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderEntryData.cs
@@ -9,6 +9,12 @@ namespace GVFS.Virtualization.Projection
         {
             public LazyUTF8String Name { get; protected set; }
             public abstract bool IsFolder { get; }
+            public bool IsIncluded { get; set; } = true;
+
+            public virtual void Include()
+            {
+                this.IsIncluded = true;
+            }
 
             protected static EventMetadata CreateEventMetadata(Exception e = null)
             {

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexEntry.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexEntry.cs
@@ -67,6 +67,21 @@ namespace GVFS.Virtualization.Projection
                get; private set;
             }
 
+            public bool BuildingProjection_ShouldInclude
+            {
+                get; set;
+            }
+
+            public bool BuildingProjection_ShouldIncludeRecursive
+            {
+                get; set;
+            }
+
+            public IncludedFolderData BuildingProjection_LastEntryIncludedFolder
+            {
+                get; set;
+            }
+
             /// <summary>
             /// Parses the path using LazyUTF8Strings. It should only be called when building a new projection.
             /// </summary>
@@ -211,6 +226,9 @@ namespace GVFS.Virtualization.Projection
             {
                 this.buildingProjectionPreviousFinalSeparatorIndex = int.MaxValue;
                 this.BuildingProjection_HasSameParentAsLastEntry = false;
+                this.BuildingProjection_ShouldInclude = false;
+                this.BuildingProjection_ShouldIncludeRecursive = false;
+                this.BuildingProjection_LastEntryIncludedFolder = null;
                 this.BuildingProjection_LastParent = null;
             }
 

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.IncludedFolder.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.IncludedFolder.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GVFS.Virtualization.Projection
+{
+    public partial class GitIndexProjection
+    {
+        internal class IncludedFolderData
+        {
+            public IncludedFolderData()
+            {
+                this.Children = new Dictionary<string, IncludedFolderData>();
+            }
+
+            public bool IsRecursive { get; set; }
+            public Dictionary<string, IncludedFolderData> Children { get; }
+        }
+    }
+}

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.IncludedFolder.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.IncludedFolder.cs
@@ -14,6 +14,7 @@ namespace GVFS.Virtualization.Projection
             }
 
             public bool IsRecursive { get; set; }
+            public int Depth { get; set; }
             public Dictionary<string, IncludedFolderData> Children { get; }
         }
     }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
@@ -94,10 +94,10 @@ namespace GVFS.Virtualization.Projection
                 return this.InsertFolder(name, insertionIndex);
             }
 
-            public FileData AddFile(LazyUTF8String name, byte[] shaBytes)
+            public FileData AddFile(LazyUTF8String name, byte[] shaBytes, bool isIncluded)
             {
                 int insertionIndex = this.GetInsertionIndex(name);
-                return this.InsertFile(name, shaBytes, insertionIndex);
+                return this.InsertFile(name, shaBytes, isIncluded, insertionIndex);
             }
 
             public FolderData GetOrAddFolder(LazyUTF8String name)
@@ -151,10 +151,10 @@ namespace GVFS.Virtualization.Projection
                 return data;
             }
 
-            private FileData InsertFile(LazyUTF8String name, byte[] shaBytes, int insertionIndex)
+            private FileData InsertFile(LazyUTF8String name, byte[] shaBytes, bool isIncluded, int insertionIndex)
             {
                 FileData data = filePool.GetNew();
-                data.ResetData(name, shaBytes);
+                data.ResetData(name, shaBytes, isIncluded);
                 this.sortedEntries.Insert(insertionIndex, data);
                 return data;
             }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -57,6 +57,7 @@ namespace GVFS.Virtualization.Projection
 
         private BlobSizes blobSizes;
         private IPlaceholderCollection placeholderDatabase;
+        private IIncludedFolderCollection includedFolderCollection;
         private GVFSGitObjects gitObjects;
         private BackgroundFileSystemTaskRunner backgroundFileSystemTaskRunner;
         private ReaderWriterLockSlim projectionReadWriteLock;
@@ -92,6 +93,7 @@ namespace GVFS.Virtualization.Projection
             RepoMetadata repoMetadata,
             FileSystemVirtualizer fileSystemVirtualizer,
             IPlaceholderCollection placeholderDatabase,
+            IIncludedFolderCollection includedFolderCollection,
             ModifiedPathsDatabase modifiedPaths)
         {
             this.context = context;
@@ -107,6 +109,7 @@ namespace GVFS.Virtualization.Projection
             this.projectionIndexBackupPath = Path.Combine(this.context.Enlistment.DotGVFSRoot, ProjectionIndexBackupName);
             this.indexPath = Path.Combine(this.context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Index);
             this.placeholderDatabase = placeholderDatabase;
+            this.includedFolderCollection = includedFolderCollection;
             this.modifiedPaths = modifiedPaths;
         }
 

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -132,6 +132,13 @@ namespace GVFS.Virtualization.Projection
             GitLink,
         }
 
+        public enum PathProjectionState
+        {
+            NotFound,
+            Included,
+            Excluded,
+        }
+
         public static void ReadIndex(ITracer tracer, string indexPath)
         {
             using (FileStream indexStream = new FileStream(indexPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, IndexFileStreamBufferSize))
@@ -422,7 +429,7 @@ namespace GVFS.Virtualization.Projection
             }
         }
 
-        public virtual bool IsPathExcluded(string virtualPath)
+        public virtual PathProjectionState GetPathProjectionState(string virtualPath)
         {
             this.GetChildNameAndParentKey(virtualPath, out string fileName, out string parentKey);
             FolderEntryData data = this.GetProjectedFolderEntryData(
@@ -430,7 +437,18 @@ namespace GVFS.Virtualization.Projection
                 childName: fileName,
                 parentKey: parentKey);
 
-            return !(data != null && data.IsIncluded);
+            if (data == null)
+            {
+                return PathProjectionState.NotFound;
+            }
+            else if (data.IsIncluded)
+            {
+                return PathProjectionState.Included;
+            }
+            else
+            {
+                return PathProjectionState.Excluded;
+            }
         }
 
         public bool TryAddIncludedFolder(string virtualPath)

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -778,6 +778,7 @@ namespace GVFS.Virtualization.Projection
                         if (!parentFolder.ContainsKey(folders[i]))
                         {
                             folderData = new IncludedFolderData();
+                            folderData.Depth = i;
                             parentFolder.Add(folders[i], folderData);
                         }
                         else
@@ -902,7 +903,8 @@ namespace GVFS.Virtualization.Projection
                     if (!indexEntry.BuildingProjection_ShouldIncludeRecursive)
                     {
                         string folderName = indexEntry.BuildingProjection_PathParts[pathIndex].GetString();
-                        if (indexEntry.BuildingProjection_LastEntryIncludedFolder.Children.ContainsKey(folderName))
+                        if (indexEntry.BuildingProjection_LastEntryIncludedFolder.Children.ContainsKey(folderName) &&
+                            indexEntry.BuildingProjection_LastEntryIncludedFolder.Children[folderName].Depth == pathIndex)
                         {
                             indexEntry.BuildingProjection_ShouldInclude = true;
                             indexEntry.BuildingProjection_ShouldIncludeRecursive = indexEntry.BuildingProjection_LastEntryIncludedFolder.Children[folderName].IsRecursive;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1610,9 +1610,10 @@ namespace GVFS.Virtualization.Projection
             string childName;
             string parentKey;
             this.GetChildNameAndParentKey(placeholder.Path, out childName, out parentKey);
+            PathProjectionState projectionState = this.GetPathProjectionState(placeholder.Path);
 
             string projectedSha;
-            if (!this.TryGetSha(childName, parentKey, out projectedSha))
+            if (projectionState != PathProjectionState.Included || !this.TryGetSha(childName, parentKey, out projectedSha))
             {
                 UpdateFailureReason failureReason = UpdateFailureReason.NoFailure;
                 FileSystemResult result = this.fileSystemVirtualizer.DeleteFile(placeholder.Path, FilePlaceholderUpdateFlags, out failureReason);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -14,6 +14,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -58,6 +59,7 @@ namespace GVFS.Virtualization.Projection
         private BlobSizes blobSizes;
         private IPlaceholderCollection placeholderDatabase;
         private IIncludedFolderCollection includedFolderCollection;
+        private IncludedFolderData rootIncludedFolder;
         private GVFSGitObjects gitObjects;
         private BackgroundFileSystemTaskRunner backgroundFileSystemTaskRunner;
         private ReaderWriterLockSlim projectionReadWriteLock;
@@ -111,6 +113,8 @@ namespace GVFS.Virtualization.Projection
             this.placeholderDatabase = placeholderDatabase;
             this.includedFolderCollection = includedFolderCollection;
             this.modifiedPaths = modifiedPaths;
+            this.rootIncludedFolder = new IncludedFolderData();
+            this.RefreshFoldersToInclude();
         }
 
         // For Unit Testing
@@ -650,7 +654,10 @@ namespace GVFS.Virtualization.Projection
         {
             if (indexEntry.BuildingProjection_HasSameParentAsLastEntry)
             {
-                indexEntry.BuildingProjection_LastParent.AddChildFile(indexEntry.BuildingProjection_GetChildName(), indexEntry.Sha);
+                if (indexEntry.BuildingProjection_ShouldInclude || indexEntry.BuildingProjection_ShouldIncludeRecursive)
+                {
+                    indexEntry.BuildingProjection_LastParent.AddChildFile(indexEntry.BuildingProjection_GetChildName(), indexEntry.Sha);
+                }
             }
             else
             {
@@ -697,7 +704,40 @@ namespace GVFS.Virtualization.Projection
             LazyUTF8String.FreePool();
             this.projectionFolderCache.Clear();
             this.nonDefaultFileTypesAndModes.Clear();
+            this.RefreshFoldersToInclude();
             this.rootFolderData.ResetData(new LazyUTF8String("<root>"));
+        }
+
+        private void RefreshFoldersToInclude()
+        {
+            this.rootIncludedFolder.Children.Clear();
+            Dictionary<string, IncludedFolderData> parentFolder = this.rootIncludedFolder.Children;
+            foreach (string directoryPath in this.includedFolderCollection.GetAll())
+            {
+                string[] folders = directoryPath.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < folders.Length; i++)
+                {
+                    IncludedFolderData folderData;
+                    if (!parentFolder.ContainsKey(folders[i]))
+                    {
+                        folderData = new IncludedFolderData();
+                        parentFolder.Add(folders[i], folderData);
+                    }
+                    else
+                    {
+                        folderData = parentFolder[folders[i]];
+                    }
+
+                    if (!folderData.IsRecursive)
+                    {
+                        folderData.IsRecursive = i == folders.Length - 1;
+                    }
+
+                    parentFolder = folderData.Children;
+                }
+
+                parentFolder = this.rootIncludedFolder.Children;
+            }
         }
 
         private bool TryGetSha(string childName, string parentKey, out string sha)
@@ -790,6 +830,36 @@ namespace GVFS.Virtualization.Projection
                     this.context.Tracer.RelatedError(metadata, "AddFileToTree: Found a file where a folder was expected");
 
                     throw new InvalidDataException("Found a file (" + parentFolderName + ") where a folder was expected: " + gitPath);
+                }
+
+                if (this.rootIncludedFolder.Children.Count > 0)
+                {
+                    if (indexEntry.BuildingProjection_LastEntryIncludedFolder == null)
+                    {
+                        indexEntry.BuildingProjection_LastEntryIncludedFolder = this.rootIncludedFolder;
+                    }
+
+                    if (!indexEntry.BuildingProjection_ShouldIncludeRecursive)
+                    {
+                        string folderName = indexEntry.BuildingProjection_PathParts[pathIndex].GetString();
+                        if (indexEntry.BuildingProjection_LastEntryIncludedFolder.Children.ContainsKey(folderName))
+                        {
+                            indexEntry.BuildingProjection_ShouldInclude = true;
+                            indexEntry.BuildingProjection_ShouldIncludeRecursive = indexEntry.BuildingProjection_LastEntryIncludedFolder.Children[folderName].IsRecursive;
+                            indexEntry.BuildingProjection_LastEntryIncludedFolder = indexEntry.BuildingProjection_LastEntryIncludedFolder.Children[folderName];
+                        }
+                        else
+                        {
+                            indexEntry.BuildingProjection_ShouldInclude = false;
+                            indexEntry.BuildingProjection_ShouldIncludeRecursive = false;
+                            indexEntry.BuildingProjection_LastEntryIncludedFolder = null;
+                        }
+
+                        if (!indexEntry.BuildingProjection_ShouldInclude)
+                        {
+                            return parentFolder;
+                        }
+                    }
                 }
 
                 parentFolder = parentFolder.ChildEntries.GetOrAddFolder(indexEntry.BuildingProjection_PathParts[pathIndex]);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -97,6 +97,7 @@ namespace GVFS.Virtualization.Projection
             IPlaceholderCollection placeholderDatabase,
             IIncludedFolderCollection includedFolderCollection,
             ModifiedPathsDatabase modifiedPaths)
+            : this()
         {
             this.context = context;
             this.gitObjects = gitObjects;
@@ -105,21 +106,21 @@ namespace GVFS.Virtualization.Projection
             this.fileSystemVirtualizer = fileSystemVirtualizer;
             this.indexParser = new GitIndexParser(this);
 
-            this.projectionReadWriteLock = new ReaderWriterLockSlim();
-            this.projectionParseComplete = new ManualResetEventSlim(initialState: false);
-            this.wakeUpIndexParsingThread = new AutoResetEvent(initialState: false);
             this.projectionIndexBackupPath = Path.Combine(this.context.Enlistment.DotGVFSRoot, ProjectionIndexBackupName);
             this.indexPath = Path.Combine(this.context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Index);
             this.placeholderDatabase = placeholderDatabase;
             this.includedFolderCollection = includedFolderCollection;
             this.modifiedPaths = modifiedPaths;
             this.rootIncludedFolder = new IncludedFolderData();
-            this.RefreshFoldersToInclude();
+            this.ClearProjectionCaches();
         }
 
-        // For Unit Testing
         protected GitIndexProjection()
         {
+            this.projectionReadWriteLock = new ReaderWriterLockSlim();
+            this.projectionParseComplete = new ManualResetEventSlim(initialState: false);
+            this.wakeUpIndexParsingThread = new AutoResetEvent(initialState: false);
+            this.rootFolderData.ResetData(new LazyUTF8String("<root>"));
         }
 
         public enum FileType : short
@@ -421,7 +422,7 @@ namespace GVFS.Virtualization.Projection
             }
         }
 
-        public bool IsPathExcluded(string virtualPath)
+        public virtual bool IsPathExcluded(string virtualPath)
         {
             this.GetChildNameAndParentKey(virtualPath, out string fileName, out string parentKey);
             FolderEntryData data = this.GetProjectedFolderEntryData(

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -421,6 +421,41 @@ namespace GVFS.Virtualization.Projection
             }
         }
 
+        public bool IsPathExcluded(string virtualPath)
+        {
+            this.GetChildNameAndParentKey(virtualPath, out string fileName, out string parentKey);
+            FolderEntryData data = this.GetProjectedFolderEntryData(
+                blobSizesConnection: null,
+                childName: fileName,
+                parentKey: parentKey);
+
+            return !(data != null && data.IsIncluded);
+        }
+
+        public bool TryAddIncludedFolder(string virtualPath)
+        {
+            try
+            {
+                this.GetChildNameAndParentKey(virtualPath, out string fileName, out string parentKey);
+                FolderEntryData data = this.GetProjectedFolderEntryData(
+                    blobSizesConnection: null,
+                    childName: fileName,
+                    parentKey: parentKey);
+
+                if (data != null && !data.IsIncluded)
+                {
+                    data.Include();
+                    this.includedFolderCollection.Add(virtualPath);
+                }
+
+                return true;
+            }
+            catch (GVFSDatabaseException)
+            {
+                return false;
+            }
+        }
+
         public virtual bool IsPathProjected(string virtualPath, out string fileName, out bool isFolder)
         {
             isFolder = false;
@@ -431,7 +466,7 @@ namespace GVFS.Virtualization.Projection
                 childName: fileName,
                 parentKey: parentKey);
 
-            if (data != null)
+            if (data != null && data.IsIncluded)
             {
                 isFolder = data.IsFolder;
                 return true;
@@ -459,7 +494,7 @@ namespace GVFS.Virtualization.Projection
                 parentKey: parentKey,
                 gitCasedChildName: out gitCasedChildName);
 
-            if (data != null)
+            if (data != null && data.IsIncluded)
             {
                 if (data.IsFolder)
                 {
@@ -632,18 +667,22 @@ namespace GVFS.Virtualization.Projection
         private static List<ProjectedFileInfo> ConvertToProjectedFileInfos(SortedFolderEntries sortedFolderEntries)
         {
             List<ProjectedFileInfo> childItems = new List<ProjectedFileInfo>(sortedFolderEntries.Count);
+            FolderEntryData childEntry;
             for (int i = 0; i < sortedFolderEntries.Count; i++)
             {
-                FolderEntryData childEntry = sortedFolderEntries[i];
+                childEntry = sortedFolderEntries[i];
 
-                if (childEntry.IsFolder)
+                if (childEntry.IsIncluded)
                 {
-                    childItems.Add(new ProjectedFileInfo(childEntry.Name.GetString(), size: 0, isFolder: true, sha: Sha1Id.None));
-                }
-                else
-                {
-                    FileData fileData = (FileData)childEntry;
-                    childItems.Add(new ProjectedFileInfo(fileData.Name.GetString(), fileData.Size, isFolder: false, sha: fileData.Sha));
+                    if (childEntry.IsFolder)
+                    {
+                        childItems.Add(new ProjectedFileInfo(childEntry.Name.GetString(), size: 0, isFolder: true, sha: Sha1Id.None));
+                    }
+                    else
+                    {
+                        FileData fileData = (FileData)childEntry;
+                        childItems.Add(new ProjectedFileInfo(fileData.Name.GetString(), fileData.Size, isFolder: false, sha: fileData.Sha));
+                    }
                 }
             }
 
@@ -654,12 +693,7 @@ namespace GVFS.Virtualization.Projection
         {
             if (indexEntry.BuildingProjection_HasSameParentAsLastEntry)
             {
-                if (this.rootIncludedFolder.Children.Count == 0 ||
-                    indexEntry.BuildingProjection_ShouldInclude ||
-                    indexEntry.BuildingProjection_ShouldIncludeRecursive)
-                {
-                    indexEntry.BuildingProjection_LastParent.AddChildFile(indexEntry.BuildingProjection_GetChildName(), indexEntry.Sha);
-                }
+                indexEntry.BuildingProjection_LastParent.AddChildFile(indexEntry.BuildingProjection_GetChildName(), indexEntry.Sha);
             }
             else
             {
@@ -837,6 +871,8 @@ namespace GVFS.Virtualization.Projection
                     throw new InvalidDataException("Found a file (" + parentFolderName + ") where a folder was expected: " + gitPath);
                 }
 
+                parentFolder = parentFolder.ChildEntries.GetOrAddFolder(indexEntry.BuildingProjection_PathParts[pathIndex]);
+
                 if (this.rootIncludedFolder.Children.Count > 0)
                 {
                     if (indexEntry.BuildingProjection_LastEntryIncludedFolder == null)
@@ -859,15 +895,10 @@ namespace GVFS.Virtualization.Projection
                             indexEntry.BuildingProjection_ShouldIncludeRecursive = false;
                             indexEntry.BuildingProjection_LastEntryIncludedFolder = null;
                         }
-
-                        if (!indexEntry.BuildingProjection_ShouldInclude)
-                        {
-                            return parentFolder;
-                        }
                     }
-                }
 
-                parentFolder = parentFolder.ChildEntries.GetOrAddFolder(indexEntry.BuildingProjection_PathParts[pathIndex]);
+                    parentFolder.IsIncluded = indexEntry.BuildingProjection_ShouldInclude || indexEntry.BuildingProjection_ShouldIncludeRecursive;
+                }
             }
 
             parentFolder.AddChildFile(indexEntry.BuildingProjection_PathParts[indexEntry.BuildingProjection_NumParts - 1], indexEntry.Sha);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1498,8 +1498,8 @@ namespace GVFS.Virtualization.Projection
             string relativeFolderPath,
             HashSet<string> existingPlaceholders)
         {
-            FolderData folderData;
-            if (!this.TryGetOrAddFolderDataFromCache(relativeFolderPath, out folderData))
+            bool foundFolder = this.TryGetOrAddFolderDataFromCache(relativeFolderPath, out FolderData folderData);
+            if (!foundFolder || !folderData.IsIncluded)
             {
                 // Folder is no longer in the projection
                 existingPlaceholders.Remove(relativeFolderPath);
@@ -1518,54 +1518,57 @@ namespace GVFS.Virtualization.Projection
             for (int i = 0; i < folderData.ChildEntries.Count; i++)
             {
                 FolderEntryData childEntry = folderData.ChildEntries[i];
-                string childRelativePath;
-                if (relativeFolderPath.Length == 0)
+                if (childEntry.IsIncluded)
                 {
-                    childRelativePath = childEntry.Name.GetString();
-                }
-                else
-                {
-                    childRelativePath = relativeFolderPath + Path.DirectorySeparatorChar + childEntry.Name.GetString();
-                }
-
-                if (!existingPlaceholders.Contains(childRelativePath))
-                {
-                    FileSystemResult result;
-                    if (childEntry.IsFolder)
+                    string childRelativePath;
+                    if (relativeFolderPath.Length == 0)
                     {
-                        result = this.fileSystemVirtualizer.WritePlaceholderDirectory(childRelativePath);
-                        if (result.Result == FSResult.Ok)
-                        {
-                            this.placeholderDatabase.AddPartialFolder(childRelativePath);
-                        }
+                        childRelativePath = childEntry.Name.GetString();
                     }
                     else
                     {
-                        FileData childFileData = childEntry as FileData;
-                        string fileSha = childFileData.Sha.ToString();
-                        result = this.fileSystemVirtualizer.WritePlaceholderFile(childRelativePath, childFileData.Size, fileSha);
-                        if (result.Result == FSResult.Ok)
-                        {
-                            this.placeholderDatabase.AddFile(childRelativePath, fileSha);
-                        }
+                        childRelativePath = relativeFolderPath + Path.DirectorySeparatorChar + childEntry.Name.GetString();
                     }
 
-                    switch (result.Result)
+                    if (!existingPlaceholders.Contains(childRelativePath))
                     {
-                        case FSResult.Ok:
-                            break;
+                        FileSystemResult result;
+                        if (childEntry.IsFolder)
+                        {
+                            result = this.fileSystemVirtualizer.WritePlaceholderDirectory(childRelativePath);
+                            if (result.Result == FSResult.Ok)
+                            {
+                                this.placeholderDatabase.AddPartialFolder(childRelativePath);
+                            }
+                        }
+                        else
+                        {
+                            FileData childFileData = childEntry as FileData;
+                            string fileSha = childFileData.Sha.ToString();
+                            result = this.fileSystemVirtualizer.WritePlaceholderFile(childRelativePath, childFileData.Size, fileSha);
+                            if (result.Result == FSResult.Ok)
+                            {
+                                this.placeholderDatabase.AddFile(childRelativePath, fileSha);
+                            }
+                        }
 
-                        case FSResult.FileOrPathNotFound:
-                            // Git command must have removed the folder being re-expanded (relativeFolderPath)
-                            // Remove the folder from existingFolderPlaceholders so that its parent will create
-                            // it again (when it's re-expanded)
-                            existingPlaceholders.Remove(relativeFolderPath);
-                            this.placeholderDatabase.Remove(relativeFolderPath);
-                            return;
+                        switch (result.Result)
+                        {
+                            case FSResult.Ok:
+                                break;
 
-                        default:
-                            // TODO(Mac): Issue #245, handle failures of WritePlaceholderDirectory and WritePlaceholderFile
-                            break;
+                            case FSResult.FileOrPathNotFound:
+                                // Git command must have removed the folder being re-expanded (relativeFolderPath)
+                                // Remove the folder from existingFolderPlaceholders so that its parent will create
+                                // it again (when it's re-expanded)
+                                existingPlaceholders.Remove(relativeFolderPath);
+                                this.placeholderDatabase.Remove(relativeFolderPath);
+                                return;
+
+                            default:
+                                // TODO(Mac): Issue #245, handle failures of WritePlaceholderDirectory and WritePlaceholderFile
+                                break;
+                        }
                     }
                 }
             }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -768,7 +768,7 @@ namespace GVFS.Virtualization.Projection
 
                         if (!folderData.IsRecursive)
                         {
-                            folderData.IsRecursive = i == folders.Length - 1;
+                            folderData.IsRecursive = (i == folders.Length - 1);
                         }
 
                         parentFolder = folderData.Children;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -654,7 +654,9 @@ namespace GVFS.Virtualization.Projection
         {
             if (indexEntry.BuildingProjection_HasSameParentAsLastEntry)
             {
-                if (indexEntry.BuildingProjection_ShouldInclude || indexEntry.BuildingProjection_ShouldIncludeRecursive)
+                if (this.rootIncludedFolder.Children.Count == 0 ||
+                    indexEntry.BuildingProjection_ShouldInclude ||
+                    indexEntry.BuildingProjection_ShouldIncludeRecursive)
                 {
                     indexEntry.BuildingProjection_LastParent.AddChildFile(indexEntry.BuildingProjection_GetChildName(), indexEntry.Sha);
                 }
@@ -711,32 +713,35 @@ namespace GVFS.Virtualization.Projection
         private void RefreshFoldersToInclude()
         {
             this.rootIncludedFolder.Children.Clear();
-            Dictionary<string, IncludedFolderData> parentFolder = this.rootIncludedFolder.Children;
-            foreach (string directoryPath in this.includedFolderCollection.GetAll())
+            if (this.includedFolderCollection != null)
             {
-                string[] folders = directoryPath.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
-                for (int i = 0; i < folders.Length; i++)
+                Dictionary<string, IncludedFolderData> parentFolder = this.rootIncludedFolder.Children;
+                foreach (string directoryPath in this.includedFolderCollection.GetAll())
                 {
-                    IncludedFolderData folderData;
-                    if (!parentFolder.ContainsKey(folders[i]))
+                    string[] folders = directoryPath.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+                    for (int i = 0; i < folders.Length; i++)
                     {
-                        folderData = new IncludedFolderData();
-                        parentFolder.Add(folders[i], folderData);
-                    }
-                    else
-                    {
-                        folderData = parentFolder[folders[i]];
+                        IncludedFolderData folderData;
+                        if (!parentFolder.ContainsKey(folders[i]))
+                        {
+                            folderData = new IncludedFolderData();
+                            parentFolder.Add(folders[i], folderData);
+                        }
+                        else
+                        {
+                            folderData = parentFolder[folders[i]];
+                        }
+
+                        if (!folderData.IsRecursive)
+                        {
+                            folderData.IsRecursive = i == folders.Length - 1;
+                        }
+
+                        parentFolder = folderData.Children;
                     }
 
-                    if (!folderData.IsRecursive)
-                    {
-                        folderData.IsRecursive = i == folders.Length - 1;
-                    }
-
-                    parentFolder = folderData.Children;
+                    parentFolder = this.rootIncludedFolder.Children;
                 }
-
-                parentFolder = this.rootIncludedFolder.Children;
             }
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -190,7 +190,7 @@ of your enlistment's src folder.
                         isMounted = true;
 
                         GitProcess git = new GitProcess(enlistment);
-                        statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false);
+                        statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false, showUntracked: true);
                         if (statusResult.ExitCodeIsFailure)
                         {
                             return false;

--- a/GVFS/GVFS/CommandLine/IncludeVerb.cs
+++ b/GVFS/GVFS/CommandLine/IncludeVerb.cs
@@ -56,8 +56,10 @@ namespace GVFS.CommandLine
                     using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.EnlistmentRoot, new SqliteDatabase()))
                     {
                         IncludedFolderTable includedFolderTable = new IncludedFolderTable(database);
+                        bool haveFoldersToAdd = !string.IsNullOrEmpty(this.Add);
+                        bool haveFoldersToRemove = !string.IsNullOrEmpty(this.Remove);
 
-                        if (this.List)
+                        if (this.List || (!haveFoldersToAdd && !haveFoldersToRemove))
                         {
                             List<string> directories = includedFolderTable.GetAll();
                             if (directories.Count == 0)
@@ -78,7 +80,7 @@ namespace GVFS.CommandLine
                         // Make sure there is a clean git status before allowing inclusions to change
                         this.CheckGitStatus(tracer, enlistment);
 
-                        if (!string.IsNullOrEmpty(this.Remove))
+                        if (haveFoldersToRemove)
                         {
                             foreach (string directoryPath in this.Remove.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                             {
@@ -86,7 +88,7 @@ namespace GVFS.CommandLine
                             }
                         }
 
-                        if (!string.IsNullOrEmpty(this.Add))
+                        if (haveFoldersToAdd)
                         {
                             foreach (string directoryPath in this.Add.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                             {

--- a/GVFS/GVFS/CommandLine/IncludeVerb.cs
+++ b/GVFS/GVFS/CommandLine/IncludeVerb.cs
@@ -125,7 +125,7 @@ namespace GVFS.CommandLine
                 () =>
                 {
                     GitProcess git = new GitProcess(enlistment);
-                    statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false);
+                    statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false, showUntracked: true);
                     if (statusResult.ExitCodeIsFailure)
                     {
                         return false;

--- a/GVFS/GVFS/CommandLine/IncludeVerb.cs
+++ b/GVFS/GVFS/CommandLine/IncludeVerb.cs
@@ -1,0 +1,173 @@
+﻿using CommandLine;
+using GVFS.Common;
+using GVFS.Common.Database;
+using GVFS.Common.FileSystem;
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GVFS.CommandLine
+{
+    [Verb(IncludeVerb.IncludeVerbName, HelpText = "Clone a git repo and mount it as a GVFS virtual repo")]
+    public class IncludeVerb : GVFSVerb.ForExistingEnlistment
+    {
+        private const string IncludeVerbName = "include";
+
+        [Option(
+            'a',
+            "add",
+            Required = false,
+            Default = "",
+            HelpText = "A semicolon-delimited list of folders to include. Wildcards are not supported.")]
+        public string Add { get; set; }
+
+        [Option(
+            'r',
+            "remove",
+            Required = false,
+            Default = "",
+            HelpText = "A semicolon-delimited list of folders to remove for being included. Wildcards are not supported.")]
+        public string Remove { get; set; }
+
+        [Option(
+            'l',
+            "list",
+            Required = false,
+            Default = false,
+            HelpText = "List of folders to for being included in projection.")]
+        public bool List { get; set; }
+
+        protected override string VerbName => IncludeVerbName;
+
+        protected override void Execute(GVFSEnlistment enlistment)
+        {
+            using (JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "Include"))
+            {
+                try
+                {
+                    tracer.AddLogFileEventListener(
+                        GVFSEnlistment.GetNewGVFSLogFileName(enlistment.GVFSLogsRoot, GVFSConstants.LogFileTypes.Include),
+                        EventLevel.Informational,
+                        Keywords.Any);
+
+                    using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.EnlistmentRoot, new SqliteDatabase()))
+                    {
+                        IncludedFolderTable includedFolderTable = new IncludedFolderTable(database);
+
+                        if (this.List)
+                        {
+                            List<string> directories = includedFolderTable.GetAll();
+                            foreach (string directory in directories)
+                            {
+                                this.Output.WriteLine(directory);
+                            }
+
+                            return;
+                        }
+
+                        // Make sure there is a clean git status before allowing inclusions to change
+                        this.CheckGitStatus(tracer, enlistment);
+
+                        if (!string.IsNullOrEmpty(this.Remove))
+                        {
+                            foreach (string directoryPath in this.Remove.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                            {
+                                includedFolderTable.Remove(directoryPath);
+                            }
+                        }
+
+                        if (!string.IsNullOrEmpty(this.Add))
+                        {
+                            foreach (string directoryPath in this.Add.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                            {
+                                includedFolderTable.Add(directoryPath);
+                            }
+                        }
+                    }
+
+                    // Force a projection update
+                    this.ForceProjectionChange(tracer, enlistment);
+                }
+                catch (Exception e)
+                {
+                    tracer.RelatedError(e.Message);
+                }
+            }
+        }
+
+        private void ForceProjectionChange(ITracer tracer, GVFSEnlistment enlistment)
+        {
+            string errorMessage = null;
+
+            if (!this.ShowStatusWhileRunning(
+                () =>
+                {
+                    GitProcess git = new GitProcess(enlistment);
+                    GitProcess.Result checkoutResult = git.ForceCheckout("HEAD");
+
+                    errorMessage = checkoutResult.Errors;
+                    return checkoutResult.ExitCodeIsSuccess;
+                },
+                "Forcing a projection change",
+                suppressGvfsLogMessage: true))
+            {
+                this.WriteMessage(tracer, "Failed to change projection: " + errorMessage);
+            }
+        }
+
+        private void CheckGitStatus(ITracer tracer, GVFSEnlistment enlistment)
+        {
+            GitProcess.Result statusResult = null;
+            if (!this.ShowStatusWhileRunning(
+                () =>
+                {
+                    GitProcess git = new GitProcess(enlistment);
+                    statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false);
+                    if (statusResult.ExitCodeIsFailure)
+                    {
+                        return false;
+                    }
+
+                    if (!statusResult.Output.Contains("nothing to commit, working tree clean"))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                },
+                "Running git status",
+                suppressGvfsLogMessage: true))
+            {
+                this.Output.WriteLine();
+
+                if (statusResult.ExitCodeIsFailure)
+                {
+                    this.WriteMessage(tracer, "Failed to run git status: " + statusResult.Errors);
+                }
+                else
+                {
+                    this.WriteMessage(tracer, statusResult.Output);
+                    this.WriteMessage(tracer, "git status reported that you have dirty files");
+                    this.WriteMessage(tracer, "Either commit your changes or reset and clean");
+                }
+
+                this.ReportErrorAndExit(tracer, "Include was aborted");
+            }
+        }
+
+        private void WriteMessage(ITracer tracer, string message)
+        {
+            this.Output.WriteLine(message);
+            tracer.RelatedEvent(
+                EventLevel.Informational,
+                IncludeVerbName,
+                new EventMetadata
+                {
+                    { TracingConstants.MessageKey.InfoMessage, message }
+                });
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/IncludeVerb.cs
+++ b/GVFS/GVFS/CommandLine/IncludeVerb.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace GVFS.CommandLine
 {
-    [Verb(IncludeVerb.IncludeVerbName, HelpText = "Clone a git repo and mount it as a GVFS virtual repo")]
+    [Verb(IncludeVerb.IncludeVerbName, HelpText = "List, add, or Remove from the list of folder that are included to project")]
     public class IncludeVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string IncludeVerbName = "include";
@@ -60,9 +60,16 @@ namespace GVFS.CommandLine
                         if (this.List)
                         {
                             List<string> directories = includedFolderTable.GetAll();
-                            foreach (string directory in directories)
+                            if (directories.Count == 0)
                             {
-                                this.Output.WriteLine(directory);
+                                this.Output.WriteLine("No folders in included list.");
+                            }
+                            else
+                            {
+                                foreach (string directory in directories)
+                                {
+                                    this.Output.WriteLine(directory);
+                                }
                             }
 
                             return;
@@ -88,7 +95,7 @@ namespace GVFS.CommandLine
                         }
                     }
 
-                    // Force a projection update
+                    // Force a projection update to get the current inclusion set
                     this.ForceProjectionChange(tracer, enlistment);
                 }
                 catch (Exception e)

--- a/GVFS/GVFS/GVFS.Windows.csproj
+++ b/GVFS/GVFS/GVFS.Windows.csproj
@@ -117,6 +117,7 @@
     <Compile Include="CommandLine\DehydrateVerb.cs" />
     <Compile Include="CommandLine\DiagnoseVerb.cs" />
     <Compile Include="CommandLine\GVFSVerb.cs" />
+    <Compile Include="CommandLine\IncludeVerb.cs" />
     <Compile Include="CommandLine\LogVerb.cs" />
     <Compile Include="CommandLine\MountVerb.cs" />
     <Compile Include="CommandLine\PrefetchVerb.cs" />

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -22,6 +22,7 @@ namespace GVFS
                 typeof(DehydrateVerb),
                 typeof(DiagnoseVerb),
                 typeof(LogVerb),
+                typeof(IncludeVerb),
                 typeof(MountVerb),
                 typeof(PrefetchVerb),
                 typeof(RepairVerb),

--- a/GVFS/GVFS/RepairJobs/RepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/RepairJob.cs
@@ -120,6 +120,7 @@ namespace GVFS.RepairJobs
                 repoMetadata: null,
                 fileSystemVirtualizer: null,
                 placeholderDatabase: null,
+                includedFolderCollection: null,
                 modifiedPaths: null))
             {
                 try


### PR DESCRIPTION
This is a feature to only include specified folders in the projection.  I'm not stuck with the naming that I have chosen so if you have better ones please let me know.  

You should be able to clone as normal and it will project everything until something is added to the included folder database via the `gvfs include` verb.

The `gvfs include` verb includes the following:
```
-a <folderlist> // add ; separated folders to the list to include
-r <folderlist> // remove ; separated folders to the list
-l // list the folders that are currently in the list
```
Examples:
```
gvfs include -l
gvfs include -a GVFS/GVFS;Scripts
gvfs include -r Scripts
```

You can use both the `-a` and `-r` in the same invocation.  The removes will be applied first and then the adds.

You must have a clean `git status` in order to add or remove folders so the the code can reproject without issue.

These changes currently don't do anything with the modified paths so if you create a directory or get a conflict that is outside the included folders then the paths will be added to the modified path list and continue to be in the working directory for git to keep up to date.

TODO:
- [x] Testing on Mac
- [x] Decide how to handle edge cases like creating a directory that is in the projection but not in the included list
- [x] Test conflict scenarios and make sure they work as expected
- [x] Performance test when no included folders
- [x] Performance test while there are included folders