### PR TITLE
Upgrader: NuGet Upgrader should use GitHub endpoint for notifications

### DIFF
--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -139,20 +139,22 @@ namespace GVFS.Service
                                 return;
                             }
                         }
+                        else
+                        {
+                            errorMessage = string.Format(
+                                "{0}.{1}: Configured Product Upgrader does not support anonymous version queries.",
+                                nameof(ProductUpgradeTimer),
+                                nameof(this.TimerCallback),
+                                errorMessage);
 
-                        errorMessage = string.Format(
-                            "{0}.{1}: Configured Product Upgrader does not support anonymous version queries.",
-                            nameof(ProductUpgradeTimer),
-                            nameof(this.TimerCallback),
-                            errorMessage);
+                            activity.RelatedWarning(
+                                metadata: new EventMetadata(),
+                                message: errorMessage,
+                                keywords: Keywords.Telemetry);
 
-                        activity.RelatedWarning(
-                            metadata: new EventMetadata(),
-                            message: errorMessage,
-                            keywords: Keywords.Telemetry);
-
-                        info.RecordHighestAvailableVersion(highestAvailableVersion: null);
-                        return;
+                            info.RecordHighestAvailableVersion(highestAvailableVersion: null);
+                            return;
+                        }
                     }
 
                     InstallerPreRunChecker prerunChecker = new InstallerPreRunChecker(this.tracer, string.Empty);


### PR DESCRIPTION
Fixes a bug where NuGet Upgrader no longer checks the GitHub endpoint to
determine whether to show a notification that an upgrade is available. This did
not affect the actual upgrade command, just whether to show a notification.

cherry picked from pr #1290 
(cherry picked from commit 9a6710335fd20acbb200ad0fbc3b6f8180925408)
