### PR TITLE
Update Git to include status deserialize fix

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190610.5</GitPackageVersion>
+    <GitPackageVersion>2.20190626.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -468,9 +468,19 @@ namespace GVFS.Common.Git
             return this.InvokeGitInWorkingDirectoryRoot("checkout -f " + target, useReadObjectHook: false);
         }
 
-        public Result Status(bool allowObjectDownloads, bool useStatusCache)
+        public Result Status(bool allowObjectDownloads, bool useStatusCache, bool showUntracked = false)
         {
-            string command = useStatusCache ? "status" : "status --no-deserialize";
+            string command = "status";
+            if (!useStatusCache)
+            {
+                command += " --no-deserialize";
+            }
+
+            if (showUntracked)
+            {
+                command += " -uall";
+            }
+
             return this.InvokeGitInWorkingDirectoryRoot(command, useReadObjectHook: allowObjectDownloads);
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -190,7 +190,7 @@ of your enlistment's src folder.
                         isMounted = true;
 
                         GitProcess git = new GitProcess(enlistment);
-                        statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false);
+                        statusResult = git.Status(allowObjectDownloads: false, useStatusCache: false, showUntracked: true);
                         if (statusResult.ExitCodeIsFailure)
                         {
                             return false;


### PR DESCRIPTION
Includes status deserialziation bug fix from microsoft/git#157.

Further, update the dehydrate verb to specifically use `-uall` when checking for local changes.