### PR TITLE
simplify Git functional tests of case-sensitive file paths

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -716,13 +716,13 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             // Confirm that no other test has caused "GVFlt_MultiThreadTest" to be added to the modified paths database
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.FileSystem, folderName);
 
-            this.FolderShouldHaveCaseMatchingName(folderName, "GVFlt_MultiThreadTest");
+            this.FolderShouldHaveCaseMatchingName(folderName);
             this.DeleteFolder(folderName);
 
             // 4141dc6023b853740795db41a06b278ebdee0192 is the commit prior to deleting GVFLT_MultiThreadTest
             // and re-adding it as as GVFlt_MultiThreadTest
             this.ValidateGitCommand("checkout 4141dc6023b853740795db41a06b278ebdee0192");
-            this.FolderShouldHaveCaseMatchingName(folderName, "GVFLT_MultiThreadTest");
+            this.FolderShouldHaveCaseMatchingName("GVFLT_MultiThreadTest");
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -408,10 +408,10 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("add .");
             this.RunGitCommand("commit -m \"Change for CaseOnlyRenameFileAndChangeBranches\"");
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
-            this.FileShouldHaveCaseMatchingName(newFileName, oldFileName);
+            this.FileShouldHaveCaseMatchingName(oldFileName);
 
             this.ValidateGitCommand("checkout " + newBranchName);
-            this.FileShouldHaveCaseMatchingName(newFileName, newFileName);
+            this.FileShouldHaveCaseMatchingName(newFileName);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -394,18 +394,20 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             virtualFilePath.ShouldBeAFile(this.FileSystem).WithContents(controlFilePath.ShouldBeAFile(this.FileSystem).WithContents());
         }
 
-        protected void FileShouldHaveCaseMatchingName(string filePath, string caseSensitiveName)
+        protected void FileShouldHaveCaseMatchingName(string caseSensitiveFilePath)
         {
-            string virtualFilePath = Path.Combine(this.Enlistment.RepoRoot, filePath);
-            string controlFilePath = Path.Combine(this.ControlGitRepo.RootPath, filePath);
+            string virtualFilePath = Path.Combine(this.Enlistment.RepoRoot, caseSensitiveFilePath);
+            string controlFilePath = Path.Combine(this.ControlGitRepo.RootPath, caseSensitiveFilePath);
+            string caseSensitiveName = Path.GetFileName(caseSensitiveFilePath);
             virtualFilePath.ShouldBeAFile(this.FileSystem).WithCaseMatchingName(caseSensitiveName);
             controlFilePath.ShouldBeAFile(this.FileSystem).WithCaseMatchingName(caseSensitiveName);
         }
 
-        protected void FolderShouldHaveCaseMatchingName(string folderPath, string caseSensitiveName)
+        protected void FolderShouldHaveCaseMatchingName(string caseSensitiveFolderPath)
         {
-            string virtualFolderPath = Path.Combine(this.Enlistment.RepoRoot, folderPath);
-            string controlFolderPath = Path.Combine(this.ControlGitRepo.RootPath, folderPath);
+            string virtualFolderPath = Path.Combine(this.Enlistment.RepoRoot, caseSensitiveFolderPath);
+            string controlFolderPath = Path.Combine(this.ControlGitRepo.RootPath, caseSensitiveFolderPath);
+            string caseSensitiveName = Path.GetFileName(caseSensitiveFolderPath);
             virtualFolderPath.ShouldBeADirectory(this.FileSystem).WithCaseMatchingName(caseSensitiveName);
             controlFolderPath.ShouldBeADirectory(this.FileSystem).WithCaseMatchingName(caseSensitiveName);
         }


### PR DESCRIPTION
The `FileShouldHaveCaseMatchingName()` and related `FolderShouldHaveCaseMatchingName()` methods used in the GitCommands functional tests currently take two arguments, first a file path, and then a file name which must match case-sensitively against the last component of the path.

On Linux, the use of at least one of these matching tests fails due to an incorrect usage: the caller,
`CaseOnlyRenameFileAndChangeBranches()`, is passing a file path which differs in case from the case-sensitive name.  This happens to work fine on Windows and Mac because the intended file is found regardless of case, but on Linux, it fails as the intended file can't be located.

In order to clarify the function of these matching test methods, we change them to take a single, case-sensitive file path, and then check that the file or folder found at that path has the matching case in its parent directory's listing.  This is effectively a no-op on Linux, but should retain the same functionality as before on other platforms.

/cc @kivikakk