### PR TITLE
createMacInstaller: generate standalone git pkg installers

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -211,6 +211,10 @@ function CreateMetaDistribution()
     eval $copyGitPkgCmd
 
     UpdateDistributionFile "$GITPKGNAME" "$GITVERSIONSTRING"
+
+    copyGitPkgInstallerCmd="/bin/cp \"${GITINSTALLERPATH}\" \"${BUILDOUTPUTDIR}/\""
+    echo $copyGitPkgInstallerCmd
+    eval $copyGitPkgInstallerCmd || exit 1
     
     METAPACKAGENAME="$INSTALLERPACKAGENAME-Git.$GITVERSION.pkg"
     buildMetapkgCmd="/usr/bin/productbuild --distribution \"${BUILDOUTPUTDIR}/Distribution.updated.xml\" --package-path \"$PACKAGESTAGINGDIR\" \"${BUILDOUTPUTDIR}/$METAPACKAGENAME\""


### PR DESCRIPTION
When creating the mac installer, downstream consumers might want to
use the git for mac pkg installer. Copy this pkg installer to the
output directory.