### PR TITLE
Reorganize health assets

### DIFF
--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -10,18 +10,18 @@ namespace GVFS.Common
     /// internally stores the calculated information. Compute or recompute via CalculateStatistics
     /// with an optional parameter to only look for paths which are under the specified directory
     /// </summary>
-    public class GVFSEnlistmentHealthCalculator
+    public partial class EnlistmentHealthCalculator
     {
         // In the context of this class, hydrated files are placeholders or modified paths
         // The total number of hydrated files is this.PlaceholderCount + this.ModifiedPathsCount
-        private readonly GVFSEnlistmentPathData enlistmentPathData;
+        private readonly EnlistmentPathData enlistmentPathData;
 
-        public GVFSEnlistmentHealthCalculator(GVFSEnlistmentPathData pathData)
+        public EnlistmentHealthCalculator(EnlistmentPathData pathData)
         {
             this.enlistmentPathData = pathData;
         }
 
-        public GVFSEnlistmentHealthData CalculateStatistics(string parentDirectory)
+        public EnlistmentHealthData CalculateStatistics(string parentDirectory)
         {
             int gitTrackedItemsCount = 0;
             int placeholderCount = 0;
@@ -64,7 +64,7 @@ namespace GVFS.Common
                 }
             }
 
-            return new GVFSEnlistmentHealthData(
+            return new EnlistmentHealthData(
                 parentDirectory,
                 gitTrackedItemsCount,
                 placeholderCount,
@@ -157,101 +157,6 @@ namespace GVFS.Common
             }
 
             return (decimal)hydratedFileCount / (decimal)totalFileCount;
-        }
-
-        public class GVFSEnlistmentPathData
-        {
-            public List<string> GitFolderPaths;
-            public List<string> GitFilePaths;
-            public List<string> PlaceholderFolderPaths;
-            public List<string> PlaceholderFilePaths;
-            public List<string> ModifiedFolderPaths;
-            public List<string> ModifiedFilePaths;
-
-            public GVFSEnlistmentPathData()
-            {
-                this.GitFolderPaths = new List<string>();
-                this.GitFilePaths = new List<string>();
-                this.PlaceholderFolderPaths = new List<string>();
-                this.PlaceholderFilePaths = new List<string>();
-                this.ModifiedFolderPaths = new List<string>();
-                this.ModifiedFilePaths = new List<string>();
-            }
-
-            public void AddGitTrackingPaths(IEnumerable<string> gitTrackingPaths)
-            {
-                this.ModifiedFilePaths.Union(gitTrackingPaths);
-            }
-
-            public void NormalizeAllPaths()
-            {
-                this.NormalizePaths(this.GitFolderPaths);
-                this.NormalizePaths(this.GitFilePaths);
-                this.NormalizePaths(this.PlaceholderFolderPaths);
-                this.NormalizePaths(this.PlaceholderFilePaths);
-                this.NormalizePaths(this.ModifiedFolderPaths);
-                this.NormalizePaths(this.ModifiedFilePaths);
-            }
-
-            private void NormalizePaths(List<string> paths)
-            {
-                for (int i = 0; i < paths.Count; i++)
-                {
-                    paths[i] = paths[i].Replace(GVFSPlatform.GVFSPlatformConstants.PathSeparator, GVFSConstants.GitPathSeparator);
-                    paths[i] = paths[i].Trim(GVFSConstants.GitPathSeparator);
-                }
-            }
-        }
-
-        public class GVFSEnlistmentHealthData
-        {
-            public GVFSEnlistmentHealthData(
-                string targetDirectory,
-                int gitItemsCount,
-                int placeholderCount,
-                int modifiedPathsCount,
-                decimal healthMetric,
-                List<KeyValuePair<string, decimal>> directoryHydrationLevels)
-            {
-                this.TargetDirectory = targetDirectory;
-                this.GitTrackedItemsCount = gitItemsCount;
-                this.PlaceholderCount = placeholderCount;
-                this.ModifiedPathsCount = modifiedPathsCount;
-                this.HealthMetric = healthMetric;
-                this.DirectoryHydrationLevels = directoryHydrationLevels;
-            }
-
-            public string TargetDirectory { get; private set; }
-            public int GitTrackedItemsCount { get; private set; }
-            public int PlaceholderCount { get; private set; }
-            public int ModifiedPathsCount { get; private set; }
-            public List<KeyValuePair<string, decimal>> DirectoryHydrationLevels { get; private set; }
-            public decimal HealthMetric { get; private set; }
-            public decimal PlaceholderPercentage
-            {
-                get
-                {
-                    if (this.GitTrackedItemsCount == 0)
-                    {
-                        return 0;
-                    }
-
-                    return (decimal)this.PlaceholderCount / this.GitTrackedItemsCount;
-                }
-            }
-
-            public decimal ModifiedPathsPercentage
-            {
-                get
-                {
-                    if (this.GitTrackedItemsCount == 0)
-                    {
-                        return 0;
-                    }
-
-                    return (decimal)this.ModifiedPathsCount / this.GitTrackedItemsCount;
-                }
-            }
         }
     }
 }

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
     /// internally stores the calculated information. Compute or recompute via CalculateStatistics
     /// with an optional parameter to only look for paths which are under the specified directory
     /// </summary>
-    public partial class EnlistmentHealthCalculator
+    public class EnlistmentHealthCalculator
     {
         // In the context of this class, hydrated files are placeholders or modified paths
         // The total number of hydrated files is this.PlaceholderCount + this.ModifiedPathsCount

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+
+namespace GVFS.Common
+{
+    public class EnlistmentHealthData
+    {
+        public EnlistmentHealthData(
+            string targetDirectory,
+            int gitItemsCount,
+            int placeholderCount,
+            int modifiedPathsCount,
+            decimal healthMetric,
+            List<KeyValuePair<string, decimal>> directoryHydrationLevels)
+        {
+            this.TargetDirectory = targetDirectory;
+            this.GitTrackedItemsCount = gitItemsCount;
+            this.PlaceholderCount = placeholderCount;
+            this.ModifiedPathsCount = modifiedPathsCount;
+            this.HealthMetric = healthMetric;
+            this.DirectoryHydrationLevels = directoryHydrationLevels;
+        }
+
+        public string TargetDirectory { get; private set; }
+        public int GitTrackedItemsCount { get; private set; }
+        public int PlaceholderCount { get; private set; }
+        public int ModifiedPathsCount { get; private set; }
+        public List<KeyValuePair<string, decimal>> DirectoryHydrationLevels { get; private set; }
+        public decimal HealthMetric { get; private set; }
+        public decimal PlaceholderPercentage
+        {
+            get
+            {
+                if (this.GitTrackedItemsCount == 0)
+                {
+                    return 0;
+                }
+
+                return (decimal)this.PlaceholderCount / this.GitTrackedItemsCount;
+            }
+        }
+
+        public decimal ModifiedPathsPercentage
+        {
+            get
+            {
+                if (this.GitTrackedItemsCount == 0)
+                {
+                    return 0;
+                }
+
+                return (decimal)this.ModifiedPathsCount / this.GitTrackedItemsCount;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentPathData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentPathData.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace GVFS.Common
+{
+    public class EnlistmentPathData
+    {
+        public List<string> GitFolderPaths;
+        public List<string> GitFilePaths;
+        public List<string> PlaceholderFolderPaths;
+        public List<string> PlaceholderFilePaths;
+        public List<string> ModifiedFolderPaths;
+        public List<string> ModifiedFilePaths;
+
+        public EnlistmentPathData()
+        {
+            this.GitFolderPaths = new List<string>();
+            this.GitFilePaths = new List<string>();
+            this.PlaceholderFolderPaths = new List<string>();
+            this.PlaceholderFilePaths = new List<string>();
+            this.ModifiedFolderPaths = new List<string>();
+            this.ModifiedFilePaths = new List<string>();
+        }
+
+        public void AddGitTrackingPaths(IEnumerable<string> gitTrackingPaths)
+        {
+            this.ModifiedFilePaths.Union(gitTrackingPaths);
+        }
+
+        public void NormalizeAllPaths()
+        {
+            this.NormalizePaths(this.GitFolderPaths);
+            this.NormalizePaths(this.GitFilePaths);
+            this.NormalizePaths(this.PlaceholderFolderPaths);
+            this.NormalizePaths(this.PlaceholderFilePaths);
+            this.NormalizePaths(this.ModifiedFolderPaths);
+            this.NormalizePaths(this.ModifiedFilePaths);
+        }
+
+        private void NormalizePaths(List<string> paths)
+        {
+            for (int i = 0; i < paths.Count; i++)
+            {
+                paths[i] = paths[i].Replace(GVFSPlatform.GVFSPlatformConstants.PathSeparator, GVFSConstants.GitPathSeparator);
+                paths[i] = paths[i].Trim(GVFSConstants.GitPathSeparator);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
@@ -8,13 +8,13 @@ namespace GVFS.UnitTests.Common
     public class GVFSEnlistmentHealthTests
     {
         private readonly char sep = GVFSPlatform.GVFSPlatformConstants.PathSeparator;
-        private GVFSEnlistmentHealthCalculator enlistmentHealthCalculator;
-        private GVFSEnlistmentHealthCalculator.GVFSEnlistmentHealthData enlistmentHealthData;
+        private EnlistmentHealthCalculator enlistmentHealthCalculator;
+        private EnlistmentHealthData enlistmentHealthData;
 
         [TestCase]
         public void SingleHydratedDirectoryShouldHaveOtherDirectoriesCompletelyHealthy()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("A/1.js", "A/2.js", "A/3.js", "A/4.js", "B/1.js", "B/2.js", "B/3.js", "B/4.js", "C/1.js", "C/2.js", "C/3.js", "C/4.js")
                 .AddPlaceholderFiles("A/1.js", "A/2.js", "A/3.js")
                 .Build();
@@ -37,7 +37,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void AllEmptyLists()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .Build();
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
@@ -52,7 +52,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void OverHydrated()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("A/1.js", "A/2.js", "A/3.js", "A/4.js", "B/1.js", "B/2.js", "B/3.js", "B/4.js", "C/1.js", "C/2.js", "C/3.js", "C/4.js")
                 .AddPlaceholderFiles("A/1.js", "A/2.js", "A/3.js", "A/4.js", "B/1.js", "B/2.js", "B/3.js", "B/4.js", "C/1.js", "C/2.js", "C/3.js", "C/4.js")
                 .AddModifiedPathFiles("A/1.js", "A/2.js", "A/3.js", "A/4.js", "B/1.js", "B/2.js", "B/3.js", "B/4.js", "C/1.js", "C/2.js", "C/3.js", "C/4.js")
@@ -70,7 +70,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void SortByHydration()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("C/1.js", "A/1.js", "B/1.js", "B/2.js", "A/2.js", "C/2.js", "A/3.js", "C/3.js", "B/3.js")
                 .AddModifiedPathFiles("C/1.js", "B/2.js", "A/3.js")
                 .AddPlaceholderFiles("B/1.js", "A/2.js")
@@ -89,7 +89,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void VariedDirectoryFormatting()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("A/1.js", "A/2.js", "A/3.js", "B/1.js", "B/2.js", "B/3.js")
                 .AddPlaceholderFolders("/A/", $"{this.sep}B{this.sep}", "A/", $"B{this.sep}", "/A", $"{this.sep}B", "A", "B")
                 .Build();
@@ -105,7 +105,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void VariedFilePathFormatting()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("A/1.js", "A/2.js", "A/3.js", "B/1.js", "B/2.js", "B/3.js")
                 .AddPlaceholderFiles("A/1.js", $"A{this.sep}2.js", "/A/1.js", $"{this.sep}A{this.sep}1.js")
                 .AddModifiedPathFiles("B/1.js", $"B{this.sep}2.js", "/B/1.js", $"{this.sep}B{this.sep}1.js")
@@ -129,7 +129,7 @@ namespace GVFS.UnitTests.Common
             string[] gitFilesDirectoryA = new string[] { "A/1.js", "A/2.js", "A/3.js" };
             string[] gitFilesDirectoryB = new string[] { "B/1.js", "B/2.js", "B/3.js" };
 
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles(gitFilesDirectoryA)
                 .AddGitFiles(gitFilesDirectoryB)
                 .AddPlaceholderFiles("A/1.js", $"A{this.sep}2.js", "/A/1.js", $"{this.sep}A{this.sep}1.js")
@@ -156,7 +156,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void FilterByDirectoryWithoutPathSeparator()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("Directory1/Child1/File1.js", "Directory1/Child1/File2.exe", "Directory2/Child2/File1.bat", "Directory2/Child2/File2.css")
                 .AddPlaceholderFiles("Directory1/File1.js", "Directory1/File2.exe", "Directory2/File1.bat", "Directory2/File2.css")
                 .Build();
@@ -179,7 +179,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void EnsureFolderNotIncludedInOwnCount()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFolders("foo/")
                 .AddGitFiles("foo/file1.jpg", "foo/file2.jpg", "foo/file3.jpg", "foo/file4.jpg", "foo/file5.jpg")
                 .AddPlaceholderFiles("foo/file1.jpg", "foo/file2.jpg", "foo/file3.jpg", "foo/file4.jpg", "foo/file5.jpg")
@@ -196,7 +196,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void FolderNotDoubleCounted()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFolders("foo/")
                 .AddGitFiles("foo/file1.jpg", "foo/file2.jpg", "foo/file3.jpg", "foo/file4.jpg", "foo/file5.jpg")
                 .AddPlaceholderFiles("foo/file1.jpg", "foo/file2.jpg", "foo/file3.jpg", "foo/file4.jpg", "foo/file5.jpg")
@@ -213,7 +213,7 @@ namespace GVFS.UnitTests.Common
         [TestCase]
         public void UnionOfSkipWorktreeAndModifiedPathsNoDuplicates()
         {
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new PathDataBuilder()
+            EnlistmentPathData pathData = new PathDataBuilder()
                 .AddGitFiles("A/1.js", "A/2.js", "A/3.js", "B/1.js", "B/2.js", "B/3.js")
                 .AddModifiedPathFiles("A/1.js", "A/2.js", "/A/3.js", "B/1.js", "B/2.js", "B/3.js")
                 .AddNonSkipWorktreeFiles("A/1.js", "/A/2.js", $"{this.sep}A/3.js", "B/1.js", $"B{this.sep}2.js", $"/B{this.sep}3.js")
@@ -228,15 +228,15 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData.DirectoryHydrationLevels.Count.ShouldEqual(2);
         }
 
-        private GVFSEnlistmentHealthCalculator.GVFSEnlistmentHealthData GenerateStatistics(GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData, string directory)
+        private EnlistmentHealthData GenerateStatistics(EnlistmentPathData pathData, string directory)
         {
-            this.enlistmentHealthCalculator = new GVFSEnlistmentHealthCalculator(pathData);
+            this.enlistmentHealthCalculator = new EnlistmentHealthCalculator(pathData);
             return this.enlistmentHealthCalculator.CalculateStatistics(directory);
         }
 
         public class PathDataBuilder
         {
-            private GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData();
+            private EnlistmentPathData pathData = new EnlistmentPathData();
 
             public PathDataBuilder AddPlaceholderFiles(params string[] placeholderFilePaths)
             {
@@ -280,7 +280,7 @@ namespace GVFS.UnitTests.Common
                 return this;
             }
 
-            public GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData Build()
+            public EnlistmentPathData Build()
             {
                 this.pathData.NormalizeAllPaths();
                 return this.pathData;

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -49,7 +49,7 @@ namespace GVFS.CommandLine
 
             this.Directory = this.Directory.Replace(GVFSPlatform.GVFSPlatformConstants.PathSeparator, GVFSConstants.GitPathSeparator);
 
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData = new GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData();
+            EnlistmentPathData pathData = new EnlistmentPathData();
 
             this.GetPathsFromGitIndex(enlistment, pathData);
             this.GetPlaceholdersFromDatabase(enlistment, pathData);
@@ -57,13 +57,13 @@ namespace GVFS.CommandLine
 
             pathData.NormalizeAllPaths();
 
-            GVFSEnlistmentHealthCalculator enlistmentHealthCalculator = new GVFSEnlistmentHealthCalculator(pathData);
-            GVFSEnlistmentHealthCalculator.GVFSEnlistmentHealthData enlistmentHealthData = enlistmentHealthCalculator.CalculateStatistics(this.Directory);
+            EnlistmentHealthCalculator enlistmentHealthCalculator = new EnlistmentHealthCalculator(pathData);
+            EnlistmentHealthData enlistmentHealthData = enlistmentHealthCalculator.CalculateStatistics(this.Directory);
 
             this.PrintOutput(enlistmentHealthData);
         }
 
-        private void PrintOutput(GVFSEnlistmentHealthCalculator.GVFSEnlistmentHealthData enlistmentHealthData)
+        private void PrintOutput(EnlistmentHealthData enlistmentHealthData)
         {
             string trackedFilesCountFormatted = enlistmentHealthData.GitTrackedItemsCount.ToString("N0");
             string placeholderCountFormatted = enlistmentHealthData.PlaceholderCount.ToString("N0");
@@ -128,7 +128,7 @@ namespace GVFS.CommandLine
         /// </summary>
         /// <param name="enlistment">The enlistment being operated on</param>
         /// <returns>An array containing all of the modified paths in string format</returns>
-        private void GetModifiedPathsFromPipe(GVFSEnlistment enlistment, GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData)
+        private void GetModifiedPathsFromPipe(GVFSEnlistment enlistment, EnlistmentPathData pathData)
         {
             using (NamedPipeClient pipeClient = new NamedPipeClient(enlistment.NamedPipeName))
             {
@@ -180,7 +180,7 @@ namespace GVFS.CommandLine
         /// <param name="enlistment">The current GVFS enlistment being operated on</param>
         /// <param name="filePlaceholders">Out parameter where the list of file placeholders will end up</param>
         /// <param name="folderPlaceholders">Out parameter where the list of folder placeholders will end up</param>
-        private void GetPlaceholdersFromDatabase(GVFSEnlistment enlistment, GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData)
+        private void GetPlaceholdersFromDatabase(GVFSEnlistment enlistment, EnlistmentPathData pathData)
         {
             List<IPlaceholderData> filePlaceholders = new List<IPlaceholderData>();
             List<IPlaceholderData> folderPlaceholders = new List<IPlaceholderData>();
@@ -195,7 +195,7 @@ namespace GVFS.CommandLine
             pathData.PlaceholderFolderPaths.AddRange(folderPlaceholders.Select(placeholderData => placeholderData.Path));
         }
 
-        private void GetPathsFromGitIndex(GVFSEnlistment enlistment, GVFSEnlistmentHealthCalculator.GVFSEnlistmentPathData pathData)
+        private void GetPathsFromGitIndex(GVFSEnlistment enlistment, EnlistmentPathData pathData)
         {
             List<string> skipWorktreeFiles = new List<string>();
             GitProcess gitProcess = new GitProcess(enlistment);


### PR DESCRIPTION
Renamed the following classes:
- `GVFSEnlistmentHealthCalculator` -> `EnlistmentHealthCalculator`
- `GVFSEnlistmentPathData` -> `EnlistmentPathData`
- `GVFSEnlistmentHealthData` -> `EnlistmentHealthData`

Extracted `EnlistmentPathData` and `EnlistmentHealthData` to be standalone
classes instead of inner classes of `EnlistmentHealthCalculator`.
Created a `GVFS.Common.HealthCalculator` directory to house the 3 health classes