### PR TITLE
Health functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj" />
     <ProjectReference Include="..\GVFS.Tests\GVFS.Tests.csproj" />
   </ItemGroup>
 

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\GVFS.Build\GVFS.cs.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\GVFS.Build\GVFS.cs.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GVFS.Common\GVFS.Common.csproj" />
     <ProjectReference Include="..\GVFS.Tests\GVFS.Tests.csproj" />
   </ItemGroup>
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -29,8 +29,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFiles: 1,
                 slowFilePercent: 0,
                 totalPercent: 0,
-                topHydratedDirectories,
-                directoryHydrationLevels,
+                topHydratedDirectories: topHydratedDirectories,
+                directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "OK");
         }
 
@@ -57,8 +57,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFiles: 1,
                 slowFilePercent: 0,
                 totalPercent:1,
-                topHydratedDirectories,
-                directoryHydrationLevels,
+                topHydratedDirectories: topHydratedDirectories,
+                directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "OK");
         }
 
@@ -82,8 +82,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFiles: 3,
                 slowFilePercent: 0,
                 totalPercent: 1,
-                topHydratedDirectories,
-                directoryHydrationLevels,
+                topHydratedDirectories: topHydratedDirectories,
+                directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "OK");
         }
 
@@ -109,8 +109,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFiles: 8,
                 slowFilePercent: 1,
                 totalPercent: 1,
-                topHydratedDirectories,
-                directoryHydrationLevels,
+                topHydratedDirectories: topHydratedDirectories,
+                directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "OK");
         }
 
@@ -129,8 +129,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFiles: 5,
                 slowFilePercent: 100,
                 totalPercent: 100,
-                topHydratedDirectories,
-                directoryHydrationLevels,
+                topHydratedDirectories: topHydratedDirectories,
+                directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "Highly Hydrated");
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -9,10 +9,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [TestFixture]
     public class HealthTests : TestsWithEnlistmentPerFixture
     {
-        [TestCase]
+        [TestCase, Order(0)]
         public void AfterCloningRepoIsPerfectlyHealthy()
         {
-            string[] healthOutputLines = this.Enlistment.Health().Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            // .gitignore is always a placeholder on creation
+            // .gitconfig is always a modified path in functional tests since it is written at run time
+            string[] healthOutputLines = this.GetHealthOutputLines();
+
             healthOutputLines[0].ShouldEqual("Health of directory: ");
             healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
             healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      1 |   0%");
@@ -28,26 +31,99 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             healthOutputLines[11].ShouldEqual("Repository status: OK");
         }
 
-        [TestCase]
+        [TestCase, Order(1)]
         public void PlaceholdersChangeHealthScores()
         {
-            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/SetupDevService.bat"));
-            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/StartDevService.bat"));
-            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/StopDevService.bat"));
+            // Hydrate all files in the Scripts/ directory as placeholders
+            // This creates 6 placeholders, 5 files along with the Scripts/ directory
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonAssemblyVersion.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonCliAssemblyVersion.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonVersionHeader.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunFunctionalTests.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
 
-            string healthInfo = this.Enlistment.Health();
+            string[] healthOutputLines = this.GetHealthOutputLines();
+
+            healthOutputLines[0].ShouldEqual("Health of directory: ");
+            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
+            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      7 |   1%");
+            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              1 |   0%");
+            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
+
+            healthOutputLines[6].ShouldEqual(" 100% | Scripts                ");
+            healthOutputLines[7].ShouldEqual("   0% | GVFS                   ");
+            healthOutputLines[8].ShouldEqual("   0% | GVFlt_BugRegressionTest");
+            healthOutputLines[9].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
+            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFolderTest ");
+
+            healthOutputLines[11].ShouldEqual("Repository status: OK");
         }
 
-        /*
-        [TestCase]
+        [TestCase, Order(2)]
         public void ModifiedPathsChangeHealthScores()
         {
+            // Hydrate all files in GVFlt_FileOperationTest as modified paths
+            // This creates 2 modified paths and one placeholder
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/DeleteExistingFile.txt"));
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/WriteAndVerify.txt"));
 
+            string[] healthOutputLines = this.GetHealthOutputLines();
+
+            healthOutputLines[0].ShouldEqual("Health of directory: ");
+            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
+            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      8 |   1%");
+            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              3 |   0%");
+            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
+
+            healthOutputLines[6].ShouldEqual(" 100% | GVFlt_FileOperationTest");
+            healthOutputLines[7].ShouldEqual(" 100% | Scripts                ");
+            healthOutputLines[8].ShouldEqual("   0% | GVFS                   ");
+            healthOutputLines[9].ShouldEqual("   0% | GVFlt_BugRegressionTest");
+            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
+
+            healthOutputLines[11].ShouldEqual("Repository status: OK");
         }
 
-        [TestCase]
-        directoryfiltering
-        */
+        [TestCase, Order(3)]
+        public void TurnPlaceholdersIntoModifiedPaths()
+        {
+            // Hydrate the files in Scripts/ from placeholders to modified paths
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonAssemblyVersion.bat"));
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonCliAssemblyVersion.bat"));
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/CreateCommonVersionHeader.bat"));
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunFunctionalTests.bat"));
+            this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
+
+            string[] healthOutputLines = this.GetHealthOutputLines();
+
+            healthOutputLines[0].ShouldEqual("Health of directory: ");
+            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
+            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      3 |   0%");
+            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              8 |   1%");
+            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
+
+            healthOutputLines[6].ShouldEqual(" 100% | GVFlt_FileOperationTest");
+            healthOutputLines[7].ShouldEqual(" 100% | Scripts                ");
+            healthOutputLines[8].ShouldEqual("   0% | GVFS                   ");
+            healthOutputLines[9].ShouldEqual("   0% | GVFlt_BugRegressionTest");
+            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
+
+            healthOutputLines[11].ShouldEqual("Repository status: OK");
+        }
+
+        [TestCase, Order(4)]
+        public void FilterIntoDirectory()
+        {
+            string[] healthOutputLines = this.GetHealthOutputLines("Scripts/");
+
+            healthOutputLines[0].ShouldEqual("Health of directory: Scripts/");
+            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           5 | 100%");
+            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):  0 |   0%");
+            healthOutputLines[3].ShouldEqual("Files managed by git (slow):          5 | 100%");
+            healthOutputLines[4].ShouldEqual("Total hydration percentage:               100%");
+
+            healthOutputLines[6].ShouldEqual("Repository status: Highly Hydrated");
+        }
 
         private void HydratePlaceholder(string filePath)
         {
@@ -57,6 +133,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void HydrateFullFile(string filePath)
         {
             File.OpenWrite(filePath).Close();
+        }
+
+        private string[] GetHealthOutputLines(string directory = null)
+        {
+            return this.Enlistment.Health(directory).Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -187,8 +188,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // "Total files in HEAD commit:           <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)%$");
 
-            int outputtedTotalFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
-            int outputtedTotalFilePercent = int.Parse(lineMatch.Groups[2].Value);
+            int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedTotalFiles).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, out int outputtedTotalFilePercent).ShouldBeTrue();
 
             outputtedTotalFiles.ShouldEqual(totalFiles);
             outputtedTotalFilePercent.ShouldEqual(totalFilePercent);
@@ -200,8 +201,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // "Files managed by VFS for Git (fast):    <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)%$");
 
-            int outputtedFastFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
-            int outputtedFastFilesPercent = int.Parse(lineMatch.Groups[2].Value);
+            int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastFiles).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, out int outputtedFastFilesPercent).ShouldBeTrue();
 
             outputtedFastFiles.ShouldEqual(fastFiles);
             outputtedFastFilesPercent.ShouldEqual(fastFilesPercent);
@@ -213,8 +214,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // "Files managed by git (slow):                <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Files managed by git \(slow\):\s*([\d,]+)\s*\|\s*(\d+)%$");
 
-            int outputtedSlowFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
-            int outputtedSlowFilesPercent = int.Parse(lineMatch.Groups[2].Value);
+            int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedSlowFiles).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, out int outputtedSlowFilesPercent).ShouldBeTrue();
 
             outputtedSlowFiles.ShouldEqual(slowFiles);
             outputtedSlowFilesPercent.ShouldEqual(slowFilesPercent);
@@ -226,7 +227,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // "Total hydration percentage:            <percentage>%
             Match lineMatch = Regex.Match(outputLine, @"^Total hydration percentage:\s*(\d+)%$");
 
-            int outputtedTotalHydration = int.Parse(lineMatch.Groups[1].Value);
+            int.TryParse(lineMatch.Groups[1].Value, out int outputtedTotalHydration).ShouldBeTrue();
 
             outputtedTotalHydration.ShouldEqual(totalHydration);
         }
@@ -239,7 +240,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 // "  <percentage>% | <directory-name>" listed several times for different directories
                 Match lineMatch = Regex.Match(outputLines[i], @"^\s*(\d+)%\s*\|\s*(\S.*\S)\s*$");
 
-                int outputtedHealthScore = int.Parse(lineMatch.Groups[1].Value);
+                int.TryParse(lineMatch.Groups[1].Value, out int outputtedHealthScore).ShouldBeTrue();
                 string outputtedSubdirectory = lineMatch.Groups[2].Value;
 
                 outputtedHealthScore.ShouldEqual(healthScores[i]);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -2,7 +2,9 @@
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
@@ -14,21 +16,22 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // .gitignore is always a placeholder on creation
             // .gitconfig is always a modified path in functional tests since it is written at run time
-            string[] healthOutputLines = this.GetHealthOutputLines();
 
-            healthOutputLines[0].ShouldEqual("Health of directory: ");
-            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
-            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      1 |   0%");
-            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              1 |   0%");
-            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     0%");
+            List<string> topHydratedDirectories = new List<string> { "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest", "GVFlt_DeleteFolderTest", "GVFlt_EnumTest" };
+            List<int> directoryHydrationLevels = new List<int> { 0, 0, 0, 0, 0 };
 
-            healthOutputLines[6].ShouldEqual("   0% | GVFS                   ");
-            healthOutputLines[7].ShouldEqual("   0% | GVFlt_BugRegressionTest");
-            healthOutputLines[8].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
-            healthOutputLines[9].ShouldEqual("   0% | GVFlt_DeleteFolderTest ");
-            healthOutputLines[10].ShouldEqual("   0% | GVFlt_EnumTest         ");
-
-            healthOutputLines[11].ShouldEqual("Repository status: OK");
+            this.ValidateHealthOutputValues(
+                directory: string.Empty,
+                totalFiles: 1211,
+                totalFilePercent: 100,
+                fastFiles: 1,
+                fastFilePercent: 0,
+                slowFiles: 1,
+                slowFilePercent: 0,
+                totalPercent: 0,
+                topHydratedDirectories,
+                directoryHydrationLevels,
+                enlistmentHealthStatus: "OK");
         }
 
         [TestCase, Order(1)]
@@ -42,21 +45,21 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunFunctionalTests.bat"));
             this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
 
-            string[] healthOutputLines = this.GetHealthOutputLines();
+            List<string> topHydratedDirectories = new List<string> { "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest", "GVFlt_DeleteFolderTest" };
+            List<int> directoryHydrationLevels = new List<int> { 100, 0, 0, 0, 0 };
 
-            healthOutputLines[0].ShouldEqual("Health of directory: ");
-            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
-            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      7 |   1%");
-            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              1 |   0%");
-            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
-
-            healthOutputLines[6].ShouldEqual(" 100% | Scripts                ");
-            healthOutputLines[7].ShouldEqual("   0% | GVFS                   ");
-            healthOutputLines[8].ShouldEqual("   0% | GVFlt_BugRegressionTest");
-            healthOutputLines[9].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
-            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFolderTest ");
-
-            healthOutputLines[11].ShouldEqual("Repository status: OK");
+            this.ValidateHealthOutputValues(
+                directory: string.Empty,
+                totalFiles: 1211,
+                totalFilePercent: 100,
+                fastFiles: 7,
+                fastFilePercent: 1,
+                slowFiles: 1,
+                slowFilePercent: 0,
+                totalPercent:1,
+                topHydratedDirectories,
+                directoryHydrationLevels,
+                enlistmentHealthStatus: "OK");
         }
 
         [TestCase, Order(2)]
@@ -67,21 +70,21 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/DeleteExistingFile.txt"));
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/WriteAndVerify.txt"));
 
-            string[] healthOutputLines = this.GetHealthOutputLines();
+            List<string> topHydratedDirectories = new List<string> { "GVFlt_FileOperationTest", "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
+            List<int> directoryHydrationLevels = new List<int> { 100, 100, 0, 0, 0 };
 
-            healthOutputLines[0].ShouldEqual("Health of directory: ");
-            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
-            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      8 |   1%");
-            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              3 |   0%");
-            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
-
-            healthOutputLines[6].ShouldEqual(" 100% | GVFlt_FileOperationTest");
-            healthOutputLines[7].ShouldEqual(" 100% | Scripts                ");
-            healthOutputLines[8].ShouldEqual("   0% | GVFS                   ");
-            healthOutputLines[9].ShouldEqual("   0% | GVFlt_BugRegressionTest");
-            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
-
-            healthOutputLines[11].ShouldEqual("Repository status: OK");
+            this.ValidateHealthOutputValues(
+                directory: string.Empty,
+                totalFiles: 1211,
+                totalFilePercent: 100,
+                fastFiles: 8,
+                fastFilePercent: 1,
+                slowFiles: 3,
+                slowFilePercent: 0,
+                totalPercent: 1,
+                topHydratedDirectories,
+                directoryHydrationLevels,
+                enlistmentHealthStatus: "OK");
         }
 
         [TestCase, Order(3)]
@@ -94,35 +97,41 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunFunctionalTests.bat"));
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
 
-            string[] healthOutputLines = this.GetHealthOutputLines();
+            List<string> topHydratedDirectories = new List<string> { "GVFlt_FileOperationTest", "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
+            List<int> directoryHydrationLevels = new List<int> { 100, 100, 0, 0, 0 };
 
-            healthOutputLines[0].ShouldEqual("Health of directory: ");
-            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
-            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      3 |   0%");
-            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              8 |   1%");
-            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     1%");
-
-            healthOutputLines[6].ShouldEqual(" 100% | GVFlt_FileOperationTest");
-            healthOutputLines[7].ShouldEqual(" 100% | Scripts                ");
-            healthOutputLines[8].ShouldEqual("   0% | GVFS                   ");
-            healthOutputLines[9].ShouldEqual("   0% | GVFlt_BugRegressionTest");
-            healthOutputLines[10].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
-
-            healthOutputLines[11].ShouldEqual("Repository status: OK");
+            this.ValidateHealthOutputValues(
+                directory: string.Empty,
+                totalFiles: 1211,
+                totalFilePercent: 100,
+                fastFiles: 3,
+                fastFilePercent: 0,
+                slowFiles: 8,
+                slowFilePercent: 1,
+                totalPercent: 1,
+                topHydratedDirectories,
+                directoryHydrationLevels,
+                enlistmentHealthStatus: "OK");
         }
 
         [TestCase, Order(4)]
         public void FilterIntoDirectory()
         {
-            string[] healthOutputLines = this.GetHealthOutputLines("Scripts/");
+            List<string> topHydratedDirectories = new List<string>();
+            List<int> directoryHydrationLevels = new List<int>();
 
-            healthOutputLines[0].ShouldEqual("Health of directory: Scripts/");
-            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           5 | 100%");
-            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):  0 |   0%");
-            healthOutputLines[3].ShouldEqual("Files managed by git (slow):          5 | 100%");
-            healthOutputLines[4].ShouldEqual("Total hydration percentage:               100%");
-
-            healthOutputLines[6].ShouldEqual("Repository status: Highly Hydrated");
+            this.ValidateHealthOutputValues(
+                directory: "Scripts/",
+                totalFiles: 5,
+                totalFilePercent: 100,
+                fastFiles: 0,
+                fastFilePercent: 0,
+                slowFiles: 5,
+                slowFilePercent: 100,
+                totalPercent: 100,
+                topHydratedDirectories,
+                directoryHydrationLevels,
+                enlistmentHealthStatus: "Highly Hydrated");
         }
 
         private void HydratePlaceholder(string filePath)
@@ -135,9 +144,111 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             File.OpenWrite(filePath).Close();
         }
 
-        private string[] GetHealthOutputLines(string directory = null)
+        private void ValidateHealthOutputValues(
+            string directory,
+            int totalFiles,
+            int totalFilePercent,
+            int fastFiles,
+            int fastFilePercent,
+            int slowFiles,
+            int slowFilePercent,
+            int totalPercent,
+            List<string> topHydratedDirectories,
+            List<int> directoryHydrationLevels,
+            string enlistmentHealthStatus)
         {
-            return this.Enlistment.Health(directory).Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            List<string> healthOutputLines = new List<string>(this.Enlistment.Health(directory).Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries));
+
+            int numberOfExpectedSubdirectories = topHydratedDirectories.Count;
+
+            this.ValidateTargetDirectory(healthOutputLines[0], directory);
+            this.ValidateTotalFileInfo(healthOutputLines[1], totalFiles, totalFilePercent);
+            this.ValidateFastFileInfo(healthOutputLines[2], fastFiles, fastFilePercent);
+            this.ValidateSlowFileInfo(healthOutputLines[3], slowFiles, slowFilePercent);
+            this.ValidateTotalHydration(healthOutputLines[4], totalPercent);
+            this.ValidateSubDirectoryHealth(healthOutputLines.GetRange(6, numberOfExpectedSubdirectories), topHydratedDirectories, directoryHydrationLevels);
+            this.ValidateEnlistmentStatus(healthOutputLines[6 + numberOfExpectedSubdirectories], enlistmentHealthStatus);
+        }
+
+        private void ValidateTargetDirectory(string outputLine, string targetDirectory)
+        {
+            // Regex to extract the target directory
+            Match lineMatch = Regex.Match(outputLine, @"^Health of directory:\s*(.*)$");
+
+            string outputtedTargetDirectory = lineMatch.Groups[1].Value;
+
+            outputtedTargetDirectory.ShouldEqual(targetDirectory);
+        }
+
+        private void ValidateTotalFileInfo(string outputLine, int totalFiles, int totalFilePercent)
+        {
+            // Regex to extract the total number of files and percentage they represent (should always be 100)
+            Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)%$");
+
+            int outputtedTotalFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
+            int outputtedTotalFilePercent = int.Parse(lineMatch.Groups[2].Value);
+
+            outputtedTotalFiles.ShouldEqual(totalFiles);
+            outputtedTotalFilePercent.ShouldEqual(totalFilePercent);
+        }
+
+        private void ValidateFastFileInfo(string outputLine, int fastFiles, int fastFilesPercent)
+        {
+            // Regex to extract the total number of fast files and percentage they represent
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)%$");
+
+            int outputtedFastFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
+            int outputtedFastFilesPercent = int.Parse(lineMatch.Groups[2].Value);
+
+            outputtedFastFiles.ShouldEqual(fastFiles);
+            outputtedFastFilesPercent.ShouldEqual(fastFilesPercent);
+        }
+
+        private void ValidateSlowFileInfo(string outputLine, int slowFiles, int slowFilesPercent)
+        {
+            // Regex to extract the total number of slow files and percentage they represent
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by git \(slow\):\s*([\d,]+)\s*\|\s*(\d+)%$");
+
+            int outputtedSlowFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
+            int outputtedSlowFilesPercent = int.Parse(lineMatch.Groups[2].Value);
+
+            outputtedSlowFiles.ShouldEqual(slowFiles);
+            outputtedSlowFilesPercent.ShouldEqual(slowFilesPercent);
+        }
+
+        private void ValidateTotalHydration(string outputLine, int totalHydration)
+        {
+            // Regex to extract the total hydration percentage of the enlistment
+            Match lineMatch = Regex.Match(outputLine, @"^Total hydration percentage:\s*(\d+)%$");
+
+            int outputtedTotalHydration = int.Parse(lineMatch.Groups[1].Value);
+
+            outputtedTotalHydration.ShouldEqual(totalHydration);
+        }
+
+        private void ValidateSubDirectoryHealth(List<string> outputLines, List<string> subdirectories, List<int> healthScores)
+        {
+            for (int i = 0; i < outputLines.Count; i++)
+            {
+                // Regex to extract the most hydrated subdirectory names and their hydration percentage
+                Match lineMatch = Regex.Match(outputLines[i], @"^\s*(\d+)%\s*\|\s*(\S.*\S)\s*$");
+
+                int outputtedHealthScore = int.Parse(lineMatch.Groups[1].Value);
+                string outputtedSubdirectory = lineMatch.Groups[2].Value;
+
+                outputtedHealthScore.ShouldEqual(healthScores[i]);
+                outputtedSubdirectory.ShouldEqual(subdirectories[i]);
+            }
+        }
+
+        private void ValidateEnlistmentStatus(string outputLine, string statusMessage)
+        {
+            // Regex to extract the status message for the enlistment
+            Match lineMatch = Regex.Match(outputLine, @"^Repository status:\s*(.*)$");
+
+            string outputtedStatusMessage = lineMatch.Groups[1].Value;
+
+            outputtedStatusMessage.ShouldEqual(statusMessage);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -1,0 +1,62 @@
+﻿using GVFS.Tests.Should;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class HealthTests : TestsWithEnlistmentPerFixture
+    {
+        [TestCase]
+        public void AfterCloningRepoIsPerfectlyHealthy()
+        {
+            string[] healthOutputLines = this.Enlistment.Health().Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            healthOutputLines[0].ShouldEqual("Health of directory: ");
+            healthOutputLines[1].ShouldEqual("Total files in HEAD commit:           1,211 | 100%");
+            healthOutputLines[2].ShouldEqual("Files managed by VFS for Git (fast):      1 |   0%");
+            healthOutputLines[3].ShouldEqual("Files managed by git (slow):              1 |   0%");
+            healthOutputLines[4].ShouldEqual("Total hydration percentage:                     0%");
+
+            healthOutputLines[6].ShouldEqual("   0% | GVFS                   ");
+            healthOutputLines[7].ShouldEqual("   0% | GVFlt_BugRegressionTest");
+            healthOutputLines[8].ShouldEqual("   0% | GVFlt_DeleteFileTest   ");
+            healthOutputLines[9].ShouldEqual("   0% | GVFlt_DeleteFolderTest ");
+            healthOutputLines[10].ShouldEqual("   0% | GVFlt_EnumTest         ");
+
+            healthOutputLines[11].ShouldEqual("Repository status: OK");
+        }
+
+        [TestCase]
+        public void PlaceholdersChangeHealthScores()
+        {
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/SetupDevService.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/StartDevService.bat"));
+            this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/StopDevService.bat"));
+
+            string healthInfo = this.Enlistment.Health();
+        }
+
+        /*
+        [TestCase]
+        public void ModifiedPathsChangeHealthScores()
+        {
+
+        }
+
+        [TestCase]
+        directoryfiltering
+        */
+
+        private void HydratePlaceholder(string filePath)
+        {
+            File.ReadAllText(filePath);
+        }
+
+        private void HydrateFullFile(string filePath)
+        {
+            File.OpenWrite(filePath).Close();
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixture]
+    [TestFixture, Category(Categories.WindowsOnly)]
     public class HealthTests : TestsWithEnlistmentPerFixture
     {
         [TestCase, Order(0)]
@@ -173,6 +173,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateTargetDirectory(string outputLine, string targetDirectory)
         {
             // Regex to extract the target directory
+            // "Health of directory: <directory>"
             Match lineMatch = Regex.Match(outputLine, @"^Health of directory:\s*(.*)$");
 
             string outputtedTargetDirectory = lineMatch.Groups[1].Value;
@@ -183,6 +184,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateTotalFileInfo(string outputLine, int totalFiles, int totalFilePercent)
         {
             // Regex to extract the total number of files and percentage they represent (should always be 100)
+            // "Total files in HEAD commit:           <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int outputtedTotalFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
@@ -195,6 +197,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateFastFileInfo(string outputLine, int fastFiles, int fastFilesPercent)
         {
             // Regex to extract the total number of fast files and percentage they represent
+            // "Files managed by VFS for Git (fast):    <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int outputtedFastFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
@@ -207,6 +210,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateSlowFileInfo(string outputLine, int slowFiles, int slowFilesPercent)
         {
             // Regex to extract the total number of slow files and percentage they represent
+            // "Files managed by git (slow):                <count> | <percentage>%"
             Match lineMatch = Regex.Match(outputLine, @"^Files managed by git \(slow\):\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int outputtedSlowFiles = int.Parse(lineMatch.Groups[1].Value, System.Globalization.NumberStyles.AllowThousands);
@@ -219,6 +223,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateTotalHydration(string outputLine, int totalHydration)
         {
             // Regex to extract the total hydration percentage of the enlistment
+            // "Total hydration percentage:            <percentage>%
             Match lineMatch = Regex.Match(outputLine, @"^Total hydration percentage:\s*(\d+)%$");
 
             int outputtedTotalHydration = int.Parse(lineMatch.Groups[1].Value);
@@ -231,6 +236,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             for (int i = 0; i < outputLines.Count; i++)
             {
                 // Regex to extract the most hydrated subdirectory names and their hydration percentage
+                // "  <percentage>% | <directory-name>" listed several times for different directories
                 Match lineMatch = Regex.Match(outputLines[i], @"^\s*(\d+)%\s*\|\s*(\S.*\S)\s*$");
 
                 int outputtedHealthScore = int.Parse(lineMatch.Groups[1].Value);
@@ -244,6 +250,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateEnlistmentStatus(string outputLine, string statusMessage)
         {
             // Regex to extract the status message for the enlistment
+            // "Repository status: <status-message>"
             Match lineMatch = Regex.Match(outputLine, @"^Repository status:\s*(.*)$");
 
             string outputtedStatusMessage = lineMatch.Groups[1].Value;

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -231,6 +231,11 @@ namespace GVFS.FunctionalTests.Tools
             return this.gvfsProcess.Status(trace);
         }
 
+        public string Health(string directory = null)
+        {
+            return this.gvfsProcess.Health(directory);
+        }
+
         public bool WaitForBackgroundOperations(int maxWaitMilliseconds = DefaultMaxWaitMSForStatusCheck)
         {
             return this.WaitForStatus(maxWaitMilliseconds, ZeroBackgroundOperations).ShouldBeTrue("Background operations failed to complete.");

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -92,6 +92,18 @@ namespace GVFS.FunctionalTests.Tools
             return this.CallGVFS("status " + this.enlistmentRoot, trace: trace);
         }
 
+        public string Health(string directory = null)
+        {
+            if (string.IsNullOrEmpty(directory))
+            {
+                return this.CallGVFS("health " + this.enlistmentRoot);
+            }
+            else
+            {
+                return this.CallGVFS("health -d " + directory + " " + this.enlistmentRoot);
+            }
+        }
+
         public string CacheServer(string args)
         {
             return this.CallGVFS("cache-server " + args + " \"" + this.enlistmentRoot + "\"");

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -123,6 +123,11 @@ namespace GVFS.CommandLine
             return line.Substring(line.IndexOf('\t') + 1);
         }
 
+        private string TrimGitIndexLineWithSkipWorktree(string line)
+        {
+            return line.Substring(line.IndexOf(' ') + 1);
+        }
+
         /// <summary>
         /// Talk to the mount process across the named pipe to get a list of the modified paths
         /// </summary>
@@ -205,10 +210,10 @@ namespace GVFS.CommandLine
                 {
                     if (line.First() == 'H')
                     {
-                        skipWorktreeFiles.Add(this.TrimGitIndexLine(line));
+                        skipWorktreeFiles.Add(this.TrimGitIndexLineWithSkipWorktree(line));
                     }
 
-                    pathData.GitFilePaths.Add(this.TrimGitIndexLine(line));
+                    pathData.GitFilePaths.Add(this.TrimGitIndexLineWithSkipWorktree(line));
                 },
                 showSkipTreeBit: true);
             GitProcess.Result folderResult = gitProcess.LsTree(


### PR DESCRIPTION
Functional tests for the health verb are now included in the solution. There are five tests:

Freshly cloned repository
Placeholders
Modified paths
Placeholders turning into modified paths
Filtering by a target directory

There is an according bug fix to the way non skip-worktree files are parsed ensuring all folders are correctly included in the returned list.