### PR TITLE
Fix GitProcess PATH

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -675,11 +675,10 @@ namespace GVFS.Common.Git
 
             processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
-            processInfo.EnvironmentVariables["PATH"] =
-                string.Join(
-                    ";",
-                    this.gitBinPath,
-                    this.gvfsHooksRoot ?? string.Empty);
+            if (!string.IsNullOrWhiteSpace(this.gvfsHooksRoot))
+            {
+                processInfo.EnvironmentVariables["PATH"] = this.gvfsHooksRoot + Path.PathSeparator + processInfo.EnvironmentVariables["PATH"];
+            }
 
             if (gitObjectsDirectory != null)
             {


### PR DESCRIPTION
- Use platform dependent PATH separator.
- Do not prepend `this.gitBinPath` which is path to binary (not a directory) and has no effect in PATH resolution anyway.
- Passthrough entire PATH to child process. Git might call 3rd party helpers (e.g. credentials helpers) that expect standard POSIX utilities to be available in PATH.