### PR TITLE
Mac build scripts: consume git installer pkg directly

### DIFF
--- a/Scripts/Mac/GetGitVersionNumber.sh
+++ b/Scripts/Mac/GetGitVersionNumber.sh
@@ -1,5 +1,5 @@
 . "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
 
 GVFSPROPS=$VFS_SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)*')"
 echo $GITVERSION


### PR DESCRIPTION
Update VFS4G build scripts to consume the macOS pkg installer package directly

Previously, the GitForMac.GVFS.Installer NuGet package contained only
the git for mac installer as a .dmg file. This .dmg package contained
the Git for Mac installer .pkg.

The VFS4G installer takes a .pkg installer as input to the combined
VFS4G / Git for Mac installer. As the NuGet package only contained the
.dmg, the script to build the VFS4G combined installer had to mount
the .dmg and extract the .pkg file.

The GitForMac.GVFS.Installer package has been updated to include both
a .dmg and .pkg file, so the installer script can now consume the
installer .pkg directory, instead of mounting and extracting it from
the .dmg file.

This change also relaxes the regex pattern to correctly handle git versions with multiple hyphens. Previously, this would fail to capture the full version string for versions such as:

1.2.3-DRAFT-pr