### PR TITLE
Making max pipe length platform-dependant

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -138,6 +138,7 @@ namespace GVFS.Common
         public abstract class GVFSPlatformConstants
         {
             public static readonly char PathSeparator = Path.DirectorySeparatorChar;
+            public abstract int MaxPipePathLength { get; }
             public abstract string ExecutableExtension { get; }
             public abstract string InstallerExtension { get; }
 

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeServer.cs
@@ -22,10 +22,6 @@ namespace GVFS.Common.NamedPipes
     /// </summary>
     public class NamedPipeServer : IDisposable
     {
-        // TODO(Mac) the limit is much shorter on macOS
-        // Tests show that 250 is the max supported pipe name length
-        private const int MaxPipeNameLength = 250;
-
         private bool isStopping;
         private string pipeName;
         private Action<Connection> handleConnection;
@@ -43,9 +39,9 @@ namespace GVFS.Common.NamedPipes
 
         public static NamedPipeServer StartNewServer(string pipeName, ITracer tracer, Action<ITracer, string, Connection> handleRequest)
         {
-            if (pipeName.Length > MaxPipeNameLength)
+            if (pipeName.Length > GVFSPlatform.Instance.Constants.MaxPipePathLength)
             {
-                throw new PipeNameLengthException(string.Format("The pipe name ({0}) exceeds the max length allowed({1})", pipeName, MaxPipeNameLength));
+                throw new PipeNameLengthException(string.Format("The pipe name ({0}) exceeds the max length allowed({1})", pipeName, GVFSPlatform.Instance.Constants.MaxPipePathLength));
             }
 
             NamedPipeServer pipeServer = new NamedPipeServer(pipeName, tracer, connection => HandleConnection(tracer, connection, handleRequest));

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -168,6 +168,7 @@ namespace GVFS.Platform.Mac
                 get { return "vfsforgit"; }
             }
 
+            // Documented here (in the addressing section): https://www.unix.com/man-page/mojave/4/unix/
             public override int MaxPipePathLength => 104;
         }
     }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -167,6 +167,8 @@ namespace GVFS.Platform.Mac
             {
                 get { return "vfsforgit"; }
             }
+
+            public override int MaxPipePathLength => 104;
         }
     }
 }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -299,6 +299,7 @@ namespace GVFS.Platform.POSIX
 
             public override bool SupportsUpgradeWhileRunning => true;
 
+            // Documented here (in the addressing section): https://www.unix.com/man-page/linux/7/unix/
             public override int MaxPipePathLength => 108;
         }
     }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -298,6 +298,8 @@ namespace GVFS.Platform.POSIX
             }
 
             public override bool SupportsUpgradeWhileRunning => true;
+
+            public override int MaxPipePathLength => 108;
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -491,6 +491,7 @@ namespace GVFS.Platform.Windows
                 get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
             }
 
+            // Tests show that 250 is the max supported pipe name length
             public override int MaxPipePathLength => 250;
         }
     }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -490,6 +490,8 @@ namespace GVFS.Platform.Windows
             {
                 get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
             }
+
+            public override int MaxPipePathLength => 250;
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -235,6 +235,8 @@ namespace GVFS.UnitTests.Mock.Common
             }
 
             public override bool SupportsUpgradeWhileRunning => false;
+
+            public override int MaxPipePathLength => 250;
         }
     }
 }


### PR DESCRIPTION
MaxPipeNameLength has been hardcoded to be 250 characters, while on Mac, it's only 104. Moving this to GVFSPlatformConstants and implementations.