### PR TITLE
Dehydrate folders

### DIFF
--- a/GVFS/GVFS.Common/Database/GVFSDatabase.cs
+++ b/GVFS/GVFS.Common/Database/GVFSDatabase.cs
@@ -45,6 +45,11 @@ namespace GVFS.Common.Database
             }
         }
 
+        public static string NormalizePath(string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim().Trim(Path.DirectorySeparatorChar);
+        }
+
         public void Dispose()
         {
             if (this.disposed)

--- a/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
@@ -21,7 +21,7 @@ namespace GVFS.Common.Database
         void AddFile(string path, string sha);
 
         void Remove(string path);
-        List<IPlaceholderData> RemoveStartingWith(string path);
+        List<IPlaceholderData> RemoveAllEntriesForFolder(string path);
         void AddPlaceholderData(IPlaceholderData data);
     }
 }

--- a/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
@@ -21,6 +21,7 @@ namespace GVFS.Common.Database
         void AddFile(string path, string sha);
 
         void Remove(string path);
-        void RemoveStartingWith(string path);
+        List<IPlaceholderData> RemoveStartingWith(string path);
+        void AddPlaceholderData(IPlaceholderData data);
     }
 }

--- a/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
@@ -21,5 +21,6 @@ namespace GVFS.Common.Database
         void AddFile(string path, string sha);
 
         void Remove(string path);
+        void RemoveStartingWith(string path);
     }
 }

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -28,11 +28,6 @@ namespace GVFS.Common.Database
             }
         }
 
-        public static string NormalizePath(string path)
-        {
-            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim().Trim(Path.DirectorySeparatorChar);
-        }
-
         public int GetCount()
         {
             try
@@ -159,7 +154,7 @@ namespace GVFS.Common.Database
         public List<IPlaceholderData> RemoveStartingWith(string path)
         {
             // Normalize the path to match what will be in the database
-            path = NormalizePath(path);
+            path = GVFSDatabase.NormalizePath(path);
 
             try
             {

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 
 namespace GVFS.Common.Database
 {
@@ -25,6 +26,11 @@ namespace GVFS.Common.Database
                 command.CommandText = $"CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY{collateConstraint}, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;";
                 command.ExecuteNonQuery();
             }
+        }
+
+        public static string NormalizePath(string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim().Trim(Path.DirectorySeparatorChar);
         }
 
         public int GetCount()
@@ -161,6 +167,9 @@ namespace GVFS.Common.Database
 
         public void RemoveStartingWith(string path)
         {
+            // Normalize the path to match what will be in the database
+            path = NormalizePath(path);
+
             try
             {
                 using (IDbConnection connection = this.connectionPool.GetConnection())

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -159,6 +159,24 @@ namespace GVFS.Common.Database
             this.Insert(new PlaceholderData() { Path = path, PathType = PlaceholderData.PlaceholderType.PossibleTombstoneFolder });
         }
 
+        public void RemoveStartingWith(string path)
+        {
+            try
+            {
+                using (IDbConnection connection = this.connectionPool.GetConnection())
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "DELETE FROM Placeholder WHERE path LIKE @path;";
+                    command.AddParameter("@path", DbType.String, $"{path}%");
+                    command.ExecuteNonQuery();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new GVFSDatabaseException($"{nameof(PlaceholderTable)}.{nameof(this.Remove)}({path}) Exception", ex);
+            }
+        }
+
         public void Remove(string path)
         {
             try

--- a/GVFS/GVFS.Common/Database/SparseTable.cs
+++ b/GVFS/GVFS.Common/Database/SparseTable.cs
@@ -38,7 +38,7 @@ namespace GVFS.Common.Database
                 using (IDbCommand command = connection.CreateCommand())
                 {
                     command.CommandText = "INSERT OR REPLACE INTO Sparse (path) VALUES (@path);";
-                    command.AddParameter("@path", DbType.String, NormalizePath(directoryPath));
+                    command.AddParameter("@path", DbType.String, GVFSDatabase.NormalizePath(directoryPath));
 
                     lock (this.writerLock)
                     {
@@ -86,7 +86,7 @@ namespace GVFS.Common.Database
                 using (IDbCommand command = connection.CreateCommand())
                 {
                     command.CommandText = "DELETE FROM Sparse WHERE path = @path;";
-                    command.AddParameter("@path", DbType.String, NormalizePath(directoryPath));
+                    command.AddParameter("@path", DbType.String, GVFSDatabase.NormalizePath(directoryPath));
 
                     lock (this.writerLock)
                     {

--- a/GVFS/GVFS.Common/Database/SparseTable.cs
+++ b/GVFS/GVFS.Common/Database/SparseTable.cs
@@ -15,11 +15,6 @@ namespace GVFS.Common.Database
             this.connectionPool = connectionPool;
         }
 
-        public static string NormalizePath(string path)
-        {
-            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim().Trim(Path.DirectorySeparatorChar);
-        }
-
         public static void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
             using (IDbCommand command = connection.CreateCommand())

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -273,6 +273,11 @@ namespace GVFS.Common
             }
         }
 
+        public void RemoveStartingWith(string path)
+        {
+            throw new NotImplementedException();
+        }
+
         private IEnumerable<string> GenerateDataLines(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
             HashSet<string> keys = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -273,7 +273,7 @@ namespace GVFS.Common
             }
         }
 
-        List<IPlaceholderData> IPlaceholderCollection.RemoveStartingWith(string path)
+        List<IPlaceholderData> IPlaceholderCollection.RemoveAllEntriesForFolder(string path)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -278,6 +278,16 @@ namespace GVFS.Common
             throw new NotImplementedException();
         }
 
+        List<IPlaceholderData> IPlaceholderCollection.RemoveStartingWith(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddPlaceholderData(IPlaceholderData data)
+        {
+            throw new NotImplementedException();
+        }
+
         private IEnumerable<string> GenerateDataLines(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
             HashSet<string> keys = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -273,11 +273,6 @@ namespace GVFS.Common
             }
         }
 
-        public void RemoveStartingWith(string path)
-        {
-            throw new NotImplementedException();
-        }
-
         List<IPlaceholderData> IPlaceholderCollection.RemoveStartingWith(string path)
         {
             throw new NotImplementedException();

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -114,6 +114,20 @@ namespace GVFS.Common
             return true;
         }
 
+        public void RemoveAllEntriesForFolder(string path)
+        {
+            string entry = this.NormalizeEntryString(path, isFolder: true);
+            foreach (string modifiedPath in this.modifiedPaths)
+            {
+                if (modifiedPath.StartsWith(entry, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.modifiedPaths.TryRemove(modifiedPath);
+                }
+            }
+
+            this.WriteAllEntriesAndFlush();
+        }
+
         public bool TryRemove(string path, bool isFolder, out bool isRetryable)
         {
             isRetryable = true;

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -83,10 +83,10 @@ namespace GVFS.Common
             return this.modifiedPaths.Contains(entry);
         }
 
-        public bool ContainsParentFolder(string path)
+        public bool ContainsParentFolder(string path, out string parentFolder)
         {
             string entry = this.NormalizeEntryString(path, isFolder: false);
-            return this.ContainsParentDirectory(entry);
+            return this.ContainsParentDirectory(entry, out parentFolder);
         }
 
         public IEnumerable<string> GetAllModifiedPaths()
@@ -235,8 +235,13 @@ namespace GVFS.Common
 
         private bool ContainsParentDirectory(string modifiedPath)
         {
+            return this.ContainsParentDirectory(modifiedPath, out _);
+        }
+
+        private bool ContainsParentDirectory(string modifiedPath, out string parentFolder)
+        {
             string[] pathParts = modifiedPath.Split(new char[] { GVFSConstants.GitPathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-            string parentFolder = string.Empty;
+            parentFolder = string.Empty;
             for (int i = 0; i < pathParts.Length - 1; i++)
             {
                 parentFolder += pathParts[i] + GVFSConstants.GitPathSeparatorString;

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -83,6 +83,12 @@ namespace GVFS.Common
             return this.modifiedPaths.Contains(entry);
         }
 
+        public bool ContainsParentFolder(string path)
+        {
+            string entry = this.NormalizeEntryString(path, isFolder: false);
+            return this.ContainsParentDirectory(entry);
+        }
+
         public IEnumerable<string> GetAllModifiedPaths()
         {
             return this.modifiedPaths;

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -64,7 +64,7 @@ namespace GVFS.Common
             {
                 foreach (string modifiedPath in this.modifiedPaths)
                 {
-                    if (this.ContainsParentDirectory(modifiedPath))
+                    if (this.ContainsParentFolderWithNormalizedPath(modifiedPath))
                     {
                         this.modifiedPaths.TryRemove(modifiedPath);
                     }
@@ -86,7 +86,7 @@ namespace GVFS.Common
         public bool ContainsParentFolder(string path, out string parentFolder)
         {
             string entry = this.NormalizeEntryString(path, isFolder: false);
-            return this.ContainsParentDirectory(entry, out parentFolder);
+            return this.ContainsParentFolderWithNormalizedPath(entry, out parentFolder);
         }
 
         public IEnumerable<string> GetAllModifiedPaths()
@@ -98,7 +98,7 @@ namespace GVFS.Common
         {
             isRetryable = true;
             string entry = this.NormalizeEntryString(path, isFolder);
-            if (!this.modifiedPaths.Contains(entry) && !this.ContainsParentDirectory(entry))
+            if (!this.modifiedPaths.Contains(entry) && !this.ContainsParentFolderWithNormalizedPath(entry))
             {
                 try
                 {
@@ -233,12 +233,12 @@ namespace GVFS.Common
             return true;
         }
 
-        private bool ContainsParentDirectory(string modifiedPath)
+        private bool ContainsParentFolderWithNormalizedPath(string modifiedPath)
         {
-            return this.ContainsParentDirectory(modifiedPath, out _);
+            return this.ContainsParentFolderWithNormalizedPath(modifiedPath, out _);
         }
 
-        private bool ContainsParentDirectory(string modifiedPath, out string parentFolder)
+        private bool ContainsParentFolderWithNormalizedPath(string modifiedPath, out string parentFolder)
         {
             string[] pathParts = modifiedPath.Split(new char[] { GVFSConstants.GitPathSeparator }, StringSplitOptions.RemoveEmptyEntries);
             parentFolder = string.Empty;

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -114,18 +114,23 @@ namespace GVFS.Common
             return true;
         }
 
-        public void RemoveAllEntriesForFolder(string path)
+        public List<string> RemoveAllEntriesForFolder(string path)
         {
+            List<string> removedEntries = new List<string>();
             string entry = this.NormalizeEntryString(path, isFolder: true);
             foreach (string modifiedPath in this.modifiedPaths)
             {
                 if (modifiedPath.StartsWith(entry, StringComparison.OrdinalIgnoreCase))
                 {
-                    this.modifiedPaths.TryRemove(modifiedPath);
+                    if (this.modifiedPaths.TryRemove(modifiedPath))
+                    {
+                        removedEntries.Add(modifiedPath);
+                    }
                 }
             }
 
             this.WriteAllEntriesAndFlush();
+            return removedEntries;
         }
 
         public bool TryRemove(string path, bool isFolder, out bool isRetryable)

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -179,6 +179,57 @@ namespace GVFS.Common.NamedPipes
             }
         }
 
+        public static class DehydrateFolders
+        {
+            public const string Dehydrate = "Dehydrate";
+            public const string DehydratedResult = "Dehydrated";
+            public const string MountNotReadyResult = "MountNotReady";
+
+            public class Request
+            {
+                public Request(string folders)
+                {
+                    this.Folders = folders;
+                }
+
+                public Request(Message message)
+                {
+                    this.Folders = message.Body;
+                }
+
+                public string Folders { get; }
+
+                public Message CreateMessage()
+                {
+                    return new Message(Dehydrate, this.Folders);
+                }
+            }
+
+            public class Response
+            {
+                public Response(string result)
+                {
+                    this.Result = result;
+                    this.SuccessfulFolders = new List<string>();
+                    this.FailedFolders = new List<string>();
+                }
+
+                public string Result { get; }
+                public List<string> SuccessfulFolders { get; }
+                public List<string> FailedFolders { get; }
+
+                public static Response FromMessage(Message message)
+                {
+                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                }
+
+                public Message CreateMessage()
+                {
+                    return new Message(this.Result, JsonConvert.SerializeObject(this));
+                }
+            }
+        }
+
         public static class RunPostFetchJob
         {
             public const string PostFetchJob = "PostFetch";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -310,7 +310,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed($"Parent folder in modified paths.  Unable to dehydrate {folderToDehydrate}.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed($"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -327,7 +327,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed($"Parent folder in modified paths.  Unable to dehydrate {folderToDehydrate}.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed($"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -45,13 +45,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void DehydrateShouldExitWithoutConfirm()
         {
-            this.DehydrateShouldSucceed("To actually execute the dehydrate, run 'gvfs dehydrate --confirm'", confirm: false, noStatus: false);
+            this.DehydrateShouldSucceed(new[] { "To actually execute the dehydrate, run 'gvfs dehydrate --confirm'" }, confirm: false, noStatus: false);
         }
 
         [TestCase]
         public void DehydrateShouldSucceedInCommonCase()
         {
-            this.DehydrateShouldSucceed("The repo was successfully dehydrated and remounted", confirm: true, noStatus: false);
+            this.DehydrateShouldSucceed(new[] { "The repo was successfully dehydrated and remounted" }, confirm: true, noStatus: false);
         }
 
         [TestCase]
@@ -66,13 +66,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             this.Enlistment.UnmountGVFS();
             RepositoryHelpers.DeleteTestDirectory(this.Enlistment.GetObjectRoot(this.fileSystem));
-            this.DehydrateShouldSucceed("The repo was successfully dehydrated and remounted", confirm: true, noStatus: true);
+            this.DehydrateShouldSucceed(new[] { "The repo was successfully dehydrated and remounted" }, confirm: true, noStatus: true);
         }
 
         [TestCase]
         public void DehydrateShouldBackupFiles()
         {
-            this.DehydrateShouldSucceed("The repo was successfully dehydrated and remounted", confirm: true, noStatus: false);
+            this.DehydrateShouldSucceed(new[] { "The repo was successfully dehydrated and remounted" }, confirm: true, noStatus: false);
             string backupFolder = Path.Combine(this.Enlistment.EnlistmentRoot, "dehydrate_backup");
             backupFolder.ShouldBeADirectory(this.fileSystem);
             string[] backupFolderItems = this.fileSystem.EnumerateDirectory(backupFolder).Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -170,7 +170,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string subFolderToEnumerate = Path.Combine(pathToEnumerate, "GVFS");
             this.fileSystem.EnumerateDirectory(subFolderToEnumerate);
 
-            this.DehydrateShouldSucceed("GVFS folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -193,7 +193,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.EnumerateDirectory(pathToReadFiles);
 
-            this.DehydrateShouldSucceed("GVFS folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -216,7 +216,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed("GVFS folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -237,7 +237,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteDirectory(pathToDelete);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -- Scripts");
 
-            this.DehydrateShouldSucceed("Scripts folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
+            this.DehydrateShouldSucceed(new[] { "Scripts folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -266,7 +266,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.AppendAllText(fileNotDehydrated2, "Append content");
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"reset --hard");
 
-            this.DehydrateShouldSucceed($"{folderToDehydrate} folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             this.PlaceholdersShouldNotContain(folderToDehydrate, Path.Combine(folderToDehydrate, "Program.cs"));
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, Path.Combine(folderToDehydrate, "App.config").Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator));
@@ -283,7 +283,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        public void FolderDehydrateNestedFolders()
+        public void FolderDehydrateNestedFoldersChildBeforeParent()
         {
             string folderToDehydrate1 = Path.Combine("GVFS", "GVFS.Mount");
             string folderToDehydrate2 = "GVFS";
@@ -292,7 +292,33 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead1);
             this.fileSystem.ReadAllText(fileToRead2);
 
-            this.DehydrateShouldSucceed($"{folderToDehydrate1} folder successfully dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
+            this.DehydrateShouldSucceed(
+                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"{folderToDehydrate2} folder successfully dehydrated." },
+                confirm: true,
+                noStatus: false,
+                foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
+
+            this.Enlistment.UnmountGVFS();
+
+            fileToRead1.ShouldNotExistOnDisk(this.fileSystem);
+            fileToRead2.ShouldNotExistOnDisk(this.fileSystem);
+        }
+
+        [TestCase]
+        public void FolderDehydrateNestedFoldersParentBeforeChild()
+        {
+            string folderToDehydrate1 = "GVFS";
+            string folderToDehydrate2 = Path.Combine("GVFS", "GVFS.Mount");
+            string fileToRead1 = this.Enlistment.GetVirtualPathTo(Path.Combine(folderToDehydrate1, "GVFS.UnitTests", "Program.cs"));
+            string fileToRead2 = this.Enlistment.GetVirtualPathTo(Path.Combine(folderToDehydrate2, "Program.cs"));
+            this.fileSystem.ReadAllText(fileToRead1);
+            this.fileSystem.ReadAllText(fileToRead2);
+
+            this.DehydrateShouldSucceed(
+                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"{folderToDehydrate2} did not exist to dehydrate." },
+                confirm: true,
+                noStatus: false,
+                foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
 
             this.Enlistment.UnmountGVFS();
 
@@ -310,7 +336,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed($"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -327,13 +353,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed($"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated.", confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Unable to dehydrate {folderToDehydrate}. Parent folder in modified paths that must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
         public void FolderDehydrateFolderThatDoesNotExist()
         {
-            this.DehydrateShouldSucceed("DoesNotExist did not exist to dehydrate.", confirm: true, noStatus: false, foldersToDehydrate: "DoesNotExist");
+            this.DehydrateShouldSucceed(new[] { "DoesNotExist did not exist to dehydrate." }, confirm: true, noStatus: false, foldersToDehydrate: "DoesNotExist");
         }
 
         [TestCase]
@@ -346,7 +372,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed("NewFolder folder successfully dehydrated", confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
+            this.DehydrateShouldSucceed(new[] { "NewFolder folder successfully dehydrated" }, confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
 
             this.Enlistment.UnmountGVFS();
             fileToCreate.ShouldNotExistOnDisk(this.fileSystem);
@@ -395,7 +421,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             onDiskItems.ShouldMatchInOrder(fileOrFolders.OrderByDescending(x => x));
         }
 
-        private void DehydrateShouldSucceed(string expectedOutput, bool confirm, bool noStatus, params string[] foldersToDehydrate)
+        private void DehydrateShouldSucceed(string[] expectedInOutput, bool confirm, bool noStatus, params string[] foldersToDehydrate)
         {
             ProcessResult result = this.RunDehydrateProcess(confirm, noStatus, foldersToDehydrate);
             result.ExitCode.ShouldEqual(0, $"mount exit code was {result.ExitCode}. Output: {result.Output}");
@@ -406,7 +432,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 TestContext.Out.WriteLine(output);
             }
 
-            result.Output.ShouldContain(expectedOutput);
+            result.Output.ShouldContain(expectedInOutput);
         }
 
         private void DehydrateShouldFail(string expectedErrorMessage, bool noStatus)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -33,7 +33,16 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string backupFolder = Path.Combine(this.Enlistment.EnlistmentRoot, "dehydrate_backup");
             if (this.fileSystem.DirectoryExists(backupFolder))
             {
-                this.fileSystem.DeleteDirectory(backupFolder);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    // Mac gets permission denied when using the System.IO DeleteDirectory
+                    BashRunner runner = new BashRunner();
+                    runner.DeleteDirectory(backupFolder);
+                }
+                else
+                {
+                    this.fileSystem.DeleteDirectory(backupFolder);
+                }
             }
 
             if (!this.Enlistment.IsMounted())

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -385,14 +385,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.Enlistment.UnmountGVFS();
             fileToCreate.ShouldNotExistOnDisk(this.fileSystem);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                directoryToCreate.ShouldNotExistOnDisk(this.fileSystem);
-            }
-            else
-            {
-                directoryToCreate.ShouldBeADirectory(this.fileSystem);
-            }
+            directoryToCreate.ShouldNotExistOnDisk(this.fileSystem);
         }
 
         private void PlaceholderShouldContain(params string[] paths)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -27,6 +27,16 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem = new SystemIORunner();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            string backupFolder = Path.Combine(this.Enlistment.EnlistmentRoot, "dehydrate_backup");
+            if (this.fileSystem.DirectoryExists(backupFolder))
+            {
+                this.fileSystem.DeleteDirectory(backupFolder);
+            }
+        }
+
         [TestCase]
         public void DehydrateShouldExitWithoutConfirm()
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -35,6 +35,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             {
                 this.fileSystem.DeleteDirectory(backupFolder);
             }
+
+            if (!this.Enlistment.IsMounted())
+            {
+                this.Enlistment.MountGVFS();
+            }
         }
 
         [TestCase]
@@ -54,7 +59,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             this.Enlistment.UnmountGVFS();
             this.DehydrateShouldFail("Failed to run git status because the repo is not mounted", noStatus: false);
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -109,8 +113,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.DeleteFile(metadataPath);
             this.fileSystem.MoveFile(metadataBackupPath, metadataPath);
-
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -135,8 +137,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.DeleteFile(metadataPath);
             this.fileSystem.MoveFile(metadataBackupPath, metadataPath);
-
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -160,8 +160,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.DehydrateShouldFail("Changes to GVFS disk layout do not allow mounting after downgrade.", noStatus: true);
 
             GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, majorVersionNum.ToString(), minorVersionNum.ToString());
-
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -184,7 +182,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
 
             subFolderToEnumerate.ShouldNotExistOnDisk(this.fileSystem);
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -208,7 +205,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
 
             fileToRead.ShouldNotExistOnDisk(this.fileSystem);
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -232,7 +228,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
 
             fileToWriteTo.ShouldNotExistOnDisk(this.fileSystem);
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]
@@ -255,8 +250,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 pathToDelete.ShouldBeADirectory(this.fileSystem);
                 Path.Combine(pathToDelete, "RunUnitTests.bat").ShouldNotExistOnDisk(this.fileSystem);
             }
-
-            this.Enlistment.MountGVFS();
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -347,7 +347,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead2);
 
             this.DehydrateShouldSucceed(
-                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"{folderToDehydrate2} did not exist to dehydrate." },
+                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"Cannot dehydrate folder '{folderToDehydrate2}': '{folderToDehydrate2}' does not exist." },
                 confirm: true,
                 noStatus: false,
                 foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
@@ -368,7 +368,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed(new[] { $"Unable to dehydrate '{folderToDehydrate}'. Parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -396,8 +396,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void FolderDehydrateCannotDehydrateDotGitFolder()
         {
-            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate '{TestConstants.DotGit.Root}' folder.  Invalid folder path." }, confirm: true, noStatus: false, foldersToDehydrate: TestConstants.DotGit.Root);
-            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate '{TestConstants.DotGit.Info.Root}' folder.  Invalid folder path." }, confirm: true, noStatus: false, foldersToDehydrate: TestConstants.DotGit.Info.Root);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{TestConstants.DotGit.Root}': invalid folder path." }, confirm: true, noStatus: false, foldersToDehydrate: TestConstants.DotGit.Root);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{TestConstants.DotGit.Info.Root}': invalid folder path." }, confirm: true, noStatus: false, foldersToDehydrate: TestConstants.DotGit.Info.Root);
         }
 
         [TestCase]
@@ -410,7 +410,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed(new[] { $"Unable to dehydrate '{folderToDehydrate}'. Parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -457,7 +457,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             List<string> errorMessages = new List<string>();
             foreach (string path in foldersToDehydrate)
             {
-                errorMessages.Add($"Cannot dehydrate '{path}' folder.  Invalid folder path.");
+                errorMessages.Add($"Cannot dehydrate folder '{path}': invalid folder path.");
             }
 
             this.DehydrateShouldSucceed(
@@ -470,7 +470,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void FolderDehydrateFolderThatDoesNotExist()
         {
-            this.DehydrateShouldSucceed(new[] { "DoesNotExist did not exist to dehydrate." }, confirm: true, noStatus: false, foldersToDehydrate: "DoesNotExist");
+            string folderToDehydrate = "DoesNotExist";
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': '{folderToDehydrate}' does not exist." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -303,7 +303,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.PlaceholdersShouldNotContain(folderToDehydrate, Path.Combine(folderToDehydrate, "Program.cs"));
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, Path.Combine(folderToDehydrate, "App.config").Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator));
 
-            this.PlaceholderShouldContain(folderNotDehydrated, Path.Combine(folderNotDehydrated, "GVFSLock.cs"));
+            this.PlaceholdersShouldContain(folderNotDehydrated, Path.Combine(folderNotDehydrated, "GVFSLock.cs"));
             GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, Path.Combine(folderNotDehydrated, "Enlistment.cs").Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator));
 
             this.Enlistment.UnmountGVFS();
@@ -498,12 +498,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
-        private void PlaceholderShouldContain(params string[] paths)
+        private void PlaceholdersShouldContain(params string[] paths)
         {
             string[] placeholderLines = this.GetPlaceholderDatabaseLines();
             foreach (string path in paths)
             {
-                placeholderLines.ShouldContain(x => x.StartsWith(path + GVFSHelpers.PlaceholderFieldDelimiter));
+                placeholderLines.ShouldContain(x => x.StartsWith(path + GVFSHelpers.PlaceholderFieldDelimiter, StringComparison.OrdinalIgnoreCase));
             }
         }
 
@@ -512,7 +512,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string[] placeholderLines = this.GetPlaceholderDatabaseLines();
             foreach (string path in paths)
             {
-                placeholderLines.ShouldNotContain(x => x.StartsWith(path + Path.DirectorySeparatorChar) || x.Equals(path, StringComparison.OrdinalIgnoreCase));
+                placeholderLines.ShouldNotContain(x => x.StartsWith(path + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) || x.Equals(path, StringComparison.OrdinalIgnoreCase));
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -195,6 +195,11 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
+        public bool IsMounted()
+        {
+            return this.gvfsProcess.IsEnlistmentMounted();
+        }
+
         public void MountGVFS()
         {
             this.gvfsProcess.Mount();

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -291,7 +291,7 @@ namespace GVFS.Mount
                 string[] folders = request.Folders.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string folder in folders)
                 {
-                    if (this.fileSystemCallbacks.DehydrateFolder(folder))
+                    if (this.fileSystemCallbacks.TryDehydrateFolder(folder))
                     {
                         response.SuccessfulFolders.Add(folder);
                     }

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -300,6 +300,10 @@ namespace GVFS.Mount
                         response.FailedFolders.Add(folder);
                     }
                 }
+
+                // Since placeholders and modified paths could have changed with the dehydrate, the index needs to be rebuilt
+                GitProcess gitProcess = new GitProcess(this.enlistment);
+                gitProcess.ForceCheckout(GVFSConstants.DotGit.HeadName);
             }
             else
             {

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -212,6 +212,13 @@ namespace GVFS.Platform.Mac
             }
         }
 
+        public override FileSystemResult DehydrateFolder(string relativePath)
+        {
+            FileSystemResult result = this.WritePlaceholderDirectory(relativePath);
+            this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
+            return result;
+        }
+
         protected override bool TryStart(out string error)
         {
             error = string.Empty;

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -219,8 +219,18 @@ namespace GVFS.Platform.Mac
 
             if (sparseState == GitIndexProjection.PathSparseState.Included)
             {
+                // When the folder is included we need to create the placeholder to make sure it is on disk for enumeration
                 result = this.WritePlaceholderDirectory(relativePath);
-                this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
+                if (result.Result == FSResult.Ok)
+                {
+                    this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
+                }
+                else
+                {
+                    EventMetadata metadata = this.CreateEventMetadata(relativePath);
+                    metadata.Add(nameof(result), result.ToString());
+                    this.Context.Tracer.RelatedError(metadata, $"{nameof(this.DehydrateFolder)}: Write placeholder failed");
+                }
             }
 
             return result;

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -225,10 +225,16 @@ namespace GVFS.Platform.Mac
                 {
                     this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
                 }
+                else if (result.Result == FSResult.FileOrPathNotFound)
+                {
+                    // This will happen when the parent folder is also in the dehydrate list and is no longer on disk.
+                    result = new FileSystemResult(FSResult.Ok, 0);
+                }
                 else
                 {
                     EventMetadata metadata = this.CreateEventMetadata(relativePath);
-                    metadata.Add(nameof(result), result.ToString());
+                    metadata.Add(nameof(result.Result), result.Result);
+                    metadata.Add(nameof(result.RawResult), result.RawResult);
                     this.Context.Tracer.RelatedError(metadata, $"{nameof(this.DehydrateFolder)}: Write placeholder failed");
                 }
             }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -214,8 +214,15 @@ namespace GVFS.Platform.Mac
 
         public override FileSystemResult DehydrateFolder(string relativePath)
         {
-            FileSystemResult result = this.WritePlaceholderDirectory(relativePath);
-            this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
+            FileSystemResult result = new FileSystemResult(FSResult.Ok, 0);
+            GitIndexProjection.PathSparseState sparseState = this.FileSystemCallbacks.GitIndexProjection.GetFolderPathSparseState(relativePath);
+
+            if (sparseState == GitIndexProjection.PathSparseState.Included)
+            {
+                result = this.WritePlaceholderDirectory(relativePath);
+                this.FileSystemCallbacks.OnPlaceholderFolderCreated(relativePath, string.Empty);
+            }
+
             return result;
         }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -196,6 +196,12 @@ namespace GVFS.Platform.Windows
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
 
+        public override FileSystemResult DehydrateFolder(string relativePath)
+        {
+            // Don't need to do anything here because the parent will reproject the folder.
+            return new FileSystemResult(FSResult.Ok, 0);
+        }
+
         // TODO: Need ProjFS 13150199 to be fixed so that GVFS doesn't leak memory if the enumeration cancelled.
         // Currently EndDirectoryEnumerationHandler must be called to remove the ActiveEnumeration from this.activeEnumerations
         public HResult StartDirectoryEnumerationCallback(int commandId, Guid enumerationId, string virtualPath, uint triggeringProcessId, string triggeringProcessImageFileName)

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/FileSystem/MockFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/FileSystem/MockFileSystemVirtualizer.cs
@@ -43,6 +43,11 @@ namespace GVFS.UnitTests.Mock.Virtualization.FileSystem
             throw new NotImplementedException();
         }
 
+        public override FileSystemResult DehydrateFolder(string relativePath)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override bool TryStart(out string error)
         {
             error = null;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -111,6 +111,8 @@ namespace GVFS.Virtualization.FileSystem
             UpdatePlaceholderType updateFlags,
             out UpdateFailureReason failureReason);
 
+        public abstract FileSystemResult DehydrateFolder(string relativePath);
+
         public void Dispose()
         {
             if (this.fileAndNetworkRequests != null)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -296,6 +296,18 @@ namespace GVFS.Virtualization
             return metadata;
         }
 
+        public bool DehydrateFolder(string relativePath)
+        {
+            // Remove all modified paths that start with the path
+            this.modifiedPaths.RemoveAllEntriesForFolder(relativePath);
+
+            // Remove all placeholders that start with the path
+            this.placeholderDatabase.RemoveStartingWith(relativePath);
+
+            FileSystemResult result = this.fileSystemVirtualizer.WritePlaceholderDirectory(relativePath);
+            return result.Result == FSResult.Ok;
+        }
+
         public void ForceIndexProjectionUpdate(bool invalidateProjection, bool invalidateModifiedPaths)
         {
             this.InvalidateState(invalidateProjection, invalidateModifiedPaths);

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -334,7 +334,10 @@ namespace GVFS.Virtualization
                 {
                     foreach (string modifiedPath in removedModifiedPaths)
                     {
-                        this.modifiedPaths.TryAdd(modifiedPath, isFolder: modifiedPath.EndsWith(GVFSConstants.GitPathSeparatorString), isRetryable: out bool isRetryable);
+                        if (!this.modifiedPaths.TryAdd(modifiedPath, isFolder: modifiedPath.EndsWith(GVFSConstants.GitPathSeparatorString), isRetryable: out bool isRetryable))
+                        {
+                            this.context.Tracer.RelatedError($"{nameof(FileSystemCallbacks)}.{nameof(this.DehydrateFolder)}: failed to add '{modifiedPath}' back into ModifiedPaths");
+                        }
                     }
                 }
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -298,13 +298,13 @@ namespace GVFS.Virtualization
 
         public bool DehydrateFolder(string relativePath)
         {
-            // Remove all modified paths that start with the path
-            this.modifiedPaths.RemoveAllEntriesForFolder(relativePath);
-
             // Remove all placeholders that start with the path
             this.placeholderDatabase.RemoveStartingWith(relativePath);
 
-            FileSystemResult result = this.fileSystemVirtualizer.WritePlaceholderDirectory(relativePath);
+            // Remove all modified paths that start with the path
+            this.modifiedPaths.RemoveAllEntriesForFolder(relativePath);
+
+            FileSystemResult result = this.fileSystemVirtualizer.DehydrateFolder(relativePath);
             return result.Result == FSResult.Ok;
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -21,6 +21,8 @@ namespace GVFS.CommandLine
     public class DehydrateVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string DehydrateVerbName = "dehydrate";
+        private const string FolderListSeparator = ";";
+
         private PhysicalFileSystem fileSystem = new PhysicalFileSystem();
 
         [Option(
@@ -41,7 +43,7 @@ namespace GVFS.CommandLine
             "folders",
             Default = "",
             Required = false,
-            HelpText = "A semicolon (;) delimited list of folders to dehydrate. Each folder must be relative to the repository root.")]
+            HelpText = "A semicolon (" + FolderListSeparator + ") delimited list of folders to dehydrate. Each folder must be relative to the repository root.")]
         public string Folders { get; set; }
 
         protected override string VerbName
@@ -194,7 +196,7 @@ from a parent of the folders list.
                 }
                 else
                 {
-                    string[] folders = this.Folders.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] folders = this.Folders.Split(new[] { FolderListSeparator }, StringSplitOptions.RemoveEmptyEntries);
 
                     if (folders.Length > 0)
                     {
@@ -318,7 +320,7 @@ from a parent of the folders list.
                         this.ReportErrorAndExit("Unable to connect to GVFS.  Try running 'gvfs mount'");
                     }
 
-                    NamedPipeMessages.DehydrateFolders.Request request = new NamedPipeMessages.DehydrateFolders.Request(string.Join(";", folders));
+                    NamedPipeMessages.DehydrateFolders.Request request = new NamedPipeMessages.DehydrateFolders.Request(string.Join(FolderListSeparator, folders));
                     pipeClient.SendRequest(request.CreateMessage());
                     response = NamedPipeMessages.DehydrateFolders.Response.FromMessage(NamedPipeMessages.Message.FromString(pipeClient.ReadRawResponse()));
                 }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -101,7 +101,9 @@ namespace GVFS.CommandLine
                     }
                 }
 
-                if (!this.Confirmed && string.IsNullOrEmpty(this.Folders))
+                bool fullDehydrate = string.IsNullOrEmpty(this.Folders);
+
+                if (!this.Confirmed && fullDehydrate)
                 {
                     this.Output.WriteLine(
 @"WARNING: THIS IS AN EXPERIMENTAL FEATURE
@@ -142,7 +144,6 @@ from a parent of the folders list.
                     return;
                 }
 
-                bool fullDehydrate = string.IsNullOrEmpty(this.Folders);
                 bool cleanStatus = this.CheckGitStatus(tracer, enlistment, fullDehydrate);
 
                 string backupRoot = Path.GetFullPath(Path.Combine(enlistment.EnlistmentRoot, "dehydrate_backup", DateTime.Now.ToString("yyyyMMdd_HHmmss")));
@@ -316,7 +317,7 @@ from a parent of the folders list.
 
                 foreach (string folder in response.FailedFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by deleting {folder} running `git reset --hard` and retry the dehydrate.");
+                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by deleting {folder}, running `git reset --hard`, and retry the dehydrate.");
                 }
             }
         }
@@ -411,7 +412,7 @@ from a parent of the folders list.
                         }
                         else
                         {
-                            this.WriteMessage(tracer, "Either commit your changes or run dehydrate with --no-status");
+                            this.WriteMessage(tracer, "Either commit your changes or reset and clean your working directory.");
                         }
                     }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -316,7 +316,7 @@ from a parent of the folders list.
 
                 foreach (string folder in response.FailedFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by running `git reset --hard` and retry the dehydrate.");
+                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by deleting {folder} running `git reset --hard` and retry the dehydrate.");
                 }
             }
         }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -246,15 +246,22 @@ from a parent of the folders list.
                                 string backupPath = Path.Combine(backupRoot, folder);
                                 if (this.fileSystem.DirectoryExists(fullPath))
                                 {
-                                    if (!this.TryIO(tracer, () => this.fileSystem.CopyDirectoryRecursive(fullPath, backupPath), $"Backing up {folder} to {backupPath}", out ioError) ||
-                                        !this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting {fullPath}", out ioError))
+                                    if (!this.TryIO(tracer, () => this.fileSystem.CopyDirectoryRecursive(fullPath, backupPath), $"Backing up {folder} to {backupPath}", out ioError))
                                     {
-                                        this.WriteMessage(tracer, $"Backup failed for {folder} and will not be dehydrated. {ioError}");
+                                        this.WriteMessage(tracer, $"Copying files to backup location failed for {folder} and will not be dehydrated. {ioError}");
                                         this.WriteMessage(tracer, $"Make sure there aren't any applications accessing the folder and try again.");
                                     }
                                     else
                                     {
-                                        foldersToDehydrate.Add(folder);
+                                        if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting {fullPath}", out ioError))
+                                        {
+                                            this.WriteMessage(tracer, $"Removing {folder} failed and will not be dehydrated. {ioError}");
+                                            this.WriteMessage(tracer, $"Make sure there aren't any applications accessing the folder and try again.");
+                                        }
+                                        else
+                                        {
+                                            foldersToDehydrate.Add(folder);
+                                        }
                                     }
                                 }
                                 else

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -144,28 +144,32 @@ of your enlistment's src folder.
 
                 // Local cache and objects paths are required for TryDownloadGitObjects
                 this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig: null, cacheServer: null);
+                RunFullDehydrate(enlistment, tracer, backupRoot, retryConfig);
+            }
+        }
 
-                if (this.TryBackupFiles(tracer, enlistment, backupRoot))
+        private void RunFullDehydrate(GVFSEnlistment enlistment, JsonTracer tracer, string backupRoot, RetryConfig retryConfig)
+        {
+            if (this.TryBackupFiles(tracer, enlistment, backupRoot))
+            {
+                if (this.TryDownloadGitObjects(tracer, enlistment, retryConfig) &&
+                    this.TryRecreateIndex(tracer, enlistment))
                 {
-                    if (this.TryDownloadGitObjects(tracer, enlistment, retryConfig) &&
-                        this.TryRecreateIndex(tracer, enlistment))
-                    {
-                        // Converting the src folder to partial must be the final step before mount
-                        this.PrepareSrcFolder(tracer, enlistment);
-                        this.Mount(tracer);
-
-                        this.Output.WriteLine();
-                        this.WriteMessage(tracer, "The repo was successfully dehydrated and remounted");
-                    }
-                }
-                else
-                {
-                    this.Output.WriteLine();
-                    this.WriteMessage(tracer, "ERROR: Backup failed. We will attempt to mount, but you may need to reclone if that fails");
-
+                    // Converting the src folder to partial must be the final step before mount
+                    this.PrepareSrcFolder(tracer, enlistment);
                     this.Mount(tracer);
-                    this.WriteMessage(tracer, "Dehydrate failed, but remounting succeeded");
+
+                    this.Output.WriteLine();
+                    this.WriteMessage(tracer, "The repo was successfully dehydrated and remounted");
                 }
+            }
+            else
+            {
+                this.Output.WriteLine();
+                this.WriteMessage(tracer, "ERROR: Backup failed. We will attempt to mount, but you may need to reclone if that fails");
+
+                this.Mount(tracer);
+                this.WriteMessage(tracer, "Dehydrate failed, but remounting succeeded");
             }
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -316,7 +316,7 @@ from a parent of the folders list.
 
                 foreach (string folder in response.FailedFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to clean the working directory and retry the dehydrate.");
+                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by running `git reset --hard` and retry the dehydrate.");
                 }
             }
         }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -185,7 +185,7 @@ from a parent of the folders list.
                 // Local cache and objects paths are required for TryDownloadGitObjects
                 this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig: null, cacheServer: null);
 
-                if (string.IsNullOrEmpty(this.Folders))
+                if (fullDehydrate)
                 {
                     this.RunFullDehydrate(tracer, enlistment, backupRoot, retryConfig);
                 }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -237,9 +237,9 @@ from a parent of the folders list.
                         {
                             // Need to check if parent folder is in the modified paths because
                             // dehydration will not do any good with a parent folder there
-                            if (modifiedPaths.ContainsParentFolder(folder))
+                            if (modifiedPaths.ContainsParentFolder(folder, out string parentFolder))
                             {
-                                this.WriteMessage(tracer, $"Unable to dehydrate {folder}. Parent folder in modified paths that must be dehydrated.");
+                                this.WriteMessage(tracer, $"Unable to dehydrate '{folder}'. Parent folder '{parentFolder}' must be dehydrated.");
                             }
                             else
                             {
@@ -249,14 +249,14 @@ from a parent of the folders list.
                                 {
                                     if (!this.TryIO(tracer, () => this.fileSystem.CopyDirectoryRecursive(fullPath, backupPath), $"Backing up {folder} to {backupPath}", out ioError))
                                     {
-                                        this.WriteMessage(tracer, $"Copying files to backup location failed for {folder} and will not be dehydrated. {ioError}");
+                                        this.WriteMessage(tracer, $"Copying files to backup location failed for '{folder}' and will not be dehydrated. {ioError}");
                                         this.WriteMessage(tracer, $"Make sure there aren't any applications accessing the folder and try again.");
                                     }
                                     else
                                     {
-                                        if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting {fullPath}", out ioError))
+                                        if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting '{fullPath}'", out ioError))
                                         {
-                                            this.WriteMessage(tracer, $"Removing {folder} failed and will not be dehydrated. {ioError}");
+                                            this.WriteMessage(tracer, $"Removing '{folder}' failed and will not be dehydrated. {ioError}");
                                             this.WriteMessage(tracer, $"Make sure there aren't any applications accessing the folder and try again.");
                                         }
                                         else
@@ -268,6 +268,9 @@ from a parent of the folders list.
                                 else
                                 {
                                     this.WriteMessage(tracer, $"{folder} did not exist to dehydrate.");
+
+                                    // Still add to foldersToDehydrate so that any placeholders or modified paths get cleaned up
+                                    foldersToDehydrate.Add(folder);
                                 }
                             }
                         }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -243,7 +243,7 @@ from a parent of the folders list.
                             string normalizedPath = GVFSDatabase.NormalizePath(folder);
                             if (!this.IsFolderValid(normalizedPath))
                             {
-                                this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}'.  Invalid folder path.");
+                                this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': invalid folder path.");
                             }
                             else
                             {
@@ -251,7 +251,7 @@ from a parent of the folders list.
                                 // dehydration will not do any good with a parent folder there
                                 if (modifiedPaths.ContainsParentFolder(folder, out string parentFolder))
                                 {
-                                    this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}'. Parent folder '{parentFolder}' must be dehydrated.");
+                                    this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': parent folder '{parentFolder}' must be dehydrated.");
                                 }
                                 else
                                 {

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -162,7 +162,7 @@ Folders need to be relative to the repos root directory.")
             else
             {
                 return folders.Split(new[] { FolderListSeparator }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(x => SparseTable.NormalizePath(x))
+                    .Select(x => GVFSDatabase.NormalizePath(x))
                     .ToArray();
             }
         }


### PR DESCRIPTION
### Allow the dehydration of specific folders
This change allows the dehydration of specific folders in the enlistment instead of having to dehydrate everything.  There is a lot happening that is from how dehydrate worked before, the main points now are:
1. Check status to make sure we are in a clean state.
2. Unmount
3. Delete folders passed in.  _Should this be a move to a backup location?_
4. Mount
5. Send message with list of folders to mount process for dehydration
    1. Remove modified paths for the folders
    2. Remove placeholders for the folders
    3. Write a new placeholder folder

### Questions
#### Do we need to backup anything?
_My thought is we don't need to since we ran status and it came back clean no data should be lost. But do we need and could we have a rollback if something goes wrong?_
#### What do we do when there is an error for one of the folders?
_I suppose there are different actions depending on where this happens.  For example if deleting the folder fails we don't need to send it to the mount process for dehydration but still need to let the user know.  But if something happens in the dehydration in the mount process what should be done?_
#### Is there anything that could happen that would cause the enlistment to be corrupt (i.e. removed modified paths but not placeholders or writing the new placeholder folder failed) and we should unmount and block mounting?


### Todos
- [x] Functional tests
- [x] Error Handling
- [x] Clean up UI messages
- [x] Testing on Mac

