### PR TITLE
Heath rating now based on total hydrated files

### DIFF
--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -47,7 +47,7 @@ namespace GVFS.Common
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFilePaths, hydratedFilesDirectoryTally, parentDirectory);
 
-            Dictionary<string, decimal> mostHydratedDirectories = new Dictionary<string, decimal>();
+            Dictionary<string, int> mostHydratedDirectories = new Dictionary<string, int>();
 
             // Map directory names to the corresponding health data from gitTrackedItemsDirectoryTally and hydratedFilesDirectoryTally
             foreach (KeyValuePair<string, int> pair in gitTrackedItemsDirectoryTally)
@@ -56,7 +56,7 @@ namespace GVFS.Common
                 {
                     // In-lining this for now until a better "health" calculation is created
                     // Another possibility is the ability to pass a function to use for health (might not be applicable)
-                    mostHydratedDirectories.Add(pair.Key, this.CalculateHealthMetric(hydratedFiles, pair.Value));
+                    mostHydratedDirectories.Add(pair.Key, hydratedFiles);
                 }
                 else
                 {

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
             int placeholderCount,
             int modifiedPathsCount,
             decimal healthMetric,
-            List<KeyValuePair<string, decimal>> directoryHydrationLevels)
+            List<KeyValuePair<string, int>> directoryHydrationLevels)
         {
             this.TargetDirectory = targetDirectory;
             this.GitTrackedItemsCount = gitItemsCount;
@@ -24,7 +24,7 @@ namespace GVFS.Common
         public int GitTrackedItemsCount { get; private set; }
         public int PlaceholderCount { get; private set; }
         public int ModifiedPathsCount { get; private set; }
-        public List<KeyValuePair<string, decimal>> DirectoryHydrationLevels { get; private set; }
+        public List<KeyValuePair<string, int>> DirectoryHydrationLevels { get; private set; }
         public decimal HealthMetric { get; private set; }
         public decimal PlaceholderPercentage
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -47,7 +47,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydratePlaceholder(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
 
             List<string> topHydratedDirectories = new List<string> { "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest", "GVFlt_DeleteFolderTest" };
-            List<int> directoryHydrationLevels = new List<int> { 100, 0, 0, 0, 0 };
+            List<int> directoryHydrationLevels = new List<int> { 5, 0, 0, 0, 0 };
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
@@ -71,8 +71,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/DeleteExistingFile.txt"));
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "GVFlt_FileOperationTest/WriteAndVerify.txt"));
 
-            List<string> topHydratedDirectories = new List<string> { "GVFlt_FileOperationTest", "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
-            List<int> directoryHydrationLevels = new List<int> { 100, 100, 0, 0, 0 };
+            List<string> topHydratedDirectories = new List<string> { "Scripts", "GVFlt_FileOperationTest", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
+            List<int> directoryHydrationLevels = new List<int> { 5, 2, 0, 0, 0 };
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
@@ -98,8 +98,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunFunctionalTests.bat"));
             this.HydrateFullFile(Path.Combine(this.Enlistment.RepoRoot, "Scripts/RunUnitTests.bat"));
 
-            List<string> topHydratedDirectories = new List<string> { "GVFlt_FileOperationTest", "Scripts", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
-            List<int> directoryHydrationLevels = new List<int> { 100, 100, 0, 0, 0 };
+            List<string> topHydratedDirectories = new List<string> { "Scripts", "GVFlt_FileOperationTest", "GVFS", "GVFlt_BugRegressionTest", "GVFlt_DeleteFileTest" };
+            List<int> directoryHydrationLevels = new List<int> { 5, 2, 0, 0, 0 };
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
@@ -237,10 +237,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             for (int i = 0; i < outputLines.Count; i++)
             {
                 // Regex to extract the most hydrated subdirectory names and their hydration percentage
-                // "  <percentage>% | <directory-name>" listed several times for different directories
-                Match lineMatch = Regex.Match(outputLines[i], @"^\s*(\d+)%\s*\|\s*(\S.*\S)\s*$");
+                // "  <hydrated-file-count> | <directory-name>" listed several times for different directories
+                Match lineMatch = Regex.Match(outputLines[i], @"^\s*([\d,]+)\s*\|\s*(\S.*\S)\s*$");
 
-                int.TryParse(lineMatch.Groups[1].Value, out int outputtedHealthScore).ShouldBeTrue();
+                int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedHealthScore).ShouldBeTrue();
                 string outputtedSubdirectory = lineMatch.Groups[2].Value;
 
                 outputtedHealthScore.ShouldEqual(healthScores[i]);

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
@@ -22,7 +22,7 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
             this.enlistmentHealthData.DirectoryHydrationLevels[0].Key.ShouldEqual("A");
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(0.75m);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(3);
             this.enlistmentHealthData.DirectoryHydrationLevels[1].Key.ShouldEqual("B");
             this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.ShouldEqual(0);
             this.enlistmentHealthData.DirectoryHydrationLevels[2].Key.ShouldEqual("C");
@@ -119,8 +119,8 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData.DirectoryHydrationLevels.Count.ShouldEqual(2);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual((decimal)pathData.PlaceholderFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsPercentage.ShouldEqual((decimal)pathData.ModifiedFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(4.0m / 3.0m);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.ShouldEqual(4.0m / 3.0m);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.ShouldEqual(4);
         }
 
         [TestCase]
@@ -187,7 +187,7 @@ namespace GVFS.UnitTests.Common
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual((decimal)(pathData.PlaceholderFilePaths.Count / pathData.GitFilePaths.Count));
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(5m / 6m);
@@ -204,7 +204,7 @@ namespace GVFS.UnitTests.Common
                 .Build();
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(1);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(5);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count + pathData.PlaceholderFolderPaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(1);

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -74,7 +74,7 @@ namespace GVFS.CommandLine
             longest = Math.Max(longest, modifiedPathsCountFormatted.Length);
 
             // Sort the dictionary to find the most hydrated directories by health score
-            List<KeyValuePair<string, decimal>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
+            List<KeyValuePair<string, int>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
 
             this.Output.WriteLine("\nHealth of directory: " + enlistmentHealthData.TargetDirectory);
             this.Output.WriteLine("Total files in HEAD commit:           " + trackedFilesCountFormatted.PadLeft(longest) + " | 100%");
@@ -85,17 +85,15 @@ namespace GVFS.CommandLine
 
             this.Output.WriteLine("\nMost hydrated top level directories:");
 
-            int maxDirectoryNameLength = 0;
-            foreach (KeyValuePair<string, decimal> pair in topLevelDirectoriesByHydration)
+            int maxCountLength = 0;
+            foreach (KeyValuePair<string, int> pair in topLevelDirectoriesByHydration)
             {
-                maxDirectoryNameLength = Math.Max(maxDirectoryNameLength, pair.Key.Length);
+                maxCountLength = Math.Max(maxCountLength, pair.Value.ToString().Length);
             }
 
-            foreach (KeyValuePair<string, decimal> pair in topLevelDirectoriesByHydration)
+            foreach (KeyValuePair<string, int> pair in topLevelDirectoriesByHydration)
             {
-                string dir = pair.Key.PadRight(maxDirectoryNameLength);
-                string percent = this.FormatPercent(pair.Value);
-                this.Output.WriteLine(" " + percent + " | " + dir);
+                this.Output.WriteLine(" " + pair.Value.ToString("N0").PadLeft(maxCountLength) + " | " + pair.Key);
             }
 
             bool healthyRepo = (enlistmentHealthData.PlaceholderPercentage + enlistmentHealthData.ModifiedPathsPercentage) < MaximumHealthyHydration;


### PR DESCRIPTION
Instead of displaying the hydration percent for directories, the total
number of hydrated files is now displayed, and that is how the list of
directories is sorted. Unit and functional tests have been updated
accordingly.