### PR TITLE
Move Enlistment Directory For Functional tests to ~/GVFS.FT

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Settings.cs
+++ b/GVFS/GVFS.FunctionalTests/Settings.cs
@@ -46,7 +46,9 @@ namespace GVFS.FunctionalTests.Properties
                 }
                 else
                 {
-                    string root = "/GVFS.FT";
+                    string root = Path.Combine(
+                        Environment.GetEnvironmentVariable("HOME"),
+                        "GVFS.FT");
                     EnlistmentRoot = Path.Combine(root, "test");
                     ControlGitRepoRoot = Path.Combine(root, "control");
                     FastFetchBaseRoot = Path.Combine(root, "FastFetch");

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -7,9 +7,7 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
-sudo mkdir /GVFS.FT
-sudo chown $USER /GVFS.FT
-
+mkdir ~/GVFS.FT
 if [ "$2" != "--test-gvfs-on-path" ]; then
   echo "Calling LoadPrjFSKext.sh as --test-gvfs-on-path not set..."
   $VFS_SRCDIR/ProjFS.Mac/Scripts/LoadPrjFSKext.sh $CONFIGURATION


### PR DESCRIPTION
"/" is readonly on Catalina so this change is needed to create Enlistment directories

Unfortunately there are several line ending fixes in the commit as well.