### PR TITLE
Update Git to include tracing updates

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190701.1</GitPackageVersion>
+    <GitPackageVersion>2.20190724.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
Includes changes from:

* microsoft/git#158 (experimental tracing: trace threading and cache-tree extension)
* microsoft/git#159 (experimental tracing: prime_cache_tree())
* microsoft/git#160 (experimental tracing: checkout and reset perf)
* microsoft/git#162 (support building with GCC v9.x)