### PR TITLE
Only setting GIT_TERMINAL_PROMPT=0 where we don't have the terminal

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -18,6 +18,8 @@ namespace GVFS.Common
         public const string WorkingDirectoryRootName = "src";
         public const string UnattendedEnvironmentVariable = "GVFS_UNATTENDED";
 
+        public const string InteractiveEnvironmentVariable = "GVFS_INTERACTIVE";
+
         public const string DefaultGVFSCacheFolderName = ".gvfsCache";
 
         public const string GitIsNotInstalledError = "Could not find git.exe.  Ensure that Git is installed.";

--- a/GVFS/GVFS.Common/GVFSEnlistment.Shared.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.Shared.cs
@@ -6,28 +6,48 @@ namespace GVFS.Common
 {
     public partial class GVFSEnlistment
     {
-        private static bool? isUnAttendedByDefault;
-        public static void SetIsUnattendedByDefault(bool defaultValue)
+        private static bool? isInteractiveByDefault;
+        public static void SetIsInteractiveByDefault(bool defaultValue)
         {
-            if (isUnAttendedByDefault.HasValue)
+            if (isInteractiveByDefault.HasValue)
             {
                 throw new InvalidOperationException("You can call this method only once");
             }
 
-            isUnAttendedByDefault = defaultValue;
+            isInteractiveByDefault = defaultValue;
+        }
+
+        public static bool IsInteractive(ITracer tracer)
+        {
+            try
+            {
+                string value = Environment.GetEnvironmentVariable(GVFSConstants.InteractiveEnvironmentVariable);
+                if (string.IsNullOrEmpty(value))
+                {
+                    return isInteractiveByDefault.GetValueOrDefault(true);
+                }
+
+                return value.Equals("1");
+            }
+            catch (SecurityException e)
+            {
+                if (tracer != null)
+                {
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add("Area", nameof(GVFSEnlistment));
+                    metadata.Add("Exception", e.ToString());
+                    tracer.RelatedError(metadata, "Unable to read environment variable " + GVFSConstants.InteractiveEnvironmentVariable);
+                }
+
+                return false;
+            }
         }
 
         public static bool IsUnattended(ITracer tracer)
         {
             try
             {
-                string value = Environment.GetEnvironmentVariable(GVFSConstants.UnattendedEnvironmentVariable);
-                if (string.IsNullOrEmpty(value))
-                {
-                    return isUnAttendedByDefault.GetValueOrDefault(false);
-                }
-
-                return value.Equals("1");
+                return Environment.GetEnvironmentVariable(GVFSConstants.UnattendedEnvironmentVariable) == "1";
             }
             catch (SecurityException e)
             {

--- a/GVFS/GVFS.Common/GVFSEnlistment.Shared.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.Shared.cs
@@ -6,11 +6,28 @@ namespace GVFS.Common
 {
     public partial class GVFSEnlistment
     {
+        private static bool? isUnAttendedByDefault;
+        public static void SetIsUnattendedByDefault(bool defaultValue)
+        {
+            if (isUnAttendedByDefault.HasValue)
+            {
+                throw new InvalidOperationException("You can call this method only once");
+            }
+
+            isUnAttendedByDefault = defaultValue;
+        }
+
         public static bool IsUnattended(ITracer tracer)
         {
             try
             {
-                return Environment.GetEnvironmentVariable(GVFSConstants.UnattendedEnvironmentVariable) == "1";
+                string value = Environment.GetEnvironmentVariable(GVFSConstants.UnattendedEnvironmentVariable);
+                if (string.IsNullOrEmpty(value))
+                {
+                    return isUnAttendedByDefault.GetValueOrDefault(false);
+                }
+
+                return value.Equals("1");
             }
             catch (SecurityException e)
             {

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -673,7 +673,7 @@ namespace GVFS.Common.Git
                 }
             }
 
-            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = !GVFSEnlistment.IsInteractive(null) && GVFSEnlistment.IsUnattended(null) ? "1" : "0";
+            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = (GVFSEnlistment.IsInteractive(null) && !GVFSEnlistment.IsUnattended(null)) ? "1" : "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
             processInfo.EnvironmentVariables["PATH"] =
                 string.Join(

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -673,7 +673,7 @@ namespace GVFS.Common.Git
                 }
             }
 
-            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = GVFSEnlistment.IsUnattended(null) ? "1" : "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
             processInfo.EnvironmentVariables["PATH"] =
                 string.Join(

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -673,7 +673,7 @@ namespace GVFS.Common.Git
                 }
             }
 
-            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = GVFSEnlistment.IsUnattended(null) ? "1" : "0";
+            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = !GVFSEnlistment.IsInteractive(null) && GVFSEnlistment.IsUnattended(null) ? "1" : "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
             processInfo.EnvironmentVariables["PATH"] =
                 string.Join(

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
     {
         private static string currentProcessVersion = null;
 
-        public static ProcessResult Run(string programName, string args, bool redirectOutput = true)
+        public static ProcessResult Run(string programName, string args, bool redirectOutput = true, bool isInteractive = true)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(programName);
             processInfo.UseShellExecute = false;
@@ -20,6 +20,8 @@ namespace GVFS.Common
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.CreateNoWindow = redirectOutput;
             processInfo.Arguments = args;
+
+            processInfo.EnvironmentVariables[GVFSConstants.UnattendedEnvironmentVariable] = isInteractive ? "0" : "1";
 
             return Run(processInfo);
         }

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -21,7 +21,7 @@ namespace GVFS.Common
             processInfo.CreateNoWindow = redirectOutput;
             processInfo.Arguments = args;
 
-            processInfo.EnvironmentVariables[GVFSConstants.UnattendedEnvironmentVariable] = isInteractive ? "0" : "1";
+            processInfo.EnvironmentVariables[GVFSConstants.InteractiveEnvironmentVariable] = isInteractive ? "1" : "0";
 
             return Run(processInfo);
         }

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -91,7 +91,7 @@ namespace GVFS.Hooks
             {
                 case "fetch":
                 case "pull":
-                    ProcessHelper.Run("gvfs", "prefetch --commits", redirectOutput: false);
+                    ProcessHelper.Run("gvfs", "prefetch --commits", redirectOutput: false, isInteractive: false);
                     break;
             }
         }

--- a/GVFS/GVFS.Mount/Program.cs
+++ b/GVFS/GVFS.Mount/Program.cs
@@ -9,7 +9,7 @@ namespace GVFS.Mount
     {
         public static void Main(string[] args)
         {
-            GVFSEnlistment.SetIsUnattendedByDefault(true);
+            GVFSEnlistment.SetIsInteractiveByDefault(false);
             GVFSPlatformLoader.Initialize();
             try
             {

--- a/GVFS/GVFS.Mount/Program.cs
+++ b/GVFS/GVFS.Mount/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using GVFS.Common;
 using GVFS.PlatformLoader;
 using System;
 
@@ -8,6 +9,7 @@ namespace GVFS.Mount
     {
         public static void Main(string[] args)
         {
+            GVFSEnlistment.SetIsUnattendedByDefault(true);
             GVFSPlatformLoader.Initialize();
             try
             {

--- a/GVFS/GVFS.Service/Program.Mac.cs
+++ b/GVFS/GVFS.Service/Program.Mac.cs
@@ -13,6 +13,7 @@ namespace GVFS.Service
     {
         public static void Main(string[] args)
         {
+            GVFSEnlistment.SetIsUnattendedByDefault(false);
             GVFSPlatformLoader.Initialize();
 
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;

--- a/GVFS/GVFS.Service/Program.Mac.cs
+++ b/GVFS/GVFS.Service/Program.Mac.cs
@@ -13,7 +13,7 @@ namespace GVFS.Service
     {
         public static void Main(string[] args)
         {
-            GVFSEnlistment.SetIsUnattendedByDefault(false);
+            GVFSEnlistment.SetIsInteractiveByDefault(false);
             GVFSPlatformLoader.Initialize();
 
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;

--- a/GVFS/GVFS.Service/Program.Windows.cs
+++ b/GVFS/GVFS.Service/Program.Windows.cs
@@ -11,7 +11,7 @@ namespace GVFS.Service
     {
         public static void Main(string[] args)
         {
-            GVFSEnlistment.SetIsUnattendedByDefault(false);
+            GVFSEnlistment.SetIsInteractiveByDefault(false);
             GVFSPlatformLoader.Initialize();
 
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;

--- a/GVFS/GVFS.Service/Program.Windows.cs
+++ b/GVFS/GVFS.Service/Program.Windows.cs
@@ -11,6 +11,7 @@ namespace GVFS.Service
     {
         public static void Main(string[] args)
         {
+            GVFSEnlistment.SetIsUnattendedByDefault(false);
             GVFSPlatformLoader.Initialize();
 
             AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -239,13 +239,14 @@ namespace GVFS.CommandLine
         protected bool ShowStatusWhileRunning(
             Func<bool> action,
             string message,
-            string gvfsLogEnlistmentRoot)
+            string gvfsLogEnlistmentRoot,
+            bool showSpinner = true)
         {
             return ConsoleHelper.ShowStatusWhileRunning(
                 action,
                 message,
                 this.Output,
-                showSpinner: !this.Unattended && this.Output == Console.Out && !GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
+                showSpinner: showSpinner && !this.Unattended && this.Output == Console.Out && !GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
                 gvfsLogEnlistmentRoot: gvfsLogEnlistmentRoot,
                 initialDelayMs: 0);
         }
@@ -272,7 +273,8 @@ namespace GVFS.CommandLine
             bool result = this.ShowStatusWhileRunning(
                 () => enlistment.Authentication.TryInitialize(tracer, enlistment, out authError),
                 "Authenticating",
-                enlistment.EnlistmentRoot);
+                enlistment.EnlistmentRoot,
+                showSpinner: false);
 
             authErrorMessage = authError;
             return result;


### PR DESCRIPTION
Currently GIT_TERMINAL_PROMPT is always set to 0, when git is invoked, which prevents things, like credential helpers, from prompting from user input in the terminal, even during `gvfs clone` and similar scenarios.

We need to differentiate between, when we have terminal and not.

This is an initial version, to start the conversation.