### PR TITLE
No longer set PATH for git process and remove use of gvfs hooks root

### DIFF
--- a/GVFS/FastFetch/GitEnlistment.cs
+++ b/GVFS/FastFetch/GitEnlistment.cs
@@ -13,7 +13,6 @@ namespace FastFetch
                   repoRoot,
                   null,
                   gitBinPath,
-                  gvfsHooksRoot: null,
                   flushFileBuffersForPacks: false,
                   authentication: null)
         {

--- a/GVFS/GVFS.Common/DiskLayoutUpgrades/DiskLayoutUpgrade.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrades/DiskLayoutUpgrade.cs
@@ -177,7 +177,6 @@ namespace GVFS.DiskLayoutUpgrades
                 enlistment = GVFSEnlistment.CreateFromDirectory(
                     enlistmentRoot,
                     GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath(),
-                    ProcessHelper.GetCurrentProcessLocation(),
                     authentication: null);
             }
             catch (InvalidRepoException e)

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -13,7 +13,6 @@ namespace GVFS.Common
             string workingDirectoryBackingRoot,
             string repoUrl,
             string gitBinPath,
-            string gvfsHooksRoot,
             bool flushFileBuffersForPacks,
             GitAuthentication authentication)
         {
@@ -27,7 +26,6 @@ namespace GVFS.Common
             this.WorkingDirectoryBackingRoot = workingDirectoryBackingRoot;
             this.DotGitRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Root);
             this.GitBinPath = gitBinPath;
-            this.GVFSHooksRoot = gvfsHooksRoot;
             this.FlushFileBuffersForPacks = flushFileBuffersForPacks;
 
             GitProcess gitProcess = new GitProcess(this);
@@ -72,7 +70,6 @@ namespace GVFS.Common
         public bool FlushFileBuffersForPacks { get; }
 
         public string GitBinPath { get; }
-        public string GVFSHooksRoot { get; }
 
         public GitAuthentication Authentication { get; }
 

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -20,14 +20,13 @@ namespace GVFS.Common
         private string gvfsHooksVersion;
 
         // New enlistment
-        public GVFSEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, string gvfsHooksRoot, GitAuthentication authentication)
+        public GVFSEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, GitAuthentication authentication)
             : base(
                   enlistmentRoot,
                   Path.Combine(enlistmentRoot, GVFSConstants.WorkingDirectoryRootName),
                   Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.WorkingDirectoryBackingRootPath),
                   repoUrl,
                   gitBinPath,
-                  gvfsHooksRoot,
                   flushFileBuffersForPacks: true,
                   authentication: authentication)
         {
@@ -40,12 +39,11 @@ namespace GVFS.Common
         }
 
         // Existing, configured enlistment
-        private GVFSEnlistment(string enlistmentRoot, string gitBinPath, string gvfsHooksRoot, GitAuthentication authentication)
+        private GVFSEnlistment(string enlistmentRoot, string gitBinPath, GitAuthentication authentication)
             : this(
                   enlistmentRoot,
                   null,
                   gitBinPath,
-                  gvfsHooksRoot,
                   authentication)
         {
         }
@@ -85,7 +83,6 @@ namespace GVFS.Common
         public static GVFSEnlistment CreateFromDirectory(
             string directory,
             string gitBinRoot,
-            string gvfsHooksRoot,
             GitAuthentication authentication,
             bool createWithoutRepoURL = false)
         {
@@ -100,10 +97,10 @@ namespace GVFS.Common
 
                 if (createWithoutRepoURL)
                 {
-                    return new GVFSEnlistment(enlistmentRoot, string.Empty, gitBinRoot, gvfsHooksRoot, authentication);
+                    return new GVFSEnlistment(enlistmentRoot, string.Empty, gitBinRoot, authentication);
                 }
 
-                return new GVFSEnlistment(enlistmentRoot, gitBinRoot, gvfsHooksRoot, authentication);
+                return new GVFSEnlistment(enlistmentRoot, gitBinRoot, authentication);
             }
 
             throw new InvalidRepoException($"Directory '{directory}' does not exist");

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -95,7 +95,7 @@ namespace GVFS.Common
 
         public abstract void ConfigureVisualStudio(string gitBinPath, ITracer tracer);
 
-        public abstract bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error);
+        public abstract bool TryGetGVFSHooksVersion(out string hooksVersion, out string error);
         public abstract bool TryInstallGitCommandHooks(GVFSContext context, string executingDirectory, string hookName, string commandHookPath, out string errorMessage);
 
         public abstract bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error);

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -206,18 +206,15 @@ namespace GVFS.Common
             public UnderConstructionFlags(
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool requiresDeprecatedGitHooksLoader = false,
                 bool supportsNuGetEncryption = true)
             {
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
-                this.RequiresDeprecatedGitHooksLoader = requiresDeprecatedGitHooksLoader;
                 this.SupportsNuGetEncryption = supportsNuGetEncryption;
             }
 
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
-            public bool RequiresDeprecatedGitHooksLoader { get; }
             public bool SupportsNuGetEncryption { get; }
         }
     }

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -32,7 +32,6 @@ namespace GVFS.Common.Git
         private string gitBinPath;
         private string workingDirectoryRoot;
         private string dotGitRoot;
-        private string gvfsHooksRoot;
         private Process executingProcess;
         private bool stopping;
 
@@ -62,11 +61,11 @@ namespace GVFS.Common.Git
         }
 
         public GitProcess(Enlistment enlistment)
-            : this(enlistment.GitBinPath, enlistment.WorkingDirectoryBackingRoot, enlistment.GVFSHooksRoot)
+            : this(enlistment.GitBinPath, enlistment.WorkingDirectoryBackingRoot)
         {
         }
 
-        public GitProcess(string gitBinPath, string workingDirectoryRoot, string gvfsHooksRoot)
+        public GitProcess(string gitBinPath, string workingDirectoryRoot)
         {
             if (string.IsNullOrWhiteSpace(gitBinPath))
             {
@@ -75,7 +74,6 @@ namespace GVFS.Common.Git
 
             this.gitBinPath = gitBinPath;
             this.workingDirectoryRoot = workingDirectoryRoot;
-            this.gvfsHooksRoot = gvfsHooksRoot;
 
             if (this.workingDirectoryRoot != null)
             {
@@ -93,27 +91,27 @@ namespace GVFS.Common.Git
         public static ConfigResult GetFromGlobalConfig(string gitBinPath, string settingName)
         {
             return new ConfigResult(
-                new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --global " + settingName),
+                new GitProcess(gitBinPath, workingDirectoryRoot: null).InvokeGitOutsideEnlistment("config --global " + settingName),
                 settingName);
         }
 
         public static ConfigResult GetFromSystemConfig(string gitBinPath, string settingName)
         {
             return new ConfigResult(
-                new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --system " + settingName),
+                new GitProcess(gitBinPath, workingDirectoryRoot: null).InvokeGitOutsideEnlistment("config --system " + settingName),
                 settingName);
         }
 
         public static ConfigResult GetFromFileConfig(string gitBinPath, string configFile, string settingName)
         {
             return new ConfigResult(
-                new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null).InvokeGitOutsideEnlistment("config --file " + configFile + " " + settingName),
+                new GitProcess(gitBinPath, workingDirectoryRoot: null).InvokeGitOutsideEnlistment("config --file " + configFile + " " + settingName),
                 settingName);
         }
 
         public static bool TryGetVersion(string gitBinPath, out GitVersion gitVersion, out string error)
         {
-            GitProcess gitProcess = new GitProcess(gitBinPath, null, null);
+            GitProcess gitProcess = new GitProcess(gitBinPath, null);
             Result result = gitProcess.InvokeGitOutsideEnlistment("--version");
             string version = result.Output;
 
@@ -683,11 +681,6 @@ namespace GVFS.Common.Git
 
             processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
-            processInfo.EnvironmentVariables["PATH"] =
-                string.Join(
-                    ";",
-                    this.gitBinPath,
-                    this.gvfsHooksRoot ?? string.Empty);
 
             if (gitObjectsDirectory != null)
             {

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -190,7 +190,7 @@ namespace GVFS.Mount
             GVFSEnlistment enlistment = null;
             try
             {
-                enlistment = GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, ProcessHelper.GetCurrentProcessLocation(), authentication: null);
+                enlistment = GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, authentication: null);
             }
             catch (InvalidRepoException e)
             {

--- a/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
+++ b/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
@@ -26,9 +26,7 @@ namespace GVFS.PerfProfiling
         private GVFSEnlistment CreateEnlistment(string enlistmentRootPath)
         {
             string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            string hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
-
-            return GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, hooksPath, authentication: null);
+            return GVFSEnlistment.CreateFromDirectory(enlistmentRootPath, gitBinPath, authentication: null);
         }
 
         private GVFSContext CreateContext()

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -85,7 +85,7 @@ namespace GVFS.Platform.Mac
         /// <summary>
         /// This is the directory in which the upgradelogs directory should go.
         /// There can be multiple logs directories, so here we return the containing
-        //  directory.
+        /// directory.
         /// </summary>
         public override string GetUpgradeLogDirectoryParentDirectory()
         {

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -38,9 +38,9 @@ namespace GVFS.Platform.POSIX
         {
         }
 
-        public override bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error)
+        public override bool TryGetGVFSHooksVersion(out string hooksVersion, out string error)
         {
-            hooksPaths = string.Empty;
+            string hooksPaths = string.Empty;
             string binPath = Path.Combine(this.Constants.GVFSBinDirectoryPath, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
             if (File.Exists(binPath))
             {

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -40,13 +40,6 @@ namespace GVFS.Platform.POSIX
 
         public override bool TryGetGVFSHooksVersion(out string hooksVersion, out string error)
         {
-            string hooksPaths = string.Empty;
-            string binPath = Path.Combine(this.Constants.GVFSBinDirectoryPath, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
-            if (File.Exists(binPath))
-            {
-                hooksPaths = binPath;
-            }
-
             // TODO(#1044): Get the hooks version rather than the GVFS version (and share that code with the Windows platform)
             hooksVersion = ProcessHelper.GetCurrentProcessVersion();
             error = null;

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -25,7 +25,7 @@ namespace GVFS.Platform.Windows
         private const string BuildLabRegistryValue = "BuildLab";
         private const string BuildLabExRegistryValue = "BuildLabEx";
 
-        public WindowsPlatform() : base(underConstruction: new UnderConstructionFlags(requiresDeprecatedGitHooksLoader: true))
+        public WindowsPlatform() : base(underConstruction: new UnderConstructionFlags())
         {
         }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -256,11 +256,11 @@ namespace GVFS.Platform.Windows
             }
         }
 
-        public override bool TryGetGVFSHooksPathAndVersion(out string hooksPath, out string hooksVersion, out string error)
+        public override bool TryGetGVFSHooksVersion(out string hooksVersion, out string error)
         {
             error = null;
             hooksVersion = null;
-            hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            string hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
             if (hooksPath == null)
             {
                 error = "Could not find " + GVFSPlatform.Instance.Constants.GVFSHooksExecutableName;

--- a/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
@@ -69,18 +69,16 @@ namespace GVFS.Service.Handlers
         private bool IsValidRepo(string repoRoot)
         {
             string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            string hooksPath = null;
 
             string hooksVersion = null;
             string error = null;
-            if (GVFSPlatform.Instance.TryGetGVFSHooksPathAndVersion(out hooksPath, out hooksVersion, out error))
+            if (GVFSPlatform.Instance.TryGetGVFSHooksVersion(out hooksVersion, out error))
             {
                 try
                 {
                     GVFSEnlistment enlistment = GVFSEnlistment.CreateFromDirectory(
                         repoRoot,
                         gitBinPath,
-                        hooksPath,
                         authentication: null);
                 }
                 catch (InvalidRepoException e)
@@ -88,7 +86,6 @@ namespace GVFS.Service.Handlers
                     EventMetadata metadata = new EventMetadata();
                     metadata.Add(nameof(repoRoot), repoRoot);
                     metadata.Add(nameof(gitBinPath), gitBinPath);
-                    metadata.Add(nameof(hooksPath), hooksPath);
                     metadata.Add("Exception", e.ToString());
                     this.tracer.RelatedInfo(metadata, $"{nameof(this.IsValidRepo)}: Found invalid repo");
 
@@ -97,7 +94,7 @@ namespace GVFS.Service.Handlers
             }
             else
             {
-                this.tracer.RelatedError($"{nameof(this.IsValidRepo)}: {nameof(GVFSPlatform.Instance.TryGetGVFSHooksPathAndVersion)} failed. {error}");
+                this.tracer.RelatedError($"{nameof(this.IsValidRepo)}: {nameof(GVFSPlatform.Instance.TryGetGVFSHooksVersion)} failed. {error}");
                 return false;
             }
 

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentTests.cs
@@ -32,7 +32,7 @@ namespace GVFS.UnitTests.Common
             private MockGitProcess gitProcess;
 
             public TestGVFSEnlistment()
-                : base("mock:\\path", "mock://repoUrl", "mock:\\git", gvfsHooksRoot: null, authentication: null)
+                : base("mock:\\path", "mock://repoUrl", "mock:\\git", authentication: null)
             {
                 this.gitProcess = new MockGitProcess();
                 this.gitProcess.SetExpectedCommandResult(

--- a/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GitStatusCacheTests.cs
@@ -44,7 +44,7 @@ namespace GVFS.UnitTests.Common
 
             this.gitProcess = new MockGitProcess();
             this.gitProcess.SetExpectedCommandResult($"--no-optional-locks status \"--serialize={statusCachePath}", () => new GitProcess.Result(string.Empty, string.Empty, 0), true);
-            MockGVFSEnlistment enlistment = new MockGVFSEnlistment(enlistmentRoot, "fake://repoUrl", "fake://gitBinPath", null, this.gitProcess);
+            MockGVFSEnlistment enlistment = new MockGVFSEnlistment(enlistmentRoot, "fake://repoUrl", "fake://gitBinPath", this.gitProcess);
             enlistment.InitializeCachePathsFromKey("fake:\\gvfsSharedCache", "fakeCacheKey");
 
             this.gitParentPath = enlistment.WorkingDirectoryBackingRoot;

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -138,7 +138,7 @@ namespace GVFS.UnitTests.Git
         private GVFSGitObjects CreateTestableGVFSGitObjects(MockHttpGitObjects httpObjects, MockFileSystemWithCallbacks fileSystem)
         {
             MockTracer tracer = new MockTracer();
-            GVFSEnlistment enlistment = new GVFSEnlistment(TestEnlistmentRoot, "https://fakeRepoUrl", "fakeGitBinPath", gvfsHooksRoot: null, authentication: null);
+            GVFSEnlistment enlistment = new GVFSEnlistment(TestEnlistmentRoot, "https://fakeRepoUrl", "fakeGitBinPath", authentication: null);
             enlistment.InitializeCachePathsFromKey(TestLocalCacheRoot, TestObjectRoot);
             GitRepo repo = new GitRepo(tracer, enlistment, fileSystem, () => new MockLibGit2Repo(tracer));
 

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockGVFSEnlistment.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockGVFSEnlistment.cs
@@ -10,15 +10,15 @@ namespace GVFS.UnitTests.Mock.Common
         private MockGitProcess gitProcess;
 
         public MockGVFSEnlistment()
-            : base(Path.Combine("mock:", "path"), "mock://repoUrl", Path.Combine("mock:", "git"), gvfsHooksRoot: null, authentication: null)
+            : base(Path.Combine("mock:", "path"), "mock://repoUrl", Path.Combine("mock:", "git"), authentication: null)
         {
             this.GitObjectsRoot = Path.Combine("mock:", "path", ".git", "objects");
             this.LocalObjectsRoot = this.GitObjectsRoot;
             this.GitPackRoot = Path.Combine("mock:", "path", ".git", "objects", "pack");
         }
 
-        public MockGVFSEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, string gvfsHooksRoot, MockGitProcess gitProcess)
-            : base(enlistmentRoot, repoUrl, gitBinPath, gvfsHooksRoot, authentication: null)
+        public MockGVFSEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, MockGitProcess gitProcess)
+            : base(enlistmentRoot, repoUrl, gitBinPath, authentication: null)
         {
             this.gitProcess = gitProcess;
         }

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override bool TryGetGVFSHooksPathAndVersion(out string hooksPaths, out string hooksVersion, out string error)
+        public override bool TryGetGVFSHooksVersion(out string hooksVersion, out string error)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
+++ b/GVFS/GVFS.UnitTests/Virtual/CommonRepoSetup.cs
@@ -15,7 +15,7 @@ namespace GVFS.UnitTests.Virtual
             MockTracer tracer = new MockTracer();
 
             string enlistmentRoot = Path.Combine("mock:", "GVFS", "UnitTests", "Repo");
-            GVFSEnlistment enlistment = new GVFSEnlistment(enlistmentRoot, "fake://repoUrl", "fake://gitBinPath", gvfsHooksRoot: null, authentication: null);
+            GVFSEnlistment enlistment = new GVFSEnlistment(enlistmentRoot, "fake://repoUrl", "fake://gitBinPath", authentication: null);
             enlistment.InitializeCachePathsFromKey("fake:\\gvfsSharedCache", "fakeCacheKey");
 
             this.GitParentPath = enlistment.WorkingDirectoryRoot;

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -188,7 +188,7 @@ namespace GVFS.Upgrader
                     return false;
                 }
 
-                ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null);
+                ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
 
                 ProductUpgrader upgrader;
                 if (!ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, new LocalGVFSConfig(), credentialStore, this.DryRun, this.NoVerify, out upgrader, out errorMessage))

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -307,7 +307,7 @@ namespace GVFS.CommandLine
                 return new Result(GVFSConstants.GitIsNotInstalledError);
             }
 
-            string hooksPath = this.GetGVFSHooksPathAndCheckVersion(tracer: null, hooksVersion: out _);
+            this.CheckGVFSHooksVersion(tracer: null, hooksVersion: out _);
 
             try
             {
@@ -315,7 +315,6 @@ namespace GVFS.CommandLine
                     normalizedEnlistementRootPath,
                     this.RepositoryURL,
                     gitBinPath,
-                    hooksPath,
                     authentication: null);
             }
             catch (InvalidRepoException e)

--- a/GVFS/GVFS/CommandLine/RepairVerb.cs
+++ b/GVFS/GVFS/CommandLine/RepairVerb.cs
@@ -38,7 +38,7 @@ namespace GVFS.CommandLine
         {
             this.ValidatePathParameter(this.EnlistmentRootPathParameter);
 
-            string hooksPath = this.GetGVFSHooksPathAndCheckVersion(tracer: null, hooksVersion: out _);
+            this.CheckGVFSHooksVersion(tracer: null, hooksVersion: out _);
 
             if (!Directory.Exists(this.EnlistmentRootPathParameter))
             {
@@ -59,7 +59,6 @@ namespace GVFS.CommandLine
                 enlistment = GVFSEnlistment.CreateFromDirectory(
                     this.EnlistmentRootPathParameter,
                     GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath(),
-                    hooksPath,
                     authentication: null,
                     createWithoutRepoURL: true);
             }

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -120,7 +120,7 @@ namespace GVFS.CommandLine
                         return false;
                     }
 
-                    ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null, gvfsHooksRoot: null);
+                    ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
 
                     ProductUpgrader upgrader;
                     if (ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, new LocalGVFSConfig(), credentialStore, this.DryRun, this.NoVerify, out upgrader, out error))

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -52,7 +52,6 @@ namespace GVFS.RepairJobs
                 GVFSEnlistment enlistment = GVFSEnlistment.CreateFromDirectory(
                     this.Enlistment.EnlistmentRoot,
                     this.Enlistment.GitBinPath,
-                    this.Enlistment.GVFSHooksRoot,
                     authentication: null);
 
                 string authError;


### PR DESCRIPTION
The git process was launched using a PATH environment variable with the
gvfs hooks path to make sure that when a path in the repo was included in
the user's PATH environment variable that it would only search outside
the repo.  This was when the code was using git cat-file to hydrate files
and searching for gvfs hooks would cause it to hydrate files which would
cause it to search for hooks and it would be in a loop.

This is no longer the case, the code is using libgit2 and the hooks are not
called.  Since the gvfs hooks root was only used for setting the PATH for
the git process, all references to it can be removed.

Todo:
- [x] Test with the large repos with the `PATH` having paths in other VFS for git repos as well as the repo being mounted with various tools.