### PR TITLE
Handle corrupt objects on Mac

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -29,9 +29,6 @@
             // Tests requires code updates so that we lock the file instead of looking for a .lock file
             public const string TestNeedsToLockFile = "TestNeedsToLockFile";
 
-            // Corrupt Objects are not redownloaded
-            public const string NeedsCorruptObjectFix = "NeedsCorruptObjectFix";
-
             // Tests that have been flaky on build servers and need additional logging and\or
             // investigation
             public const string FlakyTest = "MacFlakyTest";

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -90,7 +90,6 @@ namespace GVFS.FunctionalTests
                 excludeCategories.Add(Categories.MacTODO.NeedsDehydrate);
                 excludeCategories.Add(Categories.MacTODO.NeedsServiceVerb);
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
-                excludeCategories.Add(Categories.MacTODO.NeedsCorruptObjectFix);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);
             }

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
@@ -33,6 +33,7 @@ namespace GVFS.Virtualization.Background
             OnFilePreDelete,
             OnFolderPreDelete,
             OnFileSymLinkCreated,
+            OnFailedFileHydration,
         }
 
         public OperationType Operation { get; }
@@ -93,6 +94,11 @@ namespace GVFS.Virtualization.Background
         public static FileSystemTask OnFailedPlaceholderUpdate(string virtualPath)
         {
             return new FileSystemTask(OperationType.OnFailedPlaceholderUpdate, virtualPath, oldVirtualPath: null);
+        }
+
+        public static FileSystemTask OnFailedFileHydration(string virtualPath)
+        {
+            return new FileSystemTask(OperationType.OnFailedFileHydration, virtualPath, oldVirtualPath: null);
         }
 
         public static FileSystemTask OnFolderCreated(string virtualPath)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -383,6 +383,11 @@ namespace GVFS.Virtualization
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileConvertedToFull(relativePath));
         }
 
+        public void OnFailedFileHydration(string relativePath)
+        {
+            this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFailedFileHydration(relativePath));
+        }
+
         public virtual void OnFileRenamed(string oldRelativePath, string newRelativePath)
         {
             this.backgroundFileSystemTaskRunner.Enqueue(FileSystemTask.OnFileRenamed(oldRelativePath, newRelativePath));
@@ -687,6 +692,7 @@ namespace GVFS.Virtualization
                 case FileSystemTask.OperationType.OnFileSuperseded:
                 case FileSystemTask.OperationType.OnFileConvertedToFull:
                 case FileSystemTask.OperationType.OnFailedPlaceholderUpdate:
+                case FileSystemTask.OperationType.OnFailedFileHydration:
                     metadata.Add("virtualPath", gitUpdate.VirtualPath);
                     result = this.AddModifiedPathAndRemoveFromPlaceholderList(gitUpdate.VirtualPath);
                     break;


### PR DESCRIPTION
Remove Categories.MacTODO.NeedsCorruptObjectFix 

Handle corrupt objects on Mac by adding them to modifiedPaths.dat and printing an error.

resolves #1218