### PR TITLE
Remove all TODO(POSIX) and TODO(Mac) comments.

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -7,7 +7,6 @@ namespace GVFS.Common.FileSystem
         bool SupportsFileMode { get; }
         void FlushFileBuffers(string path);
         void MoveAndOverwriteFile(string sourceFileName, string destinationFilename);
-        void CreateHardLink(string newLinkFileName, string existingFileName);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);
         void ChangeMode(string path, ushort mode);
         bool HydrateFile(string fileName, byte[] buffer);

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -226,7 +226,6 @@ namespace GVFS.Common
 
         private string NormalizeEntryString(string virtualPath, bool isFolder)
         {
-            // TODO(Mac) This can be optimized if needed
             return virtualPath.Replace(Path.DirectorySeparatorChar, GVFSConstants.GitPathSeparator).Trim(GVFSConstants.GitPathSeparator) +
                 (isFolder ? GVFSConstants.GitPathSeparatorString : string.Empty);
         }

--- a/GVFS/GVFS.Common/NativeMethods.cs
+++ b/GVFS/GVFS.Common/NativeMethods.cs
@@ -98,14 +98,6 @@ namespace GVFS.Common
             }
         }
 
-        public static void CreateHardLink(string newLinkFileName, string existingFileName)
-        {
-            if (!CreateHardLink(newLinkFileName, existingFileName, IntPtr.Zero))
-            {
-                ThrowLastWin32Exception($"Failed to create hard link from '{newLinkFileName}' to '{existingFileName}'");
-            }
-        }
-
         /// <summary>
         /// Get the build number of the OS
         /// </summary>
@@ -169,12 +161,6 @@ namespace GVFS.Common
             string existingFileName,
             string newFileName,
             uint flags);
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        private static extern bool CreateHardLink(
-            string newLinkFileName,
-            string existingFileName,
-            IntPtr securityAttributes);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool FlushFileBuffers(SafeFileHandle hFile);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -113,7 +113,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.Enlistment.Prefetch("--files *").ShouldContain("Nothing new to prefetch.");
         }
 
-        // TODO(Mac): Handle that lock files are not deleted on Mac, they are simply unlocked
+        // TODO(#1219): Handle that lock files are not deleted on Mac, they are simply unlocked
         [TestCase, Order(11)]
         [Category(Categories.MacTODO.TestNeedsToLockFile)]
         public void PrefetchCleansUpStalePrefetchLock()

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbWithoutSharedCacheTests.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    // TODO(Mac): Before these tests can be enabled PostFetchJobShouldComplete needs
+    // TODO(#1219): Before these tests can be enabled PostFetchJobShouldComplete needs
     // to work on Mac (where post-fetch.lock is not removed from disk)
     [TestFixture]
     [Category(Categories.ExtraCoverage)]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -498,7 +498,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             (badObject as FileInfo).ShouldNotBeNull().Length.ShouldEqual(objectFileInfo.Length);
         }
 
-        // TODO(Mac): Figure out why git for Mac is not requesting a redownload of the truncated object
+        // TODO(#1218): Figure out why git for Mac is not requesting a redownload of the truncated object
         [TestCase, Order(17)]
         [Category(Categories.MacTODO.NeedsCorruptObjectFix)]
         public void TruncatedObjectRedownloaded()
@@ -630,7 +630,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                //// TODO(Mac): Add a version of PlaceHolderHasVersionInfo that works on Mac
+                // TODO(#1360): Add a version of PlaceHolderHasVersionInfo that works on Mac
                 return true;
             }
             else

--- a/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
+++ b/GVFS/GVFS.NativeHooks.Common/common.posix.cpp
@@ -13,7 +13,7 @@
 
 PATH_STRING GetFinalPathName(const PATH_STRING& path)
 {
-    // TODO(Mac): Implement
+    // TODO(#1358): Implement
     return path;
 }
 

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -88,7 +88,7 @@ namespace GVFS.Platform.Mac
             long endOfFile,
             string sha)
         {
-            // TODO(Mac): Add functional tests that validate file mode is set correctly
+            // TODO(#223): Add functional tests that validate file mode is set correctly
             GitIndexProjection.FileType fileType;
             ushort fileMode;
             this.FileSystemCallbacks.GitIndexProjection.GetFileTypeAndMode(relativePath, out fileType, out fileMode);
@@ -151,7 +151,7 @@ namespace GVFS.Platform.Mac
         {
             UpdateFailureCause failureCause = UpdateFailureCause.NoFailure;
 
-            // TODO(Mac): Add functional tests that include:
+            // TODO(#223): Add functional tests that include:
             //     - Mode + content changes between commits
             //     - Mode only changes (without any change to content, see issue #223)
             GitIndexProjection.FileType fileType;
@@ -266,7 +266,7 @@ namespace GVFS.Platform.Mac
                         byte[] buffer = new byte[SymLinkTargetBufferSize];
                         uint bufferIndex = 0;
 
-                        // TODO(Mac): Find a better solution than reading from the stream one byte at at time
+                        // TODO(#1361): Find a better solution than reading from the stream one byte at at time
                         int nextByte = stream.ReadByte();
                         while (nextByte != -1)
                         {
@@ -364,7 +364,7 @@ namespace GVFS.Platform.Mac
                     activity.RelatedError(metadata, nameof(this.OnGetFileStream) + ": Unexpected placeholder version");
                     activity.Dispose();
 
-                    // TODO(Mac): Is this the correct Result to return?
+                    // TODO(#1362): Is this the correct Result to return?
                     return Result.EIOError;
                 }
 
@@ -376,7 +376,7 @@ namespace GVFS.Platform.Mac
                         GVFSGitObjects.RequestSource.FileStreamCallback,
                         (stream, blobLength) =>
                         {
-                            // TODO(Mac): Find a better solution than reading from the stream one byte at at time
+                            // TODO(#1361): Find a better solution than reading from the stream one byte at at time
                             byte[] buffer = new byte[4096];
                             uint bufferIndex = 0;
                             int nextByte = stream.ReadByte();
@@ -408,7 +408,7 @@ namespace GVFS.Platform.Mac
                     {
                         activity.RelatedError(metadata, $"{nameof(this.OnGetFileStream)}: TryCopyBlobContentStream failed");
 
-                        // TODO(Mac): Is this the correct Result to return?
+                        // TODO(#1362): Is this the correct Result to return?
                         return Result.EFileNotFound;
                     }
                 }

--- a/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.Shared.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.Shared.cs
@@ -4,7 +4,7 @@
     {
         public static bool TryGetNormalizedPathImplementation(string path, out string normalizedPath, out string errorMessage)
         {
-            // TODO(POSIX): Properly determine normalized paths (e.g. across links)
+            // TODO(#1358): Properly determine normalized paths (e.g. across links)
             errorMessage = null;
             normalizedPath = path;
             return true;

--- a/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
@@ -30,7 +30,7 @@ namespace GVFS.Platform.POSIX
 
         public void FlushFileBuffers(string path)
         {
-            // TODO(POSIX): Use native API to flush file
+            // TODO(#1057): Use native API to flush file
         }
 
         public void MoveAndOverwriteFile(string sourceFileName, string destinationFilename)
@@ -39,12 +39,6 @@ namespace GVFS.Platform.POSIX
             {
                 NativeMethods.ThrowLastWin32Exception($"Failed to rename {sourceFileName} to {destinationFilename}");
             }
-        }
-
-        public void CreateHardLink(string newFileName, string existingFileName)
-        {
-            // TODO(POSIX): Use native API to create a hardlink
-            File.Copy(existingFileName, newFileName);
         }
 
         public abstract void ChangeMode(string path, ushort mode);

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.Shared.cs
@@ -36,14 +36,12 @@ namespace GVFS.Platform.POSIX
 
         public static bool IsConsoleOutputRedirectedToFileImplementation()
         {
-            // TODO(POSIX): Implement proper check
+            // TODO(#1355): Implement proper check
             return false;
         }
 
         public static bool TryGetGVFSEnlistmentRootImplementation(string directory, string dotGVFSRoot, out string enlistmentRoot, out string errorMessage)
         {
-            // TODO(POSIX): Merge this code with the implementation in WindowsPlatform
-
             enlistmentRoot = null;
 
             string finalDirectory;

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.POSIX
                 hooksPaths = binPath;
             }
 
-            // TODO(POSIX): Get the hooks version rather than the GVFS version (and share that code with the Windows platform)
+            // TODO(#1359): Get the hooks version rather than the GVFS version (and share that code with the Windows platform)
             hooksVersion = ProcessHelper.GetCurrentProcessVersion();
             error = null;
             return true;
@@ -183,7 +183,7 @@ namespace GVFS.Platform.POSIX
 
         public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly)
         {
-            // TODO(POSIX): Collect disk information
+            // TODO(#1356): Collect disk information
             Dictionary<string, string> result = new Dictionary<string, string>();
             result.Add("GetPhysicalDiskInfo", "Not yet implemented on POSIX");
             return result;
@@ -248,7 +248,7 @@ namespace GVFS.Platform.POSIX
 
         public override bool IsGitStatusCacheSupported()
         {
-            // TODO(POSIX): support git status cache
+            // Git status cache is only supported on Windows
             return false;
         }
 

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -47,7 +47,7 @@ namespace GVFS.Platform.POSIX
                 hooksPaths = binPath;
             }
 
-            // TODO(#1359): Get the hooks version rather than the GVFS version (and share that code with the Windows platform)
+            // TODO(#1044): Get the hooks version rather than the GVFS version (and share that code with the Windows platform)
             hooksVersion = ProcessHelper.GetCurrentProcessVersion();
             error = null;
             return true;

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -92,11 +92,6 @@ namespace GVFS.Platform.Windows
                 NativeMethods.MoveFileFlags.MoveFileReplaceExisting);
         }
 
-        public void CreateHardLink(string newFileName, string existingFileName)
-        {
-            NativeMethods.CreateHardLink(newFileName, existingFileName);
-        }
-
         public void ChangeMode(string path, ushort mode)
         {
         }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -18,11 +18,6 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
-        public void CreateHardLink(string newFileName, string existingFileName)
-        {
-            throw new NotSupportedException();
-        }
-
         public void ChangeMode(string path, ushort mode)
         {
             throw new NotSupportedException();

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -664,14 +664,9 @@ namespace GVFS.Virtualization.Projection
 
             if (GVFSPlatform.Instance.FileSystem.SupportsFileMode)
             {
-                // TODO(Mac): Test if performance could be improved by eliminating the SupportsFileMode check
-                // (e.g. by defaulting FileMode to Regular 644 and eliminating the SupportsFileMode check)
                 if (indexEntry.TypeAndMode.Type != FileType.Regular ||
                     indexEntry.TypeAndMode.Mode != FileMode644)
                 {
-                    // TODO(Mac): The line below causes a conversion from LazyUTF8String to .NET string.
-                    // Measure the perf and memory overhead of performing this conversion, and determine if we need
-                    // a way to keep the path as LazyUTF8String
                     this.nonDefaultFileTypesAndModes.Add(indexEntry.BuildingProjection_GetGitRelativePath(), indexEntry.TypeAndMode);
                 }
             }
@@ -1379,7 +1374,7 @@ namespace GVFS.Virtualization.Projection
                 return;
             }
 
-            // TODO(Mac): Issue #255, batch file sizes up-front for the new placeholders written by ReExpandFolder
+            // TODO(#255): Batch file sizes up-front for the new placeholders written by ReExpandFolder
             folderData.PopulateSizes(
                 this.context.Tracer,
                 this.gitObjects,
@@ -1436,7 +1431,7 @@ namespace GVFS.Virtualization.Projection
                             return;
 
                         default:
-                            // TODO(Mac): Issue #245, handle failures of WritePlaceholderDirectory and WritePlaceholderFile
+                            // TODO(#245): Handle failures of WritePlaceholderDirectory and WritePlaceholderFile
                             break;
                     }
                 }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -664,7 +664,7 @@ namespace GVFS.CommandLine
             return new Result(true);
         }
 
-        // TODO(#1364): either adjust to "git" or remove entirely
+        // TODO(#1364): Don't call this method on POSIX platforms (or have it no-op on them)
         private void CreateGitScript(GVFSEnlistment enlistment)
         {
             FileInfo gitCmd = new FileInfo(Path.Combine(enlistment.EnlistmentRoot, "git.cmd"));

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -664,7 +664,7 @@ namespace GVFS.CommandLine
             return new Result(true);
         }
 
-        // TODO(Linux), TODO(Mac): either adjust to "git" or remove entirely
+        // TODO(#1364): either adjust to "git" or remove entirely
         private void CreateGitScript(GVFSEnlistment enlistment)
         {
             FileInfo gitCmd = new FileInfo(Path.Combine(enlistment.EnlistmentRoot, "git.cmd"));

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -673,7 +673,7 @@ KEXT_STATIC int HandleFileOpOperation(
         // arg0 is the (const char *) fromPath (or the file being linked to)
         const char* newPath = reinterpret_cast<const char*>(arg1);
         
-        // TODO(Mac): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
+        // TODO(#1367): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
         // it's possible that we'll miss notifications
         errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
         if (0 != toErr)
@@ -740,7 +740,7 @@ KEXT_STATIC int HandleFileOpOperation(
         const char* fromPath = reinterpret_cast<const char*>(arg0);
         const char* newPath = reinterpret_cast<const char*>(arg1);
         
-        // TODO(Mac): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
+        // TODO(#1367): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
         // it's possible that we'll miss notifications
         errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
         if (0 != toErr)
@@ -757,7 +757,6 @@ KEXT_STATIC int HandleFileOpOperation(
         bool isDirectory = (0 != vnode_isdir(currentVnode));
         if (isDirectory)
         {
-            // TODO(Mac): Handle hard-linked directories?
             KextLog_Info("HandleFileOpOperation: KAUTH_FILEOP_LINK event for hardlinked directory currently not handled. ('%s' -> '%s')", fromPath, newPath);
             goto CleanupAndReturn;
         }
@@ -1127,7 +1126,7 @@ static bool TryGetVirtualizationRoot(
     ActiveProviderProperties provider = VirtualizationRoot_GetActiveProvider(*root);
     if (!provider.isOnline)
     {
-        // TODO(Mac): Protect files in the worktree from modification (and prevent
+        // TODO(#182): Protect files in the worktree from modification (and prevent
         // the creation of new files) when the provider is offline
         
         perfTracer->IncrementCount(PrjFSPerfCounter_VnodeOp_GetVirtualizationRoot_ProviderOffline);
@@ -1238,7 +1237,7 @@ static VirtualizationRootHandle FindRootForVnodeWithFileOpEvent(
     }
     else
     {
-        // TODO(Mac): Once all hardlink paths are delivered to the appropriate root(s)
+        // TODO(#1188): Once all hardlink paths are delivered to the appropriate root(s)
         // check if the KAUTH_FILEOP_LINK case can be removed.  For now the check is required to make
         // sure we're looking up the most up-to-date parent information for the vnode on the next
         // access to the vnode cache
@@ -1383,9 +1382,8 @@ static bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t _Nonnull context, ui
     errno_t err = GetVNodeAttributes(vn, context, &attributes);
     if (0 != err)
     {
-        // TODO(Mac): May fail on some file system types? Perhaps we should early-out depending on mount point anyway.
-        // We should also consider:
-        //   - Logging this error
+        // May fail on some file system types? Perhaps we should early-out depending on mount point anyway.
+        // If we see failures we should also consider:
         //   - Falling back on vnode lookup (or custom cache) to determine if file is in the root
         //   - Assuming files are empty if we can't read the flags
         KextLog_FileError(vn, "ReadVNodeFileFlags: GetVNodeAttributes failed with error %d; vnode type: %d, recycled: %s", err, vnode_vtype(vn), vnode_isrecycled(vn) ? "yes" : "no");


### PR DESCRIPTION
Resolves #1357 

For each TODO(POSIX) or TODO(Mac) comment one of the following was done:

- Comment was updated with specific issue number
- Comment was removed if no longer relevant
- Change was made to address the TODO