### PR TITLE
GitProcess: Catch InvalidOperationException when setting priority class

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -764,7 +764,14 @@ namespace GVFS.Common.Git
 
                             if (this.LowerPriority)
                             {
-                                this.executingProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
+                                try
+                                {
+                                    this.executingProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
+                                }
+                                catch (InvalidOperationException)
+                                {
+                                    // This is thrown if the process completes before we can set its priority.
+                                }
                             }
                         }
 


### PR DESCRIPTION
As specified in the documentation [1], the PriorityClass setter will
throw an InvalidOperationException if the process ID is not available.
This could happen due to a race condition where the process completes
before we can set its priority.

The other exceptions it can throw are either platform-specific or
signal a bug, so do not be overly aggressive in the 'catch'.

[1] https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.priorityclass?view=netframework-4.8