### PR TITLE
Upgrade: Fix test flakiness around upgrade reminders

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -208,19 +208,19 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private bool ReminderMessagingEnabled()
         {
-            for (int count = 0; count < 50; count++)
-            {
-                ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
-                this.Enlistment.RepoRoot,
-                "status",
-                removeWaitingMessages:true,
-                removeUpgradeMessages:false);
+            Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
+            environmentVariables["GVFS_UPGRADE_DETERMINISTIC"] = "true";
+            ProcessResult result = GitHelpers.InvokeGitAgainstGVFSRepo(
+                                                    this.Enlistment.RepoRoot,
+                                                    "status",
+                                                    environmentVariables,
+                                                    removeWaitingMessages: true,
+                                                    removeUpgradeMessages: false);
 
-                if (!string.IsNullOrEmpty(result.Errors) &&
-                    result.Errors.Contains("A new version of GVFS is available."))
-                {
-                    return true;
-                }
+            if (!string.IsNullOrEmpty(result.Errors) &&
+                result.Errors.Contains("A new version of GVFS is available."))
+            {
+                return true;
             }
 
             return false;

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -233,7 +233,7 @@ namespace GVFS.Hooks
                 {
                     if (response == null || response.ResponseData == null)
                     {
-                        Console.WriteLine("\nError communicating with GVFS: Run 'git status' to check the status of your repo");
+                        Console.WriteLine("\nError communicating with GVFS: Run 'gvfs status' to check the status of your repo");
                     }
                     else if (response.ResponseData.HasFailures)
                     {

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -109,7 +109,7 @@ namespace GVFS.Hooks
             int reminderFrequency = 10;
             int randomValue = random.Next(0, 100);
 
-            if (randomValue <= reminderFrequency &&
+            if ((IsUpgradeMessageDeterministic() || randomValue <= reminderFrequency) &&
                 ProductUpgraderInfo.IsLocalUpgradeAvailable(tracer: null, highestAvailableVersionDirectory: GVFSHooksPlatform.GetUpgradeHighestAvailableVersionDirectory()))
             {
                 Console.WriteLine(Environment.NewLine + GVFSConstants.UpgradeVerbMessages.ReminderNotification);
@@ -420,6 +420,18 @@ namespace GVFS.Hooks
             catch (Exception)
             {
                 return string.Empty;
+            }
+        }
+
+        private static bool IsUpgradeMessageDeterministic()
+        {
+            try
+            {
+                return Environment.GetEnvironmentVariable("GVFS_UPGRADE_DETERMINISTIC", EnvironmentVariableTarget.Process) != null;
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
     }

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -1,12 +1,9 @@
 using GVFS.Common;
-using GVFS.Common.Git;
 using GVFS.Common.NamedPipes;
 using GVFS.Hooks.HooksPlatform;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Security;
 
 namespace GVFS.Hooks
 {
@@ -20,7 +17,6 @@ namespace GVFS.Hooks
 
         private const int PostCommandSpinnerDelayMs = 500;
 
-        private static Dictionary<string, string> specialArgValues = new Dictionary<string, string>();
         private static string enlistmentRoot;
         private static string enlistmentPipename;
         private static Random random = new Random();
@@ -302,40 +298,19 @@ namespace GVFS.Hooks
             return message;
         }
 
-        private static bool TryRemoveArg(ref string[] args, string argName, out string output)
-        {
-            output = null;
-            int argIdx = Array.IndexOf(args, argName);
-            if (argIdx >= 0)
-            {
-                if (argIdx + 1 < args.Length)
-                {
-                    output = args[argIdx + 1];
-                    args = args.Take(argIdx).Concat(args.Skip(argIdx + 2)).ToArray();
-                    return true;
-                }
-                else
-                {
-                    ExitWithError("Missing value for {0}.", argName);
-                }
-            }
-
-            return false;
-        }
-
         private static bool IsGitEnvVarDisabled(string envVar)
         {
-                string envVarValue = Environment.GetEnvironmentVariable(envVar);
-                if (!string.IsNullOrEmpty(envVarValue))
+            string envVarValue = Environment.GetEnvironmentVariable(envVar);
+            if (!string.IsNullOrEmpty(envVarValue))
+            {
+                if (string.Equals(envVarValue, "false", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(envVarValue, "no", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(envVarValue, "off", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(envVarValue, "0", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (string.Equals(envVarValue, "false", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(envVarValue, "no", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(envVarValue, "off", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(envVarValue, "0", StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
+            }
 
             return false;
         }
@@ -411,11 +386,6 @@ namespace GVFS.Hooks
             }
 
             return true;
-        }
-
-        private static bool ContainsArg(string[] actualArgs, string expectedArg)
-        {
-            return actualArgs.Contains(expectedArg, StringComparer.OrdinalIgnoreCase);
         }
 
         private static string GetHookType(string[] args)


### PR DESCRIPTION
Should fix #852.

The fix is to use an environment variable to always show the upgrade message, if present.

While looking at the post-command hook code, I discovered some simple cleanups that are isolated to different commits:

* Removed unreachable code.
* Changed a message to refer to `gvfs status` instead of `git status`.