### PR TITLE
[TEST] Revert "Mac build scripts: consume git installer pkg directly"

### DIFF
--- a/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
+++ b/GVFS/GVFS.Installer.Mac/CreateMacInstaller.sh
@@ -179,34 +179,49 @@ function CreateVFSForGitDistribution()
 function CreateMetaDistribution()
 {
     GITVERSION="$($VFS_SCRIPTDIR/GetGitVersionNumber.sh)"
-    GITINSTALLERPKGPATH="$(find $VFS_PACKAGESDIR/gitformac.gvfs.installer/$GITVERSION -type f -name *.pkg)" || exit 1
-
-    GITPKGNAME="${GITINSTALLERPKGPATH##*/}"
-    GITINSTALLERPKGNAME="${GITPKGNAME%.pkg}"
-    GITVERSIONSTRING=`echo $GITINSTALLERPKGNAME | cut -d"-" -f2`
-
+    GITDMGPATH="$(find $VFS_PACKAGESDIR/gitformac.gvfs.installer/$GITVERSION -type f -name *.dmg)" || exit 1
+    GITDMGNAME="${GITDMGPATH##*/}"
+    GITINSTALLERNAME="${GITDMGNAME%.dmg}"
+    GITVERSIONSTRING=`echo $GITINSTALLERNAME | cut -d"-" -f2`
+    GITPKGNAME="$GITINSTALLERNAME.pkg"
+    
     if [[ -z "$GITVERSION" || -z "$GITVERSIONSTRING" ]]; then
         echo "Error creating metapackage: could not determine Git package version."
         exit 1
     fi
     
-    if [ ! -f "$GITINSTALLERPKGPATH" ]; then
+    if [ ! -f "$GITDMGPATH" ]; then
+        echo "Error creating metapackage: could not find Git disk image."
+        exit 1
+    fi
+    
+    mountCmd="/usr/bin/hdiutil attach \"$GITDMGPATH\""
+    echo "$mountCmd"
+    eval $mountCmd || exit 1
+    
+    MOUNTEDVOLUME=`/usr/bin/find /Volumes -maxdepth 1 -type d -name "Git $GITVERSIONSTRING*"`
+    GITINSTALLERPATH=`/usr/bin/find "$MOUNTEDVOLUME" -type f -name "git-$GITVERSIONSTRING*.pkg"`
+    
+    if [ ! -f "$GITINSTALLERPATH" ]; then
         echo "Error creating metapackage: could not find Git installer package."
         exit 1
     fi
     
-    copyGitInstallerPkgToStgCmd="/bin/cp -Rf \"${GITINSTALLERPKGPATH}\" \"${PACKAGESTAGINGDIR}/.\""
-    echo $copyGitInstallerPkgToStgCmd
-    eval $copyGitInstallerPkgToStgCmd || exit 1
+    copyGitPkgCmd="/bin/cp -Rf \"${GITINSTALLERPATH}\" \"${PACKAGESTAGINGDIR}/.\""
+    eval $copyGitPkgCmd
 
     UpdateDistributionFile "$GITPKGNAME" "$GITVERSIONSTRING"
-
+    
     METAPACKAGENAME="$INSTALLERPACKAGENAME-Git.$GITVERSION.pkg"
     buildMetapkgCmd="/usr/bin/productbuild --distribution \"${BUILDOUTPUTDIR}/Distribution.updated.xml\" --package-path \"$PACKAGESTAGINGDIR\" \"${BUILDOUTPUTDIR}/$METAPACKAGENAME\""
     echo $buildMetapkgCmd
     eval $buildMetapkgCmd || exit 1
     
     /bin/rm -f "${BUILDOUTPUTDIR}/$DIST_FILE_NAME"
+    
+    unmountCmd="/usr/bin/hdiutil detach \"$MOUNTEDVOLUME\""
+    echo "$unmountCmd"
+    eval $unmountCmd || exit 1
 }
 
 function Run()

--- a/Scripts/Mac/GetGitVersionNumber.sh
+++ b/Scripts/Mac/GetGitVersionNumber.sh
@@ -1,5 +1,5 @@
 . "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
 
 GVFSPROPS=$VFS_SRCDIR/GVFS/GVFS.Build/GVFS.props
-GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)*')"
+GITVERSION="$(cat $GVFSPROPS | grep GitPackageVersion | grep -Eo '[0-9.]+(-\w+)?')"
 echo $GITVERSION


### PR DESCRIPTION
Reverts microsoft/VFSForGit#1318

[The CI builds](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=10036740&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b) started failing with this merge. The issue is related to the mac GVFS.Service not loading correctly. PR builds are all failing right now with this issue.

This revert is to try and see if it fixes the problem, or if we need to get on the machine and do manual steps.