### PR TITLE
Increasing precision of timestamps being logged

### DIFF
--- a/GVFS/GVFS.Common/Tracing/EventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/EventListener.cs
@@ -41,7 +41,7 @@ namespace GVFS.Common.Tracing
         {
             // Make a smarter guess (than 16 characters) about initial size to reduce allocations
             StringBuilder message = new StringBuilder(1024);
-            message.AppendFormat("[{0:yyyy-MM-dd HH:mm:ss zzz}] {1}", DateTime.Now, eventName);
+            message.AppendFormat("[{0:yyyy-MM-dd HH:mm:ss.ffff zzz}] {1}", DateTime.Now, eventName);
 
             if (opcode != 0)
             {


### PR DESCRIPTION
Currently, we only log seconds, but for some operations, it would be great to be able to have better resolution of log timestamps, so I'm increasing the precision of timestamps in logs to 1/10^4 of seconds.