### PR TITLE
Allow non-azure URLs for upgrade nuget feed

### DIFF
--- a/GVFS/GVFS.Common/AzDevOpsOrgFromNuGetFeed.cs
+++ b/GVFS/GVFS.Common/AzDevOpsOrgFromNuGetFeed.cs
@@ -37,6 +37,14 @@ namespace GVFS.Common
         {
             if (!TryParseOrg(packageFeedUrl, out string org))
             {
+                if (!IsAzureUrl(packageFeedUrl))
+                {
+                    // If this is not an azure nuget feed, then just return the original URL
+                    error = null;
+                    azureDevOpsUrl = packageFeedUrl;
+                    return true;
+                }
+
                 azureDevOpsUrl = null;
                 error = $"Input URL {packageFeedUrl} did not match expected format for an Azure DevOps Package Feed URL";
                 return false;
@@ -46,6 +54,15 @@ namespace GVFS.Common
             error = null;
 
             return true;
+        }
+
+        private static bool IsAzureUrl(string url)
+        {
+            Regex packageUrlRegex = new Regex(
+                @"^https?://[0-9a-z-.]*azure.com/(?<org>.+?)/",
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+            return packageUrlRegex.IsMatch(url);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/AzDevOpsOrgFromNuGetFeedTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/AzDevOpsOrgFromNuGetFeedTests.cs
@@ -11,6 +11,8 @@ namespace GVFS.UnitTests.Common
         [TestCase("https://PKGS.DEV.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", "https://test-pat.visualstudio.com")]
         [TestCase("https://dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
         [TestCase("http://pkgs.dev.azure.com/test-pat/_packaging/Test-GVFS-Installers-Custom/nuget/v3/index.json", null)]
+        [TestCase("https://feeds.contoso.org/newget/v42/home.json", "https://feeds.contoso.org/newget/v42/home.json")]
+        [TestCase("http://unsecure-feeds.contoso.org/newget/v42/home.json", "http://unsecure-feeds.contoso.org/newget/v42/home.json")]
         public void CanConstructAzureDevOpsUrlFromPackageFeedUrl(string packageFeedUrl, string expectedAzureDevOpsUrl)
         {
             bool success = AzDevOpsOrgFromNuGetFeed.TryCreateCredentialQueryUrl(


### PR DESCRIPTION
Currently, if the configured upgrade feed is not from azure devops, it doesn't work. Allowing the organisations to configure internal nuget feeds would allow them to better control the rollout of new versions. 