### PR TITLE
Mac: Do not lookup or download file sizes when updating placeholders

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
+++ b/GVFS/GVFS.Common/FileSystem/IKernelDriver.cs
@@ -7,6 +7,12 @@ namespace GVFS.Common.FileSystem
     public interface IKernelDriver
     {
         bool EnumerationExpandsDirectories { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether file sizes required to write/update placeholders
+        /// </summary>
+        bool EmptyPlaceholdersRequireFileSize { get; }
+
         string LogsFolderPath { get; }
         bool IsSupported(string normalizedEnlistmentRootPath, out string warning, out string error);
         bool TryFlushLogs(out string errors);

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -143,6 +143,7 @@ namespace GVFS.Platform.Mac
             return new FileSystemResult(ResultToFSResult(result), unchecked((int)result));
         }
 
+        /// <param name="endOfFile">Length of the file, not required on the Mac platform</param>
         public override FileSystemResult UpdatePlaceholderIfNeeded(
             string relativePath,
             DateTime creationTime,
@@ -170,7 +171,6 @@ namespace GVFS.Platform.Mac
                     relativePath,
                     PlaceholderVersionId,
                     ToVersionIdByteArray(ConvertShaToContentId(shaContentId)),
-                    (ulong)endOfFile,
                     fileMode,
                     (UpdateType)updateFlags,
                     out failureCause);

--- a/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
+++ b/GVFS/GVFS.Platform.Mac/ProjFSKext.cs
@@ -3,7 +3,6 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using PrjFSLib.Mac;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -19,6 +18,7 @@ namespace GVFS.Platform.Mac
         private const int LoadKext_ExitCode_NotApproved = 27;
 
         public bool EnumerationExpandsDirectories { get; } = true;
+        public bool EmptyPlaceholdersRequireFileSize { get; } = false;
 
         public string LogsFolderPath
         {

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -48,6 +48,7 @@ namespace GVFS.Platform.Windows
         }
 
         public bool EnumerationExpandsDirectories { get; } = false;
+        public bool EmptyPlaceholdersRequireFileSize { get; } = true;
 
         public string LogsFolderPath
         {

--- a/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
@@ -95,7 +95,6 @@ namespace GVFS.UnitTests.Mock.Mac
             string relativePath,
             byte[] providerId,
             byte[] contentId,
-            ulong fileSize,
             ushort fileMode,
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1199,18 +1199,13 @@ namespace GVFS.Virtualization.Projection
 
             using (ITracer activity = this.context.Tracer.StartActivity("UpdatePlaceholders", EventLevel.Informational, metadata))
             {
-                int minItemsPerThread = 10;
-                int numThreads = Math.Max(8, Environment.ProcessorCount);
-                numThreads = Math.Min(numThreads, placeholderFilesListCopy.Count / minItemsPerThread);
-                numThreads = Math.Max(numThreads, 1);
-
                 // folderPlaceholdersToKeep always contains the empty path so as to avoid unnecessary attempts
                 // to remove the repository's root folder.
                 ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
                 folderPlaceholdersToKeep.Add(string.Empty);
 
                 stopwatch.Restart();
-                this.MultiThreadedPlaceholderUpdatesAndDeletes(numThreads, placeholderFilesListCopy, folderPlaceholdersToKeep);
+                this.MultiThreadedPlaceholderUpdatesAndDeletes(placeholderFilesListCopy, folderPlaceholdersToKeep);
                 stopwatch.Stop();
 
                 long millisecondsUpdatingFilePlaceholders = stopwatch.ElapsedMilliseconds;
@@ -1320,10 +1315,14 @@ namespace GVFS.Virtualization.Projection
         }
 
         private void MultiThreadedPlaceholderUpdatesAndDeletes(
-            int numThreads,
             List<IPlaceholderData> placeholderList,
             ConcurrentHashSet<string> folderPlaceholdersToKeep)
         {
+            int minItemsPerThread = 10;
+            int numThreads = Math.Max(8, Environment.ProcessorCount);
+            numThreads = Math.Min(numThreads, placeholderList.Count / minItemsPerThread);
+            numThreads = Math.Max(numThreads, 1);
+
             if (numThreads > 1)
             {
                 Thread[] processThreads = new Thread[numThreads];

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -43,7 +43,6 @@ namespace PrjFSLib.Mac.Interop
             byte[] providerId,
             [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
             byte[] contentId,
-            ulong fileSize,
             ushort fileMode,
             UpdateType updateType,
             ref UpdateFailureCause failureCause);

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -120,7 +120,6 @@ namespace PrjFSLib.Mac
             string relativePath,
             byte[] providerId,
             byte[] contentId,
-            ulong fileSize,
             ushort fileMode,
             UpdateType updateFlags,
             out UpdateFailureCause failureCause)
@@ -136,7 +135,6 @@ namespace PrjFSLib.Mac
                 relativePath,
                 providerId,
                 contentId,
-                fileSize,
                 fileMode,
                 updateFlags,
                 ref updateFailureCause);

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -466,7 +466,6 @@ PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
     _In_    const char*                             relativePath,
     _In_    unsigned char                           providerId[PrjFS_PlaceholderIdLength],
     _In_    unsigned char                           contentId[PrjFS_PlaceholderIdLength],
-    _In_    unsigned long                           fileSize,
     _In_    uint16_t                                fileMode,
     _In_    PrjFS_UpdateType                        updateFlags,
     _Out_   PrjFS_UpdateFailureCause*               failureCause)
@@ -477,7 +476,6 @@ PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
         << relativePath << ", "
         << (int)providerId[0] << ", "
         << (int)contentId[0] << ", "
-        << fileSize << ", "
         << oct << fileMode << dec << ", "
         << hex << updateFlags << dec << ")" << endl;
 #endif

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -112,7 +112,6 @@ extern "C" PrjFS_Result PrjFS_UpdatePlaceholderFileIfNeeded(
     _In_    const char*                             relativePath,
     _In_    unsigned char                           providerId[PrjFS_PlaceholderIdLength],
     _In_    unsigned char                           contentId[PrjFS_PlaceholderIdLength],
-    _In_    unsigned long                           fileSize,
     _In_    uint16_t                                fileMode,
     _In_    PrjFS_UpdateType                        updateFlags,
     _Out_   PrjFS_UpdateFailureCause*               failureCause);


### PR DESCRIPTION
Resolves #255 
Resolves #1397 

As part of #1130 PrjFSLib was updated to stop filling placeholders with empty data. With that change, VFS4G on Mac no longer needs to download sizes when it updates placeholders or re-expands folders in response to the index being updated.

A new `EmptyPlaceholdersRequireFileSize` property was added to `IKernelDriver` that VFS4G can use to check if the platform requires sizes for empty placeholders (allowing the current size lookup/download logic to continue working for Windows and Linux).

See related PR #1398 for a similar change to the enumeration callback path.

**Performance improvements**

*First Large Repo*

| Step | Master | This PR and #1398 | Difference
--- | --- | --- | ---
| Enumerating Folders | 147.08 | 138.86 | -8.22
| git checkout feature/gvfs/perftest/defaultBranch | 31.53 | 18.09 | -13.44

*Second Large Repo*

| Step | Master | This PR and #1398 | Difference
--- | --- | --- | ---
| Enumerating Folders | 193.69 | 172.87 | -20.82
| git checkout feature/gvfs/perftest/defaultBranch | 13.57 | 11.4 | -2.17


