### PR TITLE
Add count of sparse folders to the heartbeat and lock log information

### DIFF
--- a/GVFS/GVFS.Common/Database/ISparseCollection.cs
+++ b/GVFS/GVFS.Common/Database/ISparseCollection.cs
@@ -6,6 +6,8 @@ namespace GVFS.Common.Database
 {
     public interface ISparseCollection
     {
+        int GetCount();
+
         HashSet<string> GetAll();
 
         void Add(string directory);

--- a/GVFS/GVFS.Common/Database/SparseTable.cs
+++ b/GVFS/GVFS.Common/Database/SparseTable.cs
@@ -28,6 +28,23 @@ namespace GVFS.Common.Database
             }
         }
 
+        public int GetCount()
+        {
+            try
+            {
+                using (IDbConnection connection = this.connectionPool.GetConnection())
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "SELECT count(path) FROM Sparse;";
+                    return Convert.ToInt32(command.ExecuteScalar());
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new GVFSDatabaseException($"{nameof(SparseTable)}.{nameof(this.GetCount)} Exception", ex);
+            }
+        }
+
         public void Add(string directoryPath)
         {
             try

--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -272,6 +272,7 @@ namespace GVFS.Common
             private int folderPlaceholdersPathNotFound;
             private long parseGitIndexTimeMs;
             private long projectionWriteLockHeldMs;
+            private int sparseFolderCount;
 
             private int numBlobs;
             private long blobDownloadTimeMs;
@@ -290,6 +291,11 @@ namespace GVFS.Common
             public void RecordReleaseExternalLockRequested()
             {
                 this.lockHeldExternallyTimeMs = this.lockAcquiredTime.ElapsedMilliseconds;
+            }
+
+            public void RecordSparseFolderCount(int sparseFolderCount)
+            {
+                this.sparseFolderCount = sparseFolderCount;
             }
 
             public void RecordUpdatePlaceholders(
@@ -362,6 +368,8 @@ namespace GVFS.Common
 
                 metadata.Add("SizeQueries", this.numSizeQueries);
                 metadata.Add("SizeQueryTimeMS", this.sizeQueryTimeMs);
+
+                metadata.Add("SparseFolderCount", this.sparseFolderCount);
             }
         }
 

--- a/GVFS/GVFS.UnitTests/Common/Database/SparseTableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/SparseTableTests.cs
@@ -35,6 +35,33 @@ namespace GVFS.UnitTests.Common.Database
         protected override string CreateTableCommandString => "CREATE TABLE IF NOT EXISTS [Sparse] (path TEXT PRIMARY KEY COLLATE NOCASE) WITHOUT ROWID;";
 
         [TestCase]
+        public void GetCountTest()
+        {
+            this.TestTable(
+                (placeholders, mockCommand) =>
+                {
+                    mockCommand.SetupSet(x => x.CommandText = "SELECT count(path) FROM Sparse;");
+                    mockCommand.Setup(x => x.ExecuteScalar()).Returns(123);
+                    placeholders.GetCount().ShouldEqual(123);
+                });
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void GetCountThrowsGVFSDatabaseException()
+        {
+            this.TestTable(
+                (placeholders, mockCommand) =>
+                {
+                    mockCommand.SetupSet(x => x.CommandText = "SELECT count(path) FROM Sparse;");
+                    mockCommand.Setup(x => x.ExecuteScalar()).Throws(new Exception(DefaultExceptionMessage));
+                    GVFSDatabaseException ex = Assert.Throws<GVFSDatabaseException>(() => placeholders.GetCount());
+                    ex.Message.ShouldEqual("SparseTable.GetCount Exception");
+                    ex.InnerException.Message.ShouldEqual(DefaultExceptionMessage);
+                });
+        }
+
+        [TestCase]
         public void GetAllWithNoResults()
         {
             this.TestTableWithReader((sparseTable, mockCommand, mockReader) =>

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -93,6 +93,7 @@ namespace GVFS.UnitTests.Virtualization
             mockPlaceholderDb.Setup(x => x.GetFolderPlaceholdersCount()).Returns(() => 0);
             Mock<ISparseCollection> mockSparseDb = new Mock<ISparseCollection>(MockBehavior.Strict);
             mockSparseDb.Setup(x => x.GetAll()).Returns(new HashSet<string>());
+            mockSparseDb.Setup(x => x.GetCount()).Returns(2);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -112,6 +113,7 @@ namespace GVFS.UnitTests.Virtualization
                 // "ModifiedPathsCount" should be 1 because ".gitattributes" is always present
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("FilePlaceholderCount", 0);
+                metadata.ShouldContain("SparseFolderCount", 2);
                 metadata.ShouldContain(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
             }
 
@@ -134,6 +136,7 @@ namespace GVFS.UnitTests.Virtualization
             mockPlaceholderDb.Setup(x => x.GetFolderPlaceholdersCount()).Returns(() => folderPlaceholderCount);
             Mock<ISparseCollection> mockSparseDb = new Mock<ISparseCollection>(MockBehavior.Strict);
             mockSparseDb.Setup(x => x.GetAll()).Returns(new HashSet<string>());
+            mockSparseDb.Setup(x => x.GetCount()).Returns(2);
             using (MockBackgroundFileSystemTaskRunner backgroundTaskRunner = new MockBackgroundFileSystemTaskRunner())
             using (FileSystemCallbacks fileSystemCallbacks = new FileSystemCallbacks(
                 this.Repo.Context,
@@ -153,7 +156,7 @@ namespace GVFS.UnitTests.Virtualization
                 eventLevel.ShouldEqual(EventLevel.Informational);
 
                 // "ModifiedPathsCount" should be 1 because ".gitattributes" is always present
-                metadata.Count.ShouldEqual(8);
+                metadata.Count.ShouldEqual(9);
                 metadata.ContainsKey("FilePlaceholderCreation").ShouldBeTrue();
                 metadata.TryGetValue("FilePlaceholderCreation", out object fileNestedMetadata);
                 JsonConvert.SerializeObject(fileNestedMetadata).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe\"");
@@ -161,6 +164,7 @@ namespace GVFS.UnitTests.Virtualization
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("FilePlaceholderCount", 1);
                 metadata.ShouldContain("FolderPlaceholderCount", 0);
+                metadata.ShouldContain("SparseFolderCount", 2);
                 metadata.ShouldContain(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
                 metadata.ContainsKey("PhysicalDiskInfo").ShouldBeTrue();
 
@@ -176,7 +180,7 @@ namespace GVFS.UnitTests.Virtualization
                 eventLevel = writeToLogFile2 ? EventLevel.Informational : EventLevel.Verbose;
                 eventLevel.ShouldEqual(EventLevel.Informational);
 
-                metadata.Count.ShouldEqual(8);
+                metadata.Count.ShouldEqual(9);
 
                 // Only processes that have created placeholders since the last heartbeat should be named
                 metadata.ContainsKey("FilePlaceholderCreation").ShouldBeTrue();
@@ -194,6 +198,7 @@ namespace GVFS.UnitTests.Virtualization
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("FilePlaceholderCount", 3);
                 metadata.ShouldContain("FolderPlaceholderCount", 1);
+                metadata.ShouldContain("SparseFolderCount", 2);
                 metadata.ShouldContain(nameof(RepoMetadata.Instance.EnlistmentId), RepoMetadata.Instance.EnlistmentId);
                 metadata.ContainsKey("PhysicalDiskInfo").ShouldBeTrue();
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -33,6 +33,7 @@ namespace GVFS.Virtualization
 
         private GVFSContext context;
         private IPlaceholderCollection placeholderDatabase;
+        private ISparseCollection sparseCollection;
         private ModifiedPathsDatabase modifiedPaths;
         private ConcurrentHashSet<string> newlyCreatedFileAndFolderPaths;
         private ConcurrentDictionary<string, PlaceHolderCreateCounter> filePlaceHolderCreationCount;
@@ -82,6 +83,7 @@ namespace GVFS.Virtualization
             this.BlobSizes.Initialize();
 
             this.placeholderDatabase = placeholderDatabase;
+            this.sparseCollection = sparseCollection;
             this.GitIndexProjection = gitIndexProjection ?? new GitIndexProjection(
                 context,
                 gitObjects,
@@ -280,6 +282,7 @@ namespace GVFS.Virtualization
             metadata.Add("ModifiedPathsCount", this.modifiedPaths.Count);
             metadata.Add("FilePlaceholderCount", this.placeholderDatabase.GetFilePlaceholdersCount());
             metadata.Add("FolderPlaceholderCount", this.placeholderDatabase.GetFolderPlaceholdersCount());
+            metadata.Add("SparseFolderCount", this.sparseCollection.GetCount());
 
             if (this.gitStatusCache.WriteTelemetryandReset(metadata))
             {

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -245,6 +245,7 @@ namespace GVFS.Virtualization.Projection
                 // control returns to the user, the projection is in a consistent state
 
                 this.context.Tracer.RelatedEvent(EventLevel.Informational, "ReleaseExternalLockRequested", null);
+                this.context.Repository.GVFSLock.Stats.RecordSparseFolderCount(this.sparseCollection.GetCount());
                 this.context.Repository.GVFSLock.Stats.RecordReleaseExternalLockRequested();
 
                 this.ClearNegativePathCacheIfPollutedByGit();


### PR DESCRIPTION
This PR will add the number of folders that are in the sparse list to both the heartbeat event and when a lock is released.  If there are zero folders that will mean that the user is not using sparse folders and everything will be projected.