### PR TITLE
auto download and install VFSForGit Git on Linux

### DIFF
--- a/Scripts/Linux/BuildGVFSForLinux.sh
+++ b/Scripts/Linux/BuildGVFSForLinux.sh
@@ -41,17 +41,11 @@ if [ ! -d $BUILDDIR ]; then
   mkdir $BUILDDIR || exit 1
 fi
 
-# TODO(Linux): download VFS-enabled version of upstream Git
-#echo 'Downloading a VFS-enabled version of Git...'
-#$VFS_SCRIPTDIR/DownloadGVFSGit.sh || exit 1
+echo 'Downloading a VFS-enabled version of Git...'
+$VFS_SCRIPTDIR/DownloadGVFSGit.sh || exit 1
 GITVERSION="$($VFS_SCRIPTDIR/GetGitVersionNumber.sh)"
-#GITPATH="$(find $VFS_PACKAGESDIR/gitformac.gvfs.installer/$GITVERSION -type f -name *.dmg)" || exit 1
-#echo "Downloaded Git $GITVERSION"
-
-# TODO(Linux): git version based on .dmg filename:
-#   packages/gitformac.gvfs.installer/2.20190724.1/tools/git-2.22.0.vfs.1.1.49.ge8fe4ef9d1-intel-universal-snow-leopard.dmg
-#   downloaded from https://vfsforgit.myget.org/F/build-dependencies/api/v3/flatcontainer/gitformac.gvfs.installer/2.20190724.1/gitformac.gvfs.installer.2.20190724.1.nupkg
-GITPATH="2.22.0.vfs.1.1.49"
+GITPATH="$(find $VFS_PACKAGESDIR/gitforlinux.gvfs.installer/$GITVERSION -type f -name *.deb)" || exit 1
+echo "Downloaded Git $GITVERSION"
 # Now that we have a path containing the version number, generate GVFSConstants.GitVersion.cs
 $VFS_SCRIPTDIR/GenerateGitVersionConstants.sh "$GITPATH" $BUILDDIR || exit 1
 
@@ -89,9 +83,8 @@ done
 # Publish after native build, so installer package can include the native binaries.
 dotnet publish $VFS_SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Linux /p:Platform=x64 -p:CopyPrjFS=true --runtime linux-x64 --framework netcoreapp2.1 --self-contained --output $VFS_PUBLISHDIR /maxcpucount:1 /warnasmessage:MSB4011 || exit 1
 
-# TODO(Linux): copy installer (if any)
-#echo 'Copying Git installer to the output directory...'
-#$VFS_SCRIPTDIR/PublishGit.sh $GITPATH || exit 1
+echo 'Copying Git installer to the output directory...'
+$VFS_SCRIPTDIR/PublishGit.sh $GITPATH || exit 1
 
 echo 'Running VFS for Git unit tests...'
 $VFS_PUBLISHDIR/GVFS.UnitTests || exit 1

--- a/Scripts/Linux/DownloadGVFSGit.sh
+++ b/Scripts/Linux/DownloadGVFSGit.sh
@@ -4,4 +4,4 @@ BUILDDIR=$VFS_OUTPUTDIR/GVFS.Build
 GITVERSION="$($VFS_SCRIPTDIR/GetGitVersionNumber.sh)"
 cp $VFS_SRCDIR/nuget.config $BUILDDIR
 dotnet new classlib -n Restore.GitInstaller -o $BUILDDIR --force
-dotnet add $BUILDDIR/Restore.GitInstaller.csproj package --package-directory $VFS_PACKAGESDIR GitForMac.GVFS.Installer --version $GITVERSION
+dotnet add $BUILDDIR/Restore.GitInstaller.csproj package --package-directory $VFS_PACKAGESDIR GitForLinux.GVFS.Installer --version $GITVERSION

--- a/Scripts/Linux/PrepFunctionalTests.sh
+++ b/Scripts/Linux/PrepFunctionalTests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+# Install GVFS-aware Git (that was published by the build script)
+GITPUBLISH=$VFS_OUTPUTDIR/Git
+if [[ ! -d $GITPUBLISH ]]; then
+    echo "GVFS-aware Git package not found. Run BuildGVFSForLinux.sh and try again"
+    exit 1
+fi
+GITPKG="$(find $GITPUBLISH -type f -name *.deb)" || exit 1
+sudo apt-get install -y "$GITPKG" || exit 1
+
+# Run ldconfig to ensure libprojfs and libattr are cached for the linker
+sudo ldconfig

--- a/Scripts/Linux/PublishGit.sh
+++ b/Scripts/Linux/PublishGit.sh
@@ -1,0 +1,15 @@
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+GITPATH=$1
+INSTALLER=$(basename $GITPATH)
+
+GITPUBLISH=$VFS_OUTPUTDIR/Git
+if [[ ! -d $GITPUBLISH ]] ; then
+  mkdir $GITPUBLISH
+fi
+
+find $GITPUBLISH -type f ! -name $INSTALLER -delete
+
+if [[ ! -e $GITPUBLISH/$INSTALLER ]] ; then
+  cp $GITPATH $GITPUBLISH
+fi


### PR DESCRIPTION
These scripts are very similar to the Mac versions, but instead download the `gitforlinux.gvfs.installer` NuGet package and use the `.deb` package it contains to install the VFSForGet-enabled Git client on Linux.

We also add a `PrepFunctionalTests.sh` script to use with the functional test suite.