### PR TITLE
stop rename over .git/index on Linux without lock

### DIFF
--- a/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs
@@ -512,9 +512,7 @@ namespace GVFS.Platform.Linux
         {
             try
             {
-                bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
-                if (pathInsideDotGit &&
-                    relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.Ordinal))
+                if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
                     if (string.IsNullOrEmpty(lockedGitCommand))
@@ -542,10 +540,8 @@ namespace GVFS.Platform.Linux
         {
             try
             {
-                bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
-                if (pathInsideDotGit &&
-                    (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.Ordinal) ||
-                     relativeDestinationPath.Equals(GVFSConstants.DotGit.Index, StringComparison.Ordinal)))
+                if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison) ||
+                    relativeDestinationPath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
                     if (string.IsNullOrEmpty(lockedGitCommand))


### PR DESCRIPTION
This is a small fix to the work committed in 2e32e7694061668d8f3f7ee4e2c9b9220d654ece so that we also prevent renaming/overwriting the `.git/index` file unless the GVFS provider lock is held.  Previously we only prevented the `.git/index` file from being renamed, but failed to stop another file being renamed over it.