### PR TITLE
SubDirectoryInfo Object

### DIFF
--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -70,7 +70,7 @@ namespace GVFS.Common
                 placeholderCount,
                 modifiedPathsCount,
                 this.CalculateHealthMetric(placeholderCount + modifiedPathsCount, gitTrackedItemsCount),
-                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).ToList());
+                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).Select(item => item.Value).ToList());
         }
 
         /// <summary>

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -158,5 +158,19 @@ namespace GVFS.Common
 
             return (decimal)hydratedFileCount / (decimal)totalFileCount;
         }
+
+        public class SubDirectoryInfo
+        {
+            public SubDirectoryInfo(string name, int hydratedFileCount, int totalFileCount)
+            {
+                this.Name = name;
+                this.HydratedFileCount = hydratedFileCount;
+                this.TotalFileCount = totalFileCount;
+            }
+
+            public string Name { get; private set; }
+            public int HydratedFileCount { get; private set; }
+            public int TotalFileCount { get; private set; }
+        }
     }
 }

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -47,7 +47,7 @@ namespace GVFS.Common
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFilePaths, hydratedFilesDirectoryTally, parentDirectory);
 
-            Dictionary<string, int> mostHydratedDirectories = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, SubDirectoryInfo> mostHydratedDirectories = new Dictionary<string, SubDirectoryInfo>(StringComparer.OrdinalIgnoreCase);
 
             // Map directory names to the corresponding health data from gitTrackedItemsDirectoryTally and hydratedFilesDirectoryTally
             foreach (KeyValuePair<string, int> pair in gitTrackedItemsDirectoryTally)
@@ -56,11 +56,11 @@ namespace GVFS.Common
                 {
                     // In-lining this for now until a better "health" calculation is created
                     // Another possibility is the ability to pass a function to use for health (might not be applicable)
-                    mostHydratedDirectories.Add(pair.Key, hydratedFiles);
+                    mostHydratedDirectories.Add(pair.Key, new SubDirectoryInfo(pair.Key, hydratedFiles, pair.Value));
                 }
                 else
                 {
-                    mostHydratedDirectories.Add(pair.Key, 0);
+                    mostHydratedDirectories.Add(pair.Key, new SubDirectoryInfo(pair.Key, 0, pair.Value));
                 }
             }
 
@@ -70,7 +70,7 @@ namespace GVFS.Common
                 placeholderCount,
                 modifiedPathsCount,
                 this.CalculateHealthMetric(placeholderCount + modifiedPathsCount, gitTrackedItemsCount),
-                mostHydratedDirectories.OrderByDescending(kp => kp.Value).ToList());
+                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).ToList());
         }
 
         /// <summary>

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
             int placeholderCount,
             int modifiedPathsCount,
             decimal healthMetric,
-            List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> directoryHydrationLevels)
+            List<EnlistmentHealthCalculator.SubDirectoryInfo> directoryHydrationLevels)
         {
             this.TargetDirectory = targetDirectory;
             this.GitTrackedItemsCount = gitItemsCount;
@@ -24,7 +24,7 @@ namespace GVFS.Common
         public int GitTrackedItemsCount { get; private set; }
         public int PlaceholderCount { get; private set; }
         public int ModifiedPathsCount { get; private set; }
-        public List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> DirectoryHydrationLevels { get; private set; }
+        public List<EnlistmentHealthCalculator.SubDirectoryInfo> DirectoryHydrationLevels { get; private set; }
         public decimal HealthMetric { get; private set; }
         public decimal PlaceholderPercentage
         {

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common
             int placeholderCount,
             int modifiedPathsCount,
             decimal healthMetric,
-            List<KeyValuePair<string, int>> directoryHydrationLevels)
+            List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> directoryHydrationLevels)
         {
             this.TargetDirectory = targetDirectory;
             this.GitTrackedItemsCount = gitItemsCount;
@@ -24,7 +24,7 @@ namespace GVFS.Common
         public int GitTrackedItemsCount { get; private set; }
         public int PlaceholderCount { get; private set; }
         public int ModifiedPathsCount { get; private set; }
-        public List<KeyValuePair<string, int>> DirectoryHydrationLevels { get; private set; }
+        public List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> DirectoryHydrationLevels { get; private set; }
         public decimal HealthMetric { get; private set; }
         public decimal PlaceholderPercentage
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -240,10 +240,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             {
                 // Regex to extract the most hydrated subdirectory names and their hydration percentage
                 // "  <hydrated-file-count> | <directory-name>" listed several times for different directories
-                Match lineMatch = Regex.Match(outputLines[i], @"^\s*([\d,]+)\s*\|\s*(\S.*\S)\s*$");
+                Match lineMatch = Regex.Match(outputLines[i], @"^\s*([\d,]+)\s*/\s*([\d,]+)\s*\|\s*(\S.*\S)\s*$");
 
                 int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedHealthScore).ShouldBeTrue();
-                string outputtedSubdirectory = lineMatch.Groups[2].Value;
+                string outputtedSubdirectory = lineMatch.Groups[3].Value;
 
                 outputtedHealthScore.ShouldEqual(healthScores[i]);
                 outputtedSubdirectory.ShouldEqual(subdirectories[i]);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -239,7 +239,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             for (int i = 0; i < outputLines.Count; i++)
             {
                 // Regex to extract the most hydrated subdirectory names and their hydration percentage
-                // "  <hydrated-file-count> | <directory-name>" listed several times for different directories
+                // "  <hydrated-file-count> / <total-file-count> | <directory-name>" listed several times for different directories
                 Match lineMatch = Regex.Match(outputLines[i], @"^\s*([\d,]+)\s*/\s*([\d,]+)\s*\|\s*(\S.*\S)\s*$");
 
                 int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedHealthScore).ShouldBeTrue();

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
@@ -22,11 +22,14 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
             this.enlistmentHealthData.DirectoryHydrationLevels[0].Key.ShouldEqual("A");
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(4);
             this.enlistmentHealthData.DirectoryHydrationLevels[1].Key.ShouldEqual("B");
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.HydratedFileCount.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.TotalFileCount.ShouldEqual(4);
             this.enlistmentHealthData.DirectoryHydrationLevels[2].Key.ShouldEqual("C");
-            this.enlistmentHealthData.DirectoryHydrationLevels[2].Value.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].Value.HydratedFileCount.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].Value.TotalFileCount.ShouldEqual(4);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsCount.ShouldEqual(0);
@@ -119,8 +122,10 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData.DirectoryHydrationLevels.Count.ShouldEqual(2);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual((decimal)pathData.PlaceholderFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsPercentage.ShouldEqual((decimal)pathData.ModifiedFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(4);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.ShouldEqual(2);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.HydratedFileCount.ShouldEqual(2);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.TotalFileCount.ShouldEqual(3);
         }
 
         [TestCase]
@@ -190,7 +195,8 @@ namespace GVFS.UnitTests.Common
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(pathData.PlaceholderFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(5m / 6m);
@@ -207,7 +213,8 @@ namespace GVFS.UnitTests.Common
                 .Build();
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.ShouldEqual(5);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count + pathData.PlaceholderFolderPaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(1);

--- a/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSEnlistmentHealthTests.cs
@@ -21,15 +21,15 @@ namespace GVFS.UnitTests.Common
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Key.ShouldEqual("A");
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(3);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(4);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Key.ShouldEqual("B");
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.HydratedFileCount.ShouldEqual(0);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.TotalFileCount.ShouldEqual(4);
-            this.enlistmentHealthData.DirectoryHydrationLevels[2].Key.ShouldEqual("C");
-            this.enlistmentHealthData.DirectoryHydrationLevels[2].Value.HydratedFileCount.ShouldEqual(0);
-            this.enlistmentHealthData.DirectoryHydrationLevels[2].Value.TotalFileCount.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Name.ShouldEqual("A");
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].HydratedFileCount.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].TotalFileCount.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Name.ShouldEqual("B");
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].HydratedFileCount.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].TotalFileCount.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].Name.ShouldEqual("C");
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].HydratedFileCount.ShouldEqual(0);
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].TotalFileCount.ShouldEqual(4);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsCount.ShouldEqual(0);
@@ -84,9 +84,9 @@ namespace GVFS.UnitTests.Common
 
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsCount.ShouldEqual(pathData.ModifiedFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Key.ShouldEqual("A");
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Key.ShouldEqual("B");
-            this.enlistmentHealthData.DirectoryHydrationLevels[2].Key.ShouldEqual("C");
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].Name.ShouldEqual("A");
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].Name.ShouldEqual("B");
+            this.enlistmentHealthData.DirectoryHydrationLevels[2].Name.ShouldEqual("C");
         }
 
         [TestCase]
@@ -122,10 +122,10 @@ namespace GVFS.UnitTests.Common
             this.enlistmentHealthData.DirectoryHydrationLevels.Count.ShouldEqual(2);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual((decimal)pathData.PlaceholderFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
             this.enlistmentHealthData.ModifiedPathsPercentage.ShouldEqual((decimal)pathData.ModifiedFilePaths.Count / (decimal)pathData.GitFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(4);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(3);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.HydratedFileCount.ShouldEqual(2);
-            this.enlistmentHealthData.DirectoryHydrationLevels[1].Value.TotalFileCount.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].HydratedFileCount.ShouldEqual(4);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].TotalFileCount.ShouldEqual(3);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].HydratedFileCount.ShouldEqual(2);
+            this.enlistmentHealthData.DirectoryHydrationLevels[1].TotalFileCount.ShouldEqual(3);
         }
 
         [TestCase]
@@ -195,8 +195,8 @@ namespace GVFS.UnitTests.Common
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
 
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(5m / 6m);
@@ -213,8 +213,8 @@ namespace GVFS.UnitTests.Common
                 .Build();
 
             this.enlistmentHealthData = this.GenerateStatistics(pathData, string.Empty);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
-            this.enlistmentHealthData.DirectoryHydrationLevels[0].Value.TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].HydratedFileCount.ShouldEqual(pathData.PlaceholderFilePaths.Count);
+            this.enlistmentHealthData.DirectoryHydrationLevels[0].TotalFileCount.ShouldEqual(pathData.GitFilePaths.Count);
             this.enlistmentHealthData.PlaceholderCount.ShouldEqual(pathData.PlaceholderFilePaths.Count + pathData.PlaceholderFolderPaths.Count);
             this.enlistmentHealthData.GitTrackedItemsCount.ShouldEqual(pathData.GitFilePaths.Count + pathData.GitFolderPaths.Count);
             this.enlistmentHealthData.PlaceholderPercentage.ShouldEqual(1);
@@ -246,7 +246,7 @@ namespace GVFS.UnitTests.Common
 
         public class PathDataBuilder
         {
-            private EnlistmentPathData pathData = new EnlistmentPathData();
+            private readonly EnlistmentPathData pathData = new EnlistmentPathData();
 
             public PathDataBuilder AddPlaceholderFiles(params string[] placeholderFilePaths)
             {

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -76,7 +76,7 @@ namespace GVFS.CommandLine
             longest = Math.Max(longest, modifiedPathsCountFormatted.Length);
 
             // Sort the dictionary to find the most hydrated directories by health score
-            List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
+            List<EnlistmentHealthCalculator.SubDirectoryInfo> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
 
             this.Output.WriteLine("\nHealth of directory: " + enlistmentHealthData.TargetDirectory);
             this.Output.WriteLine("Total files in HEAD commit:           " + trackedFilesCountFormatted.PadLeft(longest) + " | 100%");
@@ -89,15 +89,15 @@ namespace GVFS.CommandLine
 
             int maxCountLength = 0;
             int maxTotalLength = 0;
-            foreach (KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo> pair in topLevelDirectoriesByHydration)
+            foreach (EnlistmentHealthCalculator.SubDirectoryInfo directoryInfo in topLevelDirectoriesByHydration)
             {
-                maxCountLength = Math.Max(maxCountLength, pair.Value.HydratedFileCount.ToString("N0").Length);
-                maxTotalLength = Math.Max(maxTotalLength, pair.Value.TotalFileCount.ToString("N0").Length);
+                maxCountLength = Math.Max(maxCountLength, directoryInfo.HydratedFileCount.ToString("N0").Length);
+                maxTotalLength = Math.Max(maxTotalLength, directoryInfo.TotalFileCount.ToString("N0").Length);
             }
 
-            foreach (KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo> pair in topLevelDirectoriesByHydration)
+            foreach (EnlistmentHealthCalculator.SubDirectoryInfo directoryInfo in topLevelDirectoriesByHydration)
             {
-                this.Output.WriteLine(" " + pair.Value.HydratedFileCount.ToString("N0").PadLeft(maxCountLength) + " / " + pair.Value.TotalFileCount.ToString("N0").PadRight(maxTotalLength) + " | " + pair.Key);
+                this.Output.WriteLine(" " + directoryInfo.HydratedFileCount.ToString("N0").PadLeft(maxCountLength) + " / " + directoryInfo.TotalFileCount.ToString("N0").PadRight(maxTotalLength) + " | " + directoryInfo.Name);
             }
 
             bool healthyRepo = (enlistmentHealthData.PlaceholderPercentage + enlistmentHealthData.ModifiedPathsPercentage) < MaximumHealthyHydration;

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -76,7 +76,7 @@ namespace GVFS.CommandLine
             longest = Math.Max(longest, modifiedPathsCountFormatted.Length);
 
             // Sort the dictionary to find the most hydrated directories by health score
-            List<KeyValuePair<string, int>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
+            List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
 
             this.Output.WriteLine("\nHealth of directory: " + enlistmentHealthData.TargetDirectory);
             this.Output.WriteLine("Total files in HEAD commit:           " + trackedFilesCountFormatted.PadLeft(longest) + " | 100%");
@@ -88,14 +88,16 @@ namespace GVFS.CommandLine
             this.Output.WriteLine("\nMost hydrated top level directories:");
 
             int maxCountLength = 0;
-            foreach (KeyValuePair<string, int> pair in topLevelDirectoriesByHydration)
+            int maxTotalLength = 0;
+            foreach (KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo> pair in topLevelDirectoriesByHydration)
             {
-                maxCountLength = Math.Max(maxCountLength, pair.Value.ToString("N0").Length);
+                maxCountLength = Math.Max(maxCountLength, pair.Value.HydratedFileCount.ToString("N0").Length);
+                maxTotalLength = Math.Max(maxTotalLength, pair.Value.TotalFileCount.ToString("N0").Length);
             }
 
-            foreach (KeyValuePair<string, int> pair in topLevelDirectoriesByHydration)
+            foreach (KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo> pair in topLevelDirectoriesByHydration)
             {
-                this.Output.WriteLine(" " + pair.Value.ToString("N0").PadLeft(maxCountLength) + " | " + pair.Key);
+                this.Output.WriteLine(" " + pair.Value.HydratedFileCount.ToString("N0").PadLeft(maxCountLength) + " / " + pair.Value.TotalFileCount.ToString("N0").PadRight(maxTotalLength) + " | " + pair.Key);
             }
 
             bool healthyRepo = (enlistmentHealthData.PlaceholderPercentage + enlistmentHealthData.ModifiedPathsPercentage) < MaximumHealthyHydration;


### PR DESCRIPTION
Added an the `SubDirectoryInfo` internal class to `EnlistmentHealthCalculator` to better organize the code. Instead of passing `KeyValuePairs` around, the `SubDirectoryInfo` object has named fields which make it more clear what information is going where. This also enables the displaying of sub directory hydration levels as fractions:

```
Gathering repository data...

Health of directory:
Total files in HEAD commit:           821 | 100%
Files managed by VFS for Git (fast):  401 |  49%
Files managed by Git:                   1 |   0%

Total hydration percentage:                  49%

Most hydrated top level directories:
 364 / 676 | GVFS
  24 / 24  | Scripts
   0 / 32  | MirrorProvider
   0 / 66  | ProjFS.Mac
   0 / 8   | GitHooksLoader

Repository status: OK
```

The unit tests and functional tests are updated accordingly. This fixes #1294 