### PR TITLE
[WIP] Support case-sensitive filesystems

### DIFF
--- a/GVFS/FastFetch/WorkingTree.cs
+++ b/GVFS/FastFetch/WorkingTree.cs
@@ -26,7 +26,7 @@ namespace FastFetch
 
             Parallel.ForEach(
                 dir.EnumerateDirectories().Where(subdir =>
-                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, StringComparison.OrdinalIgnoreCase) &&
+                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, GVFSPlatform.Instance.Constants.PathComparison) &&
                      !subdir.Attributes.HasFlag(FileAttributes.ReparsePoint))),
                 subdir => { ForAllDirectories(subdir, asyncParallelCallback); });
         }

--- a/GVFS/GVFS.Common/Database/GVFSDatabase.cs
+++ b/GVFS/GVFS.Common/Database/GVFSDatabase.cs
@@ -117,7 +117,7 @@ namespace GVFS.Common.Database
                     command.ExecuteNonQuery();
                 }
 
-                PlaceholderTable.CreateTable(connection);
+                PlaceholderTable.CreateTable(connection, GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem);
             }
         }
 

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -16,11 +16,12 @@ namespace GVFS.Common.Database
             this.connectionPool = connectionPool;
         }
 
-        public static void CreateTable(IDbConnection connection)
+        public static void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-                command.CommandText = "CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY COLLATE NOCASE, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;";
+                string collateConstraint = caseSensitiveFileSystem ? string.Empty : " COLLATE NOCASE";
+                command.CommandText = $"CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY{collateConstraint}, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;";
                 command.ExecuteNonQuery();
             }
         }

--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common.FileSystem
         {
             IEnumerable<string> valuableHooksLines = defaultHooksLines.Where(line => !string.IsNullOrEmpty(line.Trim()));
 
-            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, StringComparer.OrdinalIgnoreCase))
+            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, GVFSPlatform.Instance.Constants.PathComparer))
             {
                 throw new HooksConfigurationException(
                     $"{GVFSPlatform.Instance.Constants.GVFSHooksExecutableName} should not be specified in the configuration for "

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -170,6 +170,28 @@ namespace GVFS.Common
             /// </summary>
             public abstract HashSet<string> UpgradeBlockingProcesses { get; }
 
+            public abstract bool CaseSensitiveFileSystem { get; }
+
+            public StringComparison PathComparison
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparison.Ordinal :
+                        StringComparison.OrdinalIgnoreCase;
+                }
+            }
+
+            public StringComparer PathComparer
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparer.Ordinal :
+                        StringComparer.OrdinalIgnoreCase;
+                }
+            }
+
             public string GVFSHooksExecutableName
             {
                 get { return "GVFS.Hooks" + this.ExecutableExtension; }

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -594,6 +594,8 @@ namespace GVFS.Common.Git
 
         private LooseObjectToWrite GetLooseObjectDestination(string sha)
         {
+            // Ensure SHA path is lowercase for Linux
+            sha = sha.ToLower();
             string firstTwoDigits = sha.Substring(0, 2);
             string remainingDigits = sha.Substring(2);
             string twoLetterFolderName = Path.Combine(this.Enlistment.GitObjectsRoot, firstTwoDigits);

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -232,6 +232,8 @@ namespace GVFS.Common.Git
 
         private LooseBlobState GetLooseBlobState(string blobSha, Action<Stream, long> writeAction, out long size)
         {
+            // Ensure SHA path is lowercase for Linux
+            blobSha = blobSha.ToLower();
             string blobPath = Path.Combine(
                 this.enlistment.GitObjectsRoot,
                 blobSha.Substring(0, 2),

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -275,7 +275,7 @@ namespace GVFS.Common
 
         private IEnumerable<string> GenerateDataLines(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
-            HashSet<string> keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> keys = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
             this.count = 0;
             foreach (IPlaceholderData updated in updatedPlaceholders)

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -119,12 +119,12 @@ namespace GVFS.Common.Maintenance
             {
                 string extension = Path.GetExtension(info.Name);
 
-                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(extension, ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     count++;
                     size += info.Length;
                 }
-                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(extension, ".keep", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     hasKeep = true;
                 }

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -65,7 +65,7 @@ namespace GVFS.Common.Maintenance
 
             foreach (DirectoryItemInfo info in packDirContents)
             {
-                if (string.Equals(Path.GetExtension(info.Name), ".idx", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(info.Name), ".idx", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string pairedPack = Path.ChangeExtension(info.FullName, ".pack");
 

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -325,7 +325,7 @@ namespace GVFS.Common.Maintenance
                                          .FileSystem
                                          .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
                                          .Where(item => item.Name.StartsWith(prefix)
-                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", StringComparison.OrdinalIgnoreCase))
+                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                                          .FirstOrDefault();
             if (info == null)
             {

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -18,7 +18,7 @@ namespace GVFS.Common
         protected ModifiedPathsDatabase(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: true)
         {
-            this.modifiedPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+            this.modifiedPaths = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
         }
 
         public int Count

--- a/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
@@ -16,10 +16,10 @@ namespace GVFS.Common.Prefetch.Git
         private HashSet<string> exactFileList;
         private List<string> patternList;
         private List<string> folderList;
-        private HashSet<string> filesAdded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private HashSet<string> filesAdded = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private HashSet<DiffTreeResult> stagedDirectoryOperations = new HashSet<DiffTreeResult>(new DiffTreeByNameComparer());
-        private HashSet<string> stagedFileDeletes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private HashSet<string> stagedFileDeletes = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private Enlistment enlistment;
         private GitProcess git;
@@ -32,7 +32,7 @@ namespace GVFS.Common.Prefetch.Git
         public DiffHelper(ITracer tracer, Enlistment enlistment, GitProcess git, IEnumerable<string> fileList, IEnumerable<string> folderList, bool includeSymLinks)
         {
             this.tracer = tracer;
-            this.exactFileList = new HashSet<string>(fileList.Where(x => !x.StartsWith("*")), StringComparer.OrdinalIgnoreCase);
+            this.exactFileList = new HashSet<string>(fileList.Where(x => !x.StartsWith("*")), GVFSPlatform.Instance.Constants.PathComparer);
             this.patternList = fileList.Where(x => x.StartsWith("*")).ToList();
             this.folderList = new List<string>(folderList);
             this.enlistment = enlistment;
@@ -41,7 +41,7 @@ namespace GVFS.Common.Prefetch.Git
 
             this.DirectoryOperations = new ConcurrentQueue<DiffTreeResult>();
             this.FileDeleteOperations = new ConcurrentQueue<string>();
-            this.FileAddOperations = new ConcurrentDictionary<string, HashSet<PathWithMode>>(StringComparer.OrdinalIgnoreCase);
+            this.FileAddOperations = new ConcurrentDictionary<string, HashSet<PathWithMode>>(GVFSPlatform.Instance.Constants.PathComparer);
             this.RequiredBlobs = new BlockingCollection<string>();
         }
 
@@ -173,7 +173,7 @@ namespace GVFS.Common.Prefetch.Git
                 // Git traverses diffs in pre-order, so we are guaranteed to ignore child deletes here.
                 if (result.Operation == DiffTreeResult.Operations.Delete)
                 {
-                    if (deletedPaths.Any(path => result.TargetPath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+                    if (deletedPaths.Any(path => result.TargetPath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
                     {
                         continue;
                     }
@@ -186,7 +186,7 @@ namespace GVFS.Common.Prefetch.Git
 
             foreach (string filePath in this.stagedFileDeletes)
             {
-                if (deletedPaths.Any(path => filePath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+                if (deletedPaths.Any(path => filePath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
                 {
                     continue;
                 }
@@ -334,12 +334,12 @@ namespace GVFS.Common.Prefetch.Git
             }
 
             if (this.exactFileList.Contains(blobAdd.TargetPath) ||
-                this.patternList.Any(path => blobAdd.TargetPath.EndsWith(path.Substring(1), StringComparison.OrdinalIgnoreCase)))
+                this.patternList.Any(path => blobAdd.TargetPath.EndsWith(path.Substring(1), GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }
 
-            if (this.folderList.Any(path => blobAdd.TargetPath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+            if (this.folderList.Any(path => blobAdd.TargetPath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }
@@ -408,7 +408,7 @@ namespace GVFS.Common.Prefetch.Git
                 {
                     if (y.TargetPath != null)
                     {
-                        return x.TargetPath.Equals(y.TargetPath, StringComparison.OrdinalIgnoreCase);
+                        return x.TargetPath.Equals(y.TargetPath, GVFSPlatform.Instance.Constants.PathComparison);
                     }
 
                     return false;

--- a/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
@@ -22,7 +22,7 @@ namespace GVFS.Common.Prefetch.Git
                 return false;
             }
 
-            return x.Path.Equals(this.Path, StringComparison.OrdinalIgnoreCase);
+            return x.Path.Equals(this.Path, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public override int GetHashCode()

--- a/GVFS/GVFS.Common/RepoMetadata.cs
+++ b/GVFS/GVFS.Common/RepoMetadata.cs
@@ -48,7 +48,7 @@ namespace GVFS.Common
             string dictionaryPath = Path.Combine(dotGVFSPath, GVFSConstants.DotGVFS.Databases.RepoMetadata);
             if (Instance != null)
             {
-                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, StringComparison.OrdinalIgnoreCase))
+                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     throw new InvalidOperationException(
                         string.Format(

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,6 +6,9 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
+        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
+        public const string CaseSensitiveFileSystemOnly = "CaseSensitiveFileSystemOnly";
+
         public const string WindowsOnly = "WindowsOnly";
         public const string MacOnly = "MacOnly";
 

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -85,6 +85,8 @@ namespace GVFS.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
+
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
                 excludeCategories.Add(Categories.MacTODO.NeedsDehydrate);
@@ -95,6 +97,9 @@ namespace GVFS.FunctionalTests
             }
             else
             {
+                // Windows excludes.
+                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
+
                 excludeCategories.Add(Categories.MacOnly);
             }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
@@ -143,7 +143,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private string GetLooseObjectPath(string fileGitPath, out string sha)
         {
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"rev-parse :{fileGitPath}");
-            sha = revParseResult.Output.Trim();
+
+            // Ensure SHA path is lowercase for Linux
+            sha = revParseResult.Output.Trim().ToLower();
             sha.Length.ShouldEqual(40);
             string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), sha.Substring(0, 2), sha.Substring(2, 38));
             return objectPath;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -128,7 +128,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem
                 .EnumerateDirectory(this.Enlistment.GetPackRoot(this.fileSystem))
                 .Split()
-                .Where(file => string.Equals(Path.GetExtension(file), ".keep", StringComparison.OrdinalIgnoreCase))
+                .Where(file => string.Equals(Path.GetExtension(file), ".keep", FileSystemHelpers.PathComparison))
                 .Count()
                 .ShouldEqual(1, "Incorrect number of .keep files in pack directory");
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -89,9 +89,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 {
                     "# A comment",
                     " ",
-                    "gvfs/",
-                    "gvfs/gvfs",
-                    "gvfs/"
+                    "GVFS/",
+                    "GVFS/GVFS",
+                    "GVFS/"
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--folders-list \"" + tempFilePath + "\""), 279);
@@ -188,7 +188,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 new[]
                 {
                     Path.Combine("GVFS", "GVFS", "packages.config"),
-                    Path.Combine("GVFS", "GVFS.FunctionalTests", "App.config")
+                    Path.Combine("GVFS", "GVFS.FunctionalTests", "app.config")
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--stdin-files-list", standardInput: input), 2);
@@ -203,9 +203,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 {
                     "# A comment",
                     " ",
-                    "gvfs/",
-                    "gvfs/gvfs",
-                    "gvfs/"
+                    "GVFS/",
+                    "GVFS/GVFS",
+                    "GVFS/"
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--stdin-folders-list", standardInput: input), 279);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -303,45 +303,36 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             folderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems();
         }
 
+        // Mac and Windows only because Linux is case-sensitive
         [TestCase, Order(7)]
-        public void HydratingFileUsesNameCaseFromRepo()
+        [Category(Categories.CaseInsensitiveFileSystemOnly)]
+        public void HydratingFileUsesNameCaseFromRepoOnCaseInsensitiveFileSystem()
         {
-            string fileName = "Readme.md";
-            string parentFolderPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(fileName));
-            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
-
-            // Hydrate file with a request using different file name case
-            string wrongCaseFilePath = this.Enlistment.GetVirtualPathTo(fileName.ToUpper());
-            string fileContents = wrongCaseFilePath.ShouldBeAFile(this.fileSystem).WithContents();
-
-            // File on disk should have original case projected from repo
-            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+            this.HydratingFileUsesNameCaseFromRepo(false);
         }
 
-        [TestCase, Order(8)]
-        public void HydratingNestedFileUsesNameCaseFromRepo()
+        // Linux only because Linux is case-sensitive
+        [TestCase, Order(7)]
+        [Category(Categories.CaseSensitiveFileSystemOnly)]
+        public void HydratingFileUsesNameCaseFromRepoOnCaseSensitiveFileSystem()
         {
-            string filePath = Path.Combine("GVFS", "FastFetch", "Properties", "AssemblyInfo.cs");
-            string filePathAllCaps = filePath.ToUpper();
-            string parentFolderVirtualPathAllCaps = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePathAllCaps));
-            parentFolderVirtualPathAllCaps.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+            this.HydratingFileUsesNameCaseFromRepo(true);
+        }
 
-            // Hydrate file with a request using different file name case
-            string wrongCaseFilePath = this.Enlistment.GetVirtualPathTo(filePathAllCaps);
-            string fileContents = wrongCaseFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+        // Mac and Windows only because Linux is case-sensitive
+        [TestCase, Order(8)]
+        [Category(Categories.CaseInsensitiveFileSystemOnly)]
+        public void HydratingNestedFileUsesNameCaseFromRepoOnCaseInsensitiveFileSystem()
+        {
+            this.HydratingNestedFileUsesNameCaseFromRepo(false);
+        }
 
-            // File on disk should have original case projected from repo
-            string parentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePath));
-            parentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
-
-            // Confirm all folders up to root have the correct case
-            string parentFolderPath = Path.GetDirectoryName(filePath);
-            while (!string.IsNullOrWhiteSpace(parentFolderPath))
-            {
-                string folderName = Path.GetFileName(parentFolderPath);
-                parentFolderPath = Path.GetDirectoryName(parentFolderPath);
-                this.Enlistment.GetVirtualPathTo(parentFolderPath).ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(folderName, StringComparison.Ordinal));
-            }
+        // Linux only because Linux is case-sensitive
+        [TestCase, Order(8)]
+        [Category(Categories.CaseSensitiveFileSystemOnly)]
+        public void HydratingNestedFileUsesNameCaseFromRepoOnCaseSensitiveFileSystem()
+        {
+            this.HydratingNestedFileUsesNameCaseFromRepo(true);
         }
 
         [TestCase, Order(9)]
@@ -637,6 +628,46 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             else
             {
                 Assert.Fail("Unsupported platform");
+            }
+        }
+
+        private void HydratingFileUsesNameCaseFromRepo(bool caseSensitiveFileSystem)
+        {
+            string fileName = "Readme.md";
+            string parentFolderPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(fileName));
+            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+
+            // Hydrate file with a request using different file name case except on Linux
+            string testFileName = caseSensitiveFileSystem ? fileName : fileName.ToUpper();
+            string testFilePath = this.Enlistment.GetVirtualPathTo(testFileName);
+            string fileContents = testFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+
+            // File on disk should have original case projected from repo
+            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+        }
+
+        private void HydratingNestedFileUsesNameCaseFromRepo(bool caseSensitiveFileSystem)
+        {
+            string filePath = Path.Combine("GVFS", "FastFetch", "Properties", "AssemblyInfo.cs");
+            string testFilePath = caseSensitiveFileSystem ? filePath : filePath.ToUpper();
+            string testParentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(testFilePath));
+            testParentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+
+            // Hydrate file with a request using different file name case except on Linux
+            testFilePath = this.Enlistment.GetVirtualPathTo(testFilePath);
+            string fileContents = testFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+
+            // File on disk should have original case projected from repo
+            string parentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePath));
+            parentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+
+            // Confirm all folders up to root have the correct case
+            string parentFolderPath = Path.GetDirectoryName(filePath);
+            while (!string.IsNullOrWhiteSpace(parentFolderPath))
+            {
+                string folderName = Path.GetFileName(parentFolderPath);
+                parentFolderPath = Path.GetDirectoryName(parentFolderPath);
+                this.Enlistment.GetVirtualPathTo(parentFolderPath).ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(folderName, StringComparison.Ordinal));
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -464,7 +464,10 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "rev-parse :Test_EPF_WorkingDirectoryTests/AllNullObjectRedownloaded.txt");
             string sha = revParseResult.Output.Trim();
             sha.Length.ShouldEqual(40);
-            string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), sha.Substring(0, 2), sha.Substring(2, 38));
+
+            // Ensure SHA path is lowercase for Linux
+            string objectPathSha = sha.ToLower();
+            string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), objectPathSha.Substring(0, 2), objectPathSha.Substring(2, 38));
             objectPath.ShouldNotExistOnDisk(this.fileSystem);
 
             // At this point there should be no corrupt objects

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -494,11 +494,11 @@ namespace GVFS.FunctionalTests.Tests
             string fastfetch;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "netcoreapp2.1", "fastfetch.dll");
+                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "netcoreapp2.1", "FastFetch.dll");
             }
             else
             {
-                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "fastfetch.dll");
+                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "FastFetch.dll");
             }
 
             File.Exists(fastfetch).ShouldBeTrue($"{fastfetch} did not exist.");

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -101,7 +101,7 @@ namespace GVFS.FunctionalTests.Tests
                 .Count()
                 .ShouldEqual(345);
 
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
         }
 
         [TestCase]
@@ -123,7 +123,7 @@ namespace GVFS.FunctionalTests.Tests
             Directory.EnumerateFileSystemEntries(Path.Combine(this.fastFetchRepoRoot, "GVFS"), "*", SearchOption.AllDirectories)
                 .Count()
                 .ShouldEqual(345);
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
 
             // Run a second time in the same repo on the same branch with more folders.
             this.RunFastFetch($"--checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force-checkout");
@@ -177,7 +177,7 @@ namespace GVFS.FunctionalTests.Tests
                 Path.Combine(this.fastFetchRepoRoot, "GVFS", "GVFS", "Properties", "AssemblyInfo.cs"),
             });
 
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -315,9 +315,10 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         private void HydrateEntireRepo(GVFSFunctionalTestEnlistment enlistment)
         {
             List<string> allFiles = Directory.EnumerateFiles(enlistment.RepoRoot, "*", SearchOption.AllDirectories).ToList();
+            string dotGitRoot = enlistment.RepoRoot + Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar;
             for (int i = 0; i < allFiles.Count; ++i)
             {
-                if (!allFiles[i].StartsWith(enlistment.RepoRoot + "\\.git\\", StringComparison.OrdinalIgnoreCase))
+                if (!allFiles[i].StartsWith(dotGitRoot, FileSystemHelpers.PathComparison))
                 {
                     File.ReadAllText(allFiles[i]);
                 }

--- a/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GVFS.FunctionalTests.Tools
+{
+    public static class FileSystemHelpers
+    {
+        public static StringComparison PathComparison
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparison.Ordinal :
+                    StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        public static StringComparer PathComparer
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparer.Ordinal :
+                    StringComparer.OrdinalIgnoreCase;
+            }
+        }
+
+        private static bool CaseSensitiveFileSystem
+        {
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -123,7 +123,7 @@ namespace GVFS.FunctionalTests.Tools
             string mappingFile = Path.Combine(this.LocalCacheRoot, "mapping.dat");
             mappingFile.ShouldBeAFile(fileSystem);
 
-            HashSet<string> allowedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            HashSet<string> allowedFileNames = new HashSet<string>(FileSystemHelpers.PathComparer)
             {
                 "mapping.dat",
                 "mapping.dat.lock" // mapping.dat.lock can be present, but doesn't have to be present

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -152,7 +152,7 @@ namespace GVFS.FunctionalTests.Tools
             string[] modifedPathLines = modifedPathsContents.Split(new[] { ModifiedPathsNewLine }, StringSplitOptions.None);
             foreach (string gitPath in gitPaths)
             {
-                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath, StringComparison.OrdinalIgnoreCase));
+                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath, FileSystemHelpers.PathComparison));
             }
         }
 
@@ -165,8 +165,8 @@ namespace GVFS.FunctionalTests.Tools
                 modifedPathLines.ShouldNotContain(
                     path =>
                     {
-                        return path.Equals(ModifedPathsLineAddPrefix + gitPath, StringComparison.OrdinalIgnoreCase) ||
-                               path.Equals(ModifedPathsLineDeletePrefix + gitPath, StringComparison.OrdinalIgnoreCase);
+                        return path.Equals(ModifedPathsLineAddPrefix + gitPath, FileSystemHelpers.PathComparison) ||
+                               path.Equals(ModifedPathsLineDeletePrefix + gitPath, FileSystemHelpers.PathComparison);
                     });
             }
         }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -170,6 +170,8 @@ namespace GVFS.Platform.Mac
 
             // Documented here (in the addressing section): https://www.unix.com/man-page/mojave/4/unix/
             public override int MaxPipePathLength => 104;
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -493,6 +493,8 @@ namespace GVFS.Platform.Windows
 
             // Tests show that 250 is the max supported pipe name length
             public override int MaxPipePathLength => 250;
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -192,7 +192,7 @@ namespace GVFS.Service
 
         public Dictionary<string, RepoRegistration> ReadRegistry()
         {
-            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
 
             using (Stream stream = this.fileSystem.OpenFileStream(
                     Path.Combine(this.registryParentFolderPath, RegistryName),
@@ -233,7 +233,7 @@ namespace GVFS.Service
                                 string normalizedEnlistmentRootPath = registration.EnlistmentRoot;
                                 if (this.fileSystem.TryGetNormalizedPath(registration.EnlistmentRoot, out normalizedEnlistmentRootPath, out errorMessage))
                                 {
-                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, StringComparison.OrdinalIgnoreCase))
+                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                     {
                                         EventMetadata metadata = new EventMetadata();
                                         metadata.Add("registration.EnlistmentRoot", registration.EnlistmentRoot);

--- a/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
+++ b/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
@@ -3,5 +3,6 @@
     public static class CategoryConstants
     {
         public const string ExceptionExpected = "ExceptionExpected";
+        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
     }
 }

--- a/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
+++ b/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
@@ -4,5 +4,6 @@
     {
         public const string ExceptionExpected = "ExceptionExpected";
         public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
+        public const string CaseSensitiveFileSystemOnly = "CaseSensitiveFileSystemOnly";
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Database;
+﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.FileSystem;
@@ -74,8 +75,9 @@ namespace GVFS.UnitTests.Common.Database
             mockCommand.Setup(x => x.ExecuteScalar()).Returns(1);
             mockCommand.Setup(x => x.Dispose());
 
+            string collateConstraint = GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem ? string.Empty : " COLLATE NOCASE";
             Mock<IDbCommand> mockCommand2 = new Mock<IDbCommand>(MockBehavior.Strict);
-            mockCommand2.SetupSet(x => x.CommandText = "CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY COLLATE NOCASE, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;");
+            mockCommand2.SetupSet(x => x.CommandText = $"CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY{collateConstraint}, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;");
             if (throwException)
             {
                 mockCommand2.Setup(x => x.ExecuteNonQuery()).Throws(new Exception("Error"));

--- a/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            PlaceholderTable.CreateTable(mockConnection.Object);
+            PlaceholderTable.CreateTable(mockConnection.Object, false);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();
         }
@@ -57,7 +57,7 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            Exception ex = Assert.Throws<Exception>(() => PlaceholderTable.CreateTable(mockConnection.Object));
+            Exception ex = Assert.Throws<Exception>(() => PlaceholderTable.CreateTable(mockConnection.Object, false));
             ex.Message.ShouldEqual(DefaultExceptionMessage);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();

--- a/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
@@ -329,7 +329,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxFileExistsFailures > 0)
                 {
                     if (this.fileExistsFailureCount < this.maxFileExistsFailures &&
-                        string.Equals(path, this.fileExistsFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.fileExistsFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -342,7 +342,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 1 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -391,7 +391,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxOpenFileStreamFailures > 0)
                 {
                     if (this.openFileStreamFailureCount < this.maxOpenFileStreamFailures &&
-                        string.Equals(path, this.openFileStreamFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.openFileStreamFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.openFileStreamFailureCount;
 
@@ -408,7 +408,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 0 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.failuresAcrossOpenExistsAndOverwriteCount;
                         throw new IOException();

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests.Mock.Common
 {
@@ -237,6 +238,8 @@ namespace GVFS.UnitTests.Mock.Common
             public override bool SupportsUpgradeWhileRunning => false;
 
             public override int MaxPipePathLength => 250;
+
+            public override bool CaseSensitiveFileSystem => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -231,7 +231,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
                 // if it's called for one of those paths remap the paths to be inside the mock: root
                 string mockDirectoryPath = directoryPath;
                 string gvfsProgramData = @"C:\ProgramData\GVFS";
-                if (directoryPath.StartsWith(gvfsProgramData, StringComparison.OrdinalIgnoreCase))
+                if (directoryPath.StartsWith(gvfsProgramData, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     mockDirectoryPath = mockDirectoryPath.Substring(gvfsProgramData.Length);
                     mockDirectoryPath = "mock:" + mockDirectoryPath;

--- a/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
@@ -124,7 +124,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
         protected override bool TryDownloadAsset(Asset asset, out string errorMessage)
         {
             bool validAsset = true;
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSDownload))
                 {
@@ -132,7 +132,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                     return false;
                 }
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitDownload))
                 {
@@ -161,7 +161,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
 
         protected override bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSCleanup))
                 {
@@ -172,7 +172,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 exception = null;
                 return true;
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitCleanup))
                 {
@@ -215,7 +215,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
             exitCode = 0;
             error = null;
 
-            if (fileName.Equals(this.expectedGitAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGitAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("Git", installationInfo);
                 this.InstallerExeLaunched = true;
@@ -234,7 +234,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 return;
             }
 
-            if (fileName.Equals(this.expectedGVFSAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGVFSAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("GVFS", installationInfo);
                 this.InstallerExeLaunched = true;

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Common.Prefetch.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
 using NUnit.Framework;
@@ -102,6 +103,7 @@ namespace GVFS.UnitTests.Prefetch
         // Delete a folder with two sub folders each with a single file
         // Readd it with a different casing and same contents
         [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
         public void ParsesCaseChangesAsAdds()
         {
             MockTracer tracer = new MockTracer();

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -3,6 +3,7 @@ using GVFS.UnitTests.Category;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests
 {
@@ -17,6 +18,11 @@ namespace GVFS.UnitTests
             if (Debugger.IsAttached)
             {
                 excludeCategories.Add(CategoryConstants.ExceptionExpected);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                excludeCategories.Add(CategoryConstants.CaseInsensitiveFileSystemOnly);
             }
 
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -24,6 +24,10 @@ namespace GVFS.UnitTests
             {
                 excludeCategories.Add(CategoryConstants.CaseInsensitiveFileSystemOnly);
             }
+            else
+            {
+                excludeCategories.Add(CategoryConstants.CaseSensitiveFileSystemOnly);
+            }
 
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);
 

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -3,6 +3,7 @@ using GVFS.Common.Database;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Virtualization.Background;
 using GVFS.UnitTests.Mock.Virtualization.BlobSize;
@@ -32,10 +33,16 @@ namespace GVFS.UnitTests.Virtualization
         public void IsPathInsideDotGitIsTrueForDotGitPath()
         {
             FileSystemCallbacks.IsPathInsideDotGit(@".git" + Path.DirectorySeparatorChar).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_file.txt")).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_folder", "test_file.txt")).ShouldEqual(true);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
+        public void IsPathInsideDotGitIsTrueForDifferentCaseDotGitPath()
+        {
+            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
+            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_folder", "test_file.txt")).ShouldEqual(true);
         }
 

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
@@ -73,6 +73,19 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        public unsafe void CaseSensitiveEquals_SameName_EqualsTrue()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeTrue(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
         public unsafe void CaseInsensitiveEquals_SameNameDifferentCase1_EqualsTrue()
         {
             UseASCIIBytePointer(
@@ -82,6 +95,19 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
                     firstFolder.CaseInsensitiveEquals(secondFolder).ShouldBeTrue(nameof(firstFolder.CaseInsensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void CaseSensitiveEquals_SameNameDifferentCase1_EqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtFolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
                 });
         }
 
@@ -99,6 +125,19 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        public unsafe void CaseSensitiveEquals_SameNameDifferentCase2_EqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "FOlderonefile.txtFolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
         public unsafe void CaseInsensitiveEquals_OneNameLongerEqualsFalse()
         {
             UseASCIIBytePointer(
@@ -108,6 +147,19 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 10);
                     firstFolder.CaseInsensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseInsensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void CaseSensitiveEquals_OneNameLongerEqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfoldertest",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 10);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
                 });
         }
 
@@ -125,7 +177,20 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsZero()
+        public unsafe void CaseSensitiveEquals_OneNameShorterEqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfold",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 4);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void Compare_EqualsZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfolder",
@@ -134,11 +199,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldEqual(0, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldEqual(0, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsLessThanZero()
+        public unsafe void Compare_EqualsLessThanZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfolders",
@@ -147,11 +213,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 7);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsLessThanZero2()
+        public unsafe void Compare_EqualsLessThanZero2()
         {
             UseASCIIBytePointer(
                 "folderDKfile.txtSDKfolders",
@@ -160,11 +227,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 2);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 16, 3);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsGreaterThanZero()
+        public unsafe void Compare_EqualsGreaterThanZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfold",
@@ -173,11 +241,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 4);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsGreaterThanZero2()
+        public unsafe void Compare_EqualsGreaterThanZero2()
         {
             UseASCIIBytePointer(
                 "folderSDKfile.txtDKfolders",
@@ -186,6 +255,7 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 3);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 2);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
@@ -296,6 +366,7 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 3);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 20);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using NUnit.Framework;
 using System;
@@ -76,12 +77,23 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
         public void EntryFoundDifferentCase()
         {
             SortedFolderEntries sfe = SetupDefaultEntries();
             LazyUTF8String findName = ConstructLazyUTF8String("Folder");
             sfe.TryGetValue(findName, out FolderEntryData folderEntryData).ShouldBeTrue();
             folderEntryData.ShouldNotBeNull();
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseSensitiveFileSystemOnly)]
+        public void EntryNotFoundDifferentCase()
+        {
+            SortedFolderEntries sfe = SetupDefaultEntries();
+            LazyUTF8String findName = ConstructLazyUTF8String("Folder");
+            sfe.TryGetValue(findName, out FolderEntryData folderEntryData).ShouldBeFalse();
+            folderEntryData.ShouldBeNull();
         }
 
         [TestCase]
@@ -103,11 +115,27 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
-        public void ValidateOrderOfDefaultEntries()
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
+        public void ValidateCaseInsensitiveOrderOfDefaultEntries()
         {
             List<string> allEntries = new List<string>(defaultFiles);
             allEntries.AddRange(defaultFolders);
             allEntries.Sort(CaseInsensitiveStringCompare);
+            SortedFolderEntries sfe = SetupDefaultEntries();
+            sfe.Count.ShouldEqual(14);
+            for (int i = 0; i < allEntries.Count; i++)
+            {
+                sfe[i].Name.GetString().ShouldEqual(allEntries[i]);
+            }
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseSensitiveFileSystemOnly)]
+        public void ValidateCaseSensitiveOrderOfDefaultEntries()
+        {
+            List<string> allEntries = new List<string>(defaultFiles);
+            allEntries.AddRange(defaultFolders);
+            allEntries.Sort(CaseSensitiveStringCompare);
             SortedFolderEntries sfe = SetupDefaultEntries();
             sfe.Count.ShouldEqual(14);
             for (int i = 0; i < allEntries.Count; i++)
@@ -141,6 +169,11 @@ namespace GVFS.UnitTests.Virtualization.Git
         private static int CaseInsensitiveStringCompare(string x, string y)
         {
             return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int CaseSensitiveStringCompare(string x, string y)
+        {
+            return string.Compare(x, y, StringComparison.Ordinal);
         }
 
         private static SortedFolderEntries SetupDefaultEntries()

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
@@ -123,7 +123,7 @@ namespace GVFS.Virtualization.Background
         private bool TryParseAddLine(string line, out long key, out FileSystemTask value, out string error)
         {
             // Expected: <ID>\0<Background Update>
-            int idx = line.IndexOf(ValueTerminator, StringComparison.OrdinalIgnoreCase);
+            int idx = line.IndexOf(ValueTerminator, StringComparison.Ordinal);
             if (idx < 0)
             {
                 key = 0;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -150,17 +150,17 @@ namespace GVFS.Virtualization.FileSystem
         protected bool IsSpecialGitFile(string fileName)
         {
             return
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, StringComparison.OrdinalIgnoreCase) ||
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, StringComparison.OrdinalIgnoreCase);
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, GVFSPlatform.Instance.Constants.PathComparison) ||
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         protected void OnDotGitFileOrFolderChanged(string relativePath)
         {
-            if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+            if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnIndexFileChange();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnLogsHeadChange();
             }
@@ -168,7 +168,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -180,7 +180,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -364,9 +364,9 @@ namespace GVFS.Virtualization.FileSystem
 
         private static bool IsPathHeadOrLocalBranch(string relativePath)
         {
-            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, StringComparison.OrdinalIgnoreCase) &&
-                (relativePath.Equals(GVFSConstants.DotGit.Head, StringComparison.OrdinalIgnoreCase) ||
-                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, StringComparison.OrdinalIgnoreCase)))
+            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, GVFSPlatform.Instance.Constants.PathComparison) &&
+                (relativePath.Equals(GVFSConstants.DotGit.Head, GVFSPlatform.Instance.Constants.PathComparison) ||
+                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -61,9 +61,9 @@ namespace GVFS.Virtualization
             this.context = context;
             this.fileSystemVirtualizer = fileSystemVirtualizer;
 
-            this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
-            this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
-            this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
+            this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
+            this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
+            this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             string error;
@@ -149,7 +149,7 @@ namespace GVFS.Virtualization
         /// </summary>
         public static bool IsPathInsideDotGit(string relativePath)
         {
-            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public bool TryStart(out string error)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -64,7 +64,7 @@ namespace GVFS.Virtualization
             this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
-            this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+            this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
             string error;
             if (!ModifiedPathsDatabase.TryLoadOrCreate(

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
@@ -113,14 +113,14 @@ namespace GVFS.Virtualization.Projection
                 return lazyString;
             }
 
-            public unsafe int CaseInsensitiveCompare(LazyUTF8String other)
+            public unsafe int Compare(LazyUTF8String other, bool caseSensitive)
             {
                 // If we've already converted to a .NET String, use their implementation because it's likely to contain
                 // extended characters, which we're not set up to handle below
                 if (this.utf16string != null ||
                     other.utf16string != null)
                 {
-                    return string.Compare(this.GetString(), other.GetString(), StringComparison.OrdinalIgnoreCase);
+                    return string.Compare(this.GetString(), other.GetString(), caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
                 }
 
                 // We now know that both strings are ASCII, because if they had extended characters they would
@@ -137,6 +137,11 @@ namespace GVFS.Virtualization.Projection
                     {
                         byte thisC = *thisPtr;
                         byte otherC = *otherPtr;
+
+                        if (caseSensitive)
+                        {
+                            return thisC - otherC;
+                        }
 
                         // The more intuitive approach to checking IsLower() is to do two comparisons to see if c is within the range 'a'-'z'.
                         // However since byte is unsigned, we can rely on underflow to satisfy both conditions with one comparison.
@@ -183,9 +188,24 @@ namespace GVFS.Virtualization.Projection
                 return this.length - other.length;
             }
 
+            public unsafe int CaseInsensitiveCompare(LazyUTF8String other)
+            {
+                return this.Compare(other, false);
+            }
+
+            public unsafe int CaseSensitiveCompare(LazyUTF8String other)
+            {
+                return this.Compare(other, true);
+            }
+
             public bool CaseInsensitiveEquals(LazyUTF8String other)
             {
                 return this.CaseInsensitiveCompare(other) == 0;
+            }
+
+            public bool CaseSensitiveEquals(LazyUTF8String other)
+            {
+                return this.CaseSensitiveCompare(other) == 0;
             }
 
             public unsafe string GetString()

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Tracing;
+﻿using GVFS.Common;
+using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 
@@ -176,8 +177,10 @@ namespace GVFS.Virtualization.Projection
                 }
 
                 // Insertions are almost always at the end, because the inputs are pre-sorted by git.
-                // We only have to insert at a different spot where Windows and git disagree on the sort order.
-                int compareResult = this.sortedEntries[this.sortedEntries.Count - 1].Name.CaseInsensitiveCompare(name);
+                // We only have to insert at a different spot where Windows/Mac and git disagree on the sort order;
+                // on Linux we use a case-sensitive comparsion, which we expect t to align with git.
+                bool caseSensitive = GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem;
+                int compareResult = this.sortedEntries[this.sortedEntries.Count - 1].Name.Compare(name, caseSensitive);
                 if (compareResult == 0)
                 {
                     return this.sortedEntries.Count - 1;
@@ -193,7 +196,7 @@ namespace GVFS.Virtualization.Projection
                 while (right - left > 2)
                 {
                     int middle = left + ((right - left) / 2);
-                    int comparison = this.sortedEntries[middle].Name.CaseInsensitiveCompare(name);
+                    int comparison = this.sortedEntries[middle].Name.Compare(name, caseSensitive);
 
                     if (comparison == 0)
                     {
@@ -212,7 +215,7 @@ namespace GVFS.Virtualization.Projection
 
                 for (int i = right; i >= left; i--)
                 {
-                    compareResult = this.sortedEntries[i].Name.CaseInsensitiveCompare(name);
+                    compareResult = this.sortedEntries[i].Name.Compare(name, caseSensitive);
                     if (compareResult == 0)
                     {
                         return i;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -49,11 +49,11 @@ namespace GVFS.Virtualization.Projection
         private GitIndexParser indexParser;
 
         // Cache of folder paths (in Windows format) to folder data
-        private ConcurrentDictionary<string, FolderData> projectionFolderCache = new ConcurrentDictionary<string, FolderData>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, FolderData> projectionFolderCache = new ConcurrentDictionary<string, FolderData>(GVFSPlatform.Instance.Constants.PathComparer);
 
         // nonDefaultFileTypesAndModes is only populated when the platform supports file mode
         // On platforms that support file modes, file paths that are not in nonDefaultFileTypesAndModes are regular files with mode 644
-        private Dictionary<string, FileTypeAndMode> nonDefaultFileTypesAndModes = new Dictionary<string, FileTypeAndMode>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, FileTypeAndMode> nonDefaultFileTypesAndModes = new Dictionary<string, FileTypeAndMode>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private BlobSizes blobSizes;
         private IPlaceholderCollection placeholderDatabase;
@@ -1105,7 +1105,7 @@ namespace GVFS.Virtualization.Projection
 
                 // folderPlaceholdersToKeep always contains the empty path so as to avoid unnecessary attempts
                 // to remove the repository's root folder.
-                ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+                ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
                 folderPlaceholdersToKeep.Add(string.Empty);
 
                 stopwatch.Restart();
@@ -1141,7 +1141,7 @@ namespace GVFS.Virtualization.Projection
                         IEnumerable<string> allPlaceholders = placeholderFoldersListCopy
                             .Select(x => x.Path)
                             .Union(this.placeholderDatabase.GetAllFilePaths());
-                        existingPlaceholders = new HashSet<string>(allPlaceholders, StringComparer.OrdinalIgnoreCase);
+                        existingPlaceholders = new HashSet<string>(allPlaceholders, GVFSPlatform.Instance.Constants.PathComparer);
                     }
 
                     // Order the folders in decscending order so that we walk the tree from bottom up.

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -102,7 +102,7 @@ namespace GVFS.CommandLine
 
                 if (normalizedLocalCacheRootPath.StartsWith(
                     Path.Combine(normalizedEnlistmentRootPath, GVFSConstants.WorkingDirectoryRootName),
-                    StringComparison.OrdinalIgnoreCase))
+                    GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.ReportErrorAndExit("'--local-cache-path' cannot be inside the src folder");
                 }
@@ -293,7 +293,7 @@ namespace GVFS.CommandLine
             // LogFileEventListener will create a file in EnlistmentRootPath
             if (Directory.Exists(normalizedEnlistementRootPath) && Directory.EnumerateFileSystemEntries(normalizedEnlistementRootPath).Any())
             {
-                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, StringComparison.OrdinalIgnoreCase))
+                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     return new Result($"Clone directory '{fullEnlistmentRootPathParameter}' exists and is not empty");
                 }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -363,7 +363,7 @@ of your enlistment's src folder.
             foreach (string file in Directory.GetFiles(folderPath, searchPattern))
             {
                 string fileName = Path.GetFileName(file);
-                if (!filenamesToSkip.Any(x => x.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+                if (!filenamesToSkip.Any(x => x.Equals(fileName, GVFSPlatform.Instance.Constants.PathComparison)))
                 {
                     if (!this.TryIO(
                         tracer,

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -556,7 +556,7 @@ namespace GVFS.CommandLine
                 DriveInfo enlistmentDrive = new DriveInfo(enlistmentNormalizedPathRoot);
                 string enlistmentDriveDiskSpace = this.FormatByteCount(enlistmentDrive.AvailableFreeSpace);
 
-                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.WriteMessage("Available space on " + enlistmentDrive.Name + " drive(enlistment and local cache): " + enlistmentDriveDiskSpace);
                 }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -961,7 +961,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                                     while (!reader.EndOfStream)
                                     {
                                         string alternatesLine = reader.ReadLine();
-                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, StringComparison.OrdinalIgnoreCase))
+                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                         {
                                             gitObjectsRootInAlternates = true;
                                         }

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -16,7 +16,7 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return ".git\\config"; }
+            get { return $".git{Path.DirectorySeparatorChar}config"; }
         }
 
         public override IssueType HasIssue(List<string> messages)
@@ -58,7 +58,7 @@ namespace GVFS.RepairJobs
                 if (!enlistment.Authentication.TryInitialize(this.Tracer, enlistment, out authError))
                 {
                     messages.Add("Authentication failed. Run 'gvfs log' for more info.");
-                    messages.Add(".git\\config is valid and remote 'origin' is set, but may have a typo:");
+                    messages.Add($".git{Path.DirectorySeparatorChar}config is valid and remote 'origin' is set, but may have a typo:");
                     messages.Add(originUrl.Trim());
                     return IssueType.CantFix;
                 }
@@ -87,7 +87,7 @@ namespace GVFS.RepairJobs
             if (!GVFSVerb.TrySetRequiredGitConfigSettings(this.Enlistment) ||
                 !GVFSVerb.TrySetOptionalGitConfigSettings(this.Enlistment))
             {
-                messages.Add("Unable to create default .git\\config.");
+                messages.Add($"Unable to create default .git{Path.DirectorySeparatorChar}config.");
                 this.RestoreFromBackupFile(configBackupPath, configPath, messages);
 
                 return FixResult.Failure;
@@ -100,7 +100,7 @@ namespace GVFS.RepairJobs
             // but getting Fixable means that we still failed
             if (this.HasIssue(validationMessages) == IssueType.Fixable)
             {
-                messages.Add("Reinitializing the .git\\config did not fix the issue. Check the errors below for more details:");
+                messages.Add($"Reinitializing the .git{Path.DirectorySeparatorChar}config did not fix the issue. Check the errors below for more details:");
                 messages.AddRange(validationMessages);
 
                 this.RestoreFromBackupFile(configBackupPath, configPath, messages);
@@ -110,10 +110,10 @@ namespace GVFS.RepairJobs
 
             if (!this.TryDeleteFile(configBackupPath))
             {
-                messages.Add("Failed to delete .git\\config backup file: " + configBackupPath);
+                messages.Add($"Failed to delete .git{Path.DirectorySeparatorChar}config backup file: " + configBackupPath);
             }
 
-            messages.Add("Reinitialized .git\\config. You will need to manually add the origin remote by running");
+            messages.Add($"Reinitialized .git{Path.DirectorySeparatorChar}config. You will need to manually add the origin remote by running");
             messages.Add("git remote add origin <repo url>");
             messages.Add("If you previously configured a custom cache server, you will need to configure it again.");
 

--- a/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
@@ -17,7 +17,7 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return @".git\HEAD"; }
+            get { return $".git{Path.DirectorySeparatorChar}HEAD"; }
         }
 
         public override IssueType HasIssue(List<string> messages)
@@ -126,7 +126,7 @@ namespace GVFS.RepairJobs
             }
             catch (IOException ex)
             {
-                messages.Add("IOException while reading .git\\HEAD: " + ex.Message);
+                messages.Add($"IOException while reading .git{Path.DirectorySeparatorChar}HEAD: " + ex.Message);
                 return false;
             }
 

--- a/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
@@ -18,14 +18,14 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return @".git\index"; }
+            get { return $".git{Path.DirectorySeparatorChar}index"; }
         }
 
         public override IssueType HasIssue(List<string> messages)
         {
             if (!File.Exists(this.indexPath))
             {
-                messages.Add(".git\\index not found");
+                messages.Add($".git{Path.DirectorySeparatorChar}index not found");
                 return IssueType.Fixable;
             }
             else
@@ -62,7 +62,7 @@ namespace GVFS.RepairJobs
             {
                 if (!this.TryDeleteFile(indexBackupPath))
                 {
-                    messages.Add("Warning: Could not delete backed up .git\\index at: " + indexBackupPath);
+                    messages.Add($"Warning: Could not delete backed up .git{Path.DirectorySeparatorChar}index at: " + indexBackupPath);
                 }
             }
 

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -10,6 +10,8 @@ namespace MirrorProvider.Mac
     {
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(directory);

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -12,6 +12,8 @@ namespace MirrorProvider.Windows
         private VirtualizationInstance virtualizationInstance;
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations = new ConcurrentDictionary<Guid, ActiveEnumeration>();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             error = string.Empty;

--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -9,6 +9,8 @@ namespace MirrorProvider
     {
         protected Enlistment Enlistment { get; private set; }
 
+        protected abstract StringComparison PathComparison { get; }
+
         public abstract bool TryConvertVirtualizationRoot(string directory, out string error);
         public virtual bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)
         {
@@ -147,7 +149,7 @@ namespace MirrorProvider
             FileSystemInfo fileSystemInfo = 
                 dirInfo
                 .GetFileSystemInfos()
-                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, PathComparison));
 
             if (fileSystemInfo == null)
             {


### PR DESCRIPTION
Introduce case-sensitive file path matching and sorting of file and folder names within the repository as well as the modified paths and placeholder list databases, but only on Linux and other case-sensitive file systems, while retaining existing case-insensitive behaviour on Windows
and Mac platforms.

Use filesystem-specific case matching when comparing path throughout the functional test suite. 
 Also make sure to exclude the case-sensitive filesystem unit tests when running on Windows or Mac platforms.

Also fix the path matching in the `HydrateEntireRepo()` helper for `MultiEnlistmentTests.SharedCacheTests`, which was not excluding `{repoRoot}/.git/` paths on Mac (or Linux) due to hard-coded Windows path separators.

Divide the `HydratingFileUsesNameCaseFromRepo()` and `HydratingNestedFileUsesNameCaseFromRepo()` functional tests
into pairs, one for case-sensitive filesystems, and one for case-insensitive filesystems.

Includes some filename case corrections to prevent test case regressions on case-sensitive filesystems, use of lowercase paths generated from SHA1 values because that ensures consistency with Git's own naming scheme for files under `.git/objects` on case-sensitive filesystems, and fixes for some hard-coded uses of Windows path separators.

Resolves github#29.