### PR TITLE
[Linux] Convert tests and repair jobs to use backing root

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -57,7 +57,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             this.Enlistment.UnmountGVFS();
 
-            string readObjectPath = this.Enlistment.GetVirtualPathTo(".git", "hooks", "read-object" + Settings.Default.BinaryFileNameExtension);
+            string readObjectPath = this.Enlistment.GetDotGitPath("hooks", "read-object" + Settings.Default.BinaryFileNameExtension);
             readObjectPath.ShouldBeAFile(this.fileSystem);
             this.fileSystem.DeleteFile(readObjectPath);
             readObjectPath.ShouldNotExistOnDisk(this.fileSystem);
@@ -76,7 +76,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 .ShouldBeTrue();
 
             this.Enlistment.MountGVFS();
-            string expectedHooksPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "hooks");
+            string expectedHooksPath = this.Enlistment.GetDotGitPath("hooks");
             expectedHooksPath = GitHelpers.ConvertPathToGitFormat(expectedHooksPath);
 
             GitProcess.Invoke(
@@ -198,7 +198,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string objectsRoot = GVFSHelpers.GetPersistedGitObjectsRoot(this.Enlistment.DotGVFSRoot).ShouldNotBeNull();
 
-            string alternatesFilePath = Path.Combine(this.Enlistment.RepoRoot, ".git", "objects", "info", "alternates");
+            string alternatesFilePath = this.Enlistment.GetDotGitPath("objects", "info", "alternates");
             alternatesFilePath.ShouldBeAFile(this.fileSystem).WithContents(objectsRoot);
             this.fileSystem.WriteAllText(alternatesFilePath, "Z:\\invalidPath");
 
@@ -214,7 +214,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string objectsRoot = GVFSHelpers.GetPersistedGitObjectsRoot(this.Enlistment.DotGVFSRoot).ShouldNotBeNull();
 
-            string alternatesFilePath = Path.Combine(this.Enlistment.RepoRoot, ".git", "objects", "info", "alternates");
+            string alternatesFilePath = this.Enlistment.GetDotGitPath("objects", "info", "alternates");
             alternatesFilePath.ShouldBeAFile(this.fileSystem).WithContents(objectsRoot);
             this.fileSystem.DeleteFile(alternatesFilePath);
 
@@ -345,17 +345,26 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private class MountSubfolders
         {
             public const string MountFolders = "Folders";
-            private static object[] mountFolders =
-            {
-                new object[] { string.Empty },
-                new object[] { "GVFS" },
-            };
 
             public static object[] Folders
             {
                 get
                 {
-                    return mountFolders;
+                    // On Linux, an unmounted repository is completely empty, so we must
+                    // only try to mount from the root of the virtual path.
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        return new object[] { new object[] { string.Empty } };
+                    }
+                    else
+                    {
+                        return new object[]
+                        {
+                            new object[] { string.Empty },
+                            new object[] { "GVFS" },
+                        };
+                    }
                 }
             }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/LooseObjectStepTests.cs
@@ -188,7 +188,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             using (FileStream packFileStream = File.OpenRead(packFile))
             {
                 string output = GitProcess.InvokeProcess(
-                    this.Enlistment.RepoRoot,
+                    this.Enlistment.RepoBackingRoot,
                     "unpack-objects",
                     new Dictionary<string, string>() { { "GIT_OBJECT_DIRECTORY", this.GitObjectRoot } },
                     inputStream: packFileStream).Output;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/RepairTests.cs
@@ -25,7 +25,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string headFilePath = Path.Combine(this.Enlistment.RepoRoot, ".git", "HEAD");
+            string headFilePath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "HEAD");
             File.WriteAllText(headFilePath, "0000");
             this.Enlistment.TryMountGVFS().ShouldEqual(false, "GVFS shouldn't mount when HEAD is corrupt");
 
@@ -39,7 +39,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string headFilePath = Path.Combine(this.Enlistment.RepoRoot, ".git", "HEAD");
+            string headFilePath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "HEAD");
             File.WriteAllText(headFilePath, "ref: refs");
             this.Enlistment.TryMountGVFS().ShouldEqual(false, "GVFS shouldn't mount when HEAD is corrupt");
 
@@ -53,7 +53,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "index");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "index");
             File.Delete(gitIndexPath);
             this.Enlistment.TryMountGVFS().ShouldEqual(false, "GVFS shouldn't mount when git index is missing");
 
@@ -67,7 +67,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "index");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "index");
             this.CreateCorruptIndexAndRename(
                 gitIndexPath,
                 (current, temp) =>
@@ -90,7 +90,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "index");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "index");
 
             // Set the contents of the index file to gitIndexPath NULL
             this.CreateCorruptIndexAndRename(
@@ -114,7 +114,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "index");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "index");
 
             // Truncate the contents of the index
             this.CreateCorruptIndexAndRename(
@@ -141,7 +141,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         {
             this.Enlistment.UnmountGVFS();
 
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "config");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "config");
             File.WriteAllText(gitIndexPath, "[cor");
 
             this.Enlistment.TryMountGVFS().ShouldEqual(false, "GVFS shouldn't mount when git config is missing");
@@ -149,7 +149,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.RepairWithoutConfirmShouldNotFix();
 
             this.Enlistment.Repair(confirm: true);
-            ProcessResult result = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "remote add origin " + this.Enlistment.RepoUrl);
+            ProcessResult result = GitProcess.InvokeProcess(this.Enlistment.RepoBackingRoot, "remote add origin " + this.Enlistment.RepoUrl);
             result.ExitCode.ShouldEqual(0, result.Errors);
             this.Enlistment.MountGVFS();
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -501,7 +501,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ControlGitRepo.Fetch(GitRepoTests.ConflictTargetBranch);
 
             this.Enlistment.UnmountGVFS();
-            string gitIndexPath = Path.Combine(this.Enlistment.RepoRoot, ".git", "index");
+            string gitIndexPath = Path.Combine(this.Enlistment.RepoBackingRoot, ".git", "index");
             CopyIndexAndRename(gitIndexPath);
             this.Enlistment.MountGVFS();
 

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -294,10 +294,20 @@ namespace GVFS.FunctionalTests.Tools
             return Path.Combine(this.RepoRoot, Path.Combine(pathParts));
         }
 
+        public string GetBackingPathTo(params string[] pathParts)
+        {
+            return Path.Combine(this.RepoBackingRoot, Path.Combine(pathParts));
+        }
+
+        public string GetDotGitPath(params string[] pathParts)
+        {
+            return this.GetBackingPathTo(TestConstants.DotGit.Root, Path.Combine(pathParts));
+        }
+
         public string GetObjectPathTo(string objectHash)
         {
             return Path.Combine(
-                this.RepoRoot,
+                this.RepoBackingRoot,
                 TestConstants.DotGit.Objects.Root,
                 objectHash.Substring(0, 2),
                 objectHash.Substring(2));

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -59,6 +59,21 @@ namespace GVFS.FunctionalTests.Tools
 
         public string LocalCacheRoot { get; }
 
+        public string RepoBackingRoot
+        {
+            get
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    return Path.Combine(this.EnlistmentRoot, ".vfsforgit/lower");
+                }
+                else
+                {
+                    return this.RepoRoot;
+                }
+            }
+        }
+
         public string RepoRoot
         {
             get { return Path.Combine(this.EnlistmentRoot, "src"); }

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -74,7 +74,7 @@ namespace GVFS.RepairJobs
 
         public override FixResult TryFixIssues(List<string> messages)
         {
-            string configPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Config);
+            string configPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Config);
             string configBackupPath;
             if (!this.TryRenameToBackupFile(configPath, out configBackupPath, messages))
             {

--- a/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
@@ -52,7 +52,7 @@ namespace GVFS.RepairJobs
 
             try
             {
-                string refPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Head);
+                string refPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Head);
                 File.WriteAllText(refPath, refLog.TargetSha);
             }
             catch (IOException ex)
@@ -82,7 +82,7 @@ namespace GVFS.RepairJobs
         /// <param name="fullSymbolicRef">A full symbolic ref name. eg. HEAD, refs/remotes/origin/HEAD, refs/heads/master</param>
         private static bool TryReadLastRefLogEntry(Enlistment enlistment, string fullSymbolicRef, out RefLogEntry refLog, out string error)
         {
-            string refLogPath = Path.Combine(enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Logs.Root, fullSymbolicRef);
+            string refLogPath = Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Logs.Root, fullSymbolicRef);
             if (!File.Exists(refLogPath))
             {
                 refLog = null;
@@ -112,7 +112,7 @@ namespace GVFS.RepairJobs
 
         private static bool TryParseHead(Enlistment enlistment, List<string> messages)
         {
-            string refPath = Path.Combine(enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.Head);
+            string refPath = Path.Combine(enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Head);
             if (!File.Exists(refPath))
             {
                 messages.Add("Could not find ref file for '" + GVFSConstants.DotGit.Head + "'");
@@ -145,35 +145,35 @@ namespace GVFS.RepairJobs
         {
             Func<string, string> createErrorMessage = operation => string.Format("Can't repair HEAD while a {0} operation is in progress", operation);
 
-            string rebasePath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.RebaseApply);
+            string rebasePath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.RebaseApply);
             if (Directory.Exists(rebasePath))
             {
                 messages.Add(createErrorMessage("rebase"));
                 return false;
             }
 
-            string mergeHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.MergeHead);
+            string mergeHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.MergeHead);
             if (File.Exists(mergeHeadPath))
             {
                 messages.Add(createErrorMessage("merge"));
                 return false;
             }
 
-            string bisectStartPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.BisectStart);
+            string bisectStartPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.BisectStart);
             if (File.Exists(bisectStartPath))
             {
                 messages.Add(createErrorMessage("bisect"));
                 return false;
             }
 
-            string cherrypickHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.CherryPickHead);
+            string cherrypickHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.CherryPickHead);
             if (File.Exists(cherrypickHeadPath))
             {
                 messages.Add(createErrorMessage("cherry-pick"));
                 return false;
             }
 
-            string revertHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryRoot, GVFSConstants.DotGit.RevertHead);
+            string revertHeadPath = Path.Combine(this.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.RevertHead);
             if (File.Exists(revertHeadPath))
             {
                 messages.Add(createErrorMessage("revert"));


### PR DESCRIPTION
Convert all relevant uses of `RepoRoot` and `WorkingDirectoryRoot` in the GVFS provider and functional tests to use the backing root, to ensure these tests will pass on systems where they are distinct (e.g., Linux).

For example. repair jobs run while the GVFS enlistment is not mounted, which on Linux requires us to use the backing root in order to access the `.git` contents; similarly, the `MountTests` are adjusted to ensure they don't expect file contents within an unmounted repository.

/cc @jrbriggs, @kivikakk.