### PR TITLE
[Linux] Support case-sensitive filesystems

### DIFF
--- a/GVFS/FastFetch/Index.cs
+++ b/GVFS/FastFetch/Index.cs
@@ -377,7 +377,7 @@ namespace FastFetch
 
             this.tracer.RelatedEvent(EventLevel.Informational, "IndexData", new EventMetadata() { { "Index", this.updatedIndexPath }, { "Version", this.IndexVersion }, { "entryCount", this.entryCount } }, Keywords.Telemetry);
 
-            this.indexEntryOffsets = new Dictionary<string, long>((int)this.entryCount, StringComparer.OrdinalIgnoreCase);
+            this.indexEntryOffsets = new Dictionary<string, long>((int)this.entryCount, GVFSPlatform.Instance.Constants.PathComparer);
 
             int previousPathLength = 0;
             byte[] pathBuffer = new byte[MaxPathBufferSize];

--- a/GVFS/FastFetch/WorkingTree.cs
+++ b/GVFS/FastFetch/WorkingTree.cs
@@ -26,7 +26,7 @@ namespace FastFetch
 
             Parallel.ForEach(
                 dir.EnumerateDirectories().Where(subdir =>
-                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, StringComparison.OrdinalIgnoreCase) &&
+                    (!subdir.Name.Equals(GVFSConstants.DotGit.Root, GVFSPlatform.Instance.Constants.PathComparison) &&
                      !subdir.Attributes.HasFlag(FileAttributes.ReparsePoint))),
                 subdir => { ForAllDirectories(subdir, asyncParallelCallback); });
         }

--- a/GVFS/GVFS.Common/Database/GVFSDatabase.cs
+++ b/GVFS/GVFS.Common/Database/GVFSDatabase.cs
@@ -117,8 +117,8 @@ namespace GVFS.Common.Database
                     command.ExecuteNonQuery();
                 }
 
-                PlaceholderTable.CreateTable(connection);
-                SparseTable.CreateTable(connection);
+                PlaceholderTable.CreateTable(connection, GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem);
+                SparseTable.CreateTable(connection, GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem);
             }
         }
 

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -17,11 +17,12 @@ namespace GVFS.Common.Database
             this.connectionPool = connectionPool;
         }
 
-        public static void CreateTable(IDbConnection connection)
+        public static void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-                command.CommandText = "CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY COLLATE NOCASE, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;";
+                string collateConstraint = caseSensitiveFileSystem ? string.Empty : " COLLATE NOCASE";
+                command.CommandText = $"CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY{collateConstraint}, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;";
                 command.ExecuteNonQuery();
             }
         }

--- a/GVFS/GVFS.Common/Database/SparseTable.cs
+++ b/GVFS/GVFS.Common/Database/SparseTable.cs
@@ -20,11 +20,12 @@ namespace GVFS.Common.Database
             return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim().Trim(Path.DirectorySeparatorChar);
         }
 
-        public static void CreateTable(IDbConnection connection)
+        public static void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-                command.CommandText = "CREATE TABLE IF NOT EXISTS [Sparse] (path TEXT PRIMARY KEY COLLATE NOCASE) WITHOUT ROWID;";
+                string collateConstraint = caseSensitiveFileSystem ? string.Empty : " COLLATE NOCASE";
+                command.CommandText = $"CREATE TABLE IF NOT EXISTS [Sparse] (path TEXT PRIMARY KEY{collateConstraint}) WITHOUT ROWID;";
                 command.ExecuteNonQuery();
             }
         }
@@ -58,7 +59,7 @@ namespace GVFS.Common.Database
                 using (IDbConnection connection = this.connectionPool.GetConnection())
                 using (IDbCommand command = connection.CreateCommand())
                 {
-                    HashSet<string> directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    HashSet<string> directories = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
                     command.CommandText = $"SELECT path FROM Sparse;";
                     using (IDataReader reader = command.ExecuteReader())
                     {

--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common.FileSystem
         {
             IEnumerable<string> valuableHooksLines = defaultHooksLines.Where(line => !string.IsNullOrEmpty(line.Trim()));
 
-            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, StringComparer.OrdinalIgnoreCase))
+            if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, GVFSPlatform.Instance.Constants.PathComparer))
             {
                 throw new HooksConfigurationException(
                     $"{GVFSPlatform.Instance.Constants.GVFSHooksExecutableName} should not be specified in the configuration for "

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -176,6 +176,28 @@ namespace GVFS.Common
             /// </summary>
             public abstract HashSet<string> UpgradeBlockingProcesses { get; }
 
+            public abstract bool CaseSensitiveFileSystem { get; }
+
+            public StringComparison PathComparison
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparison.Ordinal :
+                        StringComparison.OrdinalIgnoreCase;
+                }
+            }
+
+            public StringComparer PathComparer
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparer.Ordinal :
+                        StringComparer.OrdinalIgnoreCase;
+                }
+            }
+
             public string GVFSHooksExecutableName
             {
                 get { return "GVFS.Hooks" + this.ExecutableExtension; }

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -594,6 +594,8 @@ namespace GVFS.Common.Git
 
         private LooseObjectToWrite GetLooseObjectDestination(string sha)
         {
+            // Ensure SHA path is lowercase for case-sensitive filesystems
+            sha = sha.ToLower();
             string firstTwoDigits = sha.Substring(0, 2);
             string remainingDigits = sha.Substring(2);
             string twoLetterFolderName = Path.Combine(this.Enlistment.GitObjectsRoot, firstTwoDigits);

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -595,7 +595,11 @@ namespace GVFS.Common.Git
         private LooseObjectToWrite GetLooseObjectDestination(string sha)
         {
             // Ensure SHA path is lowercase for case-sensitive filesystems
-            sha = sha.ToLower();
+            if (GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem)
+            {
+                sha = sha.ToLower();
+            }
+
             string firstTwoDigits = sha.Substring(0, 2);
             string remainingDigits = sha.Substring(2);
             string twoLetterFolderName = Path.Combine(this.Enlistment.GitObjectsRoot, firstTwoDigits);

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -232,6 +232,8 @@ namespace GVFS.Common.Git
 
         private LooseBlobState GetLooseBlobState(string blobSha, Action<Stream, long> writeAction, out long size)
         {
+            // Ensure SHA path is lowercase for case-sensitive filesystems
+            blobSha = blobSha.ToLower();
             string blobPath = Path.Combine(
                 this.enlistment.GitObjectsRoot,
                 blobSha.Substring(0, 2),

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -233,7 +233,11 @@ namespace GVFS.Common.Git
         private LooseBlobState GetLooseBlobState(string blobSha, Action<Stream, long> writeAction, out long size)
         {
             // Ensure SHA path is lowercase for case-sensitive filesystems
-            blobSha = blobSha.ToLower();
+            if (GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem)
+            {
+                blobSha = blobSha.ToLower();
+            }
+
             string blobPath = Path.Combine(
                 this.enlistment.GitObjectsRoot,
                 blobSha.Substring(0, 2),

--- a/GVFS/GVFS.Common/GitHubUpgrader.cs
+++ b/GVFS/GVFS.Common/GitHubUpgrader.cs
@@ -29,7 +29,7 @@ namespace GVFS.Common
         private const string GitSigner = "Johannes Schindelin";
         private const string GitCertIssuer = "COMODO RSA Code Signing CA";
 
-        private static readonly HashSet<string> GVFSInstallerFileNamePrefixCandidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> GVFSInstallerFileNamePrefixCandidates = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer)
         {
             "SetupGVFS",
             "VFSForGit"
@@ -152,7 +152,7 @@ namespace GVFS.Common
 
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase);
+                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, GVFSPlatform.Instance.Constants.PathComparison);
                 bool isGitAsset = this.IsGitAsset(asset);
                 bool isGVFSAsset = isGitAsset ? false : this.IsGVFSAsset(asset);
                 if (!targetOSMatch || (!isGVFSAsset && !isGitAsset))
@@ -461,7 +461,7 @@ namespace GVFS.Common
         {
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                if (string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(asset.Name), GVFSPlatform.Instance.Constants.InstallerExtension, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     path = asset.LocalPath;
                     if (assetId == GitAssetId && this.IsGitAsset(asset))
@@ -497,7 +497,7 @@ namespace GVFS.Common
         {
             foreach (string fileNamePrefix in expectedFileNamePrefixes)
             {
-                if (asset.Name.StartsWith(fileNamePrefix, StringComparison.OrdinalIgnoreCase))
+                if (asset.Name.StartsWith(fileNamePrefix, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     return true;
                 }

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -26,8 +26,8 @@ namespace GVFS.Common
             int gitTrackedItemsCount = 0;
             int placeholderCount = 0;
             int modifiedPathsCount = 0;
-            Dictionary<string, int> gitTrackedItemsDirectoryTally = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            Dictionary<string, int> hydratedFilesDirectoryTally = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, int> gitTrackedItemsDirectoryTally = new Dictionary<string, int>(GVFSPlatform.Instance.Constants.PathComparer);
+            Dictionary<string, int> hydratedFilesDirectoryTally = new Dictionary<string, int>(GVFSPlatform.Instance.Constants.PathComparer);
 
             // Parent directory is a path relative to the root of the repository which is already in git format
             if (!parentDirectory.EndsWith(GVFSConstants.GitPathSeparatorString) && parentDirectory.Length > 0)
@@ -47,7 +47,7 @@ namespace GVFS.Common
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
             modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFilePaths, hydratedFilesDirectoryTally, parentDirectory);
 
-            Dictionary<string, SubDirectoryInfo> mostHydratedDirectories = new Dictionary<string, SubDirectoryInfo>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, SubDirectoryInfo> mostHydratedDirectories = new Dictionary<string, SubDirectoryInfo>(GVFSPlatform.Instance.Constants.PathComparer);
 
             // Map directory names to the corresponding health data from gitTrackedItemsDirectoryTally and hydratedFilesDirectoryTally
             foreach (KeyValuePair<string, int> pair in gitTrackedItemsDirectoryTally)
@@ -107,12 +107,12 @@ namespace GVFS.Common
             foreach (string path in paths)
             {
                 // Only categorize if descendent of the parentDirectory
-                if (path.StartsWith(parentDirectory, StringComparison.OrdinalIgnoreCase))
+                if (path.StartsWith(parentDirectory, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     count++;
 
                     // If the path is to the parentDirectory, ignore it to avoid adding string.Empty to the data structures
-                    if (!parentDirectory.Equals(path, StringComparison.OrdinalIgnoreCase))
+                    if (!parentDirectory.Equals(path, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         // Trim the path to parent directory
                         string topDir = this.ParseTopDirectory(this.TrimDirectoryFromPath(path, parentDirectory));

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -275,7 +275,7 @@ namespace GVFS.Common
 
         private IEnumerable<string> GenerateDataLines(IEnumerable<IPlaceholderData> updatedPlaceholders)
         {
-            HashSet<string> keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> keys = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
             this.count = 0;
             foreach (IPlaceholderData updated in updatedPlaceholders)

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -150,12 +150,12 @@ namespace GVFS.Common.Maintenance
             {
                 string extension = Path.GetExtension(info.Name);
 
-                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(extension, ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     count++;
                     size += info.Length;
                 }
-                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(extension, ".keep", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     hasKeep = true;
                 }

--- a/GVFS/GVFS.Common/Maintenance/GitProcessChecker.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitProcessChecker.cs
@@ -11,7 +11,7 @@ namespace GVFS.Common.Maintenance
         {
             Process[] allProcesses = Process.GetProcesses();
             return allProcesses
-                .Where(x => x.ProcessName.Equals("git", StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.ProcessName.Equals("git", GVFSPlatform.Instance.Constants.PathComparison))
                 .Select(x => x.Id);
         }
     }

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -66,7 +66,7 @@ namespace GVFS.Common.Maintenance
 
             foreach (DirectoryItemInfo info in packDirContents)
             {
-                if (string.Equals(Path.GetExtension(info.Name), ".idx", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(info.Name), ".idx", GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string pairedPack = Path.ChangeExtension(info.FullName, ".pack");
 

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -325,7 +325,7 @@ namespace GVFS.Common.Maintenance
                                          .FileSystem
                                          .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
                                          .Where(item => item.Name.StartsWith(prefix)
-                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", StringComparison.OrdinalIgnoreCase))
+                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", GVFSPlatform.Instance.Constants.PathComparison))
                                          .FirstOrDefault();
             if (info == null)
             {

--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -18,7 +18,7 @@ namespace GVFS.Common
         protected ModifiedPathsDatabase(ITracer tracer, PhysicalFileSystem fileSystem, string dataFilePath)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: true)
         {
-            this.modifiedPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+            this.modifiedPaths = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
         }
 
         public int Count

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -576,7 +576,7 @@ namespace GVFS.Common.Prefetch
 
         private bool IsSymbolicRef(string targetCommitish)
         {
-            return targetCommitish.StartsWith("refs/", StringComparison.OrdinalIgnoreCase);
+            return targetCommitish.StartsWith("refs/", GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         private void SavePrefetchArgs(string targetCommit, bool hydrate)

--- a/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/DiffHelper.cs
@@ -16,10 +16,10 @@ namespace GVFS.Common.Prefetch.Git
         private HashSet<string> exactFileList;
         private List<string> patternList;
         private List<string> folderList;
-        private HashSet<string> filesAdded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private HashSet<string> filesAdded = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private HashSet<DiffTreeResult> stagedDirectoryOperations = new HashSet<DiffTreeResult>(new DiffTreeByNameComparer());
-        private HashSet<string> stagedFileDeletes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private HashSet<string> stagedFileDeletes = new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private Enlistment enlistment;
         private GitProcess git;
@@ -32,7 +32,7 @@ namespace GVFS.Common.Prefetch.Git
         public DiffHelper(ITracer tracer, Enlistment enlistment, GitProcess git, IEnumerable<string> fileList, IEnumerable<string> folderList, bool includeSymLinks)
         {
             this.tracer = tracer;
-            this.exactFileList = new HashSet<string>(fileList.Where(x => !x.StartsWith("*")), StringComparer.OrdinalIgnoreCase);
+            this.exactFileList = new HashSet<string>(fileList.Where(x => !x.StartsWith("*")), GVFSPlatform.Instance.Constants.PathComparer);
             this.patternList = fileList.Where(x => x.StartsWith("*")).ToList();
             this.folderList = new List<string>(folderList);
             this.enlistment = enlistment;
@@ -41,7 +41,7 @@ namespace GVFS.Common.Prefetch.Git
 
             this.DirectoryOperations = new ConcurrentQueue<DiffTreeResult>();
             this.FileDeleteOperations = new ConcurrentQueue<string>();
-            this.FileAddOperations = new ConcurrentDictionary<string, HashSet<PathWithMode>>(StringComparer.OrdinalIgnoreCase);
+            this.FileAddOperations = new ConcurrentDictionary<string, HashSet<PathWithMode>>(GVFSPlatform.Instance.Constants.PathComparer);
             this.RequiredBlobs = new BlockingCollection<string>();
         }
 
@@ -173,7 +173,7 @@ namespace GVFS.Common.Prefetch.Git
                 // Git traverses diffs in pre-order, so we are guaranteed to ignore child deletes here.
                 if (result.Operation == DiffTreeResult.Operations.Delete)
                 {
-                    if (deletedPaths.Any(path => result.TargetPath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+                    if (deletedPaths.Any(path => result.TargetPath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
                     {
                         continue;
                     }
@@ -186,7 +186,7 @@ namespace GVFS.Common.Prefetch.Git
 
             foreach (string filePath in this.stagedFileDeletes)
             {
-                if (deletedPaths.Any(path => filePath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+                if (deletedPaths.Any(path => filePath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
                 {
                     continue;
                 }
@@ -334,12 +334,12 @@ namespace GVFS.Common.Prefetch.Git
             }
 
             if (this.exactFileList.Contains(blobAdd.TargetPath) ||
-                this.patternList.Any(path => blobAdd.TargetPath.EndsWith(path.Substring(1), StringComparison.OrdinalIgnoreCase)))
+                this.patternList.Any(path => blobAdd.TargetPath.EndsWith(path.Substring(1), GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }
 
-            if (this.folderList.Any(path => blobAdd.TargetPath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+            if (this.folderList.Any(path => blobAdd.TargetPath.StartsWith(path, GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }
@@ -367,7 +367,8 @@ namespace GVFS.Common.Prefetch.Git
         /// </remarks>
         private void EnqueueFileAddOperation(ITracer activity, DiffTreeResult operation)
         {
-            // Each filepath should be case-insensitive unique. If there are duplicates, only the last parsed one should remain.
+            // Each filepath should be unique according to GVFSPlatform.Instance.Constants.PathComparer.
+            // If there are duplicates, only the last parsed one should remain.
             if (!this.filesAdded.Add(operation.TargetPath))
             {
                 foreach (KeyValuePair<string, HashSet<PathWithMode>> kvp in this.FileAddOperations)
@@ -408,7 +409,7 @@ namespace GVFS.Common.Prefetch.Git
                 {
                     if (y.TargetPath != null)
                     {
-                        return x.TargetPath.Equals(y.TargetPath, StringComparison.OrdinalIgnoreCase);
+                        return x.TargetPath.Equals(y.TargetPath, GVFSPlatform.Instance.Constants.PathComparison);
                     }
 
                     return false;
@@ -423,7 +424,7 @@ namespace GVFS.Common.Prefetch.Git
             public int GetHashCode(DiffTreeResult obj)
             {
                 return obj.TargetPath != null ?
-                    StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TargetPath) : 0;
+                    GVFSPlatform.Instance.Constants.PathComparer.GetHashCode(obj.TargetPath) : 0;
             }
         }
     }

--- a/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
+++ b/GVFS/GVFS.Common/Prefetch/Git/PathWithMode.cs
@@ -22,12 +22,12 @@ namespace GVFS.Common.Prefetch.Git
                 return false;
             }
 
-            return x.Path.Equals(this.Path, StringComparison.OrdinalIgnoreCase);
+            return x.Path.Equals(this.Path, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public override int GetHashCode()
         {
-            return StringComparer.OrdinalIgnoreCase.GetHashCode(this.Path);
+            return  GVFSPlatform.Instance.Constants.PathComparer.GetHashCode(this.Path);
         }
     }
 }

--- a/GVFS/GVFS.Common/RepoMetadata.cs
+++ b/GVFS/GVFS.Common/RepoMetadata.cs
@@ -48,7 +48,7 @@ namespace GVFS.Common
             string dictionaryPath = Path.Combine(dotGVFSPath, GVFSConstants.DotGVFS.Databases.RepoMetadata);
             if (Instance != null)
             {
-                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, StringComparison.OrdinalIgnoreCase))
+                if (!Instance.repoMetadata.DataFilePath.Equals(dictionaryPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     throw new InvalidOperationException(
                         string.Format(

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,6 +6,9 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
+        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
+        public const string CaseSensitiveFileSystemOnly = "CaseSensitiveFileSystemOnly";
+
         public const string WindowsOnly = "WindowsOnly";
         public const string MacOnly = "MacOnly";
 

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,9 +6,6 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
-        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
-        public const string CaseSensitiveFileSystemOnly = "CaseSensitiveFileSystemOnly";
-
         public const string WindowsOnly = "WindowsOnly";
         public const string MacOnly = "MacOnly";
 

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -1,3 +1,4 @@
+using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using System;
 using System.Diagnostics;
@@ -151,7 +152,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
             foreach (string directory in directories)
             {
-                if (directory.Equals(targetName, StringComparison.OrdinalIgnoreCase))
+                if (directory.Equals(targetName, FileSystemHelpers.PathComparison))
                 {
                     return true;
                 }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -103,6 +103,8 @@ namespace GVFS.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
+                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
+
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
@@ -111,6 +113,9 @@ namespace GVFS.FunctionalTests
             }
             else
             {
+                // Windows excludes.
+                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
+
                 excludeCategories.Add(Categories.MacOnly);
             }
 

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -103,8 +103,6 @@ namespace GVFS.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
-
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
@@ -114,8 +112,6 @@ namespace GVFS.FunctionalTests
             else
             {
                 // Windows excludes.
-                excludeCategories.Add(Categories.CaseSensitiveFileSystemOnly);
-
                 excludeCategories.Add(Categories.MacOnly);
             }
 

--- a/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
+++ b/GVFS/GVFS.FunctionalTests/Should/FileSystemShouldExtensions.cs
@@ -252,7 +252,7 @@ namespace GVFS.FunctionalTests.Should
                 return info;
             }
 
-            private static bool IsMatchedPath(FileSystemInfo info, string repoRoot, string[] prefixes)
+            private static bool IsMatchedPath(FileSystemInfo info, string repoRoot, string[] prefixes, bool ignoreCase)
             {
                 if (prefixes == null || prefixes.Length == 0)
                 {
@@ -260,8 +260,9 @@ namespace GVFS.FunctionalTests.Should
                 }
 
                 string localPath = info.FullName.Substring(repoRoot.Length + 1);
+                StringComparison pathComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
-                if (localPath.Equals(".git", StringComparison.OrdinalIgnoreCase))
+                if (localPath.Equals(".git", pathComparison))
                 {
                     // Include _just_ the .git folder.
                     // All sub-items are not included in the enumerator.
@@ -277,12 +278,12 @@ namespace GVFS.FunctionalTests.Should
 
                 foreach (string prefixDir in prefixes)
                 {
-                    if (localPath.StartsWith(prefixDir, StringComparison.OrdinalIgnoreCase))
+                    if (localPath.StartsWith(prefixDir, pathComparison))
                     {
                         return true;
                     }
 
-                    if (prefixDir.StartsWith(localPath, StringComparison.OrdinalIgnoreCase) &&
+                    if (prefixDir.StartsWith(localPath, pathComparison) &&
                         Directory.Exists(info.FullName))
                     {
                         // For example: localPath = "GVFS" and prefix is "GVFS\\GVFS".
@@ -308,7 +309,7 @@ namespace GVFS.FunctionalTests.Should
                 IEnumerator<FileSystemInfo> expectedEnumerator = expectedEntries
                     .Where(x => !x.FullName.Contains(dotGitFolder))
                     .OrderBy(x => x.FullName)
-                    .Where(x => IsMatchedPath(x, expectedPath, withinPrefixes))
+                    .Where(x => IsMatchedPath(x, expectedPath, withinPrefixes, ignoreCase))
                     .GetEnumerator();
                 IEnumerator<FileSystemInfo> actualEnumerator = actualEntries
                     .Where(x => !x.FullName.Contains(dotGitFolder))

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
@@ -143,7 +143,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private string GetLooseObjectPath(string fileGitPath, out string sha)
         {
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"rev-parse :{fileGitPath}");
-            sha = revParseResult.Output.Trim();
+
+            // Ensure SHA path is lowercase for case-sensitive filesystems
+            sha = revParseResult.Output.Trim().ToLower();
             sha.Length.ShouldEqual(40);
             string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), sha.Substring(0, 2), sha.Substring(2, 38));
             return objectPath;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
@@ -143,9 +143,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private string GetLooseObjectPath(string fileGitPath, out string sha)
         {
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"rev-parse :{fileGitPath}");
+            sha = revParseResult.Output.Trim();
+            if (FileSystemHelpers.CaseSensitiveFileSystem)
+            {
+                // Ensure SHA path is lowercase for case-sensitive filesystems
+                sha = sha.ToLower();
+            }
 
-            // Ensure SHA path is lowercase for case-sensitive filesystems
-            sha = revParseResult.Output.Trim().ToLower();
             sha.Length.ShouldEqual(40);
             string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), sha.Substring(0, 2), sha.Substring(2, 38));
             return objectPath;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -88,9 +88,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 {
                     "# A comment",
                     " ",
-                    "gvfs/",
-                    "gvfs/gvfs",
-                    "gvfs/"
+                    "GVFS/",
+                    "GVFS/GVFS",
+                    "GVFS/"
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--folders-list \"" + tempFilePath + "\""), 279);
@@ -166,7 +166,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 new[]
                 {
                     Path.Combine("GVFS", "GVFS", "packages.config"),
-                    Path.Combine("GVFS", "GVFS.FunctionalTests", "App.config")
+                    Path.Combine("GVFS", "GVFS.FunctionalTests", "app.config")
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--stdin-files-list", standardInput: input), 2);
@@ -181,9 +181,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 {
                     "# A comment",
                     " ",
-                    "gvfs/",
-                    "gvfs/gvfs",
-                    "gvfs/"
+                    "GVFS/",
+                    "GVFS/GVFS",
+                    "GVFS/"
                 });
 
             this.ExpectBlobCount(this.Enlistment.Prefetch("--stdin-folders-list", standardInput: input), 279);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -127,7 +127,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem
                 .EnumerateDirectory(this.Enlistment.GetPackRoot(this.fileSystem))
                 .Split()
-                .Where(file => string.Equals(Path.GetExtension(file), ".keep", StringComparison.OrdinalIgnoreCase))
+                .Where(file => string.Equals(Path.GetExtension(file), ".keep", FileSystemHelpers.PathComparison))
                 .Count()
                 .ShouldEqual(1, "Incorrect number of .keep files in pack directory");
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -303,45 +303,36 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             folderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems();
         }
 
+        // Case-insensitive filesystems only
         [TestCase, Order(7)]
-        public void HydratingFileUsesNameCaseFromRepo()
+        [Category(Categories.CaseInsensitiveFileSystemOnly)]
+        public void HydratingFileUsesNameCaseFromRepoOnCaseInsensitiveFileSystem()
         {
-            string fileName = "Readme.md";
-            string parentFolderPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(fileName));
-            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
-
-            // Hydrate file with a request using different file name case
-            string wrongCaseFilePath = this.Enlistment.GetVirtualPathTo(fileName.ToUpper());
-            string fileContents = wrongCaseFilePath.ShouldBeAFile(this.fileSystem).WithContents();
-
-            // File on disk should have original case projected from repo
-            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+            this.HydratingFileUsesNameCaseFromRepo(false);
         }
 
-        [TestCase, Order(8)]
-        public void HydratingNestedFileUsesNameCaseFromRepo()
+        // Case-sensitive filesystems only
+        [TestCase, Order(7)]
+        [Category(Categories.CaseSensitiveFileSystemOnly)]
+        public void HydratingFileUsesNameCaseFromRepoOnCaseSensitiveFileSystem()
         {
-            string filePath = Path.Combine("GVFS", "FastFetch", "Properties", "AssemblyInfo.cs");
-            string filePathAllCaps = filePath.ToUpper();
-            string parentFolderVirtualPathAllCaps = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePathAllCaps));
-            parentFolderVirtualPathAllCaps.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+            this.HydratingFileUsesNameCaseFromRepo(true);
+        }
 
-            // Hydrate file with a request using different file name case
-            string wrongCaseFilePath = this.Enlistment.GetVirtualPathTo(filePathAllCaps);
-            string fileContents = wrongCaseFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+        // Case-insensitive filesystems only
+        [TestCase, Order(8)]
+        [Category(Categories.CaseInsensitiveFileSystemOnly)]
+        public void HydratingNestedFileUsesNameCaseFromRepoOnCaseInsensitiveFileSystem()
+        {
+            this.HydratingNestedFileUsesNameCaseFromRepo(false);
+        }
 
-            // File on disk should have original case projected from repo
-            string parentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePath));
-            parentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
-
-            // Confirm all folders up to root have the correct case
-            string parentFolderPath = Path.GetDirectoryName(filePath);
-            while (!string.IsNullOrWhiteSpace(parentFolderPath))
-            {
-                string folderName = Path.GetFileName(parentFolderPath);
-                parentFolderPath = Path.GetDirectoryName(parentFolderPath);
-                this.Enlistment.GetVirtualPathTo(parentFolderPath).ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(folderName, StringComparison.Ordinal));
-            }
+        // Case-sensitive filesystems only
+        [TestCase, Order(8)]
+        [Category(Categories.CaseSensitiveFileSystemOnly)]
+        public void HydratingNestedFileUsesNameCaseFromRepoOnCaseSensitiveFileSystem()
+        {
+            this.HydratingNestedFileUsesNameCaseFromRepo(true);
         }
 
         [TestCase, Order(9)]
@@ -637,6 +628,46 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             else
             {
                 Assert.Fail("Unsupported platform");
+            }
+        }
+
+        private void HydratingFileUsesNameCaseFromRepo(bool caseSensitiveFileSystem)
+        {
+            string fileName = "Readme.md";
+            string parentFolderPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(fileName));
+            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+
+            // Hydrate file with a request using different file name case except on case-sensitive filesystems
+            string testFileName = caseSensitiveFileSystem ? fileName : fileName.ToUpper();
+            string testFilePath = this.Enlistment.GetVirtualPathTo(testFileName);
+            string fileContents = testFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+
+            // File on disk should have original case projected from repo
+            parentFolderPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(fileName, StringComparison.Ordinal));
+        }
+
+        private void HydratingNestedFileUsesNameCaseFromRepo(bool caseSensitiveFileSystem)
+        {
+            string filePath = Path.Combine("GVFS", "FastFetch", "Properties", "AssemblyInfo.cs");
+            string testFilePath = caseSensitiveFileSystem ? filePath : filePath.ToUpper();
+            string testParentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(testFilePath));
+            testParentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+
+            // Hydrate file with a request using different file name case except on case-sensitive filesystems
+            testFilePath = this.Enlistment.GetVirtualPathTo(testFilePath);
+            string fileContents = testFilePath.ShouldBeAFile(this.fileSystem).WithContents();
+
+            // File on disk should have original case projected from repo
+            string parentFolderVirtualPath = this.Enlistment.GetVirtualPathTo(Path.GetDirectoryName(filePath));
+            parentFolderVirtualPath.ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(Path.GetFileName(filePath), StringComparison.Ordinal));
+
+            // Confirm all folders up to root have the correct case
+            string parentFolderPath = Path.GetDirectoryName(filePath);
+            while (!string.IsNullOrWhiteSpace(parentFolderPath))
+            {
+                string folderName = Path.GetFileName(parentFolderPath);
+                parentFolderPath = Path.GetDirectoryName(parentFolderPath);
+                this.Enlistment.GetVirtualPathTo(parentFolderPath).ShouldBeADirectory(this.fileSystem).WithItems().ShouldContainSingle(info => info.Name.Equals(folderName, StringComparison.Ordinal));
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorkingDirectoryTests.cs
@@ -457,7 +457,10 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "rev-parse :Test_EPF_WorkingDirectoryTests/AllNullObjectRedownloaded.txt");
             string sha = revParseResult.Output.Trim();
             sha.Length.ShouldEqual(40);
-            string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), sha.Substring(0, 2), sha.Substring(2, 38));
+
+            // Ensure SHA path is lowercase for case-sensitive filesystems
+            string objectPathSha = sha.ToLower();
+            string objectPath = Path.Combine(this.Enlistment.GetObjectRoot(this.fileSystem), objectPathSha.Substring(0, 2), objectPathSha.Substring(2, 38));
             objectPath.ShouldNotExistOnDisk(this.fileSystem);
 
             // At this point there should be no corrupt objects

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -323,7 +323,7 @@ namespace GVFS.FunctionalTests.Tests
             {
                 // Ignore case differences on case-insensitive filesystems
                 this.fastFetchRepoRoot.ShouldBeADirectory(FileSystemRunner.DefaultRunner)
-                    .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot, ignoreCase: !RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+                    .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot, ignoreCase: !FileSystemHelpers.CaseSensitiveFileSystem);
             }
             finally
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -101,7 +101,7 @@ namespace GVFS.FunctionalTests.Tests
                 .Count()
                 .ShouldEqual(345);
 
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
         }
 
         [TestCase]
@@ -123,7 +123,7 @@ namespace GVFS.FunctionalTests.Tests
             Directory.EnumerateFileSystemEntries(Path.Combine(this.fastFetchRepoRoot, "GVFS"), "*", SearchOption.AllDirectories)
                 .Count()
                 .ShouldEqual(345);
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
 
             // Run a second time in the same repo on the same branch with more folders.
             this.RunFastFetch($"--checkout --folders \"/GVFS;/Scripts\" -b {Settings.Default.Commitish} --force-checkout");
@@ -177,7 +177,7 @@ namespace GVFS.FunctionalTests.Tests
                 Path.Combine(this.fastFetchRepoRoot, "GVFS", "GVFS", "Properties", "AssemblyInfo.cs"),
             });
 
-            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", StringComparison.OrdinalIgnoreCase));
+            this.AllFetchedFilePathsShouldPassCheck(path => path.StartsWith("GVFS", FileSystemHelpers.PathComparison));
         }
 
         [TestCase]
@@ -321,8 +321,9 @@ namespace GVFS.FunctionalTests.Tests
 
             try
             {
+                // Ignore case differences on case-insensitive filesystems
                 this.fastFetchRepoRoot.ShouldBeADirectory(FileSystemRunner.DefaultRunner)
-                    .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot, ignoreCase: true);
+                    .WithDeepStructure(FileSystemRunner.DefaultRunner, this.fastFetchControlRoot, ignoreCase: !RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
             }
             finally
             {

--- a/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/FastFetchTests.cs
@@ -495,11 +495,11 @@ namespace GVFS.FunctionalTests.Tests
             string fastfetch;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "netcoreapp2.1", "fastfetch.dll");
+                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "netcoreapp2.1", "FastFetch.dll");
             }
             else
             {
-                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "fastfetch.dll");
+                fastfetch = Path.Combine(Settings.Default.CurrentDirectory, "FastFetch.dll");
             }
 
             File.Exists(fastfetch).ShouldBeTrue($"{fastfetch} did not exist.");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -44,6 +44,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             "foo.cpp", // Changes to a folder in one test
             "FilenameEncoding",
             "GitCommandsTests",
+            "GVFLT_MultiThreadTest",
             "GVFlt_BugRegressionTest",
             "GVFlt_DeleteFileTest",
             "GVFlt_DeleteFolderTest",

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -1,5 +1,6 @@
 ﻿using GVFS.FunctionalTests.Properties;
 using NUnit.Framework;
+using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
@@ -29,11 +30,19 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         public override void TearDownForTest()
         {
-            // Need to ignore case changes in this test because the update-ref will have
-            // folder names that only changed the case and when checking the folder structure
-            // it will create partial folders with that case and will not get updated to the
-            // previous case when the reset --hard running in the tear down step
-            this.TestValidationAndCleanup(ignoreCase: true);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                this.TestValidationAndCleanup();
+            }
+            else
+            {
+                // On case-insensitive filesystems, we
+                // need to ignore case changes in this test because the update-ref will have
+                // folder names that only changed the case and when checking the folder structure
+                // it will create partial folders with that case and will not get updated to the
+                // previous case when the reset --hard running in the tear down step
+                this.TestValidationAndCleanup(ignoreCase: true);
+            }
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -1,6 +1,6 @@
 ﻿using GVFS.FunctionalTests.Properties;
+using GVFS.FunctionalTests.Tools;
 using NUnit.Framework;
-using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tests.GitCommands
 {
@@ -30,7 +30,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
         public override void TearDownForTest()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (FileSystemHelpers.CaseSensitiveFileSystem)
             {
                 this.TestValidationAndCleanup();
             }

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -318,7 +318,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
             string dotGitRoot = Path.Combine(enlistment.RepoRoot, ".git") + Path.DirectorySeparatorChar;
             for (int i = 0; i < allFiles.Count; ++i)
             {
-                if (!allFiles[i].StartsWith(dotGitRoot, StringComparison.OrdinalIgnoreCase))
+                if (!allFiles[i].StartsWith(dotGitRoot, FileSystemHelpers.PathComparison))
                 {
                     File.ReadAllText(allFiles[i]);
                 }

--- a/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GVFS.FunctionalTests.Tools
+{
+    public static class FileSystemHelpers
+    {
+        public static StringComparison PathComparison
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparison.Ordinal :
+                    StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        public static StringComparer PathComparer
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparer.Ordinal :
+                    StringComparer.OrdinalIgnoreCase;
+            }
+        }
+
+        private static bool CaseSensitiveFileSystem
+        {
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/FileSystemHelpers.cs
@@ -25,7 +25,7 @@ namespace GVFS.FunctionalTests.Tools
             }
         }
 
-        private static bool CaseSensitiveFileSystem
+        public static bool CaseSensitiveFileSystem
         {
             get
             {

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -138,7 +138,7 @@ namespace GVFS.FunctionalTests.Tools
             string mappingFile = Path.Combine(this.LocalCacheRoot, "mapping.dat");
             mappingFile.ShouldBeAFile(fileSystem);
 
-            HashSet<string> allowedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            HashSet<string> allowedFileNames = new HashSet<string>(FileSystemHelpers.PathComparer)
             {
                 "mapping.dat",
                 "mapping.dat.lock" // mapping.dat.lock can be present, but doesn't have to be present

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -152,7 +152,7 @@ namespace GVFS.FunctionalTests.Tools
             string[] modifedPathLines = modifedPathsContents.Split(new[] { ModifiedPathsNewLine }, StringSplitOptions.None);
             foreach (string gitPath in gitPaths)
             {
-                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath, StringComparison.OrdinalIgnoreCase));
+                modifedPathLines.ShouldContain(path => path.Equals(ModifedPathsLineAddPrefix + gitPath, FileSystemHelpers.PathComparison));
             }
         }
 
@@ -165,8 +165,8 @@ namespace GVFS.FunctionalTests.Tools
                 modifedPathLines.ShouldNotContain(
                     path =>
                     {
-                        return path.Equals(ModifedPathsLineAddPrefix + gitPath, StringComparison.OrdinalIgnoreCase) ||
-                               path.Equals(ModifedPathsLineDeletePrefix + gitPath, StringComparison.OrdinalIgnoreCase);
+                        return path.Equals(ModifedPathsLineAddPrefix + gitPath, FileSystemHelpers.PathComparison) ||
+                               path.Equals(ModifedPathsLineDeletePrefix + gitPath, FileSystemHelpers.PathComparison);
                     });
             }
         }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -495,7 +495,7 @@ namespace GVFS.Platform.Mac
                 bool pathInsideDotGit = Virtualization.FileSystemCallbacks.IsPathInsideDotGit(relativePath);
                 if (pathInsideDotGit)
                 {
-                    if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+                    if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
                         if (string.IsNullOrEmpty(lockedGitCommand))

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -234,6 +234,8 @@ namespace GVFS.Platform.Mac
             {
                 get { return $"Run {UpgradeConfirmMessage}."; }
             }
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -293,7 +293,7 @@ namespace GVFS.Platform.POSIX
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS.Mount", "git", "wish" }; }
+                get { return new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer) { "GVFS.Mount", "git", "wish" }; }
             }
 
             public override bool SupportsUpgradeWhileRunning => true;

--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Virtualization.Projection;
+﻿using GVFS.Common;
+using GVFS.Virtualization.Projection;
 using Microsoft.Windows.ProjFS;
 using System.Collections.Generic;
 
@@ -111,7 +112,7 @@ namespace GVFS.Platform.Windows
 
         private static bool NameMatchesNoWildcardFilter(string name, string filter)
         {
-            return string.Equals(name, filter, System.StringComparison.OrdinalIgnoreCase);
+            return string.Equals(name, filter, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         private void SaveFilter(string filter)

--- a/GVFS/GVFS.Platform.Windows/PatternMatcher.cs
+++ b/GVFS/GVFS.Platform.Windows/PatternMatcher.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GVFS.Common;
+using System;
 
 namespace GVFS.Platform.Windows
 {
@@ -173,7 +174,7 @@ namespace GVFS.Platform.Windows
                 // if name is shorter that the stuff to the right of * in expression, we don't
                 // need to do the string compare, otherwise we compare rightlength characters
                 // and the end of both strings.
-                if (name.Length >= rightLength && string.Compare(expression, 1, name, name.Length - rightLength, rightLength, StringComparison.OrdinalIgnoreCase) == 0)
+                if (name.Length >= rightLength && string.Compare(expression, 1, name, name.Length - rightLength, rightLength, GVFSPlatform.Instance.Constants.PathComparison) == 0)
                 {
                     return true;
                 }

--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -436,7 +436,7 @@ namespace GVFS.Platform.Windows
             {
                 exception = e;
 
-                if (e.FileName.Equals(ProjFSManagedLibFileName, StringComparison.OrdinalIgnoreCase))
+                if (e.FileName.Equals(ProjFSManagedLibFileName, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     error = $"Failed to load {ProjFSManagedLibFileName}. Ensure that ProjFS is installed and enabled";
                 }

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -109,7 +109,7 @@ namespace GVFS.Platform.Windows
         public bool IsExecutable(string fileName)
         {
             string fileExtension = Path.GetExtension(fileName);
-            return string.Equals(fileExtension, ".exe", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(fileExtension, ".exe", GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public bool IsSocket(string fileName)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -1090,7 +1090,7 @@ namespace GVFS.Platform.Windows
         {
             try
             {
-                if (destinationPath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+                if (destinationPath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     string lockedGitCommand = this.Context.Repository.GVFSLock.GetLockedGitCommand();
                     if (string.IsNullOrEmpty(lockedGitCommand))

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -494,7 +494,7 @@ namespace GVFS.Platform.Windows
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
+                get { return new HashSet<string>(GVFSPlatform.Instance.Constants.PathComparer) { "GVFS", "GVFS.Mount", "git", "ssh-agent", "wish", "bash" }; }
             }
 
             // Tests show that 250 is the max supported pipe name length
@@ -519,6 +519,8 @@ namespace GVFS.Platform.Windows
             {
                 get { return $"Run {UpgradeConfirmMessage} from an elevated command prompt."; }
             }
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -192,7 +192,7 @@ namespace GVFS.Service
 
         public Dictionary<string, RepoRegistration> ReadRegistry()
         {
-            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, RepoRegistration> allRepos = new Dictionary<string, RepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
 
             using (Stream stream = this.fileSystem.OpenFileStream(
                     Path.Combine(this.registryParentFolderPath, RegistryName),
@@ -233,7 +233,7 @@ namespace GVFS.Service
                                 string normalizedEnlistmentRootPath = registration.EnlistmentRoot;
                                 if (this.fileSystem.TryGetNormalizedPath(registration.EnlistmentRoot, out normalizedEnlistmentRootPath, out errorMessage))
                                 {
-                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, StringComparison.OrdinalIgnoreCase))
+                                    if (!normalizedEnlistmentRootPath.Equals(registration.EnlistmentRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                     {
                                         EventMetadata metadata = new EventMetadata();
                                         metadata.Add("registration.EnlistmentRoot", registration.EnlistmentRoot);

--- a/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/Virtualization/ActiveEnumerationTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Git;
+﻿using GVFS.Common;
+using GVFS.Common.Git;
 using GVFS.Platform.Windows;
 using GVFS.Tests.Should;
 using GVFS.Virtualization.Projection;
@@ -228,13 +229,13 @@ namespace GVFS.UnitTests.Windows.Virtualization
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("*.txt").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.EndsWith(".txt", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.EndsWith(".txt", GVFSPlatform.Instance.Constants.PathComparison)));
 
             // '<' = DOS_STAR, matches 0 or more characters until encountering and matching
             //                 the final . in the name
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("<.txt").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.EndsWith(".txt", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.EndsWith(".txt", GVFSPlatform.Instance.Constants.PathComparison)));
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("?").ShouldEqual(true);
@@ -242,35 +243,35 @@ namespace GVFS.UnitTests.Windows.Virtualization
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("?.txt").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.EndsWith(".txt", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.EndsWith(".txt", GVFSPlatform.Instance.Constants.PathComparison)));
 
             // '>' = DOS_QM, matches any single character, or upon encountering a period or
             //               end of name string, advances the expression to the end of the
             //               set of contiguous DOS_QMs.
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString(">.txt").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length <= 5 && entry.Name.EndsWith(".txt", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length <= 5 && entry.Name.EndsWith(".txt", GVFSPlatform.Instance.Constants.PathComparison)));
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("E.???").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.StartsWith("E.", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.StartsWith("E.", GVFSPlatform.Instance.Constants.PathComparison)));
 
             // '"' = DOS_DOT, matches either a . or zero characters beyond name string.
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("E\"*").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("E.", System.StringComparison.OrdinalIgnoreCase) || entry.Name.Equals("E", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("E.", GVFSPlatform.Instance.Constants.PathComparison) || entry.Name.Equals("E", GVFSPlatform.Instance.Constants.PathComparison)));
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("e\"*").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("E.", System.StringComparison.OrdinalIgnoreCase) || entry.Name.Equals("E", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("E.", GVFSPlatform.Instance.Constants.PathComparison) || entry.Name.Equals("E", GVFSPlatform.Instance.Constants.PathComparison)));
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("B\"*").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("B.", System.StringComparison.OrdinalIgnoreCase) || entry.Name.Equals("B", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.StartsWith("B.", GVFSPlatform.Instance.Constants.PathComparison) || entry.Name.Equals("B", GVFSPlatform.Instance.Constants.PathComparison)));
 
             activeEnumeration = CreateActiveEnumeration(entries);
             activeEnumeration.TrySaveFilterString("e.???").ShouldEqual(true);
-            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.StartsWith("E.", System.StringComparison.OrdinalIgnoreCase)));
+            this.ValidateActiveEnumeratorReturnsAllEntries(activeEnumeration, entries.Where(entry => entry.Name.Length == 5 && entry.Name.StartsWith("E.", GVFSPlatform.Instance.Constants.PathComparison)));
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
+++ b/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
@@ -3,5 +3,6 @@
     public static class CategoryConstants
     {
         public const string ExceptionExpected = "ExceptionExpected";
+        public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
     }
 }

--- a/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
+++ b/GVFS/GVFS.UnitTests/Category/CategoryConstants.cs
@@ -4,5 +4,6 @@
     {
         public const string ExceptionExpected = "ExceptionExpected";
         public const string CaseInsensitiveFileSystemOnly = "CaseInsensitiveFileSystemOnly";
+        public const string CaseSensitiveFileSystemOnly = "CaseSensitiveFileSystemOnly";
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Database;
+﻿using GVFS.Common;
+using GVFS.Common.Database;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.FileSystem;
@@ -74,8 +75,9 @@ namespace GVFS.UnitTests.Common.Database
             mockCommand.Setup(x => x.ExecuteScalar()).Returns(1);
             mockCommand.Setup(x => x.Dispose());
 
+            string collateConstraint = GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem ? string.Empty : " COLLATE NOCASE";
             Mock<IDbCommand> mockCommand2 = new Mock<IDbCommand>(MockBehavior.Strict);
-            mockCommand2.SetupSet(x => x.CommandText = "CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY COLLATE NOCASE, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;");
+            mockCommand2.SetupSet(x => x.CommandText = $"CREATE TABLE IF NOT EXISTS [Placeholder] (path TEXT PRIMARY KEY{collateConstraint}, pathType TINYINT NOT NULL, sha char(40) ) WITHOUT ROWID;");
             if (throwException)
             {
                 mockCommand2.Setup(x => x.ExecuteNonQuery()).Throws(new Exception("Error"));
@@ -88,7 +90,7 @@ namespace GVFS.UnitTests.Common.Database
             mockCommand2.Setup(x => x.Dispose());
 
             Mock<IDbCommand> mockCommand3 = new Mock<IDbCommand>(MockBehavior.Strict);
-            mockCommand3.SetupSet(x => x.CommandText = "CREATE TABLE IF NOT EXISTS [Sparse] (path TEXT PRIMARY KEY COLLATE NOCASE) WITHOUT ROWID;");
+            mockCommand3.SetupSet(x => x.CommandText = $"CREATE TABLE IF NOT EXISTS [Sparse] (path TEXT PRIMARY KEY{collateConstraint}) WITHOUT ROWID;");
             if (throwException)
             {
                 mockCommand3.Setup(x => x.ExecuteNonQuery()).Throws(new Exception("Error"));

--- a/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
@@ -495,9 +495,9 @@ namespace GVFS.UnitTests.Common.Database
             return new PlaceholderTable(pool);
         }
 
-        protected override void CreateTable(IDbConnection connection)
+        protected override void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
-            PlaceholderTable.CreateTable(connection);
+            PlaceholderTable.CreateTable(connection, caseSensitiveFileSystem);
         }
 
         private void TestPlaceholdersInsert(Action<PlaceholderTable> testCode, string path, int pathType, string sha, bool throwException = false)

--- a/GVFS/GVFS.UnitTests/Common/Database/SparseTableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/SparseTableTests.cs
@@ -127,9 +127,9 @@ namespace GVFS.UnitTests.Common.Database
             return new SparseTable(pool);
         }
 
-        protected override void CreateTable(IDbConnection connection)
+        protected override void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem)
         {
-            SparseTable.CreateTable(connection);
+            SparseTable.CreateTable(connection, caseSensitiveFileSystem);
         }
 
         private static string CombineAltForTrim(char character, params string[] folders)

--- a/GVFS/GVFS.UnitTests/Common/Database/TableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/TableTests.cs
@@ -33,7 +33,7 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            this.CreateTable(mockConnection.Object);
+            this.CreateTable(mockConnection.Object, false);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();
         }
@@ -50,14 +50,14 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            Exception ex = Assert.Throws<Exception>(() => this.CreateTable(mockConnection.Object));
+            Exception ex = Assert.Throws<Exception>(() => this.CreateTable(mockConnection.Object, false));
             ex.Message.ShouldEqual(DefaultExceptionMessage);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();
         }
 
         protected abstract T TableFactory(IGVFSConnectionPool pool);
-        protected abstract void CreateTable(IDbConnection connection);
+        protected abstract void CreateTable(IDbConnection connection, bool caseSensitiveFileSystem);
 
         protected void TestTableWithReader(Action<T, Mock<IDbCommand>, Mock<IDataReader>> testCode)
         {

--- a/GVFS/GVFS.UnitTests/Common/Database/TableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/TableTests.cs
@@ -33,7 +33,7 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            this.CreateTable(mockConnection.Object, false);
+            this.CreateTable(mockConnection.Object, caseSensitiveFileSystem: false);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();
         }
@@ -50,7 +50,7 @@ namespace GVFS.UnitTests.Common.Database
             Mock<IDbConnection> mockConnection = new Mock<IDbConnection>(MockBehavior.Strict);
             mockConnection.Setup(x => x.CreateCommand()).Returns(mockCommand.Object);
 
-            Exception ex = Assert.Throws<Exception>(() => this.CreateTable(mockConnection.Object, false));
+            Exception ex = Assert.Throws<Exception>(() => this.CreateTable(mockConnection.Object, caseSensitiveFileSystem: false));
             ex.Message.ShouldEqual(DefaultExceptionMessage);
             mockCommand.VerifyAll();
             mockConnection.VerifyAll();

--- a/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/FileBasedDictionaryTests.cs
@@ -329,7 +329,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxFileExistsFailures > 0)
                 {
                     if (this.fileExistsFailureCount < this.maxFileExistsFailures &&
-                        string.Equals(path, this.fileExistsFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.fileExistsFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -342,7 +342,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 1 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -391,7 +391,7 @@ namespace GVFS.UnitTests.Common
                 if (this.maxOpenFileStreamFailures > 0)
                 {
                     if (this.openFileStreamFailureCount < this.maxOpenFileStreamFailures &&
-                        string.Equals(path, this.openFileStreamFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.openFileStreamFailurePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.openFileStreamFailureCount;
 
@@ -408,7 +408,7 @@ namespace GVFS.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 0 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, GVFSPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.failuresAcrossOpenExistsAndOverwriteCount;
                         throw new IOException();

--- a/GVFS/GVFS.UnitTests/Common/ModifiedPathsDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/ModifiedPathsDatabaseTests.cs
@@ -161,7 +161,7 @@ A dir1/dir2
             modifiedPathsDatabase.Count.ShouldEqual(2);
             modifiedPathsDatabase.Contains(pathInList, isFolder).ShouldBeTrue();
             modifiedPathsDatabase.Contains(ToGitPathSeparators(pathInList), isFolder).ShouldBeTrue();
-            modifiedPathsDatabase.GetAllModifiedPaths().ShouldContainSingle(x => string.Compare(x, ToGitPathSeparators(pathInList), StringComparison.OrdinalIgnoreCase) == 0);
+            modifiedPathsDatabase.GetAllModifiedPaths().ShouldContainSingle(x => string.Compare(x, ToGitPathSeparators(pathInList), GVFSPlatform.Instance.Constants.PathComparison) == 0);
         }
 
         private static string ToGitPathSeparators(string path)

--- a/GVFS/GVFS.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.FileSystem;
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
@@ -241,7 +242,7 @@ namespace GVFS.UnitTests.Common
                 bool allFilesExist = false,
                 bool noOpDelete = false)
             {
-                this.ExistingFiles = new Dictionary<string, FileAttributes>(StringComparer.OrdinalIgnoreCase);
+                this.ExistingFiles = new Dictionary<string, FileAttributes>(GVFSPlatform.Instance.Constants.PathComparer);
                 foreach (KeyValuePair<string, FileAttributes> kvp in existingFiles)
                 {
                     this.ExistingFiles[kvp.Key] = kvp.Value;

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests.Mock.Common
 {
@@ -237,7 +238,7 @@ namespace GVFS.UnitTests.Mock.Common
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
+                get { return new HashSet<string>(this.PathComparer) { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }
             }
 
             public override bool SupportsUpgradeWhileRunning => false;
@@ -263,6 +264,8 @@ namespace GVFS.UnitTests.Mock.Common
             {
                 get { return "MockRunUpdateMessage"; }
             }
+
+            public override bool CaseSensitiveFileSystem => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -231,7 +231,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
                 // if it's called for one of those paths remap the paths to be inside the mock: root
                 string mockDirectoryPath = directoryPath;
                 string gvfsProgramData = @"C:\ProgramData\GVFS";
-                if (directoryPath.StartsWith(gvfsProgramData, StringComparison.OrdinalIgnoreCase))
+                if (directoryPath.StartsWith(gvfsProgramData, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     mockDirectoryPath = mockDirectoryPath.Substring(gvfsProgramData.Length);
                     mockDirectoryPath = "mock:" + mockDirectoryPath;

--- a/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
+++ b/GVFS/GVFS.UnitTests/Mock/MockGitHubUpgrader.cs
@@ -124,7 +124,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
         protected override bool TryDownloadAsset(Asset asset, out string errorMessage)
         {
             bool validAsset = true;
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSDownload))
                 {
@@ -132,7 +132,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                     return false;
                 }
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitDownload))
                 {
@@ -161,7 +161,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
 
         protected override bool TryDeleteDownloadedAsset(Asset asset, out Exception exception)
         {
-            if (this.expectedGVFSAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            if (this.expectedGVFSAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GVFSCleanup))
                 {
@@ -172,7 +172,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 exception = null;
                 return true;
             }
-            else if (this.expectedGitAssetName.Equals(asset.Name, StringComparison.OrdinalIgnoreCase))
+            else if (this.expectedGitAssetName.Equals(asset.Name, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 if (this.failActionTypes.HasFlag(ActionType.GitCleanup))
                 {
@@ -215,7 +215,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
             exitCode = 0;
             error = null;
 
-            if (fileName.Equals(this.expectedGitAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGitAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("Git", installationInfo);
                 this.InstallerExeLaunched = true;
@@ -234,7 +234,7 @@ namespace GVFS.UnitTests.Mock.Upgrader
                 return;
             }
 
-            if (fileName.Equals(this.expectedGVFSAssetName, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(this.expectedGVFSAssetName, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.InstallerArgs.Add("GVFS", installationInfo);
                 this.InstallerExeLaunched = true;

--- a/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Platform.Mac/MacFileSystemVirtualizerTests.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Platform.Mac;
+﻿using GVFS.Common;
+using GVFS.Platform.Mac;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Git;
@@ -196,7 +197,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 tester.GitIndexProjection.EnumerationInMemory = false;
                 tester.MockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFilePath, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFilePath, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode644);
             }
         }
 
@@ -218,7 +219,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 tester.GitIndexProjection.EnumerationInMemory = true;
                 tester.MockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFilePath, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFilePath, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode644);
                 tester.GitIndexProjection.ExpandedFolders.ShouldMatchInOrder(TestFolderName);
             }
         }
@@ -251,11 +252,11 @@ namespace GVFS.UnitTests.Platform.Mac
                 tester.GitIndexProjection.EnumerationInMemory = true;
                 tester.MockVirtualization.OnEnumerateDirectory(1, TestFolderName, triggeringProcessId: 1, triggeringProcessName: "UnitTests").ShouldEqual(Result.Success);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile644Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFile644Path, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode644);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile664Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode664);
+                    kvp => kvp.Key.Equals(testFile664Path, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode664);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFile755Path, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode755);
+                    kvp => kvp.Key.Equals(testFile755Path, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode755);
             }
         }
 
@@ -333,7 +334,7 @@ namespace GVFS.UnitTests.Platform.Mac
                 tester.GitIndexProjection.SparseEntries.Count.ShouldEqual(1);
                 tester.GitIndexProjection.SparseEntries.First().ShouldEqual(TestFolderName);
                 tester.MockVirtualization.CreatedPlaceholders.ShouldContain(
-                    kvp => kvp.Key.Equals(testFilePath, StringComparison.OrdinalIgnoreCase) && kvp.Value == GitIndexProjection.FileMode644);
+                    kvp => kvp.Key.Equals(testFilePath, GVFSPlatform.Instance.Constants.PathComparison) && kvp.Value == GitIndexProjection.FileMode644);
             }
         }
 

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -2,6 +2,7 @@
 using GVFS.Common.Prefetch.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
 using NUnit.Framework;
@@ -102,6 +103,7 @@ namespace GVFS.UnitTests.Prefetch
         // Delete a folder with two sub folders each with a single file
         // Readd it with a different casing and same contents
         [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
         public void ParsesCaseChangesAsAdds()
         {
             MockTracer tracer = new MockTracer();

--- a/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/DiffHelperTests.cs
@@ -120,6 +120,27 @@ namespace GVFS.UnitTests.Prefetch
             diffBackwards.TotalDirectoryOperations.ShouldEqual(3);
         }
 
+        // Delete a folder with two sub folders each with a single file
+        // Readd it with a different casing and same contents
+        [TestCase]
+        [Category(CategoryConstants.CaseSensitiveFileSystemOnly)]
+        public void ParsesCaseChangesAsRenames()
+        {
+            MockTracer tracer = new MockTracer();
+            DiffHelper diffBackwards = new DiffHelper(tracer, new Mock.Common.MockGVFSEnlistment(), new List<string>(), new List<string>(), includeSymLinks: this.IncludeSymLinks);
+            diffBackwards.ParseDiffFile(GetDataPath("caseChange.txt"));
+
+            diffBackwards.RequiredBlobs.Count.ShouldEqual(2);
+            diffBackwards.FileAddOperations.Sum(list => list.Value.Count).ShouldEqual(2);
+
+            diffBackwards.FileDeleteOperations.Count.ShouldEqual(0);
+            diffBackwards.TotalFileDeletes.ShouldEqual(2);
+
+            diffBackwards.DirectoryOperations.ShouldContain(entry => entry.Operation == DiffTreeResult.Operations.Add);
+            diffBackwards.DirectoryOperations.ShouldContain(entry => entry.Operation == DiffTreeResult.Operations.Delete);
+            diffBackwards.TotalDirectoryOperations.ShouldEqual(6);
+        }
+
         [TestCase]
         public void DetectsFailuresInDiffTree()
         {

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -25,6 +25,10 @@ namespace GVFS.UnitTests
             {
                 excludeCategories.Add(CategoryConstants.CaseInsensitiveFileSystemOnly);
             }
+            else
+            {
+                excludeCategories.Add(CategoryConstants.CaseSensitiveFileSystemOnly);
+            }
 
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);
 

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -3,6 +3,7 @@ using GVFS.UnitTests.Category;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace GVFS.UnitTests
 {
@@ -18,6 +19,11 @@ namespace GVFS.UnitTests
             if (Debugger.IsAttached)
             {
                 excludeCategories.Add(CategoryConstants.ExceptionExpected);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                excludeCategories.Add(CategoryConstants.CaseInsensitiveFileSystemOnly);
             }
 
             Environment.ExitCode = runner.RunTests(includeCategories: null, excludeCategories: excludeCategories);

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -3,6 +3,7 @@ using GVFS.Common.Database;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Virtualization.Background;
 using GVFS.UnitTests.Mock.Virtualization.BlobSize;
@@ -33,10 +34,16 @@ namespace GVFS.UnitTests.Virtualization
         public void IsPathInsideDotGitIsTrueForDotGitPath()
         {
             FileSystemCallbacks.IsPathInsideDotGit(@".git" + Path.DirectorySeparatorChar).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_file.txt")).ShouldEqual(true);
-            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".git", "test_folder", "test_file.txt")).ShouldEqual(true);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
+        public void IsPathInsideDotGitIsTrueForDifferentCaseDotGitPath()
+        {
+            FileSystemCallbacks.IsPathInsideDotGit(@".GIT" + Path.DirectorySeparatorChar).ShouldEqual(true);
+            FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_file.txt")).ShouldEqual(true);
             FileSystemCallbacks.IsPathInsideDotGit(Path.Combine(".GIT", "test_folder", "test_file.txt")).ShouldEqual(true);
         }
 

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/LazyUTF8StringTests.cs
@@ -73,6 +73,19 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        public unsafe void CaseSensitiveEquals_SameName_EqualsTrue()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeTrue(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
         public unsafe void CaseInsensitiveEquals_SameNameDifferentCase1_EqualsTrue()
         {
             UseASCIIBytePointer(
@@ -82,6 +95,19 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
                     firstFolder.CaseInsensitiveEquals(secondFolder).ShouldBeTrue(nameof(firstFolder.CaseInsensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void CaseSensitiveEquals_SameNameDifferentCase1_EqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtFolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
                 });
         }
 
@@ -99,6 +125,19 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        public unsafe void CaseSensitiveEquals_SameNameDifferentCase2_EqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "FOlderonefile.txtFolder",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
         public unsafe void CaseInsensitiveEquals_OneNameLongerEqualsFalse()
         {
             UseASCIIBytePointer(
@@ -108,6 +147,19 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 10);
                     firstFolder.CaseInsensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseInsensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void CaseSensitiveEquals_OneNameLongerEqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfoldertest",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 10);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
                 });
         }
 
@@ -125,7 +177,20 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsZero()
+        public unsafe void CaseSensitiveEquals_OneNameShorterEqualsFalse()
+        {
+            UseASCIIBytePointer(
+                "folderonefile.txtfold",
+                bufferPtr =>
+                {
+                    LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
+                    LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 4);
+                    firstFolder.CaseSensitiveEquals(secondFolder).ShouldBeFalse(nameof(firstFolder.CaseSensitiveEquals));
+                });
+        }
+
+        [TestCase]
+        public unsafe void Compare_EqualsZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfolder",
@@ -134,11 +199,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 6);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldEqual(0, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldEqual(0, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsLessThanZero()
+        public unsafe void Compare_EqualsLessThanZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfolders",
@@ -147,11 +213,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 7);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsLessThanZero2()
+        public unsafe void Compare_EqualsLessThanZero2()
         {
             UseASCIIBytePointer(
                 "folderDKfile.txtSDKfolders",
@@ -160,11 +227,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 2);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 16, 3);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsGreaterThanZero()
+        public unsafe void Compare_EqualsGreaterThanZero()
         {
             UseASCIIBytePointer(
                 "folderonefile.txtfold",
@@ -173,11 +241,12 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 0, 6);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 4);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
         [TestCase]
-        public unsafe void CaseInsensitiveCompare_EqualsGreaterThanZero2()
+        public unsafe void Compare_EqualsGreaterThanZero2()
         {
             UseASCIIBytePointer(
                 "folderSDKfile.txtDKfolders",
@@ -186,6 +255,7 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 3);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 2);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtLeast(1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 
@@ -296,6 +366,7 @@ namespace GVFS.UnitTests.Virtualization.Git
                     LazyUTF8String firstFolder = LazyUTF8String.FromByteArray(bufferPtr + 6, 3);
                     LazyUTF8String secondFolder = LazyUTF8String.FromByteArray(bufferPtr + 17, 20);
                     firstFolder.CaseInsensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseInsensitiveCompare));
+                    firstFolder.CaseSensitiveCompare(secondFolder).ShouldBeAtMost(-1, nameof(firstFolder.CaseSensitiveCompare));
                 });
         }
 

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/SortedFolderEntriesTests.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Tests.Should;
+using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock.Common;
 using NUnit.Framework;
 using System;
@@ -76,12 +77,23 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
         public void EntryFoundDifferentCase()
         {
             SortedFolderEntries sfe = SetupDefaultEntries();
             LazyUTF8String findName = ConstructLazyUTF8String("Folder");
             sfe.TryGetValue(findName, out FolderEntryData folderEntryData).ShouldBeTrue();
             folderEntryData.ShouldNotBeNull();
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseSensitiveFileSystemOnly)]
+        public void EntryNotFoundDifferentCase()
+        {
+            SortedFolderEntries sfe = SetupDefaultEntries();
+            LazyUTF8String findName = ConstructLazyUTF8String("Folder");
+            sfe.TryGetValue(findName, out FolderEntryData folderEntryData).ShouldBeFalse();
+            folderEntryData.ShouldBeNull();
         }
 
         [TestCase]
@@ -103,11 +115,27 @@ namespace GVFS.UnitTests.Virtualization.Git
         }
 
         [TestCase]
-        public void ValidateOrderOfDefaultEntries()
+        [Category(CategoryConstants.CaseInsensitiveFileSystemOnly)]
+        public void ValidateCaseInsensitiveOrderOfDefaultEntries()
         {
             List<string> allEntries = new List<string>(defaultFiles);
             allEntries.AddRange(defaultFolders);
             allEntries.Sort(CaseInsensitiveStringCompare);
+            SortedFolderEntries sfe = SetupDefaultEntries();
+            sfe.Count.ShouldEqual(14);
+            for (int i = 0; i < allEntries.Count; i++)
+            {
+                sfe[i].Name.GetString().ShouldEqual(allEntries[i]);
+            }
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.CaseSensitiveFileSystemOnly)]
+        public void ValidateCaseSensitiveOrderOfDefaultEntries()
+        {
+            List<string> allEntries = new List<string>(defaultFiles);
+            allEntries.AddRange(defaultFolders);
+            allEntries.Sort(CaseSensitiveStringCompare);
             SortedFolderEntries sfe = SetupDefaultEntries();
             sfe.Count.ShouldEqual(14);
             for (int i = 0; i < allEntries.Count; i++)
@@ -221,6 +249,11 @@ namespace GVFS.UnitTests.Virtualization.Git
         private static int CaseInsensitiveStringCompare(string x, string y)
         {
             return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int CaseSensitiveStringCompare(string x, string y)
+        {
+            return string.Compare(x, y, StringComparison.Ordinal);
         }
 
         private static SortedFolderEntries SetupDefaultEntries()

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTaskQueue.cs
@@ -123,7 +123,7 @@ namespace GVFS.Virtualization.Background
         private bool TryParseAddLine(string line, out long key, out FileSystemTask value, out string error)
         {
             // Expected: <ID>\0<Background Update>
-            int idx = line.IndexOf(ValueTerminator, StringComparison.OrdinalIgnoreCase);
+            int idx = line.IndexOf(ValueTerminator, StringComparison.Ordinal);
             if (idx < 0)
             {
                 key = 0;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -150,17 +150,17 @@ namespace GVFS.Virtualization.FileSystem
         protected bool IsSpecialGitFile(string fileName)
         {
             return
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, StringComparison.OrdinalIgnoreCase) ||
-                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, StringComparison.OrdinalIgnoreCase);
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitAttributes, GVFSPlatform.Instance.Constants.PathComparison) ||
+                fileName.Equals(GVFSConstants.SpecialGitFiles.GitIgnore, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         protected void OnDotGitFileOrFolderChanged(string relativePath)
         {
-            if (relativePath.Equals(GVFSConstants.DotGit.Index, StringComparison.OrdinalIgnoreCase))
+            if (relativePath.Equals(GVFSConstants.DotGit.Index, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnIndexFileChange();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Logs.Head, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnLogsHeadChange();
             }
@@ -168,7 +168,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -180,7 +180,7 @@ namespace GVFS.Virtualization.FileSystem
             {
                 this.FileSystemCallbacks.OnHeadOrRefChanged();
             }
-            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, StringComparison.OrdinalIgnoreCase))
+            else if (relativePath.Equals(GVFSConstants.DotGit.Info.ExcludePath, GVFSPlatform.Instance.Constants.PathComparison))
             {
                 this.FileSystemCallbacks.OnExcludeFileChanged();
             }
@@ -364,9 +364,9 @@ namespace GVFS.Virtualization.FileSystem
 
         private static bool IsPathHeadOrLocalBranch(string relativePath)
         {
-            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, StringComparison.OrdinalIgnoreCase) &&
-                (relativePath.Equals(GVFSConstants.DotGit.Head, StringComparison.OrdinalIgnoreCase) ||
-                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, StringComparison.OrdinalIgnoreCase)))
+            if (!relativePath.EndsWith(GVFSConstants.DotGit.LockExtension, GVFSPlatform.Instance.Constants.PathComparison) &&
+                (relativePath.Equals(GVFSConstants.DotGit.Head, GVFSPlatform.Instance.Constants.PathComparison) ||
+                relativePath.StartsWith(GVFSConstants.DotGit.Refs.Heads.RootFolder, GVFSPlatform.Instance.Constants.PathComparison)))
             {
                 return true;
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -62,9 +62,9 @@ namespace GVFS.Virtualization
             this.context = context;
             this.fileSystemVirtualizer = fileSystemVirtualizer;
 
-            this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
-            this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
-            this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
+            this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
+            this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
+            this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             string error;
@@ -151,7 +151,7 @@ namespace GVFS.Virtualization
         /// </summary>
         public static bool IsPathInsideDotGit(string relativePath)
         {
-            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+            return relativePath.StartsWith(GVFSConstants.DotGit.Root + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison);
         }
 
         public bool TryStart(out string error)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -65,7 +65,7 @@ namespace GVFS.Virtualization
             this.filePlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.folderPlaceHolderCreationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             this.fileHydrationCount = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
-            this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+            this.newlyCreatedFileAndFolderPaths = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
 
             string error;
             if (!ModifiedPathsDatabase.TryLoadOrCreate(
@@ -567,7 +567,7 @@ namespace GVFS.Virtualization
         private ConcurrentDictionary<string, PlaceHolderCreateCounter> GetAndResetProcessCountMetadata(ref ConcurrentDictionary<string, PlaceHolderCreateCounter> collectedData)
         {
             ConcurrentDictionary<string, PlaceHolderCreateCounter> localData = collectedData;
-            collectedData = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(StringComparer.OrdinalIgnoreCase);
+            collectedData = new ConcurrentDictionary<string, PlaceHolderCreateCounter>(GVFSPlatform.Instance.Constants.PathComparer);
             return localData;
         }
 

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
@@ -131,17 +131,34 @@ namespace GVFS.Virtualization.Projection
                 byte* thisPtr = bytePool.RawPointer + this.startIndex;
                 byte* otherPtr = bytePool.RawPointer + other.startIndex;
                 int count = 0;
+
+                // Case-sensitive comparison; always returns and never proceeds to case-insensitive comparison
+                if (caseSensitive)
+                {
+                    while (count < minLength)
+                    {
+                        if (*thisPtr != *otherPtr)
+                        {
+                            byte thisC = *thisPtr;
+                            byte otherC = *otherPtr;
+                            return thisC - otherC;
+                        }
+
+                        ++thisPtr;
+                        ++otherPtr;
+                        ++count;
+                    }
+
+                    return this.length - other.length;
+                }
+
+                // Case-insensitive comparison
                 while (count < minLength)
                 {
                     if (*thisPtr != *otherPtr)
                     {
                         byte thisC = *thisPtr;
                         byte otherC = *otherPtr;
-
-                        if (caseSensitive)
-                        {
-                            return thisC - otherC;
-                        }
 
                         // The more intuitive approach to checking IsLower() is to do two comparisons to see if c is within the range 'a'-'z'.
                         // However since byte is unsigned, we can rely on underflow to satisfy both conditions with one comparison.
@@ -190,12 +207,12 @@ namespace GVFS.Virtualization.Projection
 
             public unsafe int CaseInsensitiveCompare(LazyUTF8String other)
             {
-                return this.Compare(other, false);
+                return this.Compare(other, caseSensitive: false);
             }
 
             public unsafe int CaseSensitiveCompare(LazyUTF8String other)
             {
-                return this.Compare(other, true);
+                return this.Compare(other, caseSensitive: true);
             }
 
             public bool CaseInsensitiveEquals(LazyUTF8String other)

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.LazyUTF8String.cs
@@ -113,14 +113,14 @@ namespace GVFS.Virtualization.Projection
                 return lazyString;
             }
 
-            public unsafe int CaseInsensitiveCompare(LazyUTF8String other)
+            public unsafe int Compare(LazyUTF8String other, bool caseSensitive)
             {
                 // If we've already converted to a .NET String, use their implementation because it's likely to contain
                 // extended characters, which we're not set up to handle below
                 if (this.utf16string != null ||
                     other.utf16string != null)
                 {
-                    return string.Compare(this.GetString(), other.GetString(), StringComparison.OrdinalIgnoreCase);
+                    return string.Compare(this.GetString(), other.GetString(), caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
                 }
 
                 // We now know that both strings are ASCII, because if they had extended characters they would
@@ -137,6 +137,11 @@ namespace GVFS.Virtualization.Projection
                     {
                         byte thisC = *thisPtr;
                         byte otherC = *otherPtr;
+
+                        if (caseSensitive)
+                        {
+                            return thisC - otherC;
+                        }
 
                         // The more intuitive approach to checking IsLower() is to do two comparisons to see if c is within the range 'a'-'z'.
                         // However since byte is unsigned, we can rely on underflow to satisfy both conditions with one comparison.
@@ -183,9 +188,24 @@ namespace GVFS.Virtualization.Projection
                 return this.length - other.length;
             }
 
+            public unsafe int CaseInsensitiveCompare(LazyUTF8String other)
+            {
+                return this.Compare(other, false);
+            }
+
+            public unsafe int CaseSensitiveCompare(LazyUTF8String other)
+            {
+                return this.Compare(other, true);
+            }
+
             public bool CaseInsensitiveEquals(LazyUTF8String other)
             {
                 return this.CaseInsensitiveCompare(other) == 0;
+            }
+
+            public bool CaseSensitiveEquals(LazyUTF8String other)
+            {
+                return this.CaseSensitiveCompare(other) == 0;
             }
 
             public unsafe string GetString()

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs
@@ -1,4 +1,5 @@
-﻿using GVFS.Common.Tracing;
+﻿using GVFS.Common;
+using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 
@@ -206,8 +207,10 @@ namespace GVFS.Virtualization.Projection
                 }
 
                 // Insertions are almost always at the end, because the inputs are pre-sorted by git.
-                // We only have to insert at a different spot where Windows and git disagree on the sort order.
-                int compareResult = this.sortedEntries[this.sortedEntries.Count - 1].Name.CaseInsensitiveCompare(name);
+                // We only have to insert at a different spot where Windows/Mac and git disagree on the sort order;
+                // on Linux we use a case-sensitive comparsion, which we expect to align with git.
+                bool caseSensitive = GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem;
+                int compareResult = this.sortedEntries[this.sortedEntries.Count - 1].Name.Compare(name, caseSensitive);
                 if (compareResult == 0)
                 {
                     return this.sortedEntries.Count - 1;
@@ -223,7 +226,7 @@ namespace GVFS.Virtualization.Projection
                 while (right - left > 2)
                 {
                     int middle = left + ((right - left) / 2);
-                    int comparison = this.sortedEntries[middle].Name.CaseInsensitiveCompare(name);
+                    int comparison = this.sortedEntries[middle].Name.Compare(name, caseSensitive);
 
                     if (comparison == 0)
                     {
@@ -242,7 +245,7 @@ namespace GVFS.Virtualization.Projection
 
                 for (int i = right; i >= left; i--)
                 {
-                    compareResult = this.sortedEntries[i].Name.CaseInsensitiveCompare(name);
+                    compareResult = this.sortedEntries[i].Name.Compare(name, caseSensitive);
                     if (compareResult == 0)
                     {
                         return i;

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SparseFolder.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SparseFolder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GVFS.Common;
+using System;
 using System.Collections.Generic;
 
 namespace GVFS.Virtualization.Projection
@@ -30,7 +31,7 @@ namespace GVFS.Virtualization.Projection
         {
             public SparseFolderData()
             {
-                this.Children = new Dictionary<string, SparseFolderData>(StringComparer.OrdinalIgnoreCase);
+                this.Children = new Dictionary<string, SparseFolderData>(GVFSPlatform.Instance.Constants.PathComparer);
             }
 
             public bool IsRecursive { get; set; }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -50,11 +50,11 @@ namespace GVFS.Virtualization.Projection
         private GitIndexParser indexParser;
 
         // Cache of folder paths (in Windows format) to folder data
-        private ConcurrentDictionary<string, FolderData> projectionFolderCache = new ConcurrentDictionary<string, FolderData>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, FolderData> projectionFolderCache = new ConcurrentDictionary<string, FolderData>(GVFSPlatform.Instance.Constants.PathComparer);
 
         // nonDefaultFileTypesAndModes is only populated when the platform supports file mode
         // On platforms that support file modes, file paths that are not in nonDefaultFileTypesAndModes are regular files with mode 644
-        private Dictionary<string, FileTypeAndMode> nonDefaultFileTypesAndModes = new Dictionary<string, FileTypeAndMode>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, FileTypeAndMode> nonDefaultFileTypesAndModes = new Dictionary<string, FileTypeAndMode>(GVFSPlatform.Instance.Constants.PathComparer);
 
         private BlobSizes blobSizes;
         private IPlaceholderCollection placeholderDatabase;
@@ -1227,7 +1227,7 @@ namespace GVFS.Virtualization.Projection
             {
                 // folderPlaceholdersToKeep always contains the empty path so as to avoid unnecessary attempts
                 // to remove the repository's root folder.
-                ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+                ConcurrentHashSet<string> folderPlaceholdersToKeep = new ConcurrentHashSet<string>(GVFSPlatform.Instance.Constants.PathComparer);
                 folderPlaceholdersToKeep.Add(string.Empty);
 
                 stopwatch.Restart();
@@ -1257,7 +1257,7 @@ namespace GVFS.Virtualization.Projection
                     IEnumerable<string> allPlaceholders = placeholderFoldersListCopy
                         .Select(x => x.Path)
                         .Union(this.placeholderDatabase.GetAllFilePaths());
-                    existingPlaceholders = new HashSet<string>(allPlaceholders, StringComparer.OrdinalIgnoreCase);
+                    existingPlaceholders = new HashSet<string>(allPlaceholders, GVFSPlatform.Instance.Constants.PathComparer);
                 }
 
                 // Order the folders in decscending order so that we walk the tree from bottom up.

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -102,7 +102,7 @@ namespace GVFS.CommandLine
 
                 if (normalizedLocalCacheRootPath.StartsWith(
                     Path.Combine(normalizedEnlistmentRootPath, GVFSConstants.WorkingDirectoryRootName),
-                    StringComparison.OrdinalIgnoreCase))
+                    GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.ReportErrorAndExit("'--local-cache-path' cannot be inside the src folder");
                 }
@@ -293,7 +293,7 @@ namespace GVFS.CommandLine
             // LogFileEventListener will create a file in EnlistmentRootPath
             if (Directory.Exists(normalizedEnlistementRootPath) && Directory.EnumerateFileSystemEntries(normalizedEnlistementRootPath).Any())
             {
-                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, StringComparison.OrdinalIgnoreCase))
+                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     return new Result($"Clone directory '{fullEnlistmentRootPathParameter}' exists and is not empty");
                 }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -363,7 +363,7 @@ of your enlistment's src folder.
             foreach (string file in Directory.GetFiles(folderPath, searchPattern))
             {
                 string fileName = Path.GetFileName(file);
-                if (!filenamesToSkip.Any(x => x.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+                if (!filenamesToSkip.Any(x => x.Equals(fileName, GVFSPlatform.Instance.Constants.PathComparison)))
                 {
                     if (!this.TryIO(
                         tracer,

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -561,7 +561,7 @@ namespace GVFS.CommandLine
                 DriveInfo enlistmentDrive = new DriveInfo(enlistmentNormalizedPathRoot);
                 string enlistmentDriveDiskSpace = this.FormatByteCount(enlistmentDrive.AvailableFreeSpace);
 
-                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.WriteMessage("Available space on " + enlistmentDrive.Name + " drive(enlistment and local cache): " + enlistmentDriveDiskSpace);
                 }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -961,7 +961,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                                     while (!reader.EndOfStream)
                                     {
                                         string alternatesLine = reader.ReadLine();
-                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, StringComparison.OrdinalIgnoreCase))
+                                        if (string.Equals(alternatesLine, enlistment.GitObjectsRoot, GVFSPlatform.Instance.Constants.PathComparison))
                                         {
                                             gitObjectsRootInAlternates = true;
                                         }

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -36,7 +36,7 @@ namespace GVFS.CommandLine
             // Now default to the current working directory when running the verb without a specified path
             if (string.IsNullOrEmpty(this.Directory) || this.Directory.Equals("."))
             {
-                if (Environment.CurrentDirectory.StartsWith(enlistment.WorkingDirectoryRoot, StringComparison.OrdinalIgnoreCase))
+                if (Environment.CurrentDirectory.StartsWith(enlistment.WorkingDirectoryRoot, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     this.Directory = Environment.CurrentDirectory.Substring(enlistment.WorkingDirectoryRoot.Length);
                 }

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -10,6 +10,8 @@ namespace MirrorProvider.Mac
     {
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             Result result = VirtualizationInstance.ConvertDirectoryToVirtualizationRoot(directory);

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -12,6 +12,8 @@ namespace MirrorProvider.Windows
         private VirtualizationInstance virtualizationInstance;
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations = new ConcurrentDictionary<Guid, ActiveEnumeration>();
 
+        protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
             error = string.Empty;

--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -9,6 +9,8 @@ namespace MirrorProvider
     {
         protected Enlistment Enlistment { get; private set; }
 
+        protected abstract StringComparison PathComparison { get; }
+
         public abstract bool TryConvertVirtualizationRoot(string directory, out string error);
         public virtual bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)
         {
@@ -147,7 +149,7 @@ namespace MirrorProvider
             FileSystemInfo fileSystemInfo = 
                 dirInfo
                 .GetFileSystemInfos()
-                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(fsInfo => fsInfo.Name.Equals(fileName, PathComparison));
 
             if (fileSystemInfo == null)
             {


### PR DESCRIPTION
This PR looks to resolve a number of case-sensitivity issues with the current provider code and test suite, including:
1. Fixing case-differing references to files and path, e.g., `FastFetch.dll` not `fastfetch.dll`.  This includes references to Git object files, for which the SHA1 value needs to be lowercased.
2. Fixing hard-coded Windows path separators in messages and tests.
3. Ensuring `DiffHelper` functions correctly on case-sensitive filesystems; among other things, this allows `FastFetch` to succeed.
4. Adding case-sensitivity to the GVFS provider's databases and file path comparisons, so that, for example, the [`GitCommandsTests.CaseOnlyRenameFileAndChangeBranches()`](https://github.com/microsoft/VFSForGit/blob/3f322d3a44375d2108e1b70ee5329c6bfc565ec7/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs#L398) functional test succeeds.

The latter's failure on a case-sensitive filesystem is due to case-insensitivity in the current [modified paths database](https://github.com/microsoft/VFSForGit/blob/3f322d3a44375d2108e1b70ee5329c6bfc565ec7/GVFS/GVFS.Common/ModifiedPathsDatabase.cs#L21) and [virtualization code](https://github.com/microsoft/VFSForGit/blob/3f322d3a44375d2108e1b70ee5329c6bfc565ec7/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.SortedFolderEntries.cs#L180), among other things, which results in case-differing-only filenames being dropped from the data sent back from the GVFS provider, via the [`virtual-filesystem` hook](https://github.com/microsoft/git/blob/9b1adf3543bd5831c925fba1c4a6078a83118dfd/read-cache.c#L1887), to Git itself after it reads its `index` file.

---

Introduce case-sensitive file path matching and sorting of file and folder names within the repository as well as the modified paths and placeholder list databases, but only on Linux and other case-sensitive file systems, while retaining existing case-insensitive behaviour on Windows
and Mac platforms.

Use filesystem-specific case matching when comparing path throughout the functional test suite. 
 Also make sure to exclude the case-sensitive filesystem unit tests when running on Windows or Mac platforms.

Also fix the path matching in the `HydrateEntireRepo()` helper for `MultiEnlistmentTests.SharedCacheTests`, which was not excluding `{repoRoot}/.git/` paths on Mac (or Linux) due to hard-coded Windows path separators.

Divide the `HydratingFileUsesNameCaseFromRepo()` and `HydratingNestedFileUsesNameCaseFromRepo()` functional tests
into pairs, one for case-sensitive filesystems, and one for case-insensitive filesystems.

Includes some filename case corrections to prevent test case regressions on case-sensitive filesystems, use of lowercase paths generated from SHA1 values because that ensures consistency with Git's own naming scheme for files under `.git/objects` on case-sensitive filesystems, and fixes for some hard-coded uses of Windows path separators.

Resolves github#29.

/cc @jrbriggs, @kivikakk.