### PR TITLE
[Linux] Revise functional tests for cross-device mounts

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,6 +6,10 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
+        // Linux uses a separate device mount for its repository, and so is unable to rename(2) inodes
+        // in or out of the repository filesystem; attempts to do so fail with errno set to EXDEV.
+        // Therefore, tests which move files or directories across the repository boundary should
+        // be flagged with this category so they will be excluded on Linux.
         public const string RepositoryMountsSameFileSystem = "RepositoryMountsSameFileSystem";
 
         public const string WindowsOnly = "WindowsOnly";

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,6 +6,8 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
 
+        public const string RepositoryMountsSameFileSystem = "RepositoryMountsSameFileSystem";
+
         public const string WindowsOnly = "WindowsOnly";
         public const string MacOnly = "MacOnly";
         public const string POSIXOnly = "POSIXOnly";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -63,7 +63,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void LockPreventsRenameFromOutsideRootOnTopOfIndex()

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -63,7 +63,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void LockPreventsRenameFromOutsideRootOnTopOfIndex()
         {
             this.OverwritingIndexShouldFail(Path.Combine(this.Enlistment.EnlistmentRoot, "LockPreventsRenameFromOutsideRootOnTopOfIndex.txt"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -395,7 +395,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileNameOutsideRepo);
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(18)]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void HardlinkFromOutsideRepoToInside()
@@ -416,7 +415,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             fileLinkInsideRepo.ShouldBeAFile(this.fileSystem);
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(19)]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void HardlinkFromInsideRepoToOutside()

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitFilesTests.cs
@@ -395,7 +395,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, fileNameOutsideRepo);
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(18)]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void HardlinkFromOutsideRepoToInside()
         {
             string fileName = "OutsideRepoToInside_FileForHardlink.txt";
@@ -414,7 +416,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             fileLinkInsideRepo.ShouldBeAFile(this.fileSystem);
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(19)]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void HardlinkFromInsideRepoToOutside()
         {
             string fileName = "Readme.md";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -220,7 +220,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             result.Output.ShouldContain("deleted:    Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs");
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(11)]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void GitStatusAfterRenameFolderIntoRepo()
         {
             string folderName = "GitStatusAfterRenameFolderIntoRepo";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs
@@ -220,7 +220,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             result.Output.ShouldContain("deleted:    Test_EPF_MoveRenameFileTests/ChangeUnhydratedFileName/Program.cs");
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase, Order(11)]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void GitStatusAfterRenameFolderIntoRepo()

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -133,7 +133,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             }
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
@@ -221,7 +220,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             }
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void ModifiedPathsCorrectAfterHardLinkingOutsideRepo(FileSystemRunner fileSystem)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/ModifiedPathsTests.cs
@@ -25,20 +25,6 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
         private static readonly string FileToCreateOutsideRepo = $"{nameof(ModifiedPathsTests)}_outsideRepo.txt";
         private static readonly string FolderToCreateOutsideRepo = $"{nameof(ModifiedPathsTests)}_outsideFolder";
         private static readonly string FolderToDelete = "Scripts";
-        private static readonly string[] ExpectedModifiedFilesContentsAfterRemount =
-            {
-                $"A .gitattributes",
-                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToAdd)}",
-                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToUpdate)}",
-                $"A {FileToDelete}",
-                $"A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}",
-                $"A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}",
-                $"A {FolderToCreate}/",
-                $"A {RenameNewDotGitFileTarget}",
-                $"A {FileToCreateOutsideRepo}",
-                $"A {FolderToCreateOutsideRepo}/",
-                $"A {FolderToDelete}/",
-            };
 
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         public void DeletedTempFileIsRemovedFromModifiedFiles(FileSystemRunner fileSystem)
@@ -76,8 +62,21 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
         [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
-        public void ModifiedPathsSavedAfterRemount(FileSystemRunner fileSystem)
+        public void ModifiedPathsFromChangesInsideRepoSavedAfterRemount(FileSystemRunner fileSystem)
         {
+            string[] expectedModifiedFilesContentsAfterRemount =
+                {
+                    @"A .gitattributes",
+                    $"A {GVFSHelpers.ConvertPathToGitFormat(FileToAdd)}",
+                    $"A {GVFSHelpers.ConvertPathToGitFormat(FileToUpdate)}",
+                    $"A {FileToDelete}",
+                    $"A {GVFSHelpers.ConvertPathToGitFormat(FileToRename)}",
+                    $"A {GVFSHelpers.ConvertPathToGitFormat(RenameFileTarget)}",
+                    $"A {FolderToCreate}/",
+                    $"A {RenameNewDotGitFileTarget}",
+                    $"A {FolderToDelete}/",
+                };
+
             string fileToAdd = this.Enlistment.GetVirtualPathTo(FileToAdd);
             fileSystem.WriteAllText(fileToAdd, "Contents for the new file");
 
@@ -99,36 +98,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             string folderToRenameTarget = this.Enlistment.GetVirtualPathTo(RenameFolderTarget);
             fileSystem.MoveDirectory(folderToRename, folderToRenameTarget);
 
-            // Moving the new folder out of the repo will remove it from the modified paths file
-            string folderTargetOutsideSrc = Path.Combine(this.Enlistment.EnlistmentRoot, RenameFolderTarget);
-            folderTargetOutsideSrc.ShouldNotExistOnDisk(fileSystem);
-            fileSystem.MoveDirectory(folderToRenameTarget, folderTargetOutsideSrc);
-            folderTargetOutsideSrc.ShouldBeADirectory(fileSystem);
+            // Deleting the new folder will remove it from the modified paths file
+            fileSystem.DeleteDirectory(folderToRenameTarget);
             folderToRenameTarget.ShouldNotExistOnDisk(fileSystem);
 
             // Moving a file from the .git folder to the working directory should add the file to the modified paths
             string dotGitfileToAdd = this.Enlistment.GetVirtualPathTo(DotGitFileToCreate);
             fileSystem.WriteAllText(dotGitfileToAdd, "Contents for the new file in dot git");
             fileSystem.MoveFile(dotGitfileToAdd, this.Enlistment.GetVirtualPathTo(RenameNewDotGitFileTarget));
-
-            // Move a file from outside of src into src
-            string fileToCreateOutsideRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, FileToCreateOutsideRepo);
-            fileSystem.WriteAllText(fileToCreateOutsideRepoPath, "Contents for the new file outside of repo");
-            string fileToCreateOutsideRepoTargetPath = this.Enlistment.GetVirtualPathTo(FileToCreateOutsideRepo);
-            fileToCreateOutsideRepoTargetPath.ShouldNotExistOnDisk(fileSystem);
-            fileSystem.MoveFile(fileToCreateOutsideRepoPath, fileToCreateOutsideRepoTargetPath);
-            fileToCreateOutsideRepoTargetPath.ShouldBeAFile(fileSystem);
-            fileToCreateOutsideRepoPath.ShouldNotExistOnDisk(fileSystem);
-
-            // Move a folder from outside of src into src
-            string folderToCreateOutsideRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, FolderToCreateOutsideRepo);
-            fileSystem.CreateDirectory(folderToCreateOutsideRepoPath);
-            folderToCreateOutsideRepoPath.ShouldBeADirectory(fileSystem);
-            string folderToCreateOutsideRepoTargetPath = this.Enlistment.GetVirtualPathTo(FolderToCreateOutsideRepo);
-            folderToCreateOutsideRepoTargetPath.ShouldNotExistOnDisk(fileSystem);
-            fileSystem.MoveDirectory(folderToCreateOutsideRepoPath, folderToCreateOutsideRepoTargetPath);
-            folderToCreateOutsideRepoTargetPath.ShouldBeADirectory(fileSystem);
-            folderToCreateOutsideRepoPath.ShouldNotExistOnDisk(fileSystem);
 
             string folderToDeleteFullPath = this.Enlistment.GetVirtualPathTo(FolderToDelete);
             fileSystem.WriteAllText(Path.Combine(folderToDeleteFullPath, "NewFile.txt"), "Contents for new file");
@@ -152,20 +129,77 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
             {
                 reader.ReadToEnd().Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x)
-                    .ShouldMatchInOrder(ExpectedModifiedFilesContentsAfterRemount.OrderBy(x => x));
+                    .ShouldMatchInOrder(expectedModifiedFilesContentsAfterRemount.OrderBy(x => x));
+            }
+        }
+
+        // Mac and Windows only because Linux uses a separate repo mount device
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
+        [Category(Categories.MacTODO.NeedsNewFolderCreateNotification)]
+        public void ModifiedPathsFromRenamingOutsideRepoSavedAfterRemount(FileSystemRunner fileSystem)
+        {
+            string[] expectedModifiedFilesContentsAfterRemount =
+                {
+                    @"A .gitattributes",
+                    $"A {FileToCreateOutsideRepo}",
+                    $"A {FolderToCreateOutsideRepo}/",
+                };
+
+            string folderToRename = this.Enlistment.GetVirtualPathTo(FolderToRename);
+            fileSystem.CreateDirectory(folderToRename);
+            string folderToRenameTarget = this.Enlistment.GetVirtualPathTo(RenameFolderTarget);
+            fileSystem.MoveDirectory(folderToRename, folderToRenameTarget);
+
+            // Moving the new folder out of the repo will remove it from the modified paths file
+            string folderTargetOutsideSrc = Path.Combine(this.Enlistment.EnlistmentRoot, RenameFolderTarget);
+            folderTargetOutsideSrc.ShouldNotExistOnDisk(fileSystem);
+            fileSystem.MoveDirectory(folderToRenameTarget, folderTargetOutsideSrc);
+            folderTargetOutsideSrc.ShouldBeADirectory(fileSystem);
+            folderToRenameTarget.ShouldNotExistOnDisk(fileSystem);
+
+            // Move a file from outside of src into src
+            string fileToCreateOutsideRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, FileToCreateOutsideRepo);
+            fileSystem.WriteAllText(fileToCreateOutsideRepoPath, "Contents for the new file outside of repo");
+            string fileToCreateOutsideRepoTargetPath = this.Enlistment.GetVirtualPathTo(FileToCreateOutsideRepo);
+            fileToCreateOutsideRepoTargetPath.ShouldNotExistOnDisk(fileSystem);
+            fileSystem.MoveFile(fileToCreateOutsideRepoPath, fileToCreateOutsideRepoTargetPath);
+            fileToCreateOutsideRepoTargetPath.ShouldBeAFile(fileSystem);
+            fileToCreateOutsideRepoPath.ShouldNotExistOnDisk(fileSystem);
+
+            // Move a folder from outside of src into src
+            string folderToCreateOutsideRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, FolderToCreateOutsideRepo);
+            fileSystem.CreateDirectory(folderToCreateOutsideRepoPath);
+            folderToCreateOutsideRepoPath.ShouldBeADirectory(fileSystem);
+            string folderToCreateOutsideRepoTargetPath = this.Enlistment.GetVirtualPathTo(FolderToCreateOutsideRepo);
+            folderToCreateOutsideRepoTargetPath.ShouldNotExistOnDisk(fileSystem);
+            fileSystem.MoveDirectory(folderToCreateOutsideRepoPath, folderToCreateOutsideRepoTargetPath);
+            folderToCreateOutsideRepoTargetPath.ShouldBeADirectory(fileSystem);
+            folderToCreateOutsideRepoPath.ShouldNotExistOnDisk(fileSystem);
+
+            // Remount
+            this.Enlistment.UnmountGVFS();
+            this.Enlistment.MountGVFS();
+
+            this.Enlistment.WaitForBackgroundOperations();
+
+            string modifiedPathsDatabase = Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.ModifiedPaths);
+            modifiedPathsDatabase.ShouldBeAFile(fileSystem);
+            using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                reader.ReadToEnd().Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x)
+                    .ShouldMatchInOrder(expectedModifiedFilesContentsAfterRemount.OrderBy(x => x));
             }
         }
 
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
-        public void ModifiedPathsCorrectAfterHardLinking(FileSystemRunner fileSystem)
+        public void ModifiedPathsCorrectAfterHardLinkingInsideRepo(FileSystemRunner fileSystem)
         {
             string[] expectedModifiedFilesContentsAfterHardlinks =
                 {
                     "A .gitattributes",
                     "A LinkToReadme.md",
-                    "A LinkToFileOutsideSrc.txt",
                     "A Readme.md",
-                    "A GVFS/GVFS/Program.cs",
                 };
 
             // Create a link from src\LinkToReadme.md to src\Readme.md
@@ -175,6 +209,29 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             hardLinkToFileInRepoPath.ShouldNotExistOnDisk(fileSystem);
             fileSystem.CreateHardLink(hardLinkToFileInRepoPath, existingFileInRepoPath);
             hardLinkToFileInRepoPath.ShouldBeAFile(fileSystem).WithContents(contents);
+
+            this.Enlistment.WaitForBackgroundOperations();
+
+            string modifiedPathsDatabase = Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.ModifiedPaths);
+            modifiedPathsDatabase.ShouldBeAFile(fileSystem);
+            using (StreamReader reader = new StreamReader(File.Open(modifiedPathsDatabase, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                reader.ReadToEnd().Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(x => x)
+                    .ShouldMatchInOrder(expectedModifiedFilesContentsAfterHardlinks.OrderBy(x => x));
+            }
+        }
+
+        // Mac and Windows only because Linux uses a separate repo mount device
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
+        public void ModifiedPathsCorrectAfterHardLinkingOutsideRepo(FileSystemRunner fileSystem)
+        {
+            string[] expectedModifiedFilesContentsAfterHardlinks =
+                {
+                    "A .gitattributes",
+                    "A LinkToFileOutsideSrc.txt",
+                    "A GVFS/GVFS/Program.cs",
+                };
 
             // Create a link from src\LinkToFileOutsideSrc.txt to FileOutsideRepo.txt
             string fileOutsideOfRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, "FileOutsideRepo.txt");
@@ -188,7 +245,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
 
             // Create a link from LinkOutsideSrcToInsideSrc.cs to src\GVFS\GVFS\Program.cs
             string secondFileInRepoPath = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "Program.cs");
-            contents = secondFileInRepoPath.ShouldBeAFile(fileSystem).WithContents();
+            string contents = secondFileInRepoPath.ShouldBeAFile(fileSystem).WithContents();
             string hardLinkOutsideRepoToFileInRepoPath = Path.Combine(this.Enlistment.EnlistmentRoot, "LinkOutsideSrcToInsideSrc.cs");
             hardLinkOutsideRepoToFileInRepoPath.ShouldNotExistOnDisk(fileSystem);
             fileSystem.CreateHardLink(hardLinkOutsideRepoToFileInRepoPath, secondFileInRepoPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -415,7 +415,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileShouldHaveCaseMatchingName(newFileName);
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFileFromOutsideRepoToInsideRepoAndAdd()
         {
             string testFileContents = "0123456789";
@@ -448,7 +450,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFolderFromOutsideRepoToInsideRepoAndAdd()
         {
             string testFileContents = "0123456789";
@@ -485,7 +489,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
         }
 
+        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
+        [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFileFromInsideRepoToOutsideRepoAndCommit()
         {
             string newBranchName = "tests/functional/MoveFileFromInsideRepoToOutsideRepoAndCommit";

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -415,7 +415,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileShouldHaveCaseMatchingName(newFileName);
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFileFromOutsideRepoToInsideRepoAndAdd()
@@ -450,7 +449,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFolderFromOutsideRepoToInsideRepoAndAdd()
@@ -489,7 +487,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
         }
 
-        // Mac and Windows only because Linux uses a separate repo mount device
         [TestCase]
         [Category(Categories.RepositoryMountsSameFileSystem)]
         public void MoveFileFromInsideRepoToOutsideRepoAndCommit()


### PR DESCRIPTION
On POSIX systems, where a `rename(2)` returns `EXDEV` when trying to move a file or directory between mounted filesystems, the functional tests which do this currently fail if the
repository is mounted on a separate device (as is the case on Linux).

Therefore we create a `RepositoryMountsSameFileSystem` test category for use on VFSForGit implementations which allow renaming across repository boundaries (i.e., Windows PrjFlt
and Mac kext), and mark a number of tests with this category designation as they move files or folders in or out of the repository, or create hard links across the repository boundary.

In the `ModifiedPathsTests` suite, two specific tests which check the contents of the modified-paths database after remounting and after hard-linking, specifically, are subdivided into pairs of tests.  Each pair consists of one test which only checks changes that do not cross the repository boundary, suitable for all implementations, and one test which check changes spanning the repository boundary and which is marked with the `RepositoryMountsSameFileSystem`
category.