### PR TITLE
Mac: Fix and enable remaining dehydrate functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -23,15 +23,8 @@
             // Tests that require VFS Service
             public const string NeedsServiceVerb = "NeedsServiceVerb";
 
-            // Requires both functional and test fixes
-            public const string NeedsDehydrate = "NeedsDehydrate";
-
             // Tests requires code updates so that we lock the file instead of looking for a .lock file
             public const string TestNeedsToLockFile = "TestNeedsToLockFile";
-
-            // Tests that have been flaky on build servers and need additional logging and\or
-            // investigation
-            public const string FlakyTest = "MacFlakyTest";
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -104,7 +104,6 @@ namespace GVFS.FunctionalTests
             {
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
-                excludeCategories.Add(Categories.MacTODO.NeedsDehydrate);
                 excludeCategories.Add(Categories.MacTODO.NeedsServiceVerb);
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);

--- a/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
+++ b/GVFS/GVFS.Tests/Should/EnumerableShouldExtensions.cs
@@ -114,6 +114,11 @@ namespace GVFS.Tests.Should
                 errorMessage.AppendLine(string.Format("Missing: {0}", groupMissingItem));
             }
 
+            if (!Enumerable.SequenceEqual(group, expectedValues, comparer))
+            {
+                errorMessage.AppendLine(string.Format("Items are not in the same order: '{0}' vs. '{1}'", string.Join(",", group), string.Join(",", expectedValues)));
+            }
+
             if (errorMessage.Length > 0)
             {
                 Assert.Fail("{0}\r\n{1}", message, errorMessage);


### PR DESCRIPTION
Resolves #1216 

VFS for Git was already doing the right thing.  The only changes needed to the test code:

- Switch from `CmdRunner.DeleteDirectoryWithUnlimitedRetries` to `RepositoryHelpers.DeleteTestDirectory`
- Updated `DirectoryShouldContain` to sort the entries before comparing them as the order is different on Mac and Windows