### PR TITLE
Update mac uninstall script to remove GVFS service directory

### DIFF
--- a/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
+++ b/GVFS/GVFS.Installer.Mac/uninstall_vfsforgit.sh
@@ -6,6 +6,7 @@ PRJFSKEXTDIRECTORY="/Library/Extensions"
 LAUNCHDAEMONDIRECTORY="/Library/LaunchDaemons"
 LAUNCHAGENTDIRECTORY="/Library/LaunchAgents"
 LIBRARYAPPSUPPORTDIRECTORY="/Library/Application Support/VFS For Git"
+SERVICEAPPDIRECTORY="${HOME}/Library/Application Support/GVFS"
 LOGDAEMONLAUNCHDFILENAME="org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist"
 SERVICEAGENTLAUNCHDFILENAME="org.vfsforgit.service.plist"
 GVFSCOMMANDPATH="/usr/local/bin/gvfs"
@@ -81,6 +82,12 @@ function UnInstallVFSForGit()
         rmCmd="sudo /bin/rm -Rf \"${LIBRARYAPPSUPPORTDIRECTORY}\""
         echo "$rmCmd..."
         eval $rmCmd || { echo "Error: Could not delete ${LIBRARYAPPSUPPORTDIRECTORY}. Delete it manually."; exit 1; }
+    fi
+
+    if [ -d "${SERVICEAPPDIRECTORY}" ]; then
+        rmCmd="sudo /bin/rm -Rf \"${SERVICEAPPDIRECTORY}\""
+        echo "$rmCmd..."
+        eval $rmCmd || { echo "Error: Could not delete ${SERVICEAPPDIRECTORY}. Delete it manually."; exit 1; }
     fi
     
     if [ -d "${VFSFORDIRECTORY}" ]; then


### PR DESCRIPTION
The mac uninstall script did not remove the GVFS service directory, resulting
in GVFS artifacts being left around. This change updates the uninstall script
to also remove the GVFS service directory. This brings the behavior of the mac
uninstall script to match the Windows uninstall script in
src/Scripts/UninstallGVFS.bat.

One motivation for this change was that the Mac Functional test machines were
gathering cruft from repeated test runs, such as the list of registered
repositories in the repo-registry growing. This apparently caused the GVFS
service start up time to grow, resulting in test failures.

This address #1404 