### PR TITLE
Mac ProjFS kext: Only send NotifyFilePreDeleteFromRename on Mojave+

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -730,7 +730,7 @@ KEXT_STATIC int HandleVnodeOperation(
                 root,
                 isDirectory ?
                 MessageType_KtoU_NotifyDirectoryPreDelete :
-                isRename ? MessageType_KtoU_NotifyFilePreDeleteFromRename : MessageType_KtoU_NotifyFilePreDelete,
+                (isRename && s_osSupportsRenameDetection) ? MessageType_KtoU_NotifyFilePreDeleteFromRename : MessageType_KtoU_NotifyFilePreDelete,
                 currentVnode,
                 vnodeFsidInode,
                 nullptr, // path not needed, use fsid/inode


### PR DESCRIPTION
isRename defaults to true on High Sierra where deletes cannot distinguish between rename and non-rename. In this case we've previously been sending a MessageType_KtoU_NotifyFilePreDeleteFromRename notification, which doesn't seem right. But I'm not 100% sure about the correct behaviour here.