### PR TITLE
[M153 Hotfix] Update Git to revert slow commit-graph write

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190610.5</GitPackageVersion>
+    <GitPackageVersion>2.20190806.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
See microsoft/git#168 for full details.

v2.22.0 had a change that made writing commit-graph files much
slower by always parsing from pack-files instead of from the
commit-graph file. For some users of the OS repo, this caused
super-slow performance and high memory usage.