### PR TITLE
[M155] Update Git, drop MIDX writes

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20190805.1</GitPackageVersion>
+    <GitPackageVersion>2.20190806.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -28,6 +28,7 @@ namespace GVFS.Common.Maintenance
     {
         public const string PackfileLastRunFileName = "pack-maintenance.time";
         public const string DefaultBatchSize = "2g";
+        private const string MultiPackIndexLock = "multi-pack-index.lock";
         private readonly bool forceRun;
         private readonly string batchSize;
 
@@ -114,6 +115,11 @@ namespace GVFS.Common.Maintenance
                     activity.RelatedWarning(this.CreateEventMetadata(), "Skipping pack maintenance due to no .keep file.");
                     return;
                 }
+
+                string multiPackIndexLockPath = Path.Combine(this.Context.Enlistment.GitPackRoot, MultiPackIndexLock);
+                this.Context.FileSystem.TryDeleteFile(multiPackIndexLockPath);
+
+                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
 
                 // If a LibGit2Repo is active, then it may hold handles to the .idx and .pack files we want
                 // to delete during the 'git multi-pack-index expire' step. If one starts during the step,

--- a/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PostFetchStep.cs
@@ -10,7 +10,6 @@ namespace GVFS.Common.Maintenance
     public class PostFetchStep : GitMaintenanceStep
     {
         private const string CommitGraphChainLock = "commit-graph-chain.lock";
-        private const string MultiPackIndexLock = "multi-pack-index.lock";
         private List<string> packIndexes;
 
         public PostFetchStep(GVFSContext context, List<string> packIndexes, bool requireObjectCacheLock = true)
@@ -23,20 +22,6 @@ namespace GVFS.Common.Maintenance
 
         protected override void PerformMaintenance()
         {
-            using (ITracer activity = this.Context.Tracer.StartActivity("TryWriteMultiPackIndex", EventLevel.Informational))
-            {
-                string multiPackIndexLockPath = Path.Combine(this.Context.Enlistment.GitPackRoot, MultiPackIndexLock);
-                this.Context.FileSystem.TryDeleteFile(multiPackIndexLockPath);
-
-                this.RunGitCommand((process) => process.WriteMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.WriteMultiPackIndex));
-
-                GitProcess.Result verifyResult = this.RunGitCommand((process) => process.VerifyMultiPackIndex(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.VerifyMultiPackIndex));
-                if (!this.Stopping && verifyResult.ExitCodeIsFailure)
-                {
-                    this.LogErrorAndRewriteMultiPackIndex(activity);
-                }
-            }
-
             if (this.packIndexes == null || this.packIndexes.Count == 0)
             {
                 this.Context.Tracer.RelatedInfo(this.Area + ": Skipping commit-graph write due to no new packfiles");

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -39,11 +39,12 @@ namespace GVFS.UnitTests.Maintenance
             this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
             this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
             List<string> commands = this.gitProcess.CommandsRun;
-            commands.Count.ShouldEqual(4);
-            commands[0].ShouldEqual(this.ExpireCommand);
-            commands[1].ShouldEqual(this.VerifyCommand);
-            commands[2].ShouldEqual(this.RepackCommand);
-            commands[3].ShouldEqual(this.VerifyCommand);
+            commands.Count.ShouldEqual(5);
+            commands[0].ShouldEqual(this.WriteCommand);
+            commands[1].ShouldEqual(this.ExpireCommand);
+            commands[2].ShouldEqual(this.VerifyCommand);
+            commands[3].ShouldEqual(this.RepackCommand);
+            commands[4].ShouldEqual(this.VerifyCommand);
         }
 
         [TestCase]
@@ -82,11 +83,12 @@ namespace GVFS.UnitTests.Maintenance
             this.tracer.StartActivityTracer.RelatedErrorEvents.Count.ShouldEqual(0);
             this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(0);
             List<string> commands = this.gitProcess.CommandsRun;
-            commands.Count.ShouldEqual(4);
-            commands[0].ShouldEqual(this.ExpireCommand);
-            commands[1].ShouldEqual(this.VerifyCommand);
-            commands[2].ShouldEqual(this.RepackCommand);
-            commands[3].ShouldEqual(this.VerifyCommand);
+            commands.Count.ShouldEqual(5);
+            commands[0].ShouldEqual(this.WriteCommand);
+            commands[1].ShouldEqual(this.ExpireCommand);
+            commands[2].ShouldEqual(this.VerifyCommand);
+            commands[3].ShouldEqual(this.RepackCommand);
+            commands[4].ShouldEqual(this.VerifyCommand);
         }
 
         [TestCase]
@@ -130,13 +132,14 @@ namespace GVFS.UnitTests.Maintenance
             this.tracer.StartActivityTracer.RelatedWarningEvents.Count.ShouldEqual(2);
 
             List<string> commands = this.gitProcess.CommandsRun;
-            commands.Count.ShouldEqual(6);
-            commands[0].ShouldEqual(this.ExpireCommand);
-            commands[1].ShouldEqual(this.VerifyCommand);
-            commands[2].ShouldEqual(this.WriteCommand);
-            commands[3].ShouldEqual(this.RepackCommand);
-            commands[4].ShouldEqual(this.VerifyCommand);
-            commands[5].ShouldEqual(this.WriteCommand);
+            commands.Count.ShouldEqual(7);
+            commands[0].ShouldEqual(this.WriteCommand);
+            commands[1].ShouldEqual(this.ExpireCommand);
+            commands[2].ShouldEqual(this.VerifyCommand);
+            commands[3].ShouldEqual(this.WriteCommand);
+            commands[4].ShouldEqual(this.RepackCommand);
+            commands[5].ShouldEqual(this.VerifyCommand);
+            commands[6].ShouldEqual(this.WriteCommand);
         }
 
         [TestCase]
@@ -224,6 +227,9 @@ namespace GVFS.UnitTests.Maintenance
             this.tracer = new MockTracer();
             this.context = new GVFSContext(this.tracer, fileSystem, repository, enlistment);
 
+            this.gitProcess.SetExpectedCommandResult(
+                this.WriteCommand,
+                () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));
             this.gitProcess.SetExpectedCommandResult(
                 this.ExpireCommand,
                 () => new GitProcess.Result(string.Empty, string.Empty, GitProcess.Result.SuccessCode));


### PR DESCRIPTION
This PR does two things:

1. Updates Git to include the slow commit-graph write fix from microsoft/git#168. Also see #1420 for the M153 hotfix.

2. Removes the multi-pack-index writes from the `PostFetchStep` and instead only writes the multi-pack-index during the `PackfileMaintenanceStep`. In order to get the most out of the step, we need to ensure we have a multi-pack-index before running the `expire` and `repack` steps. Also, we can only expire the packs from that day if they are contained in the multi-pack-index.

If we agree that we should send (2) as a hotfix to the M155 release (in addition to (1), which is necessary), then I'll create a hotfix PR to that branch.