### PR TITLE
add MoveIndexFileFails() functional test

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -140,6 +140,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("-c \"mv -f '{0}' '{1}'\"", sourceBashPath, targetBashPath));
         }
 
+        public override void ReplaceFile_AccessShouldBeDenied(string sourcePath, string targetPath)
+        {
+            // bash does not report any error messages when access is denied, so just confirm the file still exists
+            this.ReplaceFile(sourcePath, targetPath);
+            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
+            this.FileExists(targetPath).ShouldBeFalse($"{targetPath} exists when it should not");
+        }
+
         public override string DeleteFile(string path)
         {
             string bashPath = this.ConvertWinPathToBashPath(path);

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -97,8 +97,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             // CMD does not report any error messages when access is denied, so just confirm the file still exists
             this.ReplaceFile(sourcePath, targetPath);
-            this.FileExists(sourcePath).ShouldEqual(true);
-            this.FileExists(targetPath).ShouldEqual(false);
+            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
+            this.FileExists(targetPath).ShouldBeFalse($"{targetPath} exists when it should not");
         }
 
         public override string DeleteFile(string path)
@@ -214,7 +214,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         {
             // CMD does not report any error messages when access is denied, so just confirm the file still exists
             this.DeleteFile(path);
-            this.FileExists(path).ShouldEqual(true);
+            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
         }
 
         public override void ReadAllText_FileShouldNotBeFound(string path)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -93,6 +93,14 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("/C move /Y \"{0}\" \"{1}\"", sourcePath, targetPath));
         }
 
+        public override void ReplaceFile_AccessShouldBeDenied(string sourcePath, string targetPath)
+        {
+            // CMD does not report any error messages when access is denied, so just confirm the file still exists
+            this.ReplaceFile(sourcePath, targetPath);
+            this.FileExists(sourcePath).ShouldEqual(true);
+            this.FileExists(targetPath).ShouldEqual(false);
+        }
+
         public override string DeleteFile(string path)
         {
             return this.RunProcess(string.Format("/C del \"{0}\"", path));

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -57,6 +57,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         public abstract void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath);
         public abstract string ReplaceFile(string sourcePath, string targetPath);
         public abstract void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath);
+        public abstract void ReplaceFile_AccessShouldBeDenied(string sourcePath, string targetPath);
         public abstract string DeleteFile(string path);
         public abstract void DeleteFile_FileShouldNotBeFound(string path);
         public abstract void DeleteFile_AccessShouldBeDenied(string path);

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -78,6 +78,13 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("-Command \"& {{ Move-Item {0} {1} -force }}\"", sourcePath, targetPath));
         }
 
+        public override void ReplaceFile_AccessShouldBeDenied(string sourcePath, string targetPath)
+        {
+            this.ReplaceFile(sourcePath, targetPath).ShouldContain(permissionDeniedMessage);
+            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
+            this.FileExists(targetPath).ShouldBeFalse($"{targetPath} exists when it should not");
+        }
+
         public override string DeleteFile(string path)
         {
             return this.RunProcess(string.Format("-Command \"& {{ Remove-Item {0} }}\"", path));

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -59,6 +59,13 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             this.ShouldFail<IOException>(() => { this.ReplaceFile(sourcePath, targetPath); });
         }
 
+        public override void ReplaceFile_AccessShouldBeDenied(string sourcePath, string targetPath)
+        {
+            this.ShouldFail<Exception>(() => { this.ReplaceFile(sourcePath, targetPath); });
+            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
+            this.FileExists(targetPath).ShouldBeFalse($"{targetPath} exists when it should not");
+        }
+
         public override string DeleteFile(string path)
         {
             File.Delete(path);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -819,6 +819,21 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
             indexFilePath.ShouldBeAFile(fileSystem);
         }
 
+        // On some platforms, a pre-rename event may be delivered prior to a
+        // file rename rather than a pre-delete event, so we check this
+        // separately from the DeleteIndexFileFails() test case
+        [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
+        public void MoveIndexFileFails(FileSystemRunner fileSystem)
+        {
+            string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));
+            string indexTargetFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index_target"));
+            indexFilePath.ShouldBeAFile(fileSystem);
+            indexTargetFilePath.ShouldNotExistOnDisk(fileSystem);
+            fileSystem.ReplaceFile_AccessShouldBeDenied(indexFilePath, indexTargetFilePath);
+            indexFilePath.ShouldBeAFile(fileSystem);
+            indexTargetFilePath.ShouldNotExistOnDisk(fileSystem);
+        }
+
         [TestCaseSource(typeof(FileRunnersAndFolders), nameof(FileRunnersAndFolders.Runners))]
         public void MoveVirtualNTFSFolderIntoInvalidFolder(FileSystemRunner fileSystem, string parentFolder)
         {


### PR DESCRIPTION
On some platforms (notably Linux), we receive only a [pre-rename permission request](https://github.com/github/libprojfs/blob/224e0542820f67175a6532d77aaf8c4a957481a4/include/projfs_notify.h#L46) rather than a pre-delete permission request during a `rename(2)` operation, so the virtualization instance's `OnPreRename()` handler becomes [responsible](https://github.com/microsoft/VFSForGit/blob/634e1cd8d1e8416af1b818c2fc4d4fa78187c7f7/GVFS/GVFS.Platform.Linux/LinuxFileSystemVirtualizer.cs#L543) for ensuring that, outside of a GVFS lock, the `.git/index` file can not be renamed or overwritten.

The [`BasicFileSystemTests.DeleteIndexFileFails()`](https://github.com/microsoft/VFSForGit/blob/1d9b7ae509c8bbf8495e9133703bb1bf663cfac3/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs#L814) test handles the case of a true delete of `.git/index`, as well as platforms which deliver a pre-delete event on the source path prior to a rename action.

As well, several `GVFSLockTests` tests such as the [`LockPreventsRenameFromInsideWorkingTreeOnTopOfIndex()`](https://github.com/microsoft/VFSForGit/blob/1d9b7ae509c8bbf8495e9133703bb1bf663cfac3/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs#L73) test the case of a file being renamed to .git/index, but no existing test checks for the case of `.git/index` being renamed to another path (although `DeleteIndexFileFails()` likely suffices on platforms which send a pre-delete event).

Therefore we add an explicit `MoveIndexFileFails()` functional test to cover this case.  Note that we use `System.IO.File.Replace()` in the `SystemIORunner` because `File.Move()` is [implemented on Unix/POSIX](https://github.com/dotnet/corefx/blob/de38804d52f6b65f0f290b81383f01e6943a6d8f/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs#L194) systems such that it actually performs a copy or hard link first, then a delete, not a true `rename(2)`.  The effect on a platform where pre-rename but not pre-delete events are delivered on rename operations is that the link succeeds, then the delete fails (since that *does* send a pre-delete permission request, which is denied as the path is `.git/index`), leaving behind a spurious extra file link.  So we want to trigger a true `rename(2)`, which is what [`File.Replace()`](https://github.com/dotnet/corefx/blob/de38804d52f6b65f0f290b81383f01e6943a6d8f/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs#L133) does.

/cc @kivikakk, @kewillford