### PR TITLE
Mac ProjFS kext: Deny I/O on offline roots, with exceptions, part 2

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -561,6 +561,24 @@ KEXT_STATIC int HandleVnodeOperation(
                 }
             }
         }
+        else if (ActionBitIsSet(action, KAUTH_VNODE_ADD_FILE | KAUTH_VNODE_ADD_SUBDIRECTORY))
+        {
+            if (!TryGetVirtualizationRoot(
+                    &perfTracer,
+                    context,
+                    currentVnode,
+                    pid,
+                    CallbackPolicy_AllowAny,
+                    // Block creating new files in offline roots.
+                    true,
+                    &root,
+                    &vnodeFsidInode,
+                    &kauthResult,
+                    kauthError))
+            {
+                goto CleanupAndReturn;
+            }
+        }
     }
     else
     {

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -1287,15 +1287,14 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
 
     kauth_action_t actions[] =
     {
-        // TODO(Mac): Also deny read access to empty files. (#182)
-//        KAUTH_VNODE_READ_ATTRIBUTES,
         KAUTH_VNODE_WRITE_ATTRIBUTES,
-//        KAUTH_VNODE_READ_EXTATTRIBUTES,
         KAUTH_VNODE_WRITE_EXTATTRIBUTES,
-//        KAUTH_VNODE_READ_DATA,
         KAUTH_VNODE_WRITE_DATA,
-//        KAUTH_VNODE_EXECUTE,
         KAUTH_VNODE_APPEND_DATA,
+        KAUTH_VNODE_READ_DATA,
+        KAUTH_VNODE_READ_ATTRIBUTES,
+        KAUTH_VNODE_EXECUTE,
+        KAUTH_VNODE_READ_EXTATTRIBUTES,
     };
     const size_t actionCount = extent<decltype(actions)>::value;
     


### PR DESCRIPTION
This is a continuation of the work on issue #182. The remaining operations to block are:

- [x] A process attempts to read/execute an empty file in an offline root. The result of the read would be bad data, so failing with denied authorisation is preferable to letting the bad data propagate.
- [x] A process attempts to create files or directories in an offline root.

The commits implementing those 2 changes are fairly straightforward, however they did cause some knock-on effects:

 * During `gvfs clone`, the `git` subprocess itself wants to create files/directories in the offline root, so we need it to inherit the parent `gvfs` process's entitlement to access offline roots. The exception check therefore now walks up the process hierarchy.
 * One of the functional tests, `CheckoutBranchWithOpenHandleBlockingProjectionDeleteAndRepoMetdataUpdate` needs to mess with the repo while it's not mounted, so I've registered the test runner for offline I/O for the duration of that test.
 * To avoid weird edge cases, I've made the offline I/O registration in the native userlib thread-safe and reference counted, so registering multiple times is fine, and we only actually deregister once it's been matched with an equal number of unregister calls.