### PR TITLE
[M155 Hotfix] Add lock around writes to SQLite database tables

### DIFF
--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -10,6 +10,7 @@ namespace GVFS.Common.Database
     public class PlaceholderTable : IPlaceholderCollection
     {
         private IGVFSConnectionPool connectionPool;
+        private object writerLock = new object();
 
         public PlaceholderTable(IGVFSConnectionPool connectionPool)
         {
@@ -166,7 +167,11 @@ namespace GVFS.Common.Database
                 {
                     command.CommandText = "DELETE FROM Placeholder WHERE path = @path;";
                     command.AddParameter("@path", DbType.String, path);
-                    command.ExecuteNonQuery();
+
+                    lock (this.writerLock)
+                    {
+                        command.ExecuteNonQuery();
+                    }
                 }
             }
             catch (Exception ex)
@@ -229,7 +234,10 @@ namespace GVFS.Common.Database
                         command.AddParameter("@sha", DbType.String, placeholder.Sha);
                     }
 
-                    command.ExecuteNonQuery();
+                    lock (this.writerLock)
+                    {
+                        command.ExecuteNonQuery();
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Because SQLite only allows one writer at a time, we need to protect writes that might happen on multiple threads.  Most of the time this isn't an issue because in WAL mode it will only be locking, appending, unlocking which is very fast but there is still a small window where another thread tries to write and it is locked and will get an exception.

This change will force threads to be synchronized before calling `ExecuteNonQuery` to make sure only one thread is writing at a time.

In the performance tests there was not any change.  I also tried turning off the shared cache as a fix but some operations became 2X slower without the shared cache.