### PR TITLE
Separate files from folders in health output

### DIFF
--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -23,9 +23,13 @@ namespace GVFS.Common
 
         public EnlistmentHealthData CalculateStatistics(string parentDirectory)
         {
-            int gitTrackedItemsCount = 0;
-            int placeholderCount = 0;
-            int modifiedPathsCount = 0;
+            int gitTrackedFileCount = 0;
+            int gitTrackedDirectoryCount = 0;
+            int placeholderFileCount = 0;
+            int placeholderDirectoryCount = 0;
+            int modifiedPathsFileCount = 0;
+            int modifiedPathsDirectoryCount = 0;
+
             Dictionary<string, int> gitTrackedItemsDirectoryTally = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             Dictionary<string, int> hydratedFilesDirectoryTally = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
@@ -40,12 +44,12 @@ namespace GVFS.Common
                 parentDirectory = parentDirectory.TrimStart(GVFSConstants.GitPathSeparator);
             }
 
-            gitTrackedItemsCount += this.CategorizePaths(this.enlistmentPathData.GitFolderPaths, gitTrackedItemsDirectoryTally, parentDirectory);
-            gitTrackedItemsCount += this.CategorizePaths(this.enlistmentPathData.GitFilePaths, gitTrackedItemsDirectoryTally, parentDirectory);
-            placeholderCount += this.CategorizePaths(this.enlistmentPathData.PlaceholderFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
-            placeholderCount += this.CategorizePaths(this.enlistmentPathData.PlaceholderFilePaths, hydratedFilesDirectoryTally, parentDirectory);
-            modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
-            modifiedPathsCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFilePaths, hydratedFilesDirectoryTally, parentDirectory);
+            gitTrackedDirectoryCount += this.CategorizePaths(this.enlistmentPathData.GitFolderPaths, gitTrackedItemsDirectoryTally, parentDirectory);
+            gitTrackedFileCount += this.CategorizePaths(this.enlistmentPathData.GitFilePaths, gitTrackedItemsDirectoryTally, parentDirectory);
+            placeholderDirectoryCount += this.CategorizePaths(this.enlistmentPathData.PlaceholderFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
+            placeholderFileCount += this.CategorizePaths(this.enlistmentPathData.PlaceholderFilePaths, hydratedFilesDirectoryTally, parentDirectory);
+            modifiedPathsDirectoryCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFolderPaths, hydratedFilesDirectoryTally, parentDirectory);
+            modifiedPathsFileCount += this.CategorizePaths(this.enlistmentPathData.ModifiedFilePaths, hydratedFilesDirectoryTally, parentDirectory);
 
             Dictionary<string, SubDirectoryInfo> mostHydratedDirectories = new Dictionary<string, SubDirectoryInfo>(StringComparer.OrdinalIgnoreCase);
 
@@ -66,11 +70,14 @@ namespace GVFS.Common
 
             return new EnlistmentHealthData(
                 parentDirectory,
-                gitTrackedItemsCount,
-                placeholderCount,
-                modifiedPathsCount,
-                this.CalculateHealthMetric(placeholderCount + modifiedPathsCount, gitTrackedItemsCount),
-                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).Select(item => item.Value).ToList());
+                gitTrackedDirectoryCount,
+                gitTrackedFileCount,
+                placeholderDirectoryCount,
+                placeholderFileCount,
+                modifiedPathsDirectoryCount,
+                modifiedPathsFileCount,
+                this.CalculateHealthMetric(placeholderDirectoryCount + placeholderFileCount + modifiedPathsDirectoryCount + modifiedPathsFileCount, gitTrackedDirectoryCount + gitTrackedFileCount),
+                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).ToList());
         }
 
         /// <summary>

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthCalculator.cs
@@ -77,7 +77,7 @@ namespace GVFS.Common
                 modifiedPathsDirectoryCount,
                 modifiedPathsFileCount,
                 this.CalculateHealthMetric(placeholderDirectoryCount + placeholderFileCount + modifiedPathsDirectoryCount + modifiedPathsFileCount, gitTrackedDirectoryCount + gitTrackedFileCount),
-                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).ToList());
+                mostHydratedDirectories.OrderByDescending(kp => kp.Value.HydratedFileCount).Select(kp => kp.Value).ToList());
         }
 
         /// <summary>

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -48,7 +48,7 @@ namespace GVFS.Common
             get { return this.ModifiedPathsFileCount + this.ModifiedPathsFolderCount; }
         }
 
-        public List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> DirectoryHydrationLevels { get; private set; }
+        public List<EnlistmentHealthCalculator.SubDirectoryInfo> DirectoryHydrationLevels { get; private set; }
         public decimal HealthMetric { get; private set; }
         public decimal PlaceholderPercentage
         {

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentHealthData.cs
@@ -6,25 +6,49 @@ namespace GVFS.Common
     {
         public EnlistmentHealthData(
             string targetDirectory,
-            int gitItemsCount,
-            int placeholderCount,
-            int modifiedPathsCount,
+            int gitFolderCount,
+            int gitFileCount,
+            int placeholderFolderCount,
+            int placeholderFileCount,
+            int modifiedPathsFolderCount,
+            int modifiedPathsFileCount,
             decimal healthMetric,
             List<EnlistmentHealthCalculator.SubDirectoryInfo> directoryHydrationLevels)
         {
             this.TargetDirectory = targetDirectory;
-            this.GitTrackedItemsCount = gitItemsCount;
-            this.PlaceholderCount = placeholderCount;
-            this.ModifiedPathsCount = modifiedPathsCount;
+            this.GitTrackedFolderCount = gitFolderCount;
+            this.GitTrackedFileCount = gitFileCount;
+            this.PlaceholderFolderCount = placeholderFolderCount;
+            this.PlaceholderFileCount = placeholderFileCount;
+            this.ModifiedPathsFolderCount = modifiedPathsFolderCount;
+            this.ModifiedPathsFileCount = modifiedPathsFileCount;
             this.HealthMetric = healthMetric;
             this.DirectoryHydrationLevels = directoryHydrationLevels;
         }
 
         public string TargetDirectory { get; private set; }
-        public int GitTrackedItemsCount { get; private set; }
-        public int PlaceholderCount { get; private set; }
-        public int ModifiedPathsCount { get; private set; }
-        public List<EnlistmentHealthCalculator.SubDirectoryInfo> DirectoryHydrationLevels { get; private set; }
+        public int GitTrackedFolderCount { get; private set; }
+        public int GitTrackedFileCount { get; private set; }
+        public int GitTrackedItemsCount
+        {
+            get { return this.GitTrackedFileCount + this.GitTrackedFolderCount; }
+        }
+
+        public int PlaceholderFolderCount { get; private set; }
+        public int PlaceholderFileCount { get; private set; }
+        public int PlaceholderCount
+        {
+            get { return this.PlaceholderFileCount + this.PlaceholderFolderCount; }
+        }
+
+        public int ModifiedPathsFolderCount { get; private set; }
+        public int ModifiedPathsFileCount { get; private set; }
+        public int ModifiedPathsCount
+        {
+            get { return this.ModifiedPathsFileCount + this.ModifiedPathsFolderCount; }
+        }
+
+        public List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> DirectoryHydrationLevels { get; private set; }
         public decimal HealthMetric { get; private set; }
         public decimal PlaceholderPercentage
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -201,7 +201,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // Regex to extract the total number of fast files and percentage they represent
             // "Files managed by VFS for Git (fast):    <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(faster\):\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastFiles).ShouldBeTrue();
             int.TryParse(lineMatch.Groups[2].Value, out int outputtedFastFilesPercent).ShouldBeTrue();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -1,10 +1,8 @@
-﻿using GVFS.FunctionalTests.Tools;
-using GVFS.Tests.Should;
+﻿using GVFS.Tests.Should;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -71,7 +69,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 slowFolders: 0,
                 slowItems: 1,
                 slowItemPercent: 0,
-                totalPercent:1,
+                totalPercent: 1,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
                 enlistmentHealthStatus: "OK");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -25,12 +25,18 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
-                totalFiles: 1211,
-                totalFilePercent: 100,
+                totalFiles: 873,
+                totalFolders: 338,
+                totalItems: 1211,
+                totalItemPercent: 100,
                 fastFiles: 1,
-                fastFilePercent: 0,
+                fastFolders: 0,
+                fastItems: 1,
+                fastItemPercent: 0,
                 slowFiles: 1,
-                slowFilePercent: 0,
+                slowFolders: 0,
+                slowItems: 1,
+                slowItemPercent: 0,
                 totalPercent: 0,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
@@ -53,12 +59,18 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
-                totalFiles: 1211,
-                totalFilePercent: 100,
-                fastFiles: 7,
-                fastFilePercent: 1,
+                totalFiles: 873,
+                totalFolders: 338,
+                totalItems: 1211,
+                totalItemPercent: 100,
+                fastFiles: 6,
+                fastFolders: 1,
+                fastItems: 7,
+                fastItemPercent: 1,
                 slowFiles: 1,
-                slowFilePercent: 0,
+                slowFolders: 0,
+                slowItems: 1,
+                slowItemPercent: 0,
                 totalPercent:1,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
@@ -78,12 +90,18 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
-                totalFiles: 1211,
-                totalFilePercent: 100,
-                fastFiles: 8,
-                fastFilePercent: 1,
+                totalFiles: 873,
+                totalFolders: 338,
+                totalItems: 1211,
+                totalItemPercent: 100,
+                fastFiles: 6,
+                fastFolders: 2,
+                fastItems: 8,
+                fastItemPercent: 1,
                 slowFiles: 3,
-                slowFilePercent: 0,
+                slowFolders: 0,
+                slowItems: 3,
+                slowItemPercent: 0,
                 totalPercent: 1,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
@@ -105,12 +123,18 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.ValidateHealthOutputValues(
                 directory: string.Empty,
-                totalFiles: 1211,
-                totalFilePercent: 100,
-                fastFiles: 3,
-                fastFilePercent: 0,
+                totalFiles: 873,
+                totalFolders: 338,
+                totalItems: 1211,
+                totalItemPercent: 100,
+                fastFiles: 1,
+                fastFolders: 2,
+                fastItems: 3,
+                fastItemPercent: 0,
                 slowFiles: 8,
-                slowFilePercent: 1,
+                slowFolders: 0,
+                slowItems: 8,
+                slowItemPercent: 1,
                 totalPercent: 1,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
@@ -126,11 +150,17 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.ValidateHealthOutputValues(
                 directory: "Scripts/",
                 totalFiles: 5,
-                totalFilePercent: 100,
+                totalFolders: 0,
+                totalItems: 5,
+                totalItemPercent: 100,
                 fastFiles: 0,
-                fastFilePercent: 0,
+                fastFolders: 0,
+                fastItems: 0,
+                fastItemPercent: 0,
                 slowFiles: 5,
-                slowFilePercent: 100,
+                slowFolders: 0,
+                slowItems: 5,
+                slowItemPercent: 100,
                 totalPercent: 100,
                 topHydratedDirectories: topHydratedDirectories,
                 directoryHydrationLevels: directoryHydrationLevels,
@@ -150,11 +180,17 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void ValidateHealthOutputValues(
             string directory,
             int totalFiles,
-            int totalFilePercent,
+            int totalFolders,
+            int totalItems,
+            int totalItemPercent,
             int fastFiles,
-            int fastFilePercent,
+            int fastFolders,
+            int fastItems,
+            int fastItemPercent,
             int slowFiles,
-            int slowFilePercent,
+            int slowFolders,
+            int slowItems,
+            int slowItemPercent,
             int totalPercent,
             List<string> topHydratedDirectories,
             List<int> directoryHydrationLevels,
@@ -165,62 +201,74 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             int numberOfExpectedSubdirectories = topHydratedDirectories.Count;
 
             this.ValidateTargetDirectory(healthOutputLines[1], directory);
-            this.ValidateTotalFileInfo(healthOutputLines[2], totalFiles, totalFilePercent);
-            this.ValidateFastFileInfo(healthOutputLines[3], fastFiles, fastFilePercent);
-            this.ValidateSlowFileInfo(healthOutputLines[4], slowFiles, slowFilePercent);
-            this.ValidateTotalHydration(healthOutputLines[5], totalPercent);
-            this.ValidateSubDirectoryHealth(healthOutputLines.GetRange(7, numberOfExpectedSubdirectories), topHydratedDirectories, directoryHydrationLevels);
-            this.ValidateEnlistmentStatus(healthOutputLines[7 + numberOfExpectedSubdirectories], enlistmentHealthStatus);
+            this.ValidateTotalFileInfo(healthOutputLines[3], totalFiles, totalFolders, totalItems, totalItemPercent);
+            this.ValidateFastFileInfo(healthOutputLines[4], fastFiles, fastFolders, fastItems, fastItemPercent);
+            this.ValidateSlowFileInfo(healthOutputLines[5], slowFiles, slowFolders, slowItems, slowItemPercent);
+            this.ValidateTotalHydration(healthOutputLines[6], totalPercent);
+            this.ValidateSubDirectoryHealth(healthOutputLines.GetRange(8, numberOfExpectedSubdirectories), topHydratedDirectories, directoryHydrationLevels);
+            this.ValidateEnlistmentStatus(healthOutputLines[8 + numberOfExpectedSubdirectories], enlistmentHealthStatus);
         }
 
         private void ValidateTargetDirectory(string outputLine, string targetDirectory)
         {
             // Regex to extract the target directory
             // "Health of directory: <directory>"
-            Match lineMatch = Regex.Match(outputLine, @"^Health of directory:\s*(.*)$");
+            Match lineMatch = Regex.Match(outputLine, @"^Health of directory:\s*(\S.*\S)\s*$");
 
             string outputtedTargetDirectory = lineMatch.Groups[1].Value;
 
             outputtedTargetDirectory.ShouldEqual(targetDirectory);
         }
 
-        private void ValidateTotalFileInfo(string outputLine, int totalFiles, int totalFilePercent)
+        private void ValidateTotalFileInfo(string outputLine, int totalFiles, int totalFolders, int totalItems, int totalItemPercent)
         {
             // Regex to extract the total number of files and percentage they represent (should always be 100)
             // "Total files in HEAD commit:           <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedTotalFiles).ShouldBeTrue();
-            int.TryParse(lineMatch.Groups[2].Value, out int outputtedTotalFilePercent).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedTotalFolders).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[3].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedTotalItems).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[4].Value, out int outputtedTotalItemPercent).ShouldBeTrue();
 
             outputtedTotalFiles.ShouldEqual(totalFiles);
-            outputtedTotalFilePercent.ShouldEqual(totalFilePercent);
+            outputtedTotalFolders.ShouldEqual(totalFolders);
+            outputtedTotalItems.ShouldEqual(totalItems);
+            outputtedTotalItemPercent.ShouldEqual(totalItemPercent);
         }
 
-        private void ValidateFastFileInfo(string outputLine, int fastFiles, int fastFilesPercent)
+        private void ValidateFastFileInfo(string outputLine, int fastFiles, int fastFolders, int fastItems, int fastItemPercent)
         {
             // Regex to extract the total number of fast files and percentage they represent
             // "Files managed by VFS for Git (fast):    <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(faster\):\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(faster\):\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastFiles).ShouldBeTrue();
-            int.TryParse(lineMatch.Groups[2].Value, out int outputtedFastFilesPercent).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastFolders).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[3].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastItems).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[4].Value, out int outputtedFastItemPercent).ShouldBeTrue();
 
             outputtedFastFiles.ShouldEqual(fastFiles);
-            outputtedFastFilesPercent.ShouldEqual(fastFilesPercent);
+            outputtedFastFolders.ShouldEqual(fastFolders);
+            outputtedFastItems.ShouldEqual(fastItems);
+            outputtedFastItemPercent.ShouldEqual(fastItemPercent);
         }
 
-        private void ValidateSlowFileInfo(string outputLine, int slowFiles, int slowFilesPercent)
+        private void ValidateSlowFileInfo(string outputLine, int slowFiles, int slowFolders, int slowItems, int slowItemPercent)
         {
             // Regex to extract the total number of slow files and percentage they represent
             // "Files managed by git (slow):                <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Files managed by Git:\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by Git:\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*(\d+)%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedSlowFiles).ShouldBeTrue();
-            int.TryParse(lineMatch.Groups[2].Value, out int outputtedSlowFilesPercent).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[2].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedSlowFolders).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[3].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedSlowItems).ShouldBeTrue();
+            int.TryParse(lineMatch.Groups[4].Value, out int outputtedSlowItemPercent).ShouldBeTrue();
 
             outputtedSlowFiles.ShouldEqual(slowFiles);
-            outputtedSlowFilesPercent.ShouldEqual(slowFilesPercent);
+            outputtedSlowFolders.ShouldEqual(slowFolders);
+            outputtedSlowItems.ShouldEqual(slowItems);
+            outputtedSlowItemPercent.ShouldEqual(slowItemPercent);
         }
 
         private void ValidateTotalHydration(string outputLine, int totalHydration)

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -96,7 +96,7 @@ namespace GVFS.CommandLine
             string formattedModifiedPathTotal = enlistmentHealthData.ModifiedPathsCount.ToString("N0").PadLeft(totalWidth);
             string formattedModifiedPathPercentage = this.FormatPercent(enlistmentHealthData.ModifiedPathsPercentage);
 
-            this.Output.WriteLine("\n" + targetDirectoryLabel.PadRight(labelWidth));
+            this.Output.WriteLine("\n" + targetDirectoryLabel);
             this.Output.WriteLine(string.Empty.PadRight(labelWidth) + fileLabel.PadLeft(fileWidth) + "   " + directoryLabel.PadLeft(directoryWidth) + "   " + totalLabel.PadLeft(totalWidth));
             this.Output.WriteLine(totalFilesLabel.PadRight(labelWidth) + formattedTrackedFiles + " | " + formattedTrackedFolders + " | " + formattedTrackedTotal + " | 100%");
             this.Output.WriteLine(placeholderLabel.PadRight(labelWidth) + formattedPlaceholderFiles + " | " + formattedPlaceholderFolders + " | " + formattedPlaceholderTotal + " | " + formattedPlaceholderPercentage);

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -68,16 +68,16 @@ namespace GVFS.CommandLine
         private void PrintOutput(EnlistmentHealthData enlistmentHealthData)
         {
             // Get the appropriate number of sub directories to display
-            List<KeyValuePair<string, EnlistmentHealthCalculator.SubDirectoryInfo>> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
+            List<EnlistmentHealthCalculator.SubDirectoryInfo> topLevelDirectoriesByHydration = enlistmentHealthData.DirectoryHydrationLevels.Take(this.DirectoryDisplayCount).ToList();
 
             string targetDirectoryLabel = "Health of directory: " + enlistmentHealthData.TargetDirectory;
-            string totalFilesLabel = "Total files in HEAD commit:";
-            string placeholderLabel = "Files managed by VFS for Git (faster):";
-            string modifiedPathsLabel = "Files managed by Git:";
+            string totalFilesLabel = "Total items in HEAD commit:";
+            string placeholderLabel = "Items managed by VFS for Git (faster):";
+            string modifiedPathsLabel = "Items managed by Git:";
 
-            string fileLabel = "File";
-            string directoryLabel = "Dir";
-            string totalLabel = "Sum";
+            string fileLabel = "Files";
+            string directoryLabel = "Directories";
+            string totalLabel = "Total";
 
             int labelWidth = Math.Max(Math.Max(targetDirectoryLabel.Length, totalFilesLabel.Length), Math.Max(placeholderLabel.Length, modifiedPathsLabel.Length)) + 1;
             int fileWidth = Math.Max(enlistmentHealthData.GitTrackedFileCount.ToString("N0").Length, fileLabel.Length);


### PR DESCRIPTION
The `gvfs health` verb now displays `files` and `folders` separately in the output. The new output looks like:
```
λ gvfs health                                                 
                                                              
Gathering repository data...                                  
                                                              
Health of directory:                                          
                                       File   Dir   Sum       
Total files in HEAD commit:             684 | 137 | 821 | 100%
Files managed by VFS for Git (faster):  318 |  83 | 401 |  49%
Files managed by Git:                     1 |   0 |   1 |   0%
                                                              
Total hydration percentage:                                49%
                                                              
Most hydrated top level directories:                          
 364 / 676 | GVFS                                             
  24 / 24  | Scripts                                          
   0 / 32  | MirrorProvider                                   
   0 / 66  | ProjFS.Mac                                       
   0 / 8   | GitHooksLoader                                   
                                                              
Repository status: OK                                         
```

There are 2 major issues I encountered with this change:

1. Git doesn't actually manage folders, but the terminology we adopted for `modified-paths ∪ non-skip worktree` is `Files managed by Git` which can have directories in it
2. The code that formats the table output is large and messy, but without writing a set of functions to display tables I don't think they can be further compressed.

I'd love feedback on these changes as well as the above points. Been a real pleasure working with everyone this summer!