### PR TITLE
Allow privileged system service 'amfid' to hydrate

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -70,7 +70,7 @@ static bool TryReadVNodeFileFlags(vnode_t vn, vfs_context_t _Nonnull context, ui
 KEXT_STATIC_INLINE bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 KEXT_STATIC_INLINE bool TryGetFileIsFlaggedAsInRoot(vnode_t vnode, vfs_context_t _Nonnull context, bool* flaggedInRoot);
 KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
-KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser();
+KEXT_STATIC bool CurrentProcessIsAllowedToHydrate();
 KEXT_STATIC bool IsFileSystemCrawler(const char* procname);
 
 static void WaitForListenerCompletion();
@@ -1265,10 +1265,10 @@ static bool TryGetVirtualizationRoot(
         return false;
     }
     
-    if (callbackPolicy == CallbackPolicy_UserInitiatedOnly && !CurrentProcessWasSpawnedByRegularUser())
+    if (callbackPolicy == CallbackPolicy_UserInitiatedOnly && !CurrentProcessIsAllowedToHydrate())
     {
         // Prevent hydration etc. by system services
-        KextLog_Info("TryGetVirtualizationRoot: process %d restricted due to owner UID.", pidMakingRequest);
+        KextLog_Info("TryGetVirtualizationRoot: process %d is not allowed to hydrate.", pidMakingRequest);
         perfTracer->IncrementCount(PrjFSPerfCounter_VnodeOp_GetVirtualizationRoot_UserRestriction);
         
         *kauthResult = KAUTH_RESULT_DENY;
@@ -1280,7 +1280,7 @@ static bool TryGetVirtualizationRoot(
     return true;
 }
 
-KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser()
+KEXT_STATIC bool CurrentProcessIsAllowedToHydrate()
 {
     bool nonServiceUser = false;
     
@@ -1309,7 +1309,7 @@ KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser()
         process = parentProcess;
         if (parentProcess == nullptr)
         {
-            KextLog_Error("CurrentProcessIsOwnedOrWasSpawnedByRegularUser: Failed to locate ancestor process %d for current process %d\n", parentPID, proc_selfpid());
+            KextLog_Error("CurrentProcessIsAllowedToHydrate: Failed to locate ancestor process %d for current process %d\n", parentPID, proc_selfpid());
             break;
         }
     }
@@ -1318,6 +1318,19 @@ KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser()
     if (process != nullptr)
     {
         proc_rele(process);
+    }
+    
+    if (!nonServiceUser)
+    {
+       // When amfid is invoked to check the code signature of a library which has not been hydrated,
+       // blocking hydration would cause the launch of an application which depends on the library to fail,
+       // so amfid should always be allowed to hydrate.
+       char buffer[MAXCOMLEN + 1] = "";
+       proc_selfname(buffer, sizeof(buffer));
+       if (0 == strcmp(buffer, "amfid"))
+       {
+          nonServiceUser = true;
+       }
     }
     
     return nonServiceUser;

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
@@ -67,7 +67,7 @@ KEXT_STATIC bool ShouldHandleFileOpEvent(
     VirtualizationRootHandle* root,
     int* pid);
 KEXT_STATIC void UseMainForkIfNamedStream(vnode_t& vnode, bool& putVnodeWhenDone);
-KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser();
+KEXT_STATIC bool CurrentProcessIsAllowedToHydrate();
 KEXT_STATIC bool InitPendingRenames();
 KEXT_STATIC void CleanupPendingRenames();
 KEXT_STATIC void ResizePendingRenames(uint32_t newMaxPendingRenames);

--- a/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
@@ -95,7 +95,7 @@ class PrjFSProviderUserClient
     self->otherRepoHandle = result.root;
 
     MockProcess_AddContext(context, 501 /*pid*/);
-    MockProcess_SetSelfPid(501);
+    MockProcess_SetSelfInfo(501, "Test");
     MockProcess_AddProcess(501 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     ProvidermessageMock_ResetResultCount();
@@ -402,7 +402,7 @@ class PrjFSProviderUserClient
 {
     MockProcess_Reset();
     MockProcess_AddContext(context, self->dummyClientPid /*pid*/);
-    MockProcess_SetSelfPid(self->dummyClientPid);
+    MockProcess_SetSelfInfo(self->dummyClientPid, "Test");
     MockProcess_AddProcess(self->dummyClientPid /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "GVFS.Mount" /*name*/);
 
     testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
@@ -432,7 +432,7 @@ class PrjFSProviderUserClient
 {
     MockProcess_Reset();
     MockProcess_AddContext(context, self->otherDummyClientPid /*pid*/);
-    MockProcess_SetSelfPid(self->otherDummyClientPid);
+    MockProcess_SetSelfInfo(self->otherDummyClientPid, "Test");
     MockProcess_AddProcess(self->otherDummyClientPid /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "GVFS.Mount" /*name*/);
 
     testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -103,7 +103,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
     self->dummyRepoHandle = result.root;
 
     MockProcess_AddContext(context, RunningMockProcessPID /*pid*/);
-    MockProcess_SetSelfPid(RunningMockProcessPID);
+    MockProcess_SetSelfInfo(RunningMockProcessPID, "Test");
     MockProcess_AddProcess(RunningMockProcessPID, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     ProvidermessageMock_ResetResultCount();

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
@@ -14,6 +14,7 @@ static map<uintptr_t /*credential ID*/, int /*UID*/> s_credentialMap;
 static map<vfs_context_t /*context*/, int /*pid*/> s_contextMap;
 static map<int /*process Id*/, proc> s_processMap;
 static int s_selfPid;
+static string s_selfName;
 static uint16_t s_currentThreadIndex = 0;
 static thread s_threadPool[MockProcess_ThreadPoolSize] = {};
 
@@ -25,9 +26,10 @@ void MockProcess_Reset()
     MockProcess_SetCurrentThreadIndex(0);
 }
 
-void MockProcess_SetSelfPid(int selfPid)
+void MockProcess_SetSelfInfo(int selfPid, const string& selfName)
 {
     s_selfPid = selfPid;
+    s_selfName = selfName;
 }
 
 int proc_pid(proc_t proc)
@@ -147,6 +149,11 @@ int proc_rele(proc_t p)
 int proc_selfpid(void)
 {
     return s_selfPid;
+}
+
+void proc_selfname(char* buf, int size)
+{
+    strlcpy(buf, s_selfName.c_str(), size);
 }
 
 void MockProcess_AddCredential(uintptr_t credentialId, uid_t UID)

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
@@ -21,6 +21,7 @@ extern "C"
     int proc_rele(proc_t p);
     int proc_selfpid(void);
     kernel_thread_t current_thread(void);
+    void proc_selfname(char* buf, int size);
 }
 
 struct proc {
@@ -30,7 +31,7 @@ struct proc {
     std::string name;
 };
 
-void MockProcess_SetSelfPid(int selfPid);
+void MockProcess_SetSelfInfo(int selfPid, const std::string& selfName);
 void MockProcess_AddCredential(uintptr_t credentialId, uid_t UID);
 void MockProcess_AddContext(vfs_context_t context, int pid);
 void MockProcess_AddProcess(int pid, uintptr_t credentialId, int ppid, std::string procName);

--- a/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
@@ -36,7 +36,7 @@ class PrjFSProviderUserClient
     self->cacheWrapper.AllocateCache();
     self->context = vfs_context_create(nullptr);
     MockProcess_AddContext(self->context, 501 /*pid*/);
-    MockProcess_SetSelfPid(501);
+    MockProcess_SetSelfInfo(501, "Test");
     MockProcess_AddProcess(501 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     self->testMount = mount::Create();
@@ -188,7 +188,7 @@ class PrjFSProviderUserClient
     // Fail when pid matches provider pid
     MockProcess_Reset();
     MockProcess_AddContext(self->context, 0 /*pid*/);
-    MockProcess_SetSelfPid(0);
+    MockProcess_SetSelfInfo(0, "Test");
     MockProcess_AddProcess(0 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     int pid;
     XCTAssertFalse(


### PR DESCRIPTION
A user attempted to run 'open project.app' and failed.  

This was because it called the system process 'amfid' used in signing.  We had blocked all system processes from hydrating.

This change creates an exception for 'amfid' and allows it to hydrate.