### PR TITLE
[releases/shipped] Allow privileged system service 'amfid' to hydrate

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
@@ -67,7 +67,7 @@ KEXT_STATIC bool ShouldHandleFileOpEvent(
     VirtualizationRootHandle* root,
     int* pid);
 KEXT_STATIC void UseMainForkIfNamedStream(vnode_t& vnode, bool& putVnodeWhenDone);
-KEXT_STATIC bool CurrentProcessWasSpawnedByRegularUser();
+KEXT_STATIC bool CurrentProcessIsAllowedToHydrate();
 KEXT_STATIC bool InitPendingRenames();
 KEXT_STATIC void CleanupPendingRenames();
 KEXT_STATIC void ResizePendingRenames(uint32_t newMaxPendingRenames);

--- a/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleFileOpOperationTests.mm
@@ -95,7 +95,7 @@ class PrjFSProviderUserClient
     self->otherRepoHandle = result.root;
 
     MockProcess_AddContext(context, 501 /*pid*/);
-    MockProcess_SetSelfPid(501);
+    MockProcess_SetSelfInfo(501, "Test");
     MockProcess_AddProcess(501 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     ProvidermessageMock_ResetResultCount();
@@ -402,7 +402,7 @@ class PrjFSProviderUserClient
 {
     MockProcess_Reset();
     MockProcess_AddContext(context, self->dummyClientPid /*pid*/);
-    MockProcess_SetSelfPid(self->dummyClientPid);
+    MockProcess_SetSelfInfo(self->dummyClientPid, "Test");
     MockProcess_AddProcess(self->dummyClientPid /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "GVFS.Mount" /*name*/);
 
     testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;
@@ -432,7 +432,7 @@ class PrjFSProviderUserClient
 {
     MockProcess_Reset();
     MockProcess_AddContext(context, self->otherDummyClientPid /*pid*/);
-    MockProcess_SetSelfPid(self->otherDummyClientPid);
+    MockProcess_SetSelfInfo(self->otherDummyClientPid, "Test");
     MockProcess_AddProcess(self->otherDummyClientPid /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "GVFS.Mount" /*name*/);
 
     testFileVnode->attrValues.va_flags = FileFlags_IsInVirtualizationRoot;

--- a/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/HandleOperationTests.mm
@@ -100,7 +100,7 @@ static void TestForAllSupportedDarwinVersions(void(^testBlock)(void))
     self->dummyRepoHandle = result.root;
 
     MockProcess_AddContext(context, 501 /*pid*/);
-    MockProcess_SetSelfPid(501);
+    MockProcess_SetSelfInfo(501, "Test");
     MockProcess_AddProcess(501 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     ProvidermessageMock_ResetResultCount();

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.cpp
@@ -14,6 +14,7 @@ static map<uintptr_t /*credential ID*/, int /*UID*/> s_credentialMap;
 static map<vfs_context_t /*context*/, int /*pid*/> s_contextMap;
 static map<int /*process Id*/, proc> s_processMap;
 static int s_selfPid;
+static string s_selfName;
 static uint16_t s_currentThreadIndex = 0;
 static thread s_threadPool[MockProcess_ThreadPoolSize] = {};
 
@@ -25,9 +26,10 @@ void MockProcess_Reset()
     MockProcess_SetCurrentThreadIndex(0);
 }
 
-void MockProcess_SetSelfPid(int selfPid)
+void MockProcess_SetSelfInfo(int selfPid, const string& selfName)
 {
     s_selfPid = selfPid;
+    s_selfName = selfName;
 }
 
 int proc_pid(proc_t proc)
@@ -147,6 +149,11 @@ int proc_rele(proc_t p)
 int proc_selfpid(void)
 {
     return s_selfPid;
+}
+
+void proc_selfname(char* buf, int size)
+{
+    strlcpy(buf, s_selfName.c_str(), size);
 }
 
 void MockProcess_AddCredential(uintptr_t credentialId, uid_t UID)

--- a/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockProc.hpp
@@ -21,6 +21,7 @@ extern "C"
     int proc_rele(proc_t p);
     int proc_selfpid(void);
     kernel_thread_t current_thread(void);
+    void proc_selfname(char* buf, int size);
 }
 
 struct proc {
@@ -30,7 +31,7 @@ struct proc {
     std::string name;
 };
 
-void MockProcess_SetSelfPid(int selfPid);
+void MockProcess_SetSelfInfo(int selfPid, const std::string& selfName);
 void MockProcess_AddCredential(uintptr_t credentialId, uid_t UID);
 void MockProcess_AddContext(vfs_context_t context, int pid);
 void MockProcess_AddProcess(int pid, uintptr_t credentialId, int ppid, std::string procName);

--- a/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/ShouldHandleFileOpTests.mm
@@ -36,7 +36,7 @@ class PrjFSProviderUserClient
     self->cacheWrapper.AllocateCache();
     self->context = vfs_context_create(nullptr);
     MockProcess_AddContext(self->context, 501 /*pid*/);
-    MockProcess_SetSelfPid(501);
+    MockProcess_SetSelfInfo(501, "Test");
     MockProcess_AddProcess(501 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     
     self->testMount = mount::Create();
@@ -191,7 +191,7 @@ class PrjFSProviderUserClient
     // Fail when pid matches provider pid
     MockProcess_Reset();
     MockProcess_AddContext(self->context, 0 /*pid*/);
-    MockProcess_SetSelfPid(0);
+    MockProcess_SetSelfInfo(0, "Test");
     MockProcess_AddProcess(0 /*pid*/, 1 /*credentialId*/, 1 /*ppid*/, "test" /*name*/);
     int pid;
     XCTAssertFalse(


### PR DESCRIPTION
A user attempted to run 'open project.app' and failed.

This was because it called the system process 'amfid' used in signing. We had blocked all system processes from hydrating.

This change creates an exception for 'amfid' and allows it to hydrate.

cherry-pick from master