### PR TITLE
[POSIX] Use platform-specific path separators in repair jobs and cache tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -315,9 +315,10 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         private void HydrateEntireRepo(GVFSFunctionalTestEnlistment enlistment)
         {
             List<string> allFiles = Directory.EnumerateFiles(enlistment.RepoRoot, "*", SearchOption.AllDirectories).ToList();
+            string dotGitRoot = Path.Combine(enlistment.RepoRoot, ".git") + Path.DirectorySeparatorChar;
             for (int i = 0; i < allFiles.Count; ++i)
             {
-                if (!allFiles[i].StartsWith(enlistment.RepoRoot + "\\.git\\", StringComparison.OrdinalIgnoreCase))
+                if (!allFiles[i].StartsWith(dotGitRoot, StringComparison.OrdinalIgnoreCase))
                 {
                     File.ReadAllText(allFiles[i]);
                 }

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -16,7 +16,7 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return ".git\\config"; }
+            get { return GVFSConstants.DotGit.Config; }
         }
 
         public override IssueType HasIssue(List<string> messages)
@@ -58,7 +58,7 @@ namespace GVFS.RepairJobs
                 if (!enlistment.Authentication.TryInitialize(this.Tracer, enlistment, out authError))
                 {
                     messages.Add("Authentication failed. Run 'gvfs log' for more info.");
-                    messages.Add(".git\\config is valid and remote 'origin' is set, but may have a typo:");
+                    messages.Add($"{GVFSConstants.DotGit.Config} is valid and remote 'origin' is set, but may have a typo:");
                     messages.Add(originUrl.Trim());
                     return IssueType.CantFix;
                 }
@@ -87,7 +87,7 @@ namespace GVFS.RepairJobs
             if (!GVFSVerb.TrySetRequiredGitConfigSettings(this.Enlistment) ||
                 !GVFSVerb.TrySetOptionalGitConfigSettings(this.Enlistment))
             {
-                messages.Add("Unable to create default .git\\config.");
+                messages.Add($"Unable to create default {GVFSConstants.DotGit.Config}.");
                 this.RestoreFromBackupFile(configBackupPath, configPath, messages);
 
                 return FixResult.Failure;
@@ -100,7 +100,7 @@ namespace GVFS.RepairJobs
             // but getting Fixable means that we still failed
             if (this.HasIssue(validationMessages) == IssueType.Fixable)
             {
-                messages.Add("Reinitializing the .git\\config did not fix the issue. Check the errors below for more details:");
+                messages.Add($"Reinitializing the {GVFSConstants.DotGit.Config} did not fix the issue. Check the errors below for more details:");
                 messages.AddRange(validationMessages);
 
                 this.RestoreFromBackupFile(configBackupPath, configPath, messages);
@@ -110,10 +110,10 @@ namespace GVFS.RepairJobs
 
             if (!this.TryDeleteFile(configBackupPath))
             {
-                messages.Add("Failed to delete .git\\config backup file: " + configBackupPath);
+                messages.Add($"Failed to delete {GVFSConstants.DotGit.Config} backup file: " + configBackupPath);
             }
 
-            messages.Add("Reinitialized .git\\config. You will need to manually add the origin remote by running");
+            messages.Add($"Reinitialized {GVFSConstants.DotGit.Config}. You will need to manually add the origin remote by running");
             messages.Add("git remote add origin <repo url>");
             messages.Add("If you previously configured a custom cache server, you will need to configure it again.");
 

--- a/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitHeadRepairJob.cs
@@ -17,7 +17,7 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return @".git\HEAD"; }
+            get { return GVFSConstants.DotGit.Head; }
         }
 
         public override IssueType HasIssue(List<string> messages)
@@ -126,7 +126,7 @@ namespace GVFS.RepairJobs
             }
             catch (IOException ex)
             {
-                messages.Add("IOException while reading .git\\HEAD: " + ex.Message);
+                messages.Add($"IOException while reading {GVFSConstants.DotGit.Head}: " + ex.Message);
                 return false;
             }
 

--- a/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitIndexRepairJob.cs
@@ -18,14 +18,14 @@ namespace GVFS.RepairJobs
 
         public override string Name
         {
-            get { return @".git\index"; }
+            get { return GVFSConstants.DotGit.Index; }
         }
 
         public override IssueType HasIssue(List<string> messages)
         {
             if (!File.Exists(this.indexPath))
             {
-                messages.Add(".git\\index not found");
+                messages.Add($"{GVFSConstants.DotGit.Index} not found");
                 return IssueType.Fixable;
             }
             else
@@ -62,7 +62,7 @@ namespace GVFS.RepairJobs
             {
                 if (!this.TryDeleteFile(indexBackupPath))
                 {
-                    messages.Add("Warning: Could not delete backed up .git\\index at: " + indexBackupPath);
+                    messages.Add($"Warning: Could not delete backed up {GVFSConstants.DotGit.Index} at: " + indexBackupPath);
                 }
             }
 


### PR DESCRIPTION
Avoid hard-coding the Windows backslash path separator in messages printed by the repair jobs.

Per @kewillford's [suggestion](https://github.com/microsoft/VFSForGit/pull/1412#discussion_r313542988), we use `GVFSConstants.DotGit.*` properties throughout.

Also fix the path matching in the `HydrateEntireRepo()` helper for `MultiEnlistmentTests.SharedCacheTests`, which was not excluding `{repoRoot}/.git/` paths on Mac (or Linux) due to hard-coded Windows path separators.

/cc @kivikakk