### PR TITLE
Don't log errors when MaintenanceSteps fail due to the repo being deleted

### DIFF
--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -20,7 +20,7 @@ namespace GVFS.Common.Git
             {
                 string reason = Native.GetLastError();
                 string message = "Couldn't open repo at " + repoPath + ": " + reason;
-                tracer.RelatedError(message);
+                tracer.RelatedWarning(message);
 
                 Native.Shutdown();
                 throw new InvalidDataException(message);

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceQueue.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceQueue.cs
@@ -60,18 +60,7 @@ namespace GVFS.Common.Maintenance
         /// </summary>
         public bool EnlistmentRootReady()
         {
-            // If a user locks their drive or disconnects an external drive while the mount process
-            // is running, then it will appear as if the directories below do not exist or throw
-            // a "Device is not ready" error.
-            try
-            {
-                return this.context.FileSystem.DirectoryExists(this.context.Enlistment.EnlistmentRoot)
-                         && this.context.FileSystem.DirectoryExists(this.context.Enlistment.GitObjectsRoot);
-            }
-            catch (IOException)
-            {
-                return false;
-            }
+            return GitMaintenanceStep.EnlistmentRootReady(this.context);
         }
 
         private void RunQueue()


### PR DESCRIPTION
Resolves #1447

- `LibGit2Repo(...)` will now log failures of `Native.Repo.Open` as warnings instead of errors.  The callers who catch the `InvalidDataException` can choose the log the problem as an error.

- `GitMaintenanceStep.Execute()` will only log exceptions as errors when `EnlistmentRootReady` is true.