### PR TITLE
Mac ProjFS: In-kext diagnostic event tracing

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A0D4DA12323EDDE00589594 /* UserClientUtilities.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = UserClientUtilities.hpp; sourceTree = "<group>"; };
 		4A2A699B2295AA7800ACAAAF /* ArrayUtilities.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ArrayUtilities.hpp; sourceTree = "<group>"; };
 		4A2A699D2296BACE00ACAAAF /* KauthHandlerPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KauthHandlerPrivate.hpp; sourceTree = "<group>"; };
 		4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KextAssertIntegration.m; sourceTree = "<group>"; };
@@ -482,6 +483,7 @@
 				4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */,
 				4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */,
 				4391F89621E42AC40008103C /* public */,
+				4A0D4DA12323EDDE00589594 /* UserClientUtilities.hpp */,
 				4391F8A721E42AC50008103C /* VirtualizationRoots.cpp */,
 				4391F89421E42AC40008103C /* VirtualizationRoots.hpp */,
 				4A781DB722299C5300DB7733 /* VirtualizationRootsTestable.hpp */,

--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				4AF558452302DF510020A270 /* PBXTargetDependency */,
 				4A08257521E77BEB00E21AFD /* PBXTargetDependency */,
 				4391F90521E4362B0008103C /* PBXTargetDependency */,
 				4391F90721E4362B0008103C /* PBXTargetDependency */,
@@ -85,6 +86,13 @@
 		4A08257721E77C4B00E21AFD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
 		4A08257821E77C5400E21AFD /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */; };
+		4A0D4D9623225DB800589594 /* KextLogEventTracer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0D4D9423225DB800589594 /* KextLogEventTracer.cpp */; };
+		4A0D4D9723225DB800589594 /* KextLogEventTracer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0D4D9423225DB800589594 /* KextLogEventTracer.cpp */; };
+		4A0D4D9823225DB800589594 /* KextLogEventTracer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A0D4D9523225DB800589594 /* KextLogEventTracer.hpp */; };
+		4A0D4D9923225DB800589594 /* KextLogEventTracer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A0D4D9523225DB800589594 /* KextLogEventTracer.hpp */; };
+		4A0D4D9C2323DE1000589594 /* PrjFSEventTraceUserClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0D4D9A2323DE1000589594 /* PrjFSEventTraceUserClient.cpp */; };
+		4A0D4D9D2323DE1000589594 /* PrjFSEventTraceUserClient.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A0D4D9B2323DE1000589594 /* PrjFSEventTraceUserClient.hpp */; };
+		4A0D4DA2232405BF00589594 /* PrjFSUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8E421E435230008103C /* PrjFSUser.cpp */; };
 		4A2A69A02297339A00ACAAAF /* KextAssertIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2A699F2297339A00ACAAAF /* KextAssertIntegration.m */; };
 		4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A558DB822357AB000AFDE07 /* ProviderMessaging.cpp */; };
 		4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4A558DB922357AB000AFDE07 /* ProviderMessaging.hpp */; };
@@ -107,6 +115,9 @@
 		4AAE3FCA22832340002673FA /* HandleFileOpOperationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE3FC922832340002673FA /* HandleFileOpOperationTests.mm */; };
 		4AE873AE2310127D003B122B /* VnodeUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8A121E42AC50008103C /* VnodeUtilities.cpp */; };
 		4AE873B0231017FB003B122B /* VnodeUtilitiesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4AE873AF231017FB003B122B /* VnodeUtilitiesTests.mm */; };
+		4AF5583D2301BE290020A270 /* prjfs-tracectl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF5583C2301BE290020A270 /* prjfs-tracectl.cpp */; };
+		4AF558422302DEB30020A270 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DC21E430EB0008103C /* IOKit.framework */; };
+		4AF558432302DEBE0020A270 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4391F8DA21E430E20008103C /* CoreFoundation.framework */; };
 		D9C087F222384670009C1110 /* MemoryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D9C087F122384670009C1110 /* MemoryTests.mm */; };
 		F554202D224BB6E5008BAE95 /* ProviderMessagingMock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F554202C224BB6E5008BAE95 /* ProviderMessagingMock.cpp */; };
 		F5554F422239883B00B31D19 /* MockProc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5554F412239883B00B31D19 /* MockProc.cpp */; };
@@ -207,6 +218,13 @@
 			remoteGlobalIDString = 4A8C139F21F23EE800002878;
 			remoteInfo = PrjFSKextTestable;
 		};
+		4AF558442302DF510020A270 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4391F87621E4278C0008103C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4AF558392301BE280020A270;
+			remoteInfo = "prjfs-tracectl";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -228,6 +246,15 @@
 				4A08257921E77C7000E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4AF558382301BE280020A270 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -288,6 +315,10 @@
 		4A08257021E77BDD00E21AFD /* org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = org.vfsforgit.prjfs.PrjFSKextLogDaemon.plist; sourceTree = "<group>"; };
 		4A08257121E77BDD00E21AFD /* PrjFSKextLogDaemon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSKextLogDaemon.cpp; sourceTree = "<group>"; };
 		4A08257221E77BDD00E21AFD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A0D4D9423225DB800589594 /* KextLogEventTracer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = KextLogEventTracer.cpp; sourceTree = "<group>"; };
+		4A0D4D9523225DB800589594 /* KextLogEventTracer.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KextLogEventTracer.hpp; sourceTree = "<group>"; };
+		4A0D4D9A2323DE1000589594 /* PrjFSEventTraceUserClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrjFSEventTraceUserClient.cpp; sourceTree = "<group>"; };
+		4A0D4D9B2323DE1000589594 /* PrjFSEventTraceUserClient.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PrjFSEventTraceUserClient.hpp; sourceTree = "<group>"; };
 		4A0D4DA12323EDDE00589594 /* UserClientUtilities.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = UserClientUtilities.hpp; sourceTree = "<group>"; };
 		4A2A699B2295AA7800ACAAAF /* ArrayUtilities.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ArrayUtilities.hpp; sourceTree = "<group>"; };
 		4A2A699D2296BACE00ACAAAF /* KauthHandlerPrivate.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KauthHandlerPrivate.hpp; sourceTree = "<group>"; };
@@ -315,6 +346,8 @@
 		4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = PrjFSKextTests.exp; sourceTree = "<group>"; };
 		4AAE3FC922832340002673FA /* HandleFileOpOperationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HandleFileOpOperationTests.mm; sourceTree = "<group>"; };
 		4AE873AF231017FB003B122B /* VnodeUtilitiesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VnodeUtilitiesTests.mm; sourceTree = "<group>"; };
+		4AF5583A2301BE280020A270 /* prjfs-tracectl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "prjfs-tracectl"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AF5583C2301BE290020A270 /* prjfs-tracectl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "prjfs-tracectl.cpp"; sourceTree = "<group>"; };
 		D9C087F122384670009C1110 /* MemoryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryTests.mm; sourceTree = "<group>"; };
 		F5151F7F226F9083004B92C9 /* ProviderMessagingMock.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessagingMock.hpp; sourceTree = "<group>"; };
 		F554202C224BB6E5008BAE95 /* ProviderMessagingMock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessagingMock.cpp; sourceTree = "<group>"; };
@@ -378,6 +411,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4AF558372301BE280020A270 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AF558432302DEBE0020A270 /* CoreFoundation.framework in Frameworks */,
+				4AF558422302DEB30020A270 /* IOKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F5E39C7421F1118D006D65C2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -426,6 +468,7 @@
 				4A08256921E77B7F00E21AFD /* PrjFSKextLogDaemon */,
 				F5E39C7821F1118D006D65C2 /* PrjFSKextTests */,
 				264E723A22930E660059E150 /* PrjFSLibTests */,
+				4AF5583B2301BE290020A270 /* prjfs-tracectl */,
 				4391F88021E4278C0008103C /* Products */,
 				4391F8D921E430E10008103C /* Frameworks */,
 			);
@@ -444,6 +487,7 @@
 				F5E39C7721F1118D006D65C2 /* PrjFSKextTests.xctest */,
 				4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */,
 				264E723922930E660059E150 /* PrjFSLibTests.xctest */,
+				4AF5583A2301BE280020A270 /* prjfs-tracectl */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -460,6 +504,8 @@
 				4391F89021E42AC40008103C /* kernel-header-wrappers */,
 				4391F89121E42AC40008103C /* KextLog.cpp */,
 				4391F89221E42AC40008103C /* KextLog.hpp */,
+				4A0D4D9423225DB800589594 /* KextLogEventTracer.cpp */,
+				4A0D4D9523225DB800589594 /* KextLogEventTracer.hpp */,
 				4391F8A621E42AC50008103C /* Locks.cpp */,
 				4391F88E21E42AC40008103C /* Locks.hpp */,
 				4391F89721E42AC40008103C /* Memory.cpp */,
@@ -470,6 +516,8 @@
 				4391F8A521E42AC50008103C /* PerformanceTracing.cpp */,
 				4391F8A321E42AC50008103C /* PerformanceTracing.hpp */,
 				4391F89D21E42AC50008103C /* PrjFSClasses.hpp */,
+				4A0D4D9A2323DE1000589594 /* PrjFSEventTraceUserClient.cpp */,
+				4A0D4D9B2323DE1000589594 /* PrjFSEventTraceUserClient.hpp */,
 				4391F89C21E42AC40008103C /* PrjFSKext.cpp */,
 				4391F8A021E42AC50008103C /* PrjFSLogUserClient.cpp */,
 				4391F89E21E42AC50008103C /* PrjFSLogUserClient.hpp */,
@@ -530,6 +578,14 @@
 			path = PrjFSKextLogDaemon;
 			sourceTree = "<group>";
 		};
+		4AF5583B2301BE290020A270 /* prjfs-tracectl */ = {
+			isa = PBXGroup;
+			children = (
+				4AF5583C2301BE290020A270 /* prjfs-tracectl.cpp */,
+			);
+			path = "prjfs-tracectl";
+			sourceTree = "<group>";
+		};
 		F5E39C7821F1118D006D65C2 /* PrjFSKextTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -576,6 +632,7 @@
 				4A5EC303229D5F12005E8D8F /* PrjFSOfflineIOUserClient.hpp in Headers */,
 				4391F8B221E42AC50008103C /* Memory.hpp in Headers */,
 				4391F8AE21E42AC50008103C /* VirtualizationRoots.hpp in Headers */,
+				4A0D4D9823225DB800589594 /* KextLogEventTracer.hpp in Headers */,
 				4391F8BE21E42AC50008103C /* KauthHandler.hpp in Headers */,
 				4391F8AC21E42AC50008103C /* KextLog.hpp in Headers */,
 				4A558DBC22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */,
@@ -585,6 +642,7 @@
 				264758CA21EFBA8B0095B9F8 /* VnodeCache.hpp in Headers */,
 				4391F8BC21E42AC50008103C /* VnodeUtilities.hpp in Headers */,
 				4391F8BD21E42AC50008103C /* PerformanceTracing.hpp in Headers */,
+				4A0D4D9D2323DE1000589594 /* PrjFSEventTraceUserClient.hpp in Headers */,
 				4391F8B921E42AC50008103C /* PrjFSProviderUserClientPrivate.hpp in Headers */,
 				F5E39C8321F11556006D65C2 /* KauthHandlerTestable.hpp in Headers */,
 			);
@@ -604,6 +662,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A558DBD22357AB000AFDE07 /* ProviderMessaging.hpp in Headers */,
+				4A0D4D9923225DB800589594 /* KextLogEventTracer.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -721,6 +780,23 @@
 			productReference = 4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		4AF558392301BE280020A270 /* prjfs-tracectl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4AF558412301BE290020A270 /* Build configuration list for PBXNativeTarget "prjfs-tracectl" */;
+			buildPhases = (
+				4AF558362301BE280020A270 /* Sources */,
+				4AF558372301BE280020A270 /* Frameworks */,
+				4AF558382301BE280020A270 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "prjfs-tracectl";
+			productName = "prjfs-tracectl";
+			productReference = 4AF5583A2301BE280020A270 /* prjfs-tracectl */;
+			productType = "com.apple.product-type.tool";
+		};
 		F5E39C7621F1118D006D65C2 /* PrjFSKextTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F5E39C7F21F1118D006D65C2 /* Build configuration list for PBXNativeTarget "PrjFSKextTests" */;
@@ -773,6 +849,9 @@
 					4A8C139F21F23EE800002878 = {
 						CreatedOnToolsVersion = 10.1;
 					};
+					4AF558392301BE280020A270 = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
 					F5E39C7621F1118D006D65C2 = {
 						CreatedOnToolsVersion = 10.1;
 					};
@@ -799,6 +878,7 @@
 				4A8C139F21F23EE800002878 /* PrjFSKextTestable */,
 				264E723822930E660059E150 /* PrjFSLibTests */,
 				26A7DE91229363EA004F6252 /* GeneratePrjFSVersionFiles */,
+				4AF558392301BE280020A270 /* prjfs-tracectl */,
 			);
 		};
 /* End PBXProject section */
@@ -885,8 +965,10 @@
 				4391F8AF21E42AC50008103C /* PrjFSProviderUserClient.cpp in Sources */,
 				4391F8BA21E42AC50008103C /* PrjFSLogUserClient.cpp in Sources */,
 				4A558DBA22357AB000AFDE07 /* ProviderMessaging.cpp in Sources */,
+				4A0D4D9C2323DE1000589594 /* PrjFSEventTraceUserClient.cpp in Sources */,
 				4391F8B621E42AC50008103C /* PrjFSKext.cpp in Sources */,
 				4391F8AB21E42AC50008103C /* KextLog.cpp in Sources */,
+				4A0D4D9623225DB800589594 /* KextLogEventTracer.cpp in Sources */,
 				264758C921EFBA8B0095B9F8 /* VnodeCache.cpp in Sources */,
 				4391F8B421E42AC50008103C /* PrjFSService.cpp in Sources */,
 			);
@@ -929,9 +1011,19 @@
 			files = (
 				4A781DA72220971E00DB7733 /* VirtualizationRoots.cpp in Sources */,
 				4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */,
+				4A0D4D9723225DB800589594 /* KextLogEventTracer.cpp in Sources */,
 				4A82C45922807C6F00276002 /* Message_Shared.cpp in Sources */,
 				264758CF21FA71E10095B9F8 /* VnodeCache.cpp in Sources */,
 				4AE873AE2310127D003B122B /* VnodeUtilities.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4AF558362301BE280020A270 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A0D4DA2232405BF00589594 /* PrjFSUser.cpp in Sources */,
+				4AF5583D2301BE290020A270 /* prjfs-tracectl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1027,6 +1119,11 @@
 			isa = PBXTargetDependency;
 			target = 4A8C139F21F23EE800002878 /* PrjFSKextTestable */;
 			targetProxy = 4A8C13A721F241ED00002878 /* PBXContainerItemProxy */;
+		};
+		4AF558452302DF510020A270 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4AF558392301BE280020A270 /* prjfs-tracectl */;
+			targetProxy = 4AF558442302DF510020A270 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1591,6 +1688,40 @@
 			};
 			name = "Profiling(Release)";
 		};
+		4AF5583E2301BE290020A270 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		4AF5583F2301BE290020A270 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		4AF558402301BE290020A270 /* Profiling(Release) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Profiling(Release)";
+		};
 		F5E39C7C21F1118D006D65C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1752,6 +1883,16 @@
 				4A8C13A121F23EE800002878 /* Debug */,
 				4A8C13A221F23EE800002878 /* Release */,
 				4A8C13A321F23EE800002878 /* Profiling(Release) */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4AF558412301BE290020A270 /* Build configuration list for PBXNativeTarget "prjfs-tracectl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4AF5583E2301BE290020A270 /* Debug */,
+				4AF5583F2301BE290020A270 /* Release */,
+				4AF558402301BE290020A270 /* Profiling(Release) */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -71,7 +71,6 @@ KEXT_STATIC_INLINE bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 KEXT_STATIC_INLINE bool TryGetFileIsFlaggedAsInRoot(vnode_t vnode, vfs_context_t _Nonnull context, bool* flaggedInRoot);
 KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 KEXT_STATIC bool CurrentProcessIsAllowedToHydrate();
-KEXT_STATIC bool IsFileSystemCrawler(const char* procname);
 
 static void WaitForListenerCompletion();
 KEXT_STATIC bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode);
@@ -1202,7 +1201,7 @@ KEXT_STATIC bool ShouldHandleVnodeOpEvent(
         // Once a vnode is hydrated, it's fine to allow crawlers to access those contents.
         
         PerfSample crawlerSample(perfTracer, PrjFSPerfCounter_VnodeOp_ShouldHandle_CheckFileSystemCrawler);
-        if (IsFileSystemCrawler(procname))
+        if (KauthHandler_IsFileSystemCrawler(procname))
         {
             // We must DENY file system crawlers rather than DEFER.
             // If we allow the crawler's access to succeed without hydrating, the kauth result will be cached and we won't
@@ -1583,7 +1582,7 @@ KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mas
     return action & mask;
 }
 
-KEXT_STATIC bool IsFileSystemCrawler(const char* procname)
+bool KauthHandler_IsFileSystemCrawler(const char* procname)
 {
     // These process will crawl the file system and force a full hydration
     if (!strcmp(procname, "mds") ||

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
@@ -7,6 +7,17 @@
 kern_return_t KauthHandler_Init();
 kern_return_t KauthHandler_Cleanup();
 
+struct KauthHandlerEventTracingSettings
+{
+    const char*    pathPrefixFilter;
+    kauth_action_t vnodeActionFilterMask;
+    bool           traceDeniedVnodeEvents;
+    bool           traceProviderMessagingVnodeEvents;
+    bool           traceAllVnodeEvents;
+    bool           traceCrawlerEvents;
+};
+
+bool KauthHandler_EnableTraceListeners(bool tracingEnabled, const KauthHandlerEventTracingSettings& settings);
 bool KauthHandler_IsFileSystemCrawler(const char* procname);
 
 #endif /* KauthHandler_h */

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.hpp
@@ -7,4 +7,6 @@
 kern_return_t KauthHandler_Init();
 kern_return_t KauthHandler_Cleanup();
 
+bool KauthHandler_IsFileSystemCrawler(const char* procname);
+
 #endif /* KauthHandler_h */

--- a/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandlerTestable.hpp
@@ -23,7 +23,6 @@ extern uint32_t s_pendingRenameCount;
 KEXT_STATIC_INLINE bool FileFlagsBitIsSet(uint32_t fileFlags, uint32_t bit);
 KEXT_STATIC_INLINE bool ActionBitIsSet(kauth_action_t action, kauth_action_t mask);
 KEXT_STATIC_INLINE bool TryGetFileIsFlaggedAsInRoot(vnode_t vnode, vfs_context_t context, bool* flaggedInRoot);
-KEXT_STATIC bool IsFileSystemCrawler(const char* procname);
 KEXT_STATIC bool ShouldIgnoreVnodeType(vtype vnodeType, vnode_t vnode);
 KEXT_STATIC int HandleVnodeOperation(
     kauth_cred_t    credential,

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -109,6 +109,37 @@ template <typename... args>
         KextLog_PrintfVnodePathAndProperties(KEXTLOG_ERROR, vnode, format " (vnode path: '%s', name: '%s', type: %d, recycling: %s, mount point mounted at path '%s')", ##__VA_ARGS__); \
     })
 
+#define KextLog_DirectoryVnodeActionFormat "%s%s%s%s%s%s%s%s%s%s%s%s%s"
+#define KextLog_FileVnodeActionFormat      "%s%s%s%s%s%s%s%s%s%s%s%s"
+
+#define KextLog_DirectoryVnodeActionArgs(action, itemPrefix) \
+    ((action) & KAUTH_VNODE_LIST_DIRECTORY)       ? itemPrefix "LIST_DIRECTORY" : "", \
+    ((action) & KAUTH_VNODE_ADD_FILE)             ? itemPrefix "ADD_FILE" : "", \
+    ((action) & KAUTH_VNODE_SEARCH)               ? itemPrefix "SEARCH" : "", \
+    ((action) & KAUTH_VNODE_DELETE)               ? itemPrefix "DELETE" : "", \
+    ((action) & KAUTH_VNODE_ADD_SUBDIRECTORY)     ? itemPrefix "ADD_SUBDIRECTORY" : "", \
+    ((action) & KAUTH_VNODE_DELETE_CHILD)         ? itemPrefix "DELETE_CHILD" : "", \
+    ((action) & KAUTH_VNODE_READ_ATTRIBUTES)      ? itemPrefix "READ_ATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? itemPrefix "WRITE_ATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? itemPrefix "READ_EXTATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? itemPrefix "WRITE_EXTATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_READ_SECURITY)        ? itemPrefix "READ_SECURITY" : "", \
+    ((action) & KAUTH_VNODE_WRITE_SECURITY)       ? itemPrefix "WRITE_SECURITY" : "", \
+    ((action) & KAUTH_VNODE_TAKE_OWNERSHIP)       ? itemPrefix "TAKE_OWNERSHIP" : ""
+
+#define KextLog_FileVnodeActionArgs(action, itemPrefix) \
+    ((action) & KAUTH_VNODE_READ_DATA)            ? itemPrefix "READ_DATA" : "", \
+    ((action) & KAUTH_VNODE_WRITE_DATA)           ? itemPrefix "WRITE_DATA" : "", \
+    ((action) & KAUTH_VNODE_EXECUTE)              ? itemPrefix "EXECUTE" : "", \
+    ((action) & KAUTH_VNODE_DELETE)               ? itemPrefix "DELETE" : "", \
+    ((action) & KAUTH_VNODE_APPEND_DATA)          ? itemPrefix "APPEND_DATA" : "", \
+    ((action) & KAUTH_VNODE_READ_ATTRIBUTES)      ? itemPrefix "READ_ATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? itemPrefix "WRITE_ATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? itemPrefix "READ_EXTATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? itemPrefix "WRITE_EXTATTRIBUTES" : "", \
+    ((action) & KAUTH_VNODE_READ_SECURITY)        ? itemPrefix "READ_SECURITY" : "", \
+    ((action) & KAUTH_VNODE_WRITE_SECURITY)       ? itemPrefix "WRITE_SECURITY" : "", \
+    ((action) & KAUTH_VNODE_TAKE_OWNERSHIP)       ? itemPrefix "TAKE_OWNERSHIP" : ""
 
 #define KextLog_VnodeOp(vnode, vnodeType, procname, action, message) \
     do { \
@@ -116,40 +147,17 @@ template <typename... args>
         { \
             KextLog_File( \
                 vnode, \
-                message ". Proc name: %s. Directory vnode action: %s%s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
+                message ". Proc name: %s. Directory vnode action: " KextLog_DirectoryVnodeActionFormat " \n    ", \
                 procname, \
-                (action & KAUTH_VNODE_LIST_DIRECTORY)       ? " \n    KAUTH_VNODE_LIST_DIRECTORY" : "", \
-                (action & KAUTH_VNODE_ADD_FILE)             ? " \n    KAUTH_VNODE_ADD_FILE" : "", \
-                (action & KAUTH_VNODE_SEARCH)               ? " \n    KAUTH_VNODE_SEARCH" : "", \
-                (action & KAUTH_VNODE_DELETE)               ? " \n    KAUTH_VNODE_DELETE" : "", \
-                (action & KAUTH_VNODE_ADD_SUBDIRECTORY)     ? " \n    KAUTH_VNODE_ADD_SUBDIRECTORY" : "", \
-                (action & KAUTH_VNODE_DELETE_CHILD)         ? " \n    KAUTH_VNODE_DELETE_CHILD" : "", \
-                (action & KAUTH_VNODE_READ_ATTRIBUTES)      ? " \n    KAUTH_VNODE_READ_ATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? " \n    KAUTH_VNODE_WRITE_ATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? " \n    KAUTH_VNODE_READ_EXTATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? " \n    KAUTH_VNODE_WRITE_EXTATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_READ_SECURITY)        ? " \n    KAUTH_VNODE_READ_SECURITY" : "", \
-                (action & KAUTH_VNODE_WRITE_SECURITY)       ? " \n    KAUTH_VNODE_WRITE_SECURITY" : "", \
-                (action & KAUTH_VNODE_TAKE_OWNERSHIP)       ? " \n    KAUTH_VNODE_TAKE_OWNERSHIP" : ""); \
+                KextLog_DirectoryVnodeActionArgs(action, " \n    KAUTH_VNODE_")); \
         } \
         else \
         { \
             KextLog_File( \
                 vnode, \
-                message ". Proc name: %s. File vnode action: %s%s%s%s%s%s%s%s%s%s%s%s \n    ", \
+                message ". Proc name: %s. File vnode action: " KextLog_FileVnodeActionFormat " \n    ", \
                 procname, \
-                (action & KAUTH_VNODE_READ_DATA)            ? " \n    KAUTH_VNODE_READ_DATA" : "", \
-                (action & KAUTH_VNODE_WRITE_DATA)           ? " \n    KAUTH_VNODE_WRITE_DATA" : "", \
-                (action & KAUTH_VNODE_EXECUTE)              ? " \n    KAUTH_VNODE_EXECUTE" : "", \
-                (action & KAUTH_VNODE_DELETE)               ? " \n    KAUTH_VNODE_DELETE" : "", \
-                (action & KAUTH_VNODE_APPEND_DATA)          ? " \n    KAUTH_VNODE_APPEND_DATA" : "", \
-                (action & KAUTH_VNODE_READ_ATTRIBUTES)      ? " \n    KAUTH_VNODE_READ_ATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_WRITE_ATTRIBUTES)     ? " \n    KAUTH_VNODE_WRITE_ATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_READ_EXTATTRIBUTES)   ? " \n    KAUTH_VNODE_READ_EXTATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_WRITE_EXTATTRIBUTES)  ? " \n    KAUTH_VNODE_WRITE_EXTATTRIBUTES" : "", \
-                (action & KAUTH_VNODE_READ_SECURITY)        ? " \n    KAUTH_VNODE_READ_SECURITY" : "", \
-                (action & KAUTH_VNODE_WRITE_SECURITY)       ? " \n    KAUTH_VNODE_WRITE_SECURITY" : "", \
-                (action & KAUTH_VNODE_TAKE_OWNERSHIP)       ? " \n    KAUTH_VNODE_TAKE_OWNERSHIP" : ""); \
+                KextLog_FileVnodeActionArgs(action, " \n    KAUTH_VNODE_")); \
         } \
     } while (0)
 

--- a/ProjFS.Mac/PrjFSKext/KextLogEventTracer.cpp
+++ b/ProjFS.Mac/PrjFSKext/KextLogEventTracer.cpp
@@ -1,0 +1,283 @@
+#include "KextLogEventTracer.hpp"
+#include "kernel-header-wrappers/vnode.h"
+#include "Memory.hpp"
+#include "KextLog.hpp"
+#include "KauthHandler.hpp"
+#include <string.h>
+#include <libkern/libkern.h>
+#include <sys/proc.h>
+#include <sys/kauth.h>
+
+RWLock KextLogTracer::traceFilterLock;
+_Atomic(char*) KextLogTracer::pathPrefixFilter;
+_Atomic(kauth_action_t) KextLogTracer::traceVnodeActionFilterMask;
+_Atomic(bool) KextLogTracer::traceDeniedVnodeEvents;
+_Atomic(bool) KextLogTracer::traceProviderMessagingEvents;
+_Atomic(bool) KextLogTracer::traceAllFileOpEvents;
+_Atomic(bool) KextLogTracer::traceAllVnodeEvents;
+_Atomic(bool) KextLogTracer::traceCrawlerEvents;
+_Atomic(uint64_t) KextLogTracer::nextTraceIndex;
+
+bool KextLogTracer::ShouldTraceEventsForVnode(vnode_t vnode, char (&pathBuffer)[PATH_MAX])
+{
+    bool shouldTrace = true;
+    if (KextLogTracer::pathPrefixFilter != nullptr)
+    {
+        int pathLen = sizeof(pathBuffer);
+        errno_t error = vn_getpath(vnode, pathBuffer, &pathLen);
+        if (error == 0)
+        {
+            RWLock_AcquireShared(KextLogTracer::traceFilterLock);
+            {
+                if (KextLogTracer::pathPrefixFilter != nullptr)
+                {
+                    shouldTrace = strprefix(pathBuffer, KextLogTracer::pathPrefixFilter);
+                }
+            }
+            RWLock_ReleaseShared(KextLogTracer::traceFilterLock);
+        }
+        else
+        {
+            snprintf(pathBuffer, sizeof(pathBuffer), "[vn_getpath() failed: %d]", error);
+        }
+    }
+    
+    return shouldTrace;
+}
+    
+uint64_t KextLogTracer::GetTraceIndex()
+{
+    if (!this->hasTraceIndex)
+    {
+        this->traceIndex = atomic_fetch_add(&KextLogTracer::nextTraceIndex, 1llu);
+        this->hasTraceIndex = true;
+    }
+    return this->traceIndex;
+}
+    
+KextLogTracer::TraceBuffer KextLogTracer::GetBuffer()
+{
+    if (this->dynamicTraceBuffer != nullptr)
+    {
+        return TraceBuffer { this->dynamicTraceBuffer, this->dynamicTraceBufferSize, this->traceBufferPosition };
+    }
+    else
+    {
+        return TraceBuffer { this->embeddedTraceBuffer, sizeof(this->embeddedTraceBuffer), this->traceBufferPosition };
+    }
+}
+
+bool KextLogTracer::GrowBuffer(uint32_t minimumSize)
+{
+    TraceBuffer currentBuffer = this->GetBuffer();
+    if (minimumSize <= currentBuffer.size)
+    {
+        return true;
+    }
+    
+    uint32_t newSize = MAX(minimumSize, currentBuffer.size * 2u);
+    char* newBuffer = static_cast<char*>(Memory_Alloc(newSize));
+    if (newBuffer == nullptr)
+    {
+        return false;
+    }
+    
+    memcpy(newBuffer, currentBuffer.buffer, currentBuffer.position);
+    newBuffer[currentBuffer.position] = '\0';
+    
+    if (this->dynamicTraceBuffer != nullptr)
+    {
+        Memory_Free(this->dynamicTraceBuffer, this->dynamicTraceBufferSize);
+    }
+    this->dynamicTraceBuffer = newBuffer;
+    this->dynamicTraceBufferSize = newSize;
+    
+    return true;
+}
+
+void KextLogTracer::Emit()
+{
+    if (!this->discarded)
+    {
+        this->willEmitTrace = true;
+
+        TraceBuffer currentBuffer = this->GetBuffer();
+        uint64_t index = this->GetTraceIndex();
+        KextLog("Event trace %9llu: %.*s", index, currentBuffer.position, currentBuffer.buffer);
+    }
+}
+
+void KextLogTracer::Flush()
+{
+    if (!this->discarded)
+    {
+        this->Emit();
+        TraceBuffer currentBuffer = this->GetBuffer();
+        currentBuffer.buffer[0] = '\0';
+        this->traceBufferPosition = 0;
+    }
+};
+
+KextLogTracer::KextLogTracer(kauth_action_t vnodeAction, vnode_t vnode) :
+    traceBufferPosition(0),
+    dynamicTraceBuffer(nullptr),
+    dynamicTraceBufferSize(0),
+    discarded(false),
+    willEmitTrace(false),
+    traceIndex(UINT64_MAX),
+    hasTraceIndex(false)
+{
+    this->embeddedTraceBuffer[0] = '\0';
+    
+    kauth_action_t mask = atomic_load(&KextLogTracer::traceVnodeActionFilterMask);
+    if (0 == (mask & vnodeAction))
+    {
+        this->discarded = true;
+    }
+    else
+    {
+        char vnodePath[PATH_MAX] = "";
+        if (!ShouldTraceEventsForVnode(vnode, vnodePath))
+        {
+            this->discarded = true;
+        }
+        else
+        {
+            pid_t pid = proc_selfpid();
+            char processName[MAXCOMLEN + 1] = "";
+            proc_selfname(processName, sizeof(processName));
+            if (!atomic_load(&KextLogTracer::traceCrawlerEvents) && KauthHandler_IsFileSystemCrawler(processName))
+            {
+                this->discarded = true;
+            }
+            else if (atomic_load(&KextLogTracer::traceAllVnodeEvents))
+            {
+                this->willEmitTrace = true;
+            }
+            
+            if (vnode_isdir(vnode))
+            {
+                this->Printf(
+                    "Directory vnode '%s' event by process '%s' (PID = %d) action" KextLog_DirectoryVnodeActionFormat,
+                    vnodePath,
+                    processName,
+                    pid,
+                    KextLog_DirectoryVnodeActionArgs(vnodeAction, " "));
+            }
+            else
+            {
+                this->Printf(
+                    "File vnode '%s' event by process '%s' (PID = %d) action" KextLog_FileVnodeActionFormat,
+                    vnodePath,
+                    processName,
+                    pid,
+                    KextLog_FileVnodeActionArgs(vnodeAction, " "));
+            }
+        }
+    }
+}
+    
+void KextLogTracer::SendProviderMessage(MessageType providerMessage)
+{
+    if (!this->discarded)
+    {
+        if (!this->willEmitTrace && atomic_load(&KextLogTracer::traceProviderMessagingEvents))
+        {
+            this->willEmitTrace = true;
+        }
+        this->Printf("\nMessage to provider: %u (%s)", providerMessage, Message_MessageTypeString(providerMessage));
+        
+        if (this->willEmitTrace)
+        {
+            this->Emit();
+        }
+    }
+}
+
+void KextLogTracer::SendProviderMessageResult(bool success)
+{
+    if (!this->discarded)
+    {
+        this->Printf(" -> result: %s", success ? "success" : "failed");
+    }
+}
+
+void KextLogTracer::SetVnodeOpResult(int result)
+{
+    if (this->discarded)
+    {
+        return;
+    }
+    
+    if (!this->willEmitTrace && atomic_load(&KextLogTracer::traceDeniedVnodeEvents))
+    {
+        if (result == KAUTH_RESULT_DENY)
+        {
+            this->willEmitTrace = true;
+        }
+        else
+        {
+            this->discarded = true;
+            return;
+        }
+    }
+    
+    this->Printf("\n-> %s",
+        result == KAUTH_RESULT_DENY ? "KAUTH_RESULT_DENY" :
+        result == KAUTH_RESULT_ALLOW ? "KAUTH_RESULT_ALLOW" :
+        result == KAUTH_RESULT_DEFER ? "KAUTH_RESULT_DEFER" :
+        "UNKNOWN");
+}
+
+KextLogTracer::~KextLogTracer()
+{
+    this->Flush();
+    
+    if (this->dynamicTraceBuffer != nullptr)
+    {
+        Memory_Free(this->dynamicTraceBuffer, this->dynamicTraceBufferSize);
+        this->dynamicTraceBuffer = nullptr;
+    }
+}
+    
+template <typename... ARGS>
+    void KextLogTracer::Printf(const char* format, ARGS... args)
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-security"
+    if (this->discarded)
+    {
+        return;
+    }
+    
+    TraceBuffer currentBuffer = this->GetBuffer();
+    uint32_t bufferSpace = currentBuffer.size - currentBuffer.position;
+    int sizeRequired = snprintf(currentBuffer.buffer + currentBuffer.position, bufferSpace, format, args...);
+    if (sizeRequired >= bufferSpace)
+    {
+        if (!this->GrowBuffer(sizeRequired))
+        {
+            this->traceBufferPosition = currentBuffer.size - 1;
+            return;
+        }
+        
+        currentBuffer = this->GetBuffer();
+        bufferSpace = currentBuffer.size - currentBuffer.position;
+        sizeRequired = snprintf(currentBuffer.buffer + currentBuffer.position, bufferSpace, format, args...);
+        assert(sizeRequired < bufferSpace);
+    }
+    
+    this->traceBufferPosition += sizeRequired;
+#pragma clang diagnostic pop
+}
+
+void KextLogTracer::Initialize()
+{
+    KextLogTracer::traceFilterLock = RWLock_Alloc();
+}
+
+void KextLogTracer::Cleanup()
+{
+    RWLock_FreeMemory(&KextLogTracer::traceFilterLock);
+}
+

--- a/ProjFS.Mac/PrjFSKext/KextLogEventTracer.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLogEventTracer.hpp
@@ -1,0 +1,58 @@
+#include "Locks.hpp"
+#include "public/Message.h"
+#include <sys/kernel_types.h>
+#include <sys/syslimits.h>
+
+class KextLogTracer
+{
+    bool discarded;
+    bool willEmitTrace;
+    bool hasTraceIndex;
+    char embeddedTraceBuffer[512];
+    char* dynamicTraceBuffer;
+    uint32_t dynamicTraceBufferSize;
+    uint32_t traceBufferPosition;
+    uint64_t traceIndex;
+
+public:
+    static RWLock traceFilterLock;
+    static _Atomic(char*) pathPrefixFilter;
+    static _Atomic(kauth_action_t) traceVnodeActionFilterMask;
+    static _Atomic(bool) traceDeniedVnodeEvents;
+    static _Atomic(bool) traceProviderMessagingEvents;
+    static _Atomic(bool) traceAllFileOpEvents;
+    static _Atomic(bool) traceAllVnodeEvents;
+    static _Atomic(bool) traceCrawlerEvents;
+    static _Atomic(uint64_t) nextTraceIndex;
+private:
+
+    KextLogTracer() = delete;
+    KextLogTracer(const KextLogTracer&) = delete;
+    KextLogTracer& operator=(const KextLogTracer&) = delete;
+
+    struct TraceBuffer
+    {
+        char* buffer;
+        uint32_t size, position;
+    };
+
+    static bool ShouldTraceEventsForVnode(vnode_t vnode, char (&pathBuffer)[PATH_MAX]);
+    uint64_t GetTraceIndex();
+    TraceBuffer GetBuffer();
+    bool GrowBuffer(uint32_t minimumSize);
+    void Emit();
+    void Flush();
+    
+public:
+    explicit KextLogTracer(kauth_action_t vnodeAction, vnode_t vnode);
+    void SendProviderMessage(MessageType providerMessage);
+    void SendProviderMessageResult(bool success);
+    void SetVnodeOpResult(int result);
+    ~KextLogTracer();
+
+    template <typename... ARGS>
+        void Printf(const char* format, ARGS... args);
+
+    static void Initialize();
+    static void Cleanup();
+};

--- a/ProjFS.Mac/PrjFSKext/Message_Shared.cpp
+++ b/ProjFS.Mac/PrjFSKext/Message_Shared.cpp
@@ -16,3 +16,23 @@ uint32_t Message_EncodedSize(const MessageHeader* messageHeader)
     }
     return size;
 }
+
+const char* Message_MessageTypeString(MessageType messageType)
+{
+    switch(messageType)
+    {
+        case MessageType_KtoU_EnumerateDirectory:            return "EnumerateDirectory";
+        case MessageType_KtoU_RecursivelyEnumerateDirectory: return "RecursivelyEnumerateDirectory";
+        case MessageType_KtoU_HydrateFile:                   return "HydrateFile";
+        case MessageType_KtoU_NotifyFileModified:            return "NotifyFileModified";
+        case MessageType_KtoU_NotifyFilePreDelete:           return "NotifyFilePreDelete";
+        case MessageType_KtoU_NotifyFilePreDeleteFromRename: return "NotifyFilePreDeleteFromRename";
+        case MessageType_KtoU_NotifyDirectoryPreDelete:      return "NotifyDirectoryPreDelete";
+        case MessageType_KtoU_NotifyFileCreated:             return "NotifyFileCreated";
+        case MessageType_KtoU_NotifyFileRenamed:             return "NotifyFileRenamed";
+        case MessageType_KtoU_NotifyDirectoryRenamed:        return "NotifyDirectoryRenamed";
+        case MessageType_KtoU_NotifyFileHardLinkCreated:     return "NotifyFileHardLinkCreated";
+        case MessageType_KtoU_NotifyFilePreConvertToFull:    return "NotifyFilePreConvertToFull";
+        default:                                             return "Unknown";
+    };
+}

--- a/ProjFS.Mac/PrjFSKext/PrjFSClasses.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSClasses.hpp
@@ -9,3 +9,5 @@ class PrjFSProviderUserClient;
 class PrjFSLogUserClient;
 #define PrjFSOfflineIOUserClient     org_vfsforgit_PrjFSOfflineIOUserClient
 class PrjFSOfflineIOUserClient;
+#define PrjFSEventTraceUserClient           org_vfsforgit_PrjFSEventTraceUserClient
+class PrjFSEventTraceUserClient;

--- a/ProjFS.Mac/PrjFSKext/PrjFSEventTraceUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSEventTraceUserClient.cpp
@@ -1,0 +1,101 @@
+#include "PrjFSEventTraceUserClient.hpp"
+#include "public/PrjFSEventTraceClientShared.h"
+#include "UserClientUtilities.hpp"
+#include "KauthHandler.hpp"
+#include "KextLog.hpp"
+#include <sys/syslimits.h>
+
+OSDefineMetaClassAndStructors(PrjFSEventTraceUserClient, IOUserClient);
+
+
+static const IOExternalMethodDispatch EventTraceClientDispatch[] =
+{
+    [EventTraceSelector_SetEventTracingMode] =
+        {
+            .function =                 &PrjFSEventTraceUserClient::setEventTracingMode,
+            // 0: event filtering flags (EventTraceFilterFlags)
+            // 1: kauth vnode action filter mask
+            .checkScalarInputCount =    2,
+            .checkStructureInputSize =  kIOUCVariableStructureSize, // path prefix filter string
+            .checkScalarOutputCount =   0,
+            .checkStructureOutputSize = 0,
+        },
+};
+
+
+IOReturn PrjFSEventTraceUserClient::externalMethod(
+    uint32_t selector,
+    IOExternalMethodArguments* arguments,
+    IOExternalMethodDispatch* dispatch,
+    OSObject* target,
+    void* reference)
+{
+    IOExternalMethodDispatch local_dispatch = {};
+    UserClient_ExternalMethodDispatch(this, EventTraceClientDispatch, local_dispatch, selector, dispatch, target);
+    return this->super::externalMethod(selector, arguments, dispatch, target, reference);
+}
+
+bool PrjFSEventTraceUserClient::initWithTask(task_t owningTask, void* securityToken, UInt32 type, OSDictionary* properties)
+{
+    if (!this->super::initWithTask(owningTask, securityToken, type, properties))
+    {
+        return false;
+    }
+    
+    // Only allow root user to trace events
+    if (kIOReturnSuccess != IOUserClient::clientHasPrivilege(securityToken, kIOClientPrivilegeAdministrator))
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+void PrjFSEventTraceUserClient::stop(IOService* provider)
+{
+    // Disable any active trace
+    KauthHandlerEventTracingSettings traceSettings = {};
+    KauthHandler_EnableTraceListeners(false, traceSettings);
+
+    this->super::stop(provider);
+}
+
+IOReturn PrjFSEventTraceUserClient::clientClose()
+{
+    this->terminate(0);
+    return kIOReturnSuccess;
+}
+
+IOReturn PrjFSEventTraceUserClient::setEventTracingMode(
+    OSObject* target,
+    void* reference,
+    IOExternalMethodArguments* arguments)
+{
+    // We don't support larger strings, including those large enough to warrant a memory descriptor
+    if (arguments->structureInputSize > PATH_MAX || nullptr == arguments->structureInput)
+    {
+        return kIOReturnBadArgument;
+    }
+    
+    const char* pathPrefixFilter = static_cast<const char*>(arguments->structureInput);
+    size_t pathPrefixFilterLength = strnlen(pathPrefixFilter, arguments->structureInputSize);
+    if (pathPrefixFilterLength != arguments->structureInputSize - 1u)
+    {
+        KextLog_Error("PrjFSEventTraceUserClient::setEventTracingMode: bad path prefix filter. Got %u bytes, string length %zu, expect string to fill buffer plus 1 null byte.", arguments->structureInputSize, pathPrefixFilterLength);
+        return kIOReturnBadArgument;
+    }
+
+    uint64_t traceFlags = arguments->scalarInput[0];
+    KauthHandlerEventTracingSettings traceSettings =
+        {
+            .pathPrefixFilter = pathPrefixFilter,
+            .vnodeActionFilterMask = static_cast<kauth_action_t>(arguments->scalarInput[1]),
+            .traceDeniedVnodeEvents =            (0 != (traceFlags & EventTraceFilter_Vnode_Denied)),
+            .traceProviderMessagingVnodeEvents = (0 != (traceFlags & EventTraceFilter_Vnode_ProviderMessage)),
+            .traceAllVnodeEvents =               (0 != (traceFlags & EventTraceFilter_Vnode_All)),
+            .traceCrawlerEvents =                (0 != (traceFlags & EventTraceFilter_Vnode_Crawler)),
+        };
+    
+    KauthHandler_EnableTraceListeners(traceFlags != 0, traceSettings);
+    return kIOReturnSuccess;
+}

--- a/ProjFS.Mac/PrjFSKext/PrjFSEventTraceUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSEventTraceUserClient.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "PrjFSClasses.hpp"
+#include "Locks.hpp"
+#include "public/PrjFSCommon.h"
+#include <IOKit/IOUserClient.h>
+
+class IOSharedDataQueue;
+struct KextLog_MessageHeader;
+
+class PrjFSEventTraceUserClient : public IOUserClient
+{
+    OSDeclareDefaultStructors(PrjFSEventTraceUserClient);
+private:
+    typedef IOUserClient super;
+public:
+    // External methods:
+    static IOReturn setEventTracingMode(
+        OSObject* target,
+        void* reference,
+        IOExternalMethodArguments* arguments);
+
+    // IOUserClient methods:
+    virtual bool initWithTask(task_t owningTask, void* securityToken, UInt32 type, OSDictionary* properties) override;
+    
+    virtual IOReturn clientClose() override;
+
+    virtual IOReturn externalMethod(
+        uint32_t selector,
+        IOExternalMethodArguments* arguments,
+        IOExternalMethodDispatch* dispatch = nullptr,
+        OSObject* target = nullptr,
+        void* reference = nullptr) override;
+
+    // IOService methods:
+    virtual void stop(IOService* provider) override;
+};

--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.cpp
@@ -5,6 +5,7 @@
 #include "public/PrjFSVnodeCacheHealth.h"
 #include "PerformanceTracing.hpp"
 #include "VnodeCache.hpp"
+#include "UserClientUtilities.hpp"
 #include <IOKit/IOSharedDataQueue.h>
 
 
@@ -172,15 +173,7 @@ IOReturn PrjFSLogUserClient::externalMethod(
     void* reference)
 {
     IOExternalMethodDispatch local_dispatch = {};
-    if (selector < sizeof(LogUserClientDispatch) / sizeof(LogUserClientDispatch[0]))
-    {
-        if (nullptr != LogUserClientDispatch[selector].function)
-        {
-            local_dispatch = LogUserClientDispatch[selector];
-            dispatch = &local_dispatch;
-            target = this;
-        }
-    }
+    UserClient_ExternalMethodDispatch(this, LogUserClientDispatch, local_dispatch, selector, dispatch, target);
     return this->super::externalMethod(selector, arguments, dispatch, target, reference);
 }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSLogUserClient.hpp
@@ -19,9 +19,9 @@ private:
     bool logMessageDropped;
     void cleanUp();
 public:
+    // IOUserClient methods:
     virtual bool initWithTask(task_t owningTask, void* securityToken, UInt32 type, OSDictionary* properties) override;
     
-    virtual void free() override;
     virtual IOReturn clientClose() override;
     virtual IOReturn clientMemoryForType(UInt32 type, IOOptionBits* options, IOMemoryDescriptor** memory) override;
     virtual IOReturn registerNotificationPort(mach_port_t port, UInt32 type, io_user_reference_t refCon) override;
@@ -33,7 +33,10 @@ public:
         OSObject* target = nullptr,
         void* reference = nullptr) override;
 
-    
+    // OSObject methods:
+    virtual void free() override;
+
+
     static IOReturn fetchProfilingData(
         OSObject* target,
         void* reference,

--- a/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSProviderUserClient.cpp
@@ -4,6 +4,7 @@
 #include "public/Message.h"
 #include "ProviderMessaging.hpp"
 #include "VirtualizationRoots.hpp"
+#include "UserClientUtilities.hpp"
 
 #include <IOKit/IOSharedDataQueue.h>
 #include <sys/proc.h>
@@ -193,15 +194,7 @@ IOReturn PrjFSProviderUserClient::externalMethod(
     void* reference)
 {
     IOExternalMethodDispatch local_dispatch = {};
-    if (selector < sizeof(ProviderUserClientDispatch) / sizeof(ProviderUserClientDispatch[0]))
-    {
-        if (nullptr != ProviderUserClientDispatch[selector].function)
-        {
-            local_dispatch = ProviderUserClientDispatch[selector];
-            dispatch = &local_dispatch;
-            target = this;
-        }
-    }
+    UserClient_ExternalMethodDispatch(this, ProviderUserClientDispatch, local_dispatch, selector, dispatch, target);
     return this->super::externalMethod(selector, arguments, dispatch, target, reference);
 }
 

--- a/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
+++ b/ProjFS.Mac/PrjFSKext/PrjFSService.cpp
@@ -4,8 +4,10 @@
 #include "PrjFSProviderUserClientPrivate.hpp"
 #include "PrjFSLogUserClient.hpp"
 #include "PrjFSOfflineIOUserClient.hpp"
+#include "PrjFSEventTraceUserClient.hpp"
 #include "KextLog.hpp"
 #include "VirtualizationRoots.hpp"
+#include "KauthHandler.hpp"
 
 #include <IOKit/IOLib.h>
 #include <kern/assert.h>
@@ -131,6 +133,16 @@ IOReturn PrjFSService::newUserClient(
             if (InitAttachAndStartUserClient(this, offline_io_client, owningTask, securityID, type, properties))
             {
                 *handler = offline_io_client;
+                result = kIOReturnSuccess;
+            }
+        }
+        break;
+    case UserClientType_EventTrace:
+        {
+            PrjFSEventTraceUserClient* eventTraceClient = new PrjFSEventTraceUserClient();
+            if (InitAttachAndStartUserClient(this, eventTraceClient, owningTask, securityID, type, properties))
+            {
+                *handler = eventTraceClient;
                 result = kIOReturnSuccess;
             }
         }

--- a/ProjFS.Mac/PrjFSKext/UserClientUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/UserClientUtilities.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <IOKit/IOUserClient.h>
+
+template <size_t DISPATCH_SIZE>
+void UserClient_ExternalMethodDispatch(
+    IOUserClient* self,
+    const IOExternalMethodDispatch (&dispatchTable)[DISPATCH_SIZE],
+    IOExternalMethodDispatch& local_dispatch,
+    uint32_t selector,
+    IOExternalMethodDispatch*& dispatch,
+    OSObject*& target)
+{
+    if (selector < DISPATCH_SIZE)
+    {
+        if (nullptr != dispatchTable[selector].function)
+        {
+            local_dispatch = dispatchTable[selector];
+            dispatch = &local_dispatch;
+            target = self;
+        }
+    }
+}

--- a/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
+++ b/ProjFS.Mac/PrjFSKext/kernel-header-wrappers/stdatomic.h
@@ -11,6 +11,7 @@ using std::memory_order_relaxed;
 using std::atomic_store_explicit;
 using std::atomic_exchange_explicit;
 using std::atomic_fetch_add_explicit;
+using std::atomic_load;
 #else
 #include <stdatomic.h>
 #endif

--- a/ProjFS.Mac/PrjFSKext/public/Message.h
+++ b/ProjFS.Mac/PrjFSKext/public/Message.h
@@ -70,5 +70,6 @@ struct Message
 
 
 uint32_t Message_EncodedSize(const MessageHeader* messageHeader);
+const char* Message_MessageTypeString(MessageType messageType);
 
 #endif /* Message_h */

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSCommon.h
@@ -14,6 +14,8 @@
 // Name of property on the main PrjFS IOService indicating the kext version, to be checked by user space
 #define PrjFSKextVersionKey "org.vfsforgit.PrjFSKext.Version"
 
+#define PrjFSEventTracingKey "org.vfsforgit.PrjFSKext.EventTracing"
+
 #define PrjFSProviderPathKey "org.vfsforgit.PrjFSKext.ProviderUserClient.Path"
 
 typedef enum
@@ -33,6 +35,7 @@ enum PrjFSServiceUserClientType
     UserClientType_Provider,
     UserClientType_Log,
     UserClientType_OfflineIO,
+    UserClientType_EventTrace,
 };
 
 // When building the kext in user space for unit testing, we want some functions
@@ -45,6 +48,8 @@ enum PrjFSServiceUserClientType
 #define KEXT_STATIC_INLINE static inline
 #endif
 
+#ifdef __cplusplus
+
 namespace PrjFSDarwinMajorVersion
 {
     enum
@@ -54,5 +59,7 @@ namespace PrjFSDarwinMajorVersion
         MacOS10_15_Catalina = 19,
     };
 }
+
+#endif
 
 #endif /* PrjFSCommon_h */

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSEventTraceClientShared.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSEventTraceClientShared.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+// External method selectors for event trace user clients
+enum PrjFSEventTraceUserClientSelector
+{
+    EventTraceSelector_Invalid = 0,
+	
+    EventTraceSelector_SetEventTracingMode,
+};
+
+enum EventTraceFilterFlags : uint64_t
+{
+    EventTraceFilter_Vnode_Denied = 0x1,
+    EventTraceFilter_Vnode_ProviderMessage = 0x2,
+    EventTraceFilter_Vnode_All = 0x4,
+    EventTraceFilter_Vnode_Crawler = 0x8,
+
+    // TODO(Mac): Add fileop trace modes
+};

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -51,15 +51,15 @@ using std::string;
 }
 
 - (void)testIsFileSystemCrawler {
-    XCTAssertTrue(IsFileSystemCrawler("mds"));
-    XCTAssertTrue(IsFileSystemCrawler("mdworker"));
-    XCTAssertTrue(IsFileSystemCrawler("mdworker_shared"));
-    XCTAssertTrue(IsFileSystemCrawler("mds_stores"));
-    XCTAssertTrue(IsFileSystemCrawler("fseventsd"));
-    XCTAssertTrue(IsFileSystemCrawler("Spotlight"));
-    XCTAssertFalse(IsFileSystemCrawler("mds_"));
-    XCTAssertFalse(IsFileSystemCrawler("spotlight"));
-    XCTAssertFalse(IsFileSystemCrawler("git"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("mds"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("mdworker"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("mdworker_shared"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("mds_stores"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("fseventsd"));
+    XCTAssertTrue(KauthHandler_IsFileSystemCrawler("Spotlight"));
+    XCTAssertFalse(KauthHandler_IsFileSystemCrawler("mds_"));
+    XCTAssertFalse(KauthHandler_IsFileSystemCrawler("spotlight"));
+    XCTAssertFalse(KauthHandler_IsFileSystemCrawler("git"));
 }
 
 - (void)testFileFlagsBitIsSet {

--- a/ProjFS.Mac/Scripts/Build.sh
+++ b/ProjFS.Mac/Scripts/Build.sh
@@ -95,7 +95,11 @@ while read line; do
 	 [[ $line != *"vnode_lookup"* ]] && 
 	 [[ $line != *"RetainIOCount"* ]] && 
 	 [[ $line != *"ProviderMessaging_"* ]] && 
-	 [[ $line != *"RWLock_DropExclusiveToShared"* ]] && 
+	 [[ $line != *"RWLock_DropExclusiveToShared"* ]] &&
+	 [[ $line != *"MessageTypeString"* ]] &&
+	 [[ $line != *"KauthHandler_EnableTraceListeners"* ]] &&
+	 [[ $line != *"NullTracer::"* ]] &&
+	 [[ $line != *"KextLogTracer::"* ]] &&
       # Not going down the "unexpected" code path in isKextAssertionFailureExpected, Assert & panic is good!
 	 [[ $line != *"PFSKextTestCase isKextAssertionFailureExpected"* ]] &&
 	 [[ $line != *"Assert"* ]] &&

--- a/ProjFS.Mac/prjfs-tracectl/prjfs-tracectl.cpp
+++ b/ProjFS.Mac/prjfs-tracectl/prjfs-tracectl.cpp
@@ -1,0 +1,157 @@
+#include <IOKit/IOKitLib.h>
+#include <cstdio>
+#include "../PrjFSKext/public/PrjFSCommon.h"
+#include "../PrjFSKext/public/PrjFSEventTraceClientShared.h"
+#include "../PrjFSLib/PrjFSUser.hpp"
+#include <unistd.h>
+#include <getopt.h>
+#include <cstdlib>
+#include <type_traits>
+
+using std::strtoul;
+using std::fprintf;
+using std::extent;
+
+struct EventTraceSettings
+{
+    const char* pathFilterString;
+    uint64_t filterFlags;
+    uint64_t vnodeActionMask;
+};
+
+static bool GenerateEventTracingSettings(int argc, char* argv[], EventTraceSettings& outSettings)
+{
+    const char* pathFilterString = NULL;
+    int tracingEnabled = 0, tracingDisabled = 0;
+    uint32_t vnodeActionFilter = UINT32_MAX;
+    int traceAllVnodeEvents = 0, traceDeniedVnodeEvents = 0, traceProviderMessagingEvents = 0, traceCrawlerEvents = 0;
+    int traceAllFileopEvents = 0;
+
+    int ch;
+
+    struct option longopts[] = {
+         { "enable",               no_argument,            &tracingEnabled,  1 },
+         { "disable",              no_argument,            &tracingDisabled, 1 },
+         { "vnode-events-denied",  no_argument,            &traceDeniedVnodeEvents, 1 },
+         { "vnode-message-events", no_argument,            &traceProviderMessagingEvents, 1 },
+         { "vnode-crawler-events", no_argument,            &traceCrawlerEvents, 1 },
+         { "vnode-all-events",     no_argument,            &traceAllVnodeEvents, 1 },
+         { "fileop-all-events",    no_argument,            &traceAllFileopEvents, 1 },
+         { "path-filter",          required_argument,      NULL,             'p' },
+         { "vnode-action-filter",  required_argument,      NULL,             'a' },
+         { NULL,                   0,                      NULL,             0 }
+    };
+
+    while ((ch = getopt_long(argc, argv, "bf:", longopts, NULL)) != -1)
+    {
+        switch (ch)
+        {
+        case 'a':
+            {
+                char* end = NULL;
+                unsigned long filter = strtoul(optarg, &end, 16 /* base */);
+                if (end != optarg && end != NULL && filter <= UINT32_MAX)
+                {
+                    vnodeActionFilter = (uint32_t)filter;
+                }
+                else
+                {
+                    fprintf(stderr, "--vnode-action-filter: Bad filter mask value, must be in range 0-ffffffff");
+                    return false;
+                }
+            }
+            
+            break;
+        case 'p':
+            if (pathFilterString != NULL)
+            {
+                fprintf(stderr, "--path-filter: Currently only one path filter is supported\n");
+                return false;
+            }
+            
+            pathFilterString = optarg;
+            
+            break;
+        case 0:
+            printf("Processing argument %s\n", argv[optind]);
+            break;
+        default:
+            fprintf(stderr, "TODO: %u\n", ch);
+            return false;
+        }
+    }
+    
+    if ((tracingEnabled ^ tracingDisabled) == 0)
+    {
+        fprintf(stderr, "Must use exactly one of --enable or --disable");
+        return false;
+    }
+    else if (pathFilterString == NULL)
+    {
+        fprintf(stderr, "--path-filter is required");
+        return false;
+    }
+    else if (tracingEnabled && !(traceAllVnodeEvents || traceDeniedVnodeEvents || traceProviderMessagingEvents))
+    {
+        fprintf(stderr, "Warning: tracing enabled, but no base vnode event filter selected, this means no events will be traced.\n");
+    }
+
+    if (tracingDisabled)
+    {
+        if (pathFilterString != NULL)
+        {
+            CFRelease(pathFilterString);
+        }
+        outSettings = EventTraceSettings{ "", 0, 0 };
+        return true;
+    }
+    else
+    {
+        outSettings = EventTraceSettings
+            {
+                pathFilterString,
+                ((traceCrawlerEvents           ? EventTraceFilter_Vnode_Crawler         : 0) |
+                 (traceDeniedVnodeEvents       ? EventTraceFilter_Vnode_Denied          : 0) |
+                 (traceProviderMessagingEvents ? EventTraceFilter_Vnode_ProviderMessage : 0) |
+                 (traceAllVnodeEvents          ? EventTraceFilter_Vnode_All             : 0)),
+                vnodeActionFilter
+            };
+        return true;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    EventTraceSettings traceSettings = {};
+    if (!GenerateEventTracingSettings(argc, argv, traceSettings))
+    {
+        fprintf(stderr, "Failed to generate tracing settings\n");
+        return 1;
+    }
+
+    io_connect_t eventTraceConnection = PrjFSService_ConnectToDriver(UserClientType_EventTrace);
+    if (eventTraceConnection == IO_OBJECT_NULL)
+    {
+        fprintf(stderr, "Connecting to PrjFS Service failed.\n");
+        return 1;
+    }
+    
+    uint64_t scalarInputs[] = { traceSettings.filterFlags, traceSettings.vnodeActionMask };
+    IOReturn result = IOConnectCallMethod(
+        eventTraceConnection, EventTraceSelector_SetEventTracingMode,
+        scalarInputs, extent<decltype(scalarInputs)>::value,
+        traceSettings.pathFilterString, strlen(traceSettings.pathFilterString) + 1,
+        nullptr, nullptr,
+        nullptr, nullptr);
+    if (result != kIOReturnSuccess)
+    {
+        fprintf(stderr, "SetEventTracingMode call failed: 0x%x.\n", result);
+        return 1;
+    }
+    
+    CFRunLoopRun();
+    
+    IOServiceClose(eventTraceConnection);
+    
+    return 0;
+}


### PR DESCRIPTION
This is an early draft of my implementation of #1437 - event-level logging that can be turned on on demand.

The current approach is as follows:

 * When enabled, events are logged to the KextLog mechanism. Currently vnode listener events only, FILEOP is still TODO.
 * To avoid any runtime overhead when disabled, I've moved the code from `HandleVnodeOperation` into a templated function; the tracing calls *should* (I will verify this in due course) compile away to nothing when instantiated with the `NullTracer`. When tracing is enabled, the `KextLogTracer` instance of the template is used, in which the tracing calls actually do something and of course have a runtime overhead. Doing it this way avoids the need to have 2 versions of the kext or any such nonsense.
 * There is a new tool `prjfs-tracectl` which toggles this feature on or off with `--enable` or `--disable`. When enabling, other options control what is traced:
 * You must filter by path prefix using `--path-filter=/Users/test/devel/Adium4/` for example. If you want all files' events, set `/` as the filter. Note that globs are not supported, but `--path-filter=/Users/test/devel/Adium` (no trailing slash!) will match `/Users/test/devel/Adium1/`, `/Users/test/devel/Adium2/` and so on too.
 * You can also set a bitmask of VNODE actions using `--vnode-action-filter=<some-hex-value>` and only vnode events which bitwise AND with that mask to something nonzero will be logged.
 * `--vnode-message-events` turns on logging for any events that caused a message to be sent to the provider
 * `--vnode-events-denied turns on logging of anything which returned KAUTH_RESULT_DENY`
 * those 2 can be combined to log any event that either has a side effect via a message or caused an action to be denied.
 * Alternatively, `--vnode-all-events` will log any vnode event, even if it was a DEFER and didn't send a message

Log entries look something like this:
```
Event trace        11: Directory vnode '/Users/test/devel/Adium4/src/ASUnitTests' event by process 'bash' (PID = 616) action KAUTH_VNODE_READ_ATTRIBUTES KAUTH_VNODE_READ_SECURITY
Message to provider: 2 (RecursivelyEnumerateDirectory)
```
The above message is logged *before* the message is sent to the provider. Once it returns and the listener callback completes, you get:

```
Event trace        11: Directory vnode '/Users/test/devel/Adium4/src/ASUnitTests' event by process 'bash' (PID = 616) action KAUTH_VNODE_READ_ATTRIBUTES KAUTH_VNODE_READ_SECURITY
Message to provider: 2 (RecursivelyEnumerateDirectory) -> result: success
-> KAUTH_RESULT_DEFER
```

Note the index, so you can match them up and spot if the provider is taking a long time or not responding.


Things I would add if we like the broad approach:

 * Give the fileop handler the same treatment.
 * Try to add information for the *reason* why a vnode event was denied and the vnode or event metadata that led to the decision. Unfortunately the handler code is structured in a way that makes this difficult to do with zero runtime overhead when disabled (a lot of decisions are made in helper functions), so I'm probably going to have to compromise on level of detail or do some refactoring after all.
 * Require root privileges, or at minimum, membership of the "admin" group, for `prjfs-tracectl`. Only admins should be able to turn this on as it will log other users' file I/O metadata.
 * Add usage instructions in a `--help` mode for `prjfs-tracectl`

Note that the code still very much needs cleaning up (I need to move the tracers to a different file for example), so I'm definitely not interested in feedback on code style, organisation, etc. I **am** interested in feedback on:

 1. The UX of enabling/disabling the feature and the filtering options.
 2. The style of logging the events to the KextLog facility.
 3. Whether you like the general approach for inserting log statements using a template.