### PR TITLE
Mac ProjFS Kext: Block renames of projected directories

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -16,6 +16,9 @@
         public const string MacOnly = "MacOnly";
         public const string POSIXOnly = "POSIXOnly";
 
+        public const string PartialFolderRenamesAllowed = "PartialFolderRenamesAllowed";
+        public const string PartialFolderRenamesBlocked = "PartialFolderRenamesBlocked";
+
         public static class MacTODO
         {
             // Tests that require #360 (detecting/handling new empty folders)

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -39,6 +39,11 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             "Resource temporarily unavailable"
         };
 
+        private static string[] macOperationNotSupportedMessage = new string[]
+        {
+            "Operation not supported"
+        };
+
         private readonly string pathToBash;
 
         public BashRunner()
@@ -225,7 +230,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
 
         public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
         {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(moveDirectoryNotSupportedMessage);
+            string[] expectedErrorMessage = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? macOperationNotSupportedMessage : moveDirectoryNotSupportedMessage;
+            this.MoveFile(sourcePath, targetPath).ShouldContain(expectedErrorMessage);
         }
 
         public override void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath)

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -108,12 +108,23 @@ namespace GVFS.FunctionalTests
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);
+
+                // Darwin 18 is macOS 10.14. Don't run tests expecting allowed directory renames
+                if (Environment.OSVersion.Version.Major >= 18)
+                {
+                    excludeCategories.Add(Categories.PartialFolderRenamesAllowed);
+                }
+                else
+                {
+                    excludeCategories.Add(Categories.PartialFolderRenamesBlocked);
+                }
             }
             else
             {
                 // Windows excludes.
                 excludeCategories.Add(Categories.MacOnly);
                 excludeCategories.Add(Categories.POSIXOnly);
+                excludeCategories.Add(Categories.PartialFolderRenamesAllowed);
             }
 
             GVFSTestConfig.DotGVFSRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ".vfsforgit" : ".gvfs";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -40,15 +40,16 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.fileSystem = fileSystem;
         }
 
-        // WindowsOnly because renames of partial folders are blocked only on Windows
+        // Test applies only on platforms where renaming partial folders is blocked
         [TestCase]
-        [Category(Categories.WindowsOnly)]
+        [Category(Categories.PartialFolderRenamesBlocked)]
         public void RenameFolderShouldFail()
         {
             string testFileName = "RenameFolderShouldFail.cpp";
             string oldFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "RenameFolderShouldFail", "source");
             string newFolderName = Path.Combine("Test_EPF_MoveRenameFolderTests", "RenameFolderShouldFail", "sourcerenamed");
             this.Enlistment.GetVirtualPathTo(newFolderName).ShouldNotExistOnDisk(this.fileSystem);
+            this.Enlistment.GetVirtualPathTo(oldFolderName).ShouldBeADirectory(this.fileSystem);
 
             this.fileSystem.MoveDirectory_RequestShouldNotBeSupported(this.Enlistment.GetVirtualPathTo(oldFolderName), this.Enlistment.GetVirtualPathTo(newFolderName));
 
@@ -59,9 +60,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(oldFolderName, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void ChangeUnhydratedFolderName()
         {
             string testFileName = "ChangeUnhydratedFolderName.cpp";
@@ -78,9 +79,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(newFolderName, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveUnhydratedFolderToNewFolder()
         {
             string testFileName = "MoveUnhydratedFolderToVirtualNTFSFolder.cpp";
@@ -101,9 +102,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(movedFolderPath, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveUnhydratedFolderToFullFolderInDotGitFolder()
         {
             string testFileName = "MoveUnhydratedFolderToFullFolderInDotGitFolder.cpp";
@@ -151,9 +152,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             Path.Combine(movedFolderPath, testFileName).ShouldBeAFile(this.fileSystem).WithContents(fileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveAndRenameUnhydratedFolderToNewFolder()
         {
             string testFileName = "MoveAndRenameUnhydratedFolderToNewFolder.cpp";
@@ -174,9 +175,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(movedFolderPath, testFileName)).ShouldBeAFile(this.fileSystem).WithContents(TestFileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveFolderWithUnhydratedAndFullContents()
         {
             string testFileName = "MoveFolderWithUnhydratedAndFullContents.cpp";
@@ -206,9 +207,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.Enlistment.GetVirtualPathTo(Path.Combine(movedFolderPath, newFile)).ShouldBeAFile(this.fileSystem).WithContents(newFileContents);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveFolderWithUnexpandedChildFolders()
         {
             string oldFolderPath = this.Enlistment.GetVirtualPathTo("Test_EPF_MoveRenameFileTests");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/CaseOnlyFolderRenameTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/CaseOnlyFolderRenameTests.cs
@@ -17,9 +17,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerTestCase
             this.fileSystem = new BashRunner();
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void CaseRenameFoldersAndRemountAndRenameAgain()
         {
             // Projected folder without a physical folder

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -554,9 +554,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.RenameFile);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Test applies only to platforms where renaming partial folders is allowed
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.PartialFolderRenamesAllowed)]
         public void MoveFolderCommitChangesSwitchBranchSwitchBackTest()
         {
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.MoveFolder);

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -139,7 +139,7 @@ namespace GVFS.Platform.Mac
 
         public override FileSystemResult WritePlaceholderDirectory(string relativePath)
         {
-            Result result = this.virtualizationInstance.WritePlaceholderDirectory(relativePath);
+            Result result = this.virtualizationInstance.WritePlaceholderDirectory(relativePath, PlaceholderVersionId);
             return new FileSystemResult(ResultToFSResult(result), unchecked((int)result));
         }
 

--- a/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Mac/MockVirtualizationInstance.cs
@@ -68,7 +68,8 @@ namespace GVFS.UnitTests.Mock.Mac
         }
 
         public override Result WritePlaceholderDirectory(
-            string relativePath)
+            string relativePath,
+            byte[] providerId)
         {
             throw new NotImplementedException();
         }

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -70,7 +70,7 @@ namespace MirrorProvider.Mac
                     if (child.Type == ProjectedFileInfo.FileType.Directory)
                     {
                         Result result = this.virtualizationInstance.WritePlaceholderDirectory(
-                            Path.Combine(relativePath, child.Name));
+                            Path.Combine(relativePath, child.Name), ToVersionIdByteArray(1));
 
                         if (result != Result.Success)
                         {

--- a/ProjFS.Mac/PrjFSKext/public/PrjFSXattrs.h
+++ b/ProjFS.Mac/PrjFSKext/public/PrjFSXattrs.h
@@ -6,6 +6,7 @@
 // TODO: Issue #584, update xattr names
 #define PrjFSVirtualizationRootXAttrName "org.vfsforgit.xattr.virtualizationroot"
 #define PrjFSFileXAttrName "org.vfsforgit.xattr.file"
+#define PrjFSDirectoryXAttrName "org.vfsforgit.xattr.directory"
 
 #define PrjFS_PlaceholderIdLength 128
 
@@ -29,4 +30,11 @@ struct PrjFSFileXAttrData
     
     unsigned char providerId[PrjFS_PlaceholderIdLength];
     unsigned char contentId[PrjFS_PlaceholderIdLength];
+};
+
+struct PrjFSDirectoryXAttrData
+{
+    PrjFSXattrHeader header;
+
+    unsigned char providerId[PrjFS_PlaceholderIdLength];
 };

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/Interop/PrjFSLib.cs
@@ -20,7 +20,9 @@ namespace PrjFSLib.Mac.Interop
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderDirectory")]
         public static extern Result WritePlaceholderDirectory(
-            string relativePath);
+            string relativePath,
+            [MarshalAs(UnmanagedType.LPArray, SizeConst = PlaceholderIdLength)]
+            byte[] providerId);
 
         [DllImport(PrjFSLibPath, EntryPoint = "PrjFS_WritePlaceholderFile")]
         public static extern Result WritePlaceholderFile(

--- a/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
+++ b/ProjFS.Mac/PrjFSLib.Mac.Managed/VirtualizationInstance.cs
@@ -89,9 +89,15 @@ namespace PrjFSLib.Mac
         }
 
         public virtual Result WritePlaceholderDirectory(
-            string relativePath)
+            string relativePath,
+            byte[] providerId)
         {
-            return Interop.PrjFSLib.WritePlaceholderDirectory(relativePath);
+            if (providerId.Length != Interop.PrjFSLib.PlaceholderIdLength)
+            {
+                throw new ArgumentException();
+            }
+
+            return Interop.PrjFSLib.WritePlaceholderDirectory(relativePath, providerId);
         }
 
         public virtual Result WritePlaceholderFile(

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -364,7 +364,8 @@ PrjFS_Result PrjFS_ConvertDirectoryToVirtualizationRoot(
 }
 
 PrjFS_Result PrjFS_WritePlaceholderDirectory(
-    _In_    const char*                             relativePath)
+    _In_    const char*                             relativePath,
+    _In_    unsigned char                           providerId[PrjFS_PlaceholderIdLength])
 {
 #ifdef DEBUG
     cout
@@ -398,11 +399,15 @@ PrjFS_Result PrjFS_WritePlaceholderDirectory(
         
         goto CleanupAndFail;
     }
-    
-    if (!InitializeEmptyPlaceholder(fullPath))
+
     {
-        result = PrjFS_Result_EIOError;
-        goto CleanupAndFail;
+        PrjFSDirectoryXAttrData directoryXattrData = {};
+        memcpy(directoryXattrData.providerId, providerId, sizeof(directoryXattrData.providerId));
+        if (!InitializeEmptyPlaceholder(fullPath, &directoryXattrData, PrjFSDirectoryXAttrName))
+        {
+            result = PrjFS_Result_EIOError;
+            goto CleanupAndFail;
+        }
     }
     
     return PrjFS_Result_Success;

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.h
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.h
@@ -79,7 +79,8 @@ PrjFS_Result PrjFS_ConvertDirectoryToPlaceholder(
     _In_    const char*                             relativePath);
 
 extern "C" PrjFS_Result PrjFS_WritePlaceholderDirectory(
-    _In_    const char*                             relativePath);
+    _In_    const char*                             relativePath,
+    _In_    unsigned char                           providerId[PrjFS_PlaceholderIdLength]);
 
 extern "C" PrjFS_Result PrjFS_WritePlaceholderFile(
     _In_    const char*                             relativePath,


### PR DESCRIPTION
This is an implementation of #515, blocking renames of projected folders.

Making this work involves 2 changes:

 * To distinguish between user-created directories and projected directories, the latter are tagged with a new xattr at the placeholder creation stage.
 * When a delete authorisation is received and can be reliably identified as a rename operation (macOS Mojave and newer), the directory's xattr is checked, and if present, it must be a projected directory, and the delete can therefore be blocked.

Note that blocking will not work for directories which were enumerated by a provider built prior to this change due to the missing xattr; in this case, the behaviour will simply revert to the original code's and force a recursive enumeration.