### PR TITLE
Better installer logs

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -98,6 +98,7 @@ namespace GVFS.Common
             public const string Sparse = "sparse";
             public const string UpgradeVerb = UpgradePrefix + "_verb";
             public const string UpgradeProcess = UpgradePrefix + "_process";
+            public const string UpgradeSystemInstaller = UpgradePrefix + "_system_installer";
         }
 
         public static class DotGVFS

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -109,12 +109,13 @@ namespace GVFS.Common
         public static string GetNewGVFSLogFileName(
             string logsRoot,
             string logFileType,
+            string logId = null,
             PhysicalFileSystem fileSystem = null)
         {
             return Enlistment.GetNewLogFileName(
                 logsRoot,
                 "gvfs_" + logFileType,
-                logId: null,
+                logId: logId,
                 fileSystem: fileSystem);
         }
 

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -29,6 +29,11 @@ namespace GVFS.Common
 
         public abstract string GVFSConfigPath { get; }
 
+        /// <summary>
+        /// Returns true if the platform keeps a system-wide installer log.
+        /// </summary>
+        public abstract bool SupportsSystemInstallLog { get; }
+
         public static void Register(GVFSPlatform platform)
         {
             if (GVFSPlatform.Instance != null)
@@ -86,6 +91,7 @@ namespace GVFS.Common
         /// containing directory to place them in.
         /// </summary>
         public abstract string GetUpgradeLogDirectoryParentDirectory();
+        public abstract string GetSystemInstallerLogPath();
 
         /// <summary>
         /// Directory that contains the file indicating that a new

--- a/GVFS/GVFS.Installer.Mac/scripts/postinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/postinstall
@@ -56,7 +56,7 @@ declare -a launchAgents=(
     "org.vfsforgit.usernotification"
     "org.vfsforgit.service"
 )
-for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+for uid in $(ps -Ac -o uid,command | grep -iw "Finder" | awk '{print $1}'); do
     for nextLaunchAgent in "${launchAgents[@]}"; do
         startOrRestartService "gui/$uid" $nextLaunchAgent
     done

--- a/GVFS/GVFS.Notifications/VFSForGit.Mac/org.vfsforgit.usernotification.plist
+++ b/GVFS/GVFS.Notifications/VFSForGit.Mac/org.vfsforgit.usernotification.plist
@@ -24,6 +24,8 @@
         <string>/usr/local/vfsforgit</string>
         <key>ProcessType</key>
         <string>Interactive</string>
+        <key>LimitLoadToSessionType</key>
+        <string>Aqua</string>
         <key>Disabled</key>
         <false/>
         <key>OnDemand</key>

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -17,6 +17,7 @@ namespace GVFS.Platform.Mac
         private const string UpgradeProtectedDataDirectory = "/usr/local/vfsforgit_upgrader";
         private const string DiagnosticReportsDirectory = "/Library/Logs/DiagnosticReports";
         private const string PanicFileNamePattern = "*panic";
+        private const string SystemInstallerLogPath = "/var/log/install.log";
 
         public MacPlatform() : base(
              underConstruction: new UnderConstructionFlags(
@@ -37,6 +38,19 @@ namespace GVFS.Platform.Mac
             get
             {
                 return Path.Combine(this.Constants.GVFSBinDirectoryPath, LocalGVFSConfig.FileName);
+            }
+        }
+
+        /// <summary>
+        /// On the Mac VFSForGit installer messages get captured in the system
+        /// wide installer log file. There is no customized log file specific
+        /// to VFSForGit installer.
+        /// </summary>
+        public override bool SupportsSystemInstallLog
+        {
+            get
+            {
+                return true;
             }
         }
 
@@ -92,6 +106,11 @@ namespace GVFS.Platform.Mac
         public override string GetUpgradeLogDirectoryParentDirectory()
         {
             return this.GetUpgradeNonProtectedDataDirectory();
+        }
+
+        public override string GetSystemInstallerLogPath()
+        {
+            return SystemInstallerLogPath;
         }
 
         public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly)

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -47,6 +47,19 @@ namespace GVFS.Platform.Windows
             }
         }
 
+        /// <summary>
+        /// On Windows VFSForGit does not need to use system wide logs to track
+        /// installer messages. VFSForGit is able to specifiy a custom installer
+        /// log file as a commandline argument to the installer.
+        /// </summary>
+        public override bool SupportsSystemInstallLog
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public static string GetStringFromRegistry(string key, string valueName)
         {
             object value = GetValueFromRegistry(RegistryHive.LocalMachine, key, valueName);
@@ -340,6 +353,11 @@ namespace GVFS.Platform.Windows
         public override string GetUpgradeLogDirectoryParentDirectory()
         {
             return this.GetUpgradeProtectedDataDirectory();
+        }
+
+        public override string GetSystemInstallerLogPath()
+        {
+            return null;
         }
 
         public override string GetUpgradeHighestAvailableVersionDirectory()

--- a/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
+++ b/GVFS/GVFS.Service/Mac/org.vfsforgit.service.plist
@@ -24,6 +24,8 @@
     <string>/usr/local/vfsforgit</string>
     <key>ProcessType</key>
     <string>Interactive</string>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
     <key>Disabled</key>
     <false/>
     <key>OnDemand</key>

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -31,6 +31,14 @@ namespace GVFS.UnitTests.Mock.Common
 
         public override string GVFSConfigPath { get => Path.Combine("mock:", LocalGVFSConfig.FileName); }
 
+        public override bool SupportsSystemInstallLog
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public override GVFSPlatformConstants Constants { get; } = new MockPlatformConstants();
 
         public HashSet<int> ActiveProcesses { get; } = new HashSet<int>();
@@ -111,6 +119,11 @@ namespace GVFS.UnitTests.Mock.Common
         public override string GetUpgradeLogDirectoryParentDirectory()
         {
             return this.GetUpgradeProtectedDataDirectory();
+        }
+
+        public override string GetSystemInstallerLogPath()
+        {
+            return "MockPath";
         }
 
         public override string GetUpgradeHighestAvailableVersionDirectory()

--- a/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
+++ b/GVFS/GVFS.Upgrader/UpgradeOrchestrator.cs
@@ -1,4 +1,4 @@
-using GVFS.Common;
+﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Tracing;
@@ -165,7 +165,8 @@ namespace GVFS.Upgrader
             string logFilePath = GVFSEnlistment.GetNewGVFSLogFileName(
                 this.logDirectory,
                 GVFSConstants.LogFileTypes.UpgradeProcess,
-                this.fileSystem);
+                logId: null,
+                fileSystem: this.fileSystem);
 
             JsonTracer jsonTracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "UpgradeProcess");
 


### PR DESCRIPTION
#### Fix mac installer/upgrader failure

VFSForGit installer fails in postinstall script while trying to launch Service and UserNotification agents in GUI context of logged in users. To determine users logged into the GUI context, postinstall script looks for loginwindow commands and the user running the command. When Fast User switching is enabled, then loginwindow can be running as root user, even though root user is Not logged in. In such cases, postinstall tries to launch Service and UserNotifcation agents in GUI context of root user (that does not exist) resulting in failure. This commit makes
postinstall look for Finder command (which only runs after a user has successfully logged into GUI context and is therefore more reliably associated with GUI session) rather than
loginwindow.

Also Updated launchd plist for Service and Notification agents, added LimitLoadToSessionType = Aqua, just to make sure the agents get launched into the GUI context only.

#### [macOS] Capture installer log on upgrade failure
- Save last 100KB of /var/log/installer.log immediately after  an upgrade failure.
- Installer logs would be available through `gvfs diagnose`.
- Added new platform property SupportsSystemInstallLog. This will be  set to true for Platforms(macOS) that keep system wide installer log (vs custom logs specific to VFSForGit installer package).

#### Steps to repro mac installer/upgrader failure issue - 
1. Click on "Login Window..." item from "FastUser Switching" menu.
<img width="475" alt="Screen Shot 2019-08-28 at 1 49 46 PM" src="https://user-images.githubusercontent.com/378580/63880103-0efbaf00-c99b-11e9-89ba-c0ba250cd656.png">

2. A login window prompting for user credentials would appear. Login as the same user you were logged-in as in step 1.
3. Now there will be a `loginwindow` process running as `root` - even though no `root` user is logged in.
<img width="817" alt="Screen Shot 2019-08-28 at 1 52 52 PM" src="https://user-images.githubusercontent.com/378580/63880155-2c307d80-c99b-11e9-95e5-349c633e71e4.png">

4. Now run `VFSForGit` installer manually or run `sudo gvfs upgrade --confirm --no-verify` and notice that the installation fails in the `postinstall` script, while trying to auto-launch `VFSForGit` services for `root` user.

#### References 
- [ Login sessions](https://developer.apple.com/library/archive/technotes/tn2083/_index.html#//apple_ref/doc/uid/DTS10003794-CH1-SUBSECTION3)

Fixes #1444