### PR TITLE
Add a global setup class when using a --test= option

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -15,6 +15,7 @@ namespace GVFS.FunctionalTests
         {
             Properties.Settings.Default.Initialize();
             NUnitRunner runner = new NUnitRunner(args);
+            runner.AddGlobalSetupIfNeeded("GVFS.FunctionalTests.GlobalSetup");
 
             if (runner.HasCustomArg("--no-shared-gvfs-cache"))
             {

--- a/GVFS/GVFS.Tests/NUnitRunner.cs
+++ b/GVFS/GVFS.Tests/NUnitRunner.cs
@@ -33,6 +33,15 @@ namespace GVFS.Tests
             return this.args.Remove(arg);
         }
 
+        public void AddGlobalSetupIfNeeded(string globalSetup)
+        {
+            // If there are any test filters, the GlobalSetup still needs to run so add it.
+            if (this.args.Any(x => x.StartsWith("--test=")))
+            {
+                this.args.Add($"--test={globalSetup}");
+            }
+        }
+
         public int RunTests(ICollection<string> includeCategories, ICollection<string> excludeCategories)
         {
             string filters = GetFiltersArgument(includeCategories, excludeCategories);

--- a/GVFS/GVFS.UnitTests/Program.cs
+++ b/GVFS/GVFS.UnitTests/Program.cs
@@ -11,6 +11,7 @@ namespace GVFS.UnitTests
         public static void Main(string[] args)
         {
             NUnitRunner runner = new NUnitRunner(args);
+            runner.AddGlobalSetupIfNeeded("GVFS.UnitTests.Setup");
 
             List<string> excludeCategories = new List<string>();
 


### PR DESCRIPTION
When using the `--test=` option for filtering the tests that run, the `GlobalSetup` also gets filtered out and does not run.  The issue this causes is that the `GVFS.Service` doesn't get uninstalled and there are files that don't get copied like `gvfs.exe` and `gvfs.mount.exe` for subsequent runs of the functional tests.

This change will add the `GlobalSetup` to the tests if there is a `--test=` option passed.