### PR TITLE
Enabling Service verb Functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -20,9 +20,6 @@
             // Tests that require Config to be built
             public const string NeedsGVFSConfig = "NeedsConfig";
 
-            // Tests that require VFS Service
-            public const string NeedsServiceVerb = "NeedsServiceVerb";
-
             // Tests requires code updates so that we lock the file instead of looking for a .lock file
             public const string TestNeedsToLockFile = "TestNeedsToLockFile";
         }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -104,7 +104,6 @@ namespace GVFS.FunctionalTests
             {
                 excludeCategories.Add(Categories.MacTODO.NeedsNewFolderCreateNotification);
                 excludeCategories.Add(Categories.MacTODO.NeedsGVFSConfig);
-                excludeCategories.Add(Categories.MacTODO.NeedsServiceVerb);
                 excludeCategories.Add(Categories.MacTODO.NeedsStatusCache);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
@@ -7,7 +7,6 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.ExtraCoverage)]
-    [Category(Categories.MacTODO.NeedsServiceVerb)]
     public class ServiceVerbTests : TestsWithMultiEnlistment
     {
         private static readonly string[] EmptyRepoList = new string[] { };

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -80,7 +80,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsServiceVerb)]
+        [Category(Categories.MacTODO.TestNeedsToLockFile)]
         public void CloneCleansUpStaleMetadataLock()
         {
             GVFSFunctionalTestEnlistment enlistment1 = this.CloneAndMountEnlistment();


### PR DESCRIPTION
- Removed Category.MacTODO.NeedsServiceVerb
- Updated the category of SharedCacheTests::CloneCleansUpStaleMetadataLock
  to TestNeedsToLockFile. The test case assumes Windows style file
  locking behavior; causing it to fail on the Mac.

Fixes #1217