### PR TITLE
Mac: Add mdworker_shared to the IsFileSystemCrawler block list

### DIFF
--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -1584,6 +1584,7 @@ KEXT_STATIC bool IsFileSystemCrawler(const char* procname)
     // These process will crawl the file system and force a full hydration
     if (!strcmp(procname, "mds") ||
         !strcmp(procname, "mdworker") ||
+        !strcmp(procname, "mdworker_shared") ||
         !strcmp(procname, "mds_stores") ||
         !strcmp(procname, "fseventsd") ||
         !strcmp(procname, "Spotlight"))

--- a/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/KauthHandlerTests.mm
@@ -53,6 +53,7 @@ using std::string;
 - (void)testIsFileSystemCrawler {
     XCTAssertTrue(IsFileSystemCrawler("mds"));
     XCTAssertTrue(IsFileSystemCrawler("mdworker"));
+    XCTAssertTrue(IsFileSystemCrawler("mdworker_shared"));
     XCTAssertTrue(IsFileSystemCrawler("mds_stores"));
     XCTAssertTrue(IsFileSystemCrawler("fseventsd"));
     XCTAssertTrue(IsFileSystemCrawler("Spotlight"));


### PR DESCRIPTION
Resolves #1472 

mdworker_shared is part of the Spotlight indexing service and should not be allowed to hydrate files.