### PR TITLE
Mac ProjFS: Don't follow symlinks in kext & userlib, logging improvements

### DIFF
--- a/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/PrjFS.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F89321E42AC40008103C /* KauthHandler.cpp */; };
 		4A8C13A621F2418400002878 /* libPrjFSKextTestable.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */; };
 		4AAE3FCA22832340002673FA /* HandleFileOpOperationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4AAE3FC922832340002673FA /* HandleFileOpOperationTests.mm */; };
+		4AE873AE2310127D003B122B /* VnodeUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4391F8A121E42AC50008103C /* VnodeUtilities.cpp */; };
+		4AE873B0231017FB003B122B /* VnodeUtilitiesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4AE873AF231017FB003B122B /* VnodeUtilitiesTests.mm */; };
 		D9C087F222384670009C1110 /* MemoryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D9C087F122384670009C1110 /* MemoryTests.mm */; };
 		F554202D224BB6E5008BAE95 /* ProviderMessagingMock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F554202C224BB6E5008BAE95 /* ProviderMessagingMock.cpp */; };
 		F5554F422239883B00B31D19 /* MockProc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5554F412239883B00B31D19 /* MockProc.cpp */; };
@@ -311,6 +313,7 @@
 		4A8C13A021F23EE800002878 /* libPrjFSKextTestable.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPrjFSKextTestable.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A8C13AA21F268FE00002878 /* PrjFSKextTests.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = PrjFSKextTests.exp; sourceTree = "<group>"; };
 		4AAE3FC922832340002673FA /* HandleFileOpOperationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = HandleFileOpOperationTests.mm; sourceTree = "<group>"; };
+		4AE873AF231017FB003B122B /* VnodeUtilitiesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VnodeUtilitiesTests.mm; sourceTree = "<group>"; };
 		D9C087F122384670009C1110 /* MemoryTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryTests.mm; sourceTree = "<group>"; };
 		F5151F7F226F9083004B92C9 /* ProviderMessagingMock.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProviderMessagingMock.hpp; sourceTree = "<group>"; };
 		F554202C224BB6E5008BAE95 /* ProviderMessagingMock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProviderMessagingMock.cpp; sourceTree = "<group>"; };
@@ -553,6 +556,7 @@
 				4A781DB322233A4500DB7733 /* TestMemory.cpp */,
 				263DD5AD225D44C2005FEE9C /* VnodeCacheEntriesWrapper.hpp */,
 				264758CD21FA71140095B9F8 /* VnodeCacheTests.mm */,
+				4AE873AF231017FB003B122B /* VnodeUtilitiesTests.mm */,
 				4A781DA42220946000DB7733 /* VirtualizationRootsTests.mm */,
 			);
 			path = PrjFSKextTests;
@@ -925,6 +929,7 @@
 				4A8C13A521F23F0200002878 /* KauthHandler.cpp in Sources */,
 				4A82C45922807C6F00276002 /* Message_Shared.cpp in Sources */,
 				264758CF21FA71E10095B9F8 /* VnodeCache.cpp in Sources */,
+				4AE873AE2310127D003B122B /* VnodeUtilities.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -935,6 +940,7 @@
 				4A781DAB222330F700DB7733 /* KextMockUtilities.cpp in Sources */,
 				264F8B642298455900B6EF84 /* ShouldHandleFileOpTests.mm in Sources */,
 				4A82C45C228086F800276002 /* MessageTests.mm in Sources */,
+				4AE873B0231017FB003B122B /* VnodeUtilitiesTests.mm in Sources */,
 				265504D0224ADE11005FAD74 /* MockPerfTracing.cpp in Sources */,
 				4A781DA52220946000DB7733 /* VirtualizationRootsTests.mm in Sources */,
 				4A2A69A02297339A00ACAAAF /* KextAssertIntegration.m in Sources */,

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -811,7 +811,9 @@ KEXT_STATIC int HandleFileOpOperation(
         errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
         if (0 != toErr)
         {
-            KextLog_Error("HandleFileOpOperation (KAUTH_FILEOP_RENAME): vnode_lookup failed, errno %d for path '%s'", toErr, newPath);
+            VirtualizationRootHandle providerHandle = ActiveProvider_FindForPath(newPath);
+            // TODO(#1480): Drop log level to KEXTLOG_DEFAULT when providerHandle is 'none' once these failures become rare
+            KextLog_Error("HandleFileOpOperation (KAUTH_FILEOP_RENAME): vnode_lookup failed, errno %d for path '%s'; path lies within root %d%s", toErr, newPath, providerHandle, providerHandle == RootHandle_None ? "" : " with active provider");
             goto CleanupAndReturn;
         }
         
@@ -878,7 +880,9 @@ KEXT_STATIC int HandleFileOpOperation(
         errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
         if (0 != toErr)
         {
-            KextLog_Error("HandleFileOpOperation (KAUTH_FILEOP_LINK): vnode_lookup failed, errno %d for path '%s'", toErr, newPath);
+            VirtualizationRootHandle providerHandle = ActiveProvider_FindForPath(newPath);
+            // TODO(#1480): Drop log level to KEXTLOG_DEFAULT when providerHandle is 'none' once these failures become rare
+            KextLog_Error("HandleFileOpOperation (KAUTH_FILEOP_LINK): vnode_lookup failed, errno %d for path '%s'; path lies within root %d%s", toErr, newPath, providerHandle, providerHandle == RootHandle_None ? "" : " with active provider");
             goto CleanupAndReturn;
         }
         

--- a/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
+++ b/ProjFS.Mac/PrjFSKext/KauthHandler.cpp
@@ -808,7 +808,7 @@ KEXT_STATIC int HandleFileOpOperation(
         
         // TODO(#1367): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
         // it's possible that we'll miss notifications
-        errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
+        errno_t toErr = vnode_lookup(newPath, /* flags: */ VNODE_LOOKUP_NOFOLLOW, &currentVnode, context);
         if (0 != toErr)
         {
             VirtualizationRootHandle providerHandle = ActiveProvider_FindForPath(newPath);
@@ -877,7 +877,7 @@ KEXT_STATIC int HandleFileOpOperation(
         
         // TODO(#1367): We need to handle failures to lookup the vnode.  If we fail to lookup the vnode
         // it's possible that we'll miss notifications
-        errno_t toErr = vnode_lookup(newPath, 0 /* flags */, &currentVnode, context);
+        errno_t toErr = vnode_lookup(newPath, /* flags: */ VNODE_LOOKUP_NOFOLLOW, &currentVnode, context);
         if (0 != toErr)
         {
             VirtualizationRootHandle providerHandle = ActiveProvider_FindForPath(newPath);

--- a/ProjFS.Mac/PrjFSKext/KextLog.hpp
+++ b/ProjFS.Mac/PrjFSKext/KextLog.hpp
@@ -4,6 +4,7 @@
 #include "public/PrjFSCommon.h"
 #include "PrjFSClasses.hpp"
 #include "public/PrjFSLogClientShared.h"
+#include "VnodeUtilities.hpp"
 #include "kernel-header-wrappers/vnode.h"
 #include "kernel-header-wrappers/mount.h"
 #include <os/log.h>
@@ -44,16 +45,17 @@ template <typename... args>
         char vnodePath[PrjFSMaxPath] = "";
         int vnodePathLength = PrjFSMaxPath;
         vn_getpath(vnode, vnodePath, &vnodePathLength);
-        KextLog_Printf(loglevel, fmt, a..., vnodePath);
+        const char* vnodeTypeString = Vnode_GetTypeAsString(vnode);
+        KextLog_Printf(loglevel, fmt, a..., vnodePath, vnodeTypeString);
     }
 
 // The dummy _os_log_verify_format_str() expression here is for using its
 // compile time printf format checking, as template varargs can't be annotated
 // as __printflike.
 // The %s at the end of the format string for the vnode path is implicit.
-#define KextLog_FileError(vnode, format, ...) ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_ERROR, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
-#define KextLog_FileInfo(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_INFO, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
-#define KextLog_File(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_DEFAULT, vnode, format " (vnode path: '%s')", ##__VA_ARGS__); })
+#define KextLog_FileError(vnode, format, ...) ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_ERROR, vnode, format " (vnode path: '%s', type = %s)", ##__VA_ARGS__); })
+#define KextLog_FileInfo(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_INFO, vnode, format " (vnode path: '%s', type = %s)", ##__VA_ARGS__); })
+#define KextLog_File(vnode, format, ...)  ({ _os_log_verify_format_str(format, ##__VA_ARGS__); KextLogFile_Printf(KEXTLOG_DEFAULT, vnode, format " (vnode path: '%s', type = %s)", ##__VA_ARGS__); })
 
 
 // See comments for KextLogFile_Printf() above for rationale.

--- a/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
+++ b/ProjFS.Mac/PrjFSKext/VirtualizationRoots.cpp
@@ -450,7 +450,7 @@ VirtualizationRootResult VirtualizationRoot_RegisterProviderForPath(PrjFSProvide
     vfs_context_t _Nonnull vfsContext = vfs_context_create(nullptr);
     
     VirtualizationRootHandle rootIndex = RootHandle_None;
-    errno_t err = vnode_lookup(virtualizationRootPath, 0 /* flags */, &virtualizationRootVNode, vfsContext);
+    errno_t err = vnode_lookup(virtualizationRootPath, /* flags: */ VNODE_LOOKUP_NOFOLLOW, &virtualizationRootVNode, vfsContext);
     if (0 == err)
     {
         if (!VirtualizationRoot_VnodeIsOnAllowedFilesystem(virtualizationRootVNode))

--- a/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
@@ -51,6 +51,6 @@ const char* Vnode_GetTypeAsString(vnode_t _Nullable vnode)
         case VBAD:  return "VBAD";
         case VSTR:  return "VSTR";
         case VCPLX: return "VCPLX";
-        default:    return "[???]";
     }
+    return "[???]";
 }

--- a/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeUtilities.cpp
@@ -6,6 +6,7 @@
 
 extern "C" int mac_vnop_getxattr(struct vnode *, const char *, char *, size_t, size_t *);
 
+#ifndef KEXT_UNIT_TESTING // Kext testing environment has mock versions of these functions
 FsidInode Vnode_GetFsidAndInode(vnode_t vnode, vfs_context_t _Nonnull context, bool useLinkIDForInode)
 {
     vnode_attr attrs;
@@ -28,4 +29,28 @@ SizeOrError Vnode_ReadXattr(vnode_t vnode, const char* xattrName, void* buffer, 
     size_t actualSize = bufferSize;
     errno_t error = mac_vnop_getxattr(vnode, xattrName, static_cast<char*>(buffer), bufferSize, &actualSize);
     return SizeOrError { actualSize, error };
+}
+#endif
+
+const char* Vnode_GetTypeAsString(vnode_t _Nullable vnode)
+{
+    if (vnode == NULLVP)
+    {
+        return "[NULL]";
+    }
+    switch (vnode_vtype(vnode))
+    {
+        case VNON:  return "VNON";
+        case VREG:  return "VREG";
+        case VDIR:  return "VDIR";
+        case VBLK:  return "VBLK";
+        case VCHR:  return "VCHR";
+        case VLNK:  return "VLNK";
+        case VSOCK: return "VSOCK";
+        case VFIFO: return "VFIFO";
+        case VBAD:  return "VBAD";
+        case VSTR:  return "VSTR";
+        case VCPLX: return "VCPLX";
+        default:    return "[???]";
+    }
 }

--- a/ProjFS.Mac/PrjFSKext/VnodeUtilities.hpp
+++ b/ProjFS.Mac/PrjFSKext/VnodeUtilities.hpp
@@ -12,3 +12,4 @@ struct SizeOrError
 
 SizeOrError Vnode_ReadXattr(vnode_t _Nonnull vnode, const char* _Nonnull xattrName, void* _Nullable buffer, size_t bufferSize);
 FsidInode Vnode_GetFsidAndInode(vnode_t _Nonnull vnode, vfs_context_t _Nonnull context, bool useLinkIDForInode);
+const char* _Nonnull Vnode_GetTypeAsString(vnode_t _Nullable vnode);

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.cpp
@@ -34,7 +34,7 @@ shared_ptr<mount> mount::Create(const char* fileSystemTypeName, fsid_t fsid, uin
 vnode::vnode(const shared_ptr<mount>& mount) :
     mountPoint(mount),
     name(nullptr),
-    inode(mount->nextInode++)
+    inode(mount != nullptr ? mount->nextInode++ : 0)
 {
 }
 

--- a/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
+++ b/ProjFS.Mac/PrjFSKextTests/MockVnodeAndMount.hpp
@@ -121,6 +121,7 @@ public:
     mount_t GetMountPoint() const      { return this->mountPoint.get(); }
     bool IsRecycling() const           { return this->isRecycling; }
     vtype GetVnodeType() const         { return this->type; }
+    void SetVnodeType(vtype vtype)     { this->type = vtype; }
     std::shared_ptr<vnode> const GetParentVnode() { return this->parent; }
     
     struct BytesOrError

--- a/ProjFS.Mac/PrjFSKextTests/VnodeUtilitiesTests.mm
+++ b/ProjFS.Mac/PrjFSKextTests/VnodeUtilitiesTests.mm
@@ -1,0 +1,47 @@
+#include "VnodeUtilities.hpp"
+#include "MockVnodeAndMount.hpp"
+#import <XCTest/XCTest.h>
+
+using std::shared_ptr;
+
+@interface VnodeUtilitiesTests : XCTestCase
+
+@end
+
+@implementation VnodeUtilitiesTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testVnodeGetTypeAsString
+{
+    // Ensure NULL vnode case is handled correctly
+    XCTAssertEqual(0, strcmp("[NULL]", Vnode_GetTypeAsString(NULLVP)));
+    
+    // VREG, VDIR, and VLNK are the most useful for our purposes in practice
+    shared_ptr<vnode> testVnode = vnode::Create(nullptr, "/foo", VREG);
+    XCTAssertEqual(0, strcmp("VREG", Vnode_GetTypeAsString(testVnode.get())));
+    testVnode->SetVnodeType(VDIR);
+    XCTAssertEqual(0, strcmp("VDIR", Vnode_GetTypeAsString(testVnode.get())));
+    testVnode->SetVnodeType(VLNK);
+    XCTAssertEqual(0, strcmp("VLNK", Vnode_GetTypeAsString(testVnode.get())));
+    
+    // Verify that we always get back some kind of sensible string, even if we go out of bounds
+    static_assert(VNON == 0, "We want to start iterating at 0");
+    for (unsigned vtype = VNON; vtype < VCPLX + 10; ++vtype)
+    {
+        testVnode->SetVnodeType(static_cast<enum vtype>(vtype));
+        const char* vtypeString = Vnode_GetTypeAsString(testVnode.get());
+        XCTAssertNotEqual(vtypeString, nullptr);
+        XCTAssertGreaterThan(strlen(vtypeString), 0);
+    }
+}
+
+@end

--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -599,7 +599,7 @@ PrjFS_Result PrjFS_DeleteFile(
     CombinePaths(s_virtualizationRootFullPath.c_str(), relativePath, fullPath);
     
     struct stat path_stat;
-    if (0 != stat(fullPath, &path_stat))
+    if (0 != lstat(fullPath, &path_stat))
     {
         switch(errno)
         {
@@ -1355,7 +1355,7 @@ static bool IsBitSetInFileFlags(const char* fullPath, uint32_t bit)
 
 static errno_t AddXAttr(const char* fullPath, const char* name, const void* value, size_t size)
 {
-    if (0 != setxattr(fullPath, name, value, size, 0, 0))
+    if (0 != setxattr(fullPath, name, value, size, 0, XATTR_NOFOLLOW))
     {
         // We do not log a warning here, since files in the .git folder are expected to fail this check
         return errno;
@@ -1366,7 +1366,7 @@ static errno_t AddXAttr(const char* fullPath, const char* name, const void* valu
 
 static bool TryGetXAttr(const char* fullPath, const char* name, size_t expectedSize, _Out_ void* value)
 {
-    if (expectedSize != getxattr(fullPath, name, value, expectedSize, 0, 0))
+    if (expectedSize != getxattr(fullPath, name, value, expectedSize, 0, XATTR_NOFOLLOW))
     {
         return false;
     }


### PR DESCRIPTION
This change improves symlink handling in the Mac ProjFS implementation, and improves file access error logging in the kext:

 * File metadata reads and writes in the userlib now consistently *do not* follow symlinks in paths, as we want them to operate on the links themselves.
 * Path lookups in the kext *do not* follow symlinks as again, we are interested in rename events for the link itself, and we do not want to allow registering virtualisation root paths which contain symlinks.
 * To improve the quality of telemetry and logs, when we log using `KextLog_File*` macros, the vnode type (VDIR, VREG, VLNK, etc.) is logged in addition to the path.
 * To reduce the amount of uninteresting errors in telemetry, the log level for `vnode_lookup()` failures in the fileop handler now depends on whether the path falls within an active root.

This fixes #1478 and #1479.

**Note to reviewers:** I recommend reviewing the commits individually.