### PR TITLE
Use the full path to GVFS.Hooks executable in the hook configuration

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -28,6 +28,7 @@ namespace GVFS.Common.FileSystem
         public static string MergeHooksData(string[] defaultHooksLines, string filename, string hookName)
         {
             IEnumerable<string> valuableHooksLines = defaultHooksLines.Where(line => !string.IsNullOrEmpty(line.Trim()));
+            string absolutePathToHooksExecutable = Path.Combine(ExecutingDirectory, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
 
             if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, GVFSPlatform.Instance.Constants.PathComparer))
             {
@@ -37,15 +38,15 @@ namespace GVFS.Common.FileSystem
             }
             else if (!valuableHooksLines.Any())
             {
-                return GVFSPlatform.Instance.Constants.GVFSHooksExecutableName;
+                return absolutePathToHooksExecutable;
             }
             else if (hookName.Equals(GVFSConstants.DotGit.Hooks.PostCommandHookName))
             {
-                return string.Join("\n", new string[] { GVFSPlatform.Instance.Constants.GVFSHooksExecutableName }.Concat(valuableHooksLines));
+                return string.Join("\n", new string[] { absolutePathToHooksExecutable }.Concat(valuableHooksLines));
             }
             else
             {
-                return string.Join("\n", valuableHooksLines.Concat(new string[] { GVFSPlatform.Instance.Constants.GVFSHooksExecutableName }));
+                return string.Join("\n", valuableHooksLines.Concat(new string[] { absolutePathToHooksExecutable }));
             }
         }
 

--- a/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
+++ b/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
@@ -5,7 +5,9 @@ using GVFS.UnitTests.Category;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace GVFS.UnitTests.CommandLine
 {
@@ -33,7 +35,8 @@ namespace GVFS.UnitTests.CommandLine
                 .Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(line => !line.StartsWith("#"));
 
-            resultLines.Single().ShouldEqual(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.Single().ShouldContain(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            resultLines.Single().ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
         }
 
         [TestCase]
@@ -47,7 +50,7 @@ namespace GVFS.UnitTests.CommandLine
             resultLines.Count().ShouldEqual(3);
             resultLines.ElementAt(0).ShouldEqual("first");
             resultLines.ElementAt(1).ShouldEqual("second");
-            resultLines.ElementAt(2).ShouldEqual(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(2).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
         }
 
         [TestCase]
@@ -59,7 +62,7 @@ namespace GVFS.UnitTests.CommandLine
                 .Where(line => !line.StartsWith("#"));
 
             resultLines.Count().ShouldEqual(3);
-            resultLines.ElementAt(0).ShouldEqual(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(0).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
             resultLines.ElementAt(1).ShouldEqual("first");
             resultLines.ElementAt(2).ShouldEqual("second");
         }
@@ -75,7 +78,7 @@ namespace GVFS.UnitTests.CommandLine
             resultLines.Count().ShouldEqual(3);
             resultLines.ElementAt(0).ShouldEqual("first");
             resultLines.ElementAt(1).ShouldEqual("second");
-            resultLines.ElementAt(2).ShouldEqual(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(2).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
+++ b/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
@@ -15,6 +15,10 @@ namespace GVFS.UnitTests.CommandLine
     public class HooksInstallerTests
     {
         private const string Filename = "hooksfile";
+        private readonly string expectedAbsoluteGvfsHookPath =
+            Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
@@ -24,7 +28,7 @@ namespace GVFS.UnitTests.CommandLine
                 () => HooksInstaller.MergeHooksData(
                     new string[] { "first", GVFSPlatform.Instance.Constants.GVFSHooksExecutableName },
                     Filename,
-                    GVFSConstants.DotGit.Hooks.PreCommandHookName));
+                    this.expectedAbsoluteGvfsHookPath));
         }
 
         [TestCase]
@@ -35,8 +39,7 @@ namespace GVFS.UnitTests.CommandLine
                 .Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(line => !line.StartsWith("#"));
 
-            resultLines.Single().ShouldContain(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-            resultLines.Single().ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.Single().ShouldEqual(this.expectedAbsoluteGvfsHookPath);
         }
 
         [TestCase]
@@ -50,7 +53,7 @@ namespace GVFS.UnitTests.CommandLine
             resultLines.Count().ShouldEqual(3);
             resultLines.ElementAt(0).ShouldEqual("first");
             resultLines.ElementAt(1).ShouldEqual("second");
-            resultLines.ElementAt(2).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(2).ShouldEqual(this.expectedAbsoluteGvfsHookPath);
         }
 
         [TestCase]
@@ -62,7 +65,7 @@ namespace GVFS.UnitTests.CommandLine
                 .Where(line => !line.StartsWith("#"));
 
             resultLines.Count().ShouldEqual(3);
-            resultLines.ElementAt(0).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(0).ShouldEqual(this.expectedAbsoluteGvfsHookPath);
             resultLines.ElementAt(1).ShouldEqual("first");
             resultLines.ElementAt(2).ShouldEqual("second");
         }
@@ -78,7 +81,7 @@ namespace GVFS.UnitTests.CommandLine
             resultLines.Count().ShouldEqual(3);
             resultLines.ElementAt(0).ShouldEqual("first");
             resultLines.ElementAt(1).ShouldEqual("second");
-            resultLines.ElementAt(2).ShouldContain(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            resultLines.ElementAt(2).ShouldEqual(this.expectedAbsoluteGvfsHookPath);
         }
     }
 }


### PR DESCRIPTION
Resolves #1481 