### PR TITLE
Setting FileSystemCallback instance in FileSystemVirtualizer early

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -257,6 +257,22 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GVFSHelpers.ModifiedPathsShouldContain(this.Enlistment, this.fileSystem, deletedDirEntry);
         }
 
+        [TestCase]
+        public void MountingARepositoryThatRequiresPlaceholderUpdatesWorks()
+        {
+            string[] files = Directory.GetFiles(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
+
+            this.Enlistment.UnmountGVFS();
+
+            File.Delete(files[0]);
+            GVFSHelpers.DeletePlaceholder(
+                Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.VFSForGit),
+                files[0]);
+            GVFSHelpers.SetPlaceholderUpdatesRequired(this.Enlistment.DotGVFSRoot, true);
+
+            this.Enlistment.MountGVFS();
+        }
+
         [TestCaseSource(typeof(MountSubfolders), MountSubfolders.MountFolders)]
         public void MountFailsAfterBreakingDowngrade(string mountSubfolder)
         {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -260,14 +260,18 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void MountingARepositoryThatRequiresPlaceholderUpdatesWorks()
         {
-            string[] files = Directory.GetFiles(Path.Combine(this.Enlistment.RepoRoot, "EnumerateAndReadTestFiles"));
+            string placeholderRelativePath = Path.Combine("EnumerateAndReadTestFiles", "a.txt");
+            string placeholderPath = this.Enlistment.GetVirtualPathTo(placeholderRelativePath);
+
+            // Ensure the placeholder is on disk and hydrated
+            placeholderPath.ShouldBeAFile(this.fileSystem).WithContents();
 
             this.Enlistment.UnmountGVFS();
 
-            File.Delete(files[0]);
+            File.Delete(placeholderPath);
             GVFSHelpers.DeletePlaceholder(
                 Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.VFSForGit),
-                Path.GetFullPath(files[0]).Replace(Path.GetFullPath(this.Enlistment.RepoRoot), string.Empty).TrimStart(Path.DirectorySeparatorChar));
+                placeholderRelativePath);
             GVFSHelpers.SetPlaceholderUpdatesRequired(this.Enlistment.DotGVFSRoot, true);
 
             this.Enlistment.MountGVFS();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -267,7 +267,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             File.Delete(files[0]);
             GVFSHelpers.DeletePlaceholder(
                 Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.VFSForGit),
-                Path.GetRelativePath(this.Enlistment.RepoRoot, files[0]));
+                Path.GetFullPath(files[0]).Replace(Path.GetFullPath(this.Enlistment.RepoRoot), string.Empty).TrimStart(Path.DirectorySeparatorChar));
             GVFSHelpers.SetPlaceholderUpdatesRequired(this.Enlistment.DotGVFSRoot, true);
 
             this.Enlistment.MountGVFS();

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -260,14 +260,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void MountingARepositoryThatRequiresPlaceholderUpdatesWorks()
         {
-            string[] files = Directory.GetFiles(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
+            string[] files = Directory.GetFiles(Path.Combine(this.Enlistment.RepoRoot, "EnumerateAndReadTestFiles"));
 
             this.Enlistment.UnmountGVFS();
 
             File.Delete(files[0]);
             GVFSHelpers.DeletePlaceholder(
                 Path.Combine(this.Enlistment.DotGVFSRoot, TestConstants.Databases.VFSForGit),
-                files[0]);
+                Path.GetRelativePath(this.Enlistment.RepoRoot, files[0]));
             GVFSHelpers.SetPlaceholderUpdatesRequired(this.Enlistment.DotGVFSRoot, true);
 
             this.Enlistment.MountGVFS();

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -28,6 +28,7 @@ namespace GVFS.FunctionalTests.Tools
         private const string DiskLayoutMinorVersionKey = "DiskLayoutMinorVersion";
         private const string LocalCacheRootKey = "LocalCacheRoot";
         private const string GitObjectsRootKey = "GitObjectsRoot";
+        private const string PlaceholdersNeedUpdate = "PlaceholdersNeedUpdate";
         private const string BlobSizesRootKey = "BlobSizesRoot";
 
         private const string PrjFSLibPath = "libPrjFSLib.dylib";
@@ -63,6 +64,11 @@ namespace GVFS.FunctionalTests.Tools
         public static void SaveGitObjectsRoot(string dotGVFSRoot, string value)
         {
             SavePersistedValue(dotGVFSRoot, GitObjectsRootKey, value);
+        }
+
+        public static void SetPlaceholderUpdatesRequired(string dotGVFSRoot, bool isUpdateRequired)
+        {
+            SavePersistedValue(dotGVFSRoot, PlaceholdersNeedUpdate, isUpdateRequired.ToString());
         }
 
         public static string GetPersistedGitObjectsRoot(string dotGVFSRoot)
@@ -130,6 +136,16 @@ namespace GVFS.FunctionalTests.Tools
                 command.CommandText = "INSERT OR REPLACE INTO Placeholder (path, pathType, sha) VALUES (@path, @pathType, NULL)";
                 command.Parameters.AddWithValue("@path", path);
                 command.Parameters.AddWithValue("@pathType", pathType);
+                return command.ExecuteNonQuery();
+            });
+        }
+
+        public static void DeletePlaceholder(string placeholdersDbPath, string path)
+        {
+            RunSqliteCommand(placeholdersDbPath, command =>
+            {
+                command.CommandText = "DELETE FROM Placeholder WHERE path = @path";
+                command.Parameters.AddWithValue("@path", path);
                 return command.ExecuteNonQuery();
             });
         }

--- a/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystemVirtualizer.cs
@@ -242,7 +242,7 @@ namespace GVFS.Platform.Mac
             return result;
         }
 
-        protected override bool TryStart(out string error)
+        public override bool TryStart(out string error)
         {
             error = string.Empty;
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -551,7 +551,7 @@ namespace GVFS.Platform.Windows
             return HResult.Pending;
         }
 
-        protected override bool TryStart(out string error)
+        public override bool TryStart(out string error)
         {
             error = string.Empty;
 

--- a/GVFS/GVFS.UnitTests/Mock/Virtualization/FileSystem/MockFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Virtualization/FileSystem/MockFileSystemVirtualizer.cs
@@ -48,7 +48,7 @@ namespace GVFS.UnitTests.Mock.Virtualization.FileSystem
             throw new NotImplementedException();
         }
 
-        protected override bool TryStart(out string error)
+        public override bool TryStart(out string error)
         {
             error = null;
             return true;

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -66,13 +66,10 @@ namespace GVFS.Virtualization.FileSystem
             return Encoding.Unicode.GetBytes(sha);
         }
 
-        public virtual void Initialize(FileSystemCallbacks fileSystemCallbacks)
+        public virtual bool TryStart(FileSystemCallbacks fileSystemCallbacks, out string error)
         {
             this.FileSystemCallbacks = fileSystemCallbacks;
-        }
 
-        public virtual bool TryStartWorkers(out string error)
-        {
             this.fileAndNetworkWorkerThreads = new Thread[this.numWorkerThreads];
             for (int i = 0; i < this.fileAndNetworkWorkerThreads.Length; ++i)
             {

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -66,13 +66,10 @@ namespace GVFS.Virtualization.FileSystem
             return Encoding.Unicode.GetBytes(sha);
         }
 
-        public virtual void Initialize(FileSystemCallbacks fileSystemCallbacks)
+        public void Initialize(FileSystemCallbacks fileSystemCallbacks)
         {
             this.FileSystemCallbacks = fileSystemCallbacks;
-        }
 
-        public virtual bool TryStartWorkers(out string error)
-        {
             this.fileAndNetworkWorkerThreads = new Thread[this.numWorkerThreads];
             for (int i = 0; i < this.fileAndNetworkWorkerThreads.Length; ++i)
             {
@@ -80,8 +77,6 @@ namespace GVFS.Virtualization.FileSystem
                 this.fileAndNetworkWorkerThreads[i].IsBackground = true;
                 this.fileAndNetworkWorkerThreads[i].Start();
             }
-
-            return this.TryStart(out error);
         }
 
         public void PrepareToStop()
@@ -125,6 +120,8 @@ namespace GVFS.Virtualization.FileSystem
             }
         }
 
+        public abstract bool TryStart(out string error);
+
         protected static string GetShaFromContentId(byte[] contentId)
         {
             return Encoding.Unicode.GetString(contentId, 0, GVFSConstants.ShaStringLength * sizeof(char));
@@ -134,8 +131,6 @@ namespace GVFS.Virtualization.FileSystem
         {
             return providerId[0];
         }
-
-        protected abstract bool TryStart(out string error);
 
         /// <remarks>
         /// If a git-status or git-add is running, we don't want to fail placeholder creation because users will

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -66,10 +66,13 @@ namespace GVFS.Virtualization.FileSystem
             return Encoding.Unicode.GetBytes(sha);
         }
 
-        public virtual bool TryStart(FileSystemCallbacks fileSystemCallbacks, out string error)
+        public virtual void Initialize(FileSystemCallbacks fileSystemCallbacks)
         {
             this.FileSystemCallbacks = fileSystemCallbacks;
+        }
 
+        public virtual bool TryStartWorkers(out string error)
+        {
             this.fileAndNetworkWorkerThreads = new Thread[this.numWorkerThreads];
             for (int i = 0; i < this.fileAndNetworkWorkerThreads.Length; ++i)
             {

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -156,6 +156,7 @@ namespace GVFS.Virtualization
 
         public bool TryStart(out string error)
         {
+            this.fileSystemVirtualizer.Initialize(this);
             this.modifiedPaths.RemoveEntriesWithParentFolderEntry(this.context.Tracer);
             this.modifiedPaths.WriteAllEntriesAndFlush();
 
@@ -168,7 +169,7 @@ namespace GVFS.Virtualization
 
             this.backgroundFileSystemTaskRunner.Start();
 
-            if (!this.fileSystemVirtualizer.TryStart(this, out error))
+            if (!this.fileSystemVirtualizer.TryStartWorkers(out error))
             {
                 return false;
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -156,7 +156,6 @@ namespace GVFS.Virtualization
 
         public bool TryStart(out string error)
         {
-            this.fileSystemVirtualizer.Initialize(this);
             this.modifiedPaths.RemoveEntriesWithParentFolderEntry(this.context.Tracer);
             this.modifiedPaths.WriteAllEntriesAndFlush();
 
@@ -169,7 +168,7 @@ namespace GVFS.Virtualization
 
             this.backgroundFileSystemTaskRunner.Start();
 
-            if (!this.fileSystemVirtualizer.TryStartWorkers(out error))
+            if (!this.fileSystemVirtualizer.TryStart(this, out error))
             {
                 return false;
             }

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -169,7 +169,7 @@ namespace GVFS.Virtualization
 
             this.backgroundFileSystemTaskRunner.Start();
 
-            if (!this.fileSystemVirtualizer.TryStartWorkers(out error))
+            if (!this.fileSystemVirtualizer.TryStart(out error))
             {
                 return false;
             }


### PR DESCRIPTION
Addresses #1491 

The current solution is a bandaid to the underlying problem, the `MacFileSystemVirtualizer` depends on `GitIndexProjection`, but transitively, via `FileSystemCallbacks` instance. The only reason for that, is that `FileSystemCallbacks` is the one constructing `GitIndexProjection` :) 