### PR TITLE
Functional test to expose Phython Executable Failure

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Settings.cs
+++ b/GVFS/GVFS.FunctionalTests/Settings.cs
@@ -35,7 +35,7 @@ namespace GVFS.FunctionalTests.Properties
                 CurrentDirectory = Path.GetFullPath(Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]));
 
                 RepoToClone = @"https://gvfs.visualstudio.com/ci/_git/ForTests";
-                Commitish = @"FunctionalTests/20180214";
+                Commitish = @"FunctionalTests/20190827";
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {


### PR DESCRIPTION
This exposes the failure when a Phython Executable is called before hydration.

Note I had to create a wrapper script to repro in the C# framework.  It appears calling the script directory from Process in C# does an implicit hydration missing the repro.