### PR TITLE
Mac ProjFS: Don't perform user/kernel version validation for offline I/O

### DIFF
--- a/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSLib.cpp
@@ -175,7 +175,9 @@ PrjFS_Result PrjFS_RegisterForOfflineIO()
     if (s_kernelServiceOfflineClientCount == 0)
     {
         assert(s_kernelServiceOfflineWriterConnection == IO_OBJECT_NULL);
-        s_kernelServiceOfflineWriterConnection = PrjFSService_ConnectToDriver(UserClientType_OfflineIO);
+        s_kernelServiceOfflineWriterConnection = PrjFSService_ConnectToDriver(
+            UserClientType_OfflineIO,
+            false); // Don't require user/kernel versions to match, as this type of user client does not have a version-sensitive API at this time.
         if (s_kernelServiceOfflineWriterConnection == IO_OBJECT_NULL)
         {
             return PrjFS_Result_EDriverNotLoaded;

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.cpp
@@ -57,7 +57,7 @@ CleanupAndFail:
     return false;
 }
 
-io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType)
+io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType, bool performVersionValidation)
 {
     CFDictionaryRef matchDict = IOServiceMatching(PrjFSServiceClass);
     io_service_t prjfsService = IOServiceGetMatchingService(kIOMasterPortDefault, matchDict); // matchDict consumed
@@ -70,7 +70,7 @@ io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType client
         return IO_OBJECT_NULL;
     }
     
-    if (!PrjFSService_ValidateVersion(prjfsService))
+    if (performVersionValidation && !PrjFSService_ValidateVersion(prjfsService))
     {
         IOObjectRelease(prjfsService);
         return IO_OBJECT_NULL;

--- a/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
+++ b/ProjFS.Mac/PrjFSLib/PrjFSUser.hpp
@@ -16,7 +16,7 @@ struct DataQueueResources
     dispatch_source_t dispatchSource;
 };
 
-io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType);
+io_connect_t PrjFSService_ConnectToDriver(enum PrjFSServiceUserClientType clientType, bool performVersionValidation = true);
 
 struct PrjFSService_WatchContext;
 PrjFSService_WatchContext* PrjFSService_WatchForServiceAndConnect(


### PR DESCRIPTION
Offline I/O registration uses a trivial user/kernel API which is not sensitive to version differences, and there have been instances where gvfs upgrade has failed and left VFS4G in an unusable state because version validation failed mid-upgrade.

This change disables validation for offline I/O registration only.