### PR TITLE
Windows native toasts

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -95,6 +95,7 @@ namespace GVFS.Common
             public const string Prefetch = "prefetch";
             public const string Repair = "repair";
             public const string Service = "service";
+            public const string ServiceUI = "service_ui";
             public const string Sparse = "sparse";
             public const string UpgradeVerb = UpgradePrefix + "_verb";
             public const string UpgradeProcess = UpgradePrefix + "_process";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -80,7 +80,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.RestartService();
 
             bool timerScheduled = false;
-            for (int trialCount = 0; trialCount < 15; trialCount++)
+
+            // Service starts upgrade checks after 60 seconds.
+            Thread.Sleep(TimeSpan.FromSeconds(60));
+            for (int trialCount = 0; trialCount < 30; trialCount++)
             {
                 Thread.Sleep(TimeSpan.FromSeconds(1));
                 if (this.ServiceLogContainsUpgradeMessaging())

--- a/GVFS/GVFS.Service.UI/Data/ActionItem.cs
+++ b/GVFS/GVFS.Service.UI/Data/ActionItem.cs
@@ -2,12 +2,16 @@
 
 namespace GVFS.Service.UI.Data
 {
+    [XmlRoot("action")]
     public class ActionItem
     {
-        [XmlElement("content")]
+        [XmlAttribute("content")]
         public string Content { get; set; }
 
-        [XmlElement("arguments")]
+        [XmlAttribute("arguments")]
         public string Arguments { get; set; }
+
+        [XmlAttribute("activationtype")]
+        public string ActivationType { get; set; }
     }
 }

--- a/GVFS/GVFS.Service.UI/GVFS.Service.UI.csproj
+++ b/GVFS/GVFS.Service.UI/GVFS.Service.UI.csproj
@@ -55,8 +55,12 @@
     <Compile Include="Data\BindingData.cs" />
     <Compile Include="Data\BindingItem.cs" />
     <Compile Include="Data\VisualData.cs" />
+    <Compile Include="GVFSServiceUI.cs" />
+    <Compile Include="GVFSToastRequestHandler.cs" />
+    <Compile Include="IToastNotifier.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Data\ToastData.cs" />
+    <Compile Include="WinToastNotifier.cs" />
     <Compile Include="XmlList.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GVFS/GVFS.Service.UI/GVFSServiceUI.cs
+++ b/GVFS/GVFS.Service.UI/GVFSServiceUI.cs
@@ -1,0 +1,61 @@
+﻿using GVFS.Common;
+using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceProcess;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.Service.UI
+{
+    public class GVFSServiceUI
+    {
+        private readonly ITracer tracer;
+        private readonly GVFSToastRequestHandler toastRequestHandler;
+
+        public GVFSServiceUI(ITracer tracer, GVFSToastRequestHandler toastRequestHandler)
+        {
+            this.tracer = tracer;
+            this.toastRequestHandler = toastRequestHandler;
+        }
+
+        public void Start(string[] args)
+        {
+            using (ITracer activity = this.tracer.StartActivity("Start", EventLevel.Informational))
+            using (NamedPipeServer server = NamedPipeServer.StartNewServer(GVFSConstants.Service.UIName, this.tracer, this.HandleRequest))
+            {
+                ManualResetEvent mre = new ManualResetEvent(false);
+                mre.WaitOne();
+            }
+        }
+
+        private void HandleRequest(ITracer tracer, string request, NamedPipeServer.Connection connection)
+        {
+            try
+            {
+                NamedPipeMessages.Message message = NamedPipeMessages.Message.FromString(request);
+                switch (message.Header)
+                {
+                    case NamedPipeMessages.Notification.Request.Header:
+                        NamedPipeMessages.Notification.Request toastRequest = NamedPipeMessages.Notification.Request.FromMessage(message);
+                        if (toastRequest != null)
+                        {
+                            using (ITracer activity = this.tracer.StartActivity("SendToast", EventLevel.Informational))
+                            {
+                                this.toastRequestHandler.HandleToastRequest(activity, toastRequest);
+                            }
+                        }
+
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedError("Unhandled exception: {0}", e.ToString());
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Service.UI/GVFSToastRequestHandler.cs
+++ b/GVFS/GVFS.Service.UI/GVFSToastRequestHandler.cs
@@ -1,0 +1,190 @@
+﻿using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace GVFS.Service.UI
+{
+    public class GVFSToastRequestHandler
+    {
+        private const string VFSForGitAutomountStartTitle= "VFS For Git Automount";
+        private const string VFSForGitAutomountStartMessageFormat = "Attempting to mount {0} VFS For Git repos(s)";
+
+        private const string VFSForGitAutomountSuccessTitle = "VFS For Git Automount";
+        private const string VFSForGitAutomountSuccessMessageFormat = "The following VFS For Git repo is now mounted: {0}{1}";
+
+        private const string VFSForGitAutomountErrorTitle = "VFS For Git Automount";
+        private const string VFSForGitAutomountErrorMessageFormat = "The following VFS For Git repo failed to mount: {0}{1}";
+        private const string VFSForGitAutomountButtonTitle = "Retry";
+
+        private const string VFSForGitUpgradeTitleFormat = "New version {0} is available";
+        private const string VFSForGitUpgradeMessage = "Upgrade will unmount and remount VFS For Git repos, ensure you are at a stopping point. When ready, click Upgrade button to run upgrade.";
+        private const string VFSForGitUpgradeButtonTitle = "Upgrade";
+
+        private const string VFSForGitRemountActionPrefix = "gvfs mount";
+        private const string VFSForGitUpgradeActionPrefix = "gvfs upgrade --confirm";
+
+        private readonly ITracer tracer;
+        private readonly IToastNotifier toastNotifier;
+
+        public GVFSToastRequestHandler(IToastNotifier toastNotifier, ITracer tracer)
+        {
+            this.toastNotifier = toastNotifier;
+            this.toastNotifier.UserResponseCallback = this.UserResponseCallback;
+            this.tracer = tracer;
+        }
+
+        public void HandleToastRequest(ITracer tracer, NamedPipeMessages.Notification.Request request)
+        {
+            string title = null;
+            string message = null;
+            string buttonTitle = null;
+            string args = null;
+            string path = null;
+
+            switch (request.Id)
+            {
+                case NamedPipeMessages.Notification.Request.Identifier.AutomountStart:
+                    title = VFSForGitAutomountStartTitle;
+                    message = string.Format(VFSForGitAutomountStartMessageFormat, request.EnlistmentCount);
+                    break;
+
+                case NamedPipeMessages.Notification.Request.Identifier.MountSuccess:
+                    if (this.TryValidatePath(request.Enlistment, out path, this.tracer))
+                    {
+                        title = VFSForGitAutomountSuccessTitle;
+                        message = string.Format(VFSForGitAutomountSuccessMessageFormat, Environment.NewLine, path);
+                    }
+
+                    break;
+
+                case NamedPipeMessages.Notification.Request.Identifier.MountFailure:
+                    if (this.TryValidatePath(request.Enlistment, out path, this.tracer))
+                    {
+                        title = VFSForGitAutomountErrorTitle;
+                        message = string.Format(VFSForGitAutomountErrorMessageFormat, Environment.NewLine, path);
+                        buttonTitle = VFSForGitAutomountButtonTitle;
+                        args = $"{VFSForGitRemountActionPrefix} {path}";
+                    }
+
+                    break;
+
+                case NamedPipeMessages.Notification.Request.Identifier.UpgradeAvailable:
+                    title = string.Format(VFSForGitUpgradeTitleFormat, request.NewVersion);
+                    message = string.Format(VFSForGitUpgradeMessage);
+                    buttonTitle = VFSForGitUpgradeButtonTitle;
+                    args = $"{VFSForGitUpgradeActionPrefix}";
+                    break;
+            }
+
+            if (title != null && message != null)
+            {
+                this.toastNotifier.Notify(title, message, buttonTitle, args);
+            }
+        }
+
+        public void UserResponseCallback(string args)
+        {
+            if (string.IsNullOrEmpty(args))
+            {
+                this.tracer.RelatedError($"{nameof(this.UserResponseCallback)}: Received null arguments in Toaster callback.");
+                return;
+            }
+
+            using (ITracer activity = this.tracer.StartActivity("GVFSToastCallback", EventLevel.Informational))
+            {
+                string gvfsCmd = null;
+                bool elevate = false;
+
+                if (args.StartsWith(VFSForGitUpgradeActionPrefix))
+                {
+                    this.tracer.RelatedInfo($"gvfs upgrade action.");
+                    gvfsCmd = "gvfs upgrade --confirm";
+                    elevate = true;
+                }
+                else if (args.StartsWith(VFSForGitRemountActionPrefix))
+                {
+                    string path = args.Substring(VFSForGitRemountActionPrefix.Length, args.Length - VFSForGitRemountActionPrefix.Length);
+                    if (this.TryValidatePath(path, out string enlistment, activity))
+                    {
+                        this.tracer.RelatedInfo($"gvfs mount action {enlistment}.");
+                        gvfsCmd = $"gvfs mount \"{enlistment}\"";
+                    }
+                    else
+                    {
+                        EventMetadata metadata = new EventMetadata();
+                        metadata.Add(nameof(args), args);
+                        metadata.Add(nameof(path), path);
+                        this.tracer.RelatedError(metadata, $"{nameof(this.UserResponseCallback)}- Invalid enlistment path specified in Toaster callback.");
+                    }
+                }
+                else
+                {
+                    this.tracer.RelatedError($"{nameof(this.UserResponseCallback)}- Unknown action({args}) specified in Toaster callback.");
+                }
+
+                if (!string.IsNullOrEmpty(gvfsCmd))
+                {
+                    this.launchGVFSInCommandPrompt(gvfsCmd, elevate, activity);
+                }
+            }
+        }
+
+        private bool TryValidatePath(string path, out string validatedPath, ITracer tracer)
+        {
+            try
+            {
+                validatedPath = Path.GetFullPath(path);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", ex.ToString());
+                metadata.Add("Path", path);
+
+                tracer.RelatedError(metadata, $"{nameof(this.TryValidatePath)}: {path}. {ex.ToString()}");
+            }
+
+            validatedPath = null;
+            return false;
+        }
+
+        private void launchGVFSInCommandPrompt(string fullGvfsCmd, bool elevate, ITracer tracer)
+        {
+            const string cmdPath = "CMD.exe";
+            ProcessStartInfo processInfo = new ProcessStartInfo(cmdPath);
+            processInfo.UseShellExecute = true;
+            processInfo.RedirectStandardInput = false;
+            processInfo.RedirectStandardOutput = false;
+            processInfo.RedirectStandardError = false;
+            processInfo.WindowStyle = ProcessWindowStyle.Normal;
+            processInfo.CreateNoWindow = false;
+
+            // /K option is so the user gets the time to read the output of the command and
+            // manually close the cmd window after that.
+            processInfo.Arguments = "/K " + fullGvfsCmd;
+            if (elevate)
+            {
+                processInfo.Verb = "runas";
+            }
+
+            tracer.RelatedInfo($"{nameof(this.UserResponseCallback)}- Running {cmdPath} /K {fullGvfsCmd}");
+
+            try
+            {
+                Process.Start(processInfo);
+            }
+            catch (Exception ex)
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("Exception", ex.ToString());
+                metadata.Add(nameof(fullGvfsCmd), fullGvfsCmd);
+                metadata.Add(nameof(elevate), elevate);
+
+                tracer.RelatedError(metadata, $"{nameof(this.launchGVFSInCommandPrompt)}: Error launching {fullGvfsCmd}. {ex.ToString()}");
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Service.UI/GVFSToastRequestHandler.cs
+++ b/GVFS/GVFS.Service.UI/GVFSToastRequestHandler.cs
@@ -9,7 +9,9 @@ namespace GVFS.Service.UI
     public class GVFSToastRequestHandler
     {
         private const string VFSForGitAutomountStartTitle= "VFS For Git Automount";
-        private const string VFSForGitAutomountStartMessageFormat = "Attempting to mount {0} VFS For Git repos(s)";
+        private const string VFSForGitAutomountStartMessageFormat = "Attempting to mount {0} VFS For Git {1}";
+        private const string VFSForGitMultipleRepos = "repos";
+        private const string VFSForGitSingleRepo = "repo";
 
         private const string VFSForGitAutomountSuccessTitle = "VFS For Git Automount";
         private const string VFSForGitAutomountSuccessMessageFormat = "The following VFS For Git repo is now mounted: {0}{1}";
@@ -46,8 +48,9 @@ namespace GVFS.Service.UI
             switch (request.Id)
             {
                 case NamedPipeMessages.Notification.Request.Identifier.AutomountStart:
+                    string reposSuffix = request.EnlistmentCount <= 1 ? VFSForGitSingleRepo : VFSForGitMultipleRepos;
                     title = VFSForGitAutomountStartTitle;
-                    message = string.Format(VFSForGitAutomountStartMessageFormat, request.EnlistmentCount);
+                    message = string.Format(VFSForGitAutomountStartMessageFormat, request.EnlistmentCount, reposSuffix);
                     break;
 
                 case NamedPipeMessages.Notification.Request.Identifier.MountSuccess:

--- a/GVFS/GVFS.Service.UI/IToastNotifier.cs
+++ b/GVFS/GVFS.Service.UI/IToastNotifier.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GVFS.Service.UI
+{
+    public interface IToastNotifier
+    {
+        Action<string> UserResponseCallback { get; set; }
+        void Notify(string title, string message, string actionButtonTitle, string callbackArgs);
+    }
+}

--- a/GVFS/GVFS.Service.UI/Program.cs
+++ b/GVFS/GVFS.Service.UI/Program.cs
@@ -1,122 +1,46 @@
 ﻿using GVFS.Common;
-using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.PlatformLoader;
-using GVFS.Service.UI.Data;
 using System;
-using System.IO;
-using System.Linq;
-using System.ServiceProcess;
-using System.Xml;
-using System.Xml.Serialization;
-using Windows.UI.Notifications;
-using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 
 namespace GVFS.Service.UI
 {
-    public class GVFSServiceUI
+    public static class Program
     {
-        private const string ServiceAppId = "GVFS";
-
-        private readonly ITracer tracer;
-
-        public GVFSServiceUI(ITracer tracer)
-        {
-            this.tracer = tracer;
-        }
-
         public static void Main(string[] args)
         {
             GVFSPlatformLoader.Initialize();
 
             using (JsonTracer tracer = new JsonTracer("Microsoft.Git.GVFS.Service.UI", "Service.UI"))
             {
-                string logLocation = Path.Combine(
-                    Environment.GetEnvironmentVariable("LocalAppData"),
-                    GVFSConstants.Service.UIName,
-                    "serviceUI.log");
+                string error;
+                string serviceUILogDirectory = GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.UIName);
+                if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(serviceUILogDirectory, out error))
+                {
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add(nameof(serviceUILogDirectory), serviceUILogDirectory);
+                    metadata.Add(nameof(error), error);
+                    tracer.RelatedWarning(
+                        metadata,
+                        "Failed to create service UI logs directory",
+                        Keywords.Telemetry);
+                }
+                else
+                {
+                    string logFilePath = GVFSEnlistment.GetNewGVFSLogFileName(
+                        serviceUILogDirectory,
+                        GVFSConstants.LogFileTypes.ServiceUI,
+                        logId: Environment.UserName);
 
-                tracer.AddLogFileEventListener(logLocation, EventLevel.Informational, Keywords.Any);
-                GVFSServiceUI process = new GVFSServiceUI(tracer);
+                    tracer.AddLogFileEventListener(logFilePath, EventLevel.Informational, Keywords.Any);
+                }
+
+                WinToastNotifier winToastNotifier = new WinToastNotifier(tracer);
+                GVFSToastRequestHandler toastRequestHandler = new GVFSToastRequestHandler(winToastNotifier, tracer);
+                GVFSServiceUI process = new GVFSServiceUI(tracer, toastRequestHandler);
+
                 process.Start(args);
             }
-        }
-
-        private void Start(string[] args)
-        {
-            using (ITracer activity = this.tracer.StartActivity("Start", EventLevel.Informational))
-            using (NamedPipeServer server = NamedPipeServer.StartNewServer(GVFSConstants.Service.UIName, this.tracer, this.HandleRequest))
-            {
-                ServiceController controller = new ServiceController(GVFSConstants.Service.ServiceName);
-                try
-                {
-                    controller.WaitForStatus(ServiceControllerStatus.Stopped);
-                }
-                catch (InvalidOperationException)
-                {
-                    // Service might not exist anymore -- that's ok, just exit
-                }
-
-                this.tracer.RelatedInfo("{0} stop detected -- exiting UI.", GVFSConstants.Service.ServiceName);
-            }
-        }
-
-        private void HandleRequest(ITracer tracer, string request, NamedPipeServer.Connection connection)
-        {
-            try
-            {
-                NamedPipeMessages.Message message = NamedPipeMessages.Message.FromString(request);
-                switch (message.Header)
-                {
-                    case NamedPipeMessages.Notification.Request.Header:
-                        NamedPipeMessages.Notification.Request toastRequest = NamedPipeMessages.Notification.Request.FromMessage(message);
-                        if (toastRequest != null)
-                        {
-                            using (ITracer activity = this.tracer.StartActivity("SendToast", EventLevel.Informational))
-                            {
-                                this.ShowToast(activity, toastRequest);
-                            }
-                        }
-
-                        break;
-                }
-            }
-            catch (Exception e)
-            {
-                this.tracer.RelatedError("Unhandled exception: {0}", e.ToString());
-            }
-        }
-
-        private void ShowToast(ITracer tracer, NamedPipeMessages.Notification.Request request)
-        {
-            ToastData toastData = new ToastData();
-            toastData.Visual = new VisualData();
-
-            BindingData binding = new BindingData();
-            toastData.Visual.Binding = binding;
-
-            binding.Template = "ToastGeneric";
-            binding.Items = new XmlList<BindingItem>();
-            binding.Items.Add(new BindingItem.TextData(request.Title));
-            binding.Items.AddRange(request.Message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(t => new BindingItem.TextData(t)));
-
-            XmlDocument toastXml = new XmlDocument();
-            using (StringWriter stringWriter = new StringWriter())
-            using (XmlWriter xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { OmitXmlDeclaration = true }))
-            {
-                XmlSerializer serializer = new XmlSerializer(toastData.GetType());
-                XmlSerializerNamespaces namespaces = new XmlSerializerNamespaces();
-                namespaces.Add(string.Empty, string.Empty);
-
-                serializer.Serialize(xmlWriter, toastData, namespaces);
-
-                toastXml.LoadXml(stringWriter.ToString());
-            }
-
-            ToastNotification toastNotification = new ToastNotification(toastXml);
-
-            ToastNotifier toastNotifier = ToastNotificationManager.CreateToastNotifier(ServiceAppId);
-            toastNotifier.Show(toastNotification);
         }
     }
 }

--- a/GVFS/GVFS.Service.UI/WinToastNotifier.cs
+++ b/GVFS/GVFS.Service.UI/WinToastNotifier.cs
@@ -1,0 +1,103 @@
+﻿using GVFS.Common;
+using GVFS.Common.Tracing;
+using GVFS.Service.UI.Data;
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+using Windows.UI.Notifications;
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
+
+namespace GVFS.Service.UI
+{
+    public class WinToastNotifier : IToastNotifier
+    {
+        private const string ServiceAppId = "GVFS";
+        private const string GVFSIconName = "GitVirtualFileSystem.ico";
+        private ITracer tracer;
+
+        public WinToastNotifier(ITracer tracer)
+        {
+            this.tracer = tracer;
+        }
+
+        public Action<string> UserResponseCallback { get; set; }
+
+        public void Notify(string title, string message, string actionButtonTitle, string callbackArgs)
+        {
+            // Reference: https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts
+            ToastData toastData = new ToastData();
+
+            toastData.Visual = new VisualData();
+
+            BindingData binding = new BindingData();
+            toastData.Visual.Binding = binding;
+
+            // ToastGeneric- Our toast contains VFSForGit icon and text
+            binding.Template = "ToastGeneric";
+            binding.Items = new XmlList<BindingItem>();
+            binding.Items.Add(new BindingItem.TextData(title));
+            binding.Items.Add(new BindingItem.TextData(message));
+
+            string logo = "file:///" + Path.Combine(ProcessHelper.GetCurrentProcessLocation(), GVFSIconName);
+            binding.Items.Add(new BindingItem.ImageData()
+            {
+                Source = logo,
+                Placement = "appLogoOverride",
+                HintCrop = "circle"
+            });
+
+            if (!string.IsNullOrEmpty(actionButtonTitle))
+            {
+                ActionsData actionsData = new ActionsData();
+                actionsData.Actions = new XmlList<ActionItem>();
+                actionsData.Actions.Add(new ActionItem()
+                {
+                    Content = actionButtonTitle,
+                    Arguments = string.IsNullOrEmpty(callbackArgs) ? string.Empty : callbackArgs,
+                    ActivationType = "background"
+                });
+
+                toastData.Actions = actionsData;
+            }
+
+            XmlDocument toastXml = new XmlDocument();
+            using (StringWriter stringWriter = new StringWriter())
+            using (XmlWriter xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { OmitXmlDeclaration = true }))
+            {
+                XmlSerializer serializer = new XmlSerializer(toastData.GetType());
+                XmlSerializerNamespaces namespaces = new XmlSerializerNamespaces();
+                namespaces.Add(string.Empty, string.Empty);
+
+                serializer.Serialize(xmlWriter, toastData, namespaces);
+
+                toastXml.LoadXml(stringWriter.ToString());
+            }
+
+            ToastNotification toastNotification = new ToastNotification(toastXml);
+            toastNotification.Activated += this.ToastActivated;
+            toastNotification.Dismissed += this.ToastDismissed;
+            toastNotification.Failed += this.ToastFailed;
+
+            ToastNotifier toastNotifier = ToastNotificationManager.CreateToastNotifier(ServiceAppId);
+            toastNotifier.Show(toastNotification);
+        }
+
+        private void ToastActivated(ToastNotification sender, object e)
+        {
+            ToastActivatedEventArgs args = (ToastActivatedEventArgs)e;
+
+            this.UserResponseCallback?.Invoke(args.Arguments);
+        }
+
+        private void ToastDismissed(ToastNotification sender, ToastDismissedEventArgs e)
+        {
+            this.tracer.RelatedInfo($"{nameof(this.ToastDismissed)}: {e.Reason}");
+        }
+
+        private void ToastFailed(ToastNotification sender, ToastFailedEventArgs e)
+        {
+            this.tracer.RelatedInfo($"{nameof(this.ToastFailed)}: {e.ErrorCode.ToString()}");
+        }
+    }
+}

--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -5,6 +5,7 @@ using GVFS.Common.Tracing;
 using GVFS.Platform.Windows;
 using GVFS.Service.Handlers;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -27,13 +28,15 @@ namespace GVFS.Service
         private RepoRegistry repoRegistry;
         private ProductUpgradeTimer productUpgradeTimer;
         private WindowsRequestHandler requestHandler;
+        private INotificationHandler notificationHandler;
 
         public GVFSService(JsonTracer tracer)
         {
             this.tracer = tracer;
             this.serviceName = GVFSConstants.Service.ServiceName;
             this.CanHandleSessionChangeEvent = true;
-            this.productUpgradeTimer = new ProductUpgradeTimer(tracer);
+            this.notificationHandler = new NotificationHandler(tracer);
+            this.productUpgradeTimer = new ProductUpgradeTimer(tracer, this.notificationHandler);
         }
 
         public void Run()
@@ -49,7 +52,7 @@ namespace GVFS.Service
                     new PhysicalFileSystem(),
                     this.serviceDataLocation,
                     new GVFSMountProcess(this.tracer),
-                    new NotificationHandler(this.tracer));
+                    this.notificationHandler);
                 this.repoRegistry.Upgrade();
                 this.requestHandler = new WindowsRequestHandler(this.tracer, EtwArea, this.repoRegistry);
 
@@ -139,6 +142,9 @@ namespace GVFS.Service
                     if (changeDescription.Reason == SessionChangeReason.SessionLogon)
                     {
                         this.tracer.RelatedInfo("SessionLogon detected, sessionId: {0}", changeDescription.SessionId);
+
+                        this.LaunchServiceUIIfNotRunning(changeDescription.SessionId);
+
                         using (ITracer activity = this.tracer.StartActivity("LogonAutomount", EventLevel.Informational))
                         {
                             this.repoRegistry.AutoMountRepos(
@@ -320,23 +326,22 @@ namespace GVFS.Service
             Directory.SetAccessControl(serviceDataRootPath, serviceDataRootSecurity);
 
             // Special rules for the upgrader logs, as non-elevated users need to be be able to write
-            this.CreateAndConfigureUpgradeLogDirectory();
+            this.CreateAndConfigureLogDirectory(ProductUpgraderInfo.GetLogDirectoryPath());
+            this.CreateAndConfigureLogDirectory(GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.UIName));
         }
 
-        private void CreateAndConfigureUpgradeLogDirectory()
+        private void CreateAndConfigureLogDirectory(string path)
         {
-            string upgradeLogsPath = ProductUpgraderInfo.GetLogDirectoryPath();
-
             string error;
-            if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(upgradeLogsPath, out error))
+            if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(path, out error))
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("Area", EtwArea);
-                metadata.Add(nameof(upgradeLogsPath), upgradeLogsPath);
+                metadata.Add(nameof(path), path);
                 metadata.Add(nameof(error), error);
                 this.tracer.RelatedWarning(
                     metadata,
-                    $"{nameof(this.CreateAndConfigureUpgradeLogDirectory)}: Failed to create upgrade logs directory",
+                    $"{nameof(this.CreateAndConfigureLogDirectory)}: Failed to create logs directory",
                     Keywords.Telemetry);
             }
         }
@@ -364,6 +369,52 @@ namespace GVFS.Service
             WindowsFileSystem.AddAdminAccessRulesToDirectorySecurity(serviceDataRootSecurity);
 
             return serviceDataRootSecurity;
+        }
+
+        private void LaunchServiceUIIfNotRunning(int sessionId)
+        {
+            NamedPipeClient client;
+            using (client = new NamedPipeClient(GVFSConstants.Service.UIName))
+            {
+                if (!client.Connect())
+                {
+                    this.tracer.RelatedError($"Could not connect with {GVFSConstants.Service.UIName}. Attempting to relaunch.");
+
+                    this.TerminateExistingProcess(GVFSConstants.Service.UIName, sessionId);
+
+                    CurrentUser currentUser = new CurrentUser(this.tracer, sessionId);
+                    if (!currentUser.RunAs(
+                        Configuration.Instance.GVFSServiceUILocation,
+                        string.Empty))
+                    {
+                        this.tracer.RelatedError("Could not start " + GVFSConstants.Service.UIName);
+                    }
+                    else
+                    {
+                        this.tracer.RelatedInfo($"Successfully launched {GVFSConstants.Service.UIName}. ");
+                    }
+                }
+            }
+        }
+
+        private void TerminateExistingProcess(string processName, int sessionId)
+        {
+            try
+            {
+                foreach (Process process in Process.GetProcessesByName(processName))
+                {
+                    if (process.SessionId == sessionId)
+                    {
+                        this.tracer.RelatedInfo($"{nameof(this.TerminateExistingProcess)}- Stopping {processName}, in session {sessionId}.");
+
+                        process.Kill();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                this.tracer.RelatedError("Could not find and kill existing instances of {0}: {1}", processName, ex.Message);
+            }
         }
     }
 }

--- a/GVFS/GVFS.Service/Handlers/INotificationHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/INotificationHandler.cs
@@ -4,6 +4,6 @@ namespace GVFS.Service.Handlers
 {
     public interface INotificationHandler
     {
-        void SendNotification(int sessionId, NamedPipeMessages.Notification.Request request);
+        void SendNotification(NamedPipeMessages.Notification.Request request);
     }
 }

--- a/GVFS/GVFS.Service/Handlers/NotificationHandler.Mac.cs
+++ b/GVFS/GVFS.Service/Handlers/NotificationHandler.Mac.cs
@@ -15,7 +15,7 @@ namespace GVFS.Service.Handlers
             this.tracer = tracer;
         }
 
-        public void SendNotification(int sessionId, NamedPipeMessages.Notification.Request request)
+        public void SendNotification(NamedPipeMessages.Notification.Request request)
         {
             string pipeName = Path.Combine(Path.GetTempPath(), NotificationServerPipeName);
             using (NamedPipeClient client = new NamedPipeClient(pipeName))

--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -1,7 +1,9 @@
 ﻿using GVFS.Common;
 using GVFS.Common.FileSystem;
+using GVFS.Common.NamedPipes;
 using GVFS.Common.NuGetUpgrade;
 using GVFS.Common.Tracing;
+using GVFS.Service.Handlers;
 using GVFS.Upgrader;
 using System;
 using System.IO;
@@ -15,10 +17,12 @@ namespace GVFS.Service
         private JsonTracer tracer;
         private PhysicalFileSystem fileSystem;
         private Timer timer;
+        private INotificationHandler notificationHandler;
 
-        public ProductUpgradeTimer(JsonTracer tracer)
+        public ProductUpgradeTimer(JsonTracer tracer, INotificationHandler notificationHandler)
         {
             this.tracer = tracer;
+            this.notificationHandler = notificationHandler;
             this.fileSystem = new PhysicalFileSystem();
         }
 
@@ -26,7 +30,10 @@ namespace GVFS.Service
         {
             if (!GVFSEnlistment.IsUnattended(this.tracer))
             {
-                TimeSpan startTime = TimeSpan.Zero;
+                // Adding 60 seconds wait time here. This gives VFSForGit installer/upgrader
+                // sufficient enough time to launch GVFS.Service.UI that is needed to display
+                // Upgrade available toaster.
+                TimeSpan startTime = TimeSpan.FromSeconds(60);
 
                 this.tracer.RelatedInfo("Starting auto upgrade checks.");
                 this.timer = new Timer(
@@ -210,6 +217,8 @@ namespace GVFS.Service
                     }
 
                     info.RecordHighestAvailableVersion(highestAvailableVersion: newerVersion);
+
+                    this.DisplayUpgradeAvailableToast(newerVersion.ToString());
                 }
                 catch (Exception ex) when (
                     ex is IOException ||
@@ -245,6 +254,15 @@ namespace GVFS.Service
             tracer.RelatedInfo(logMessage);
 
             return true;
+        }
+
+        private void DisplayUpgradeAvailableToast(string version)
+        {
+            NamedPipeMessages.Notification.Request request = new NamedPipeMessages.Notification.Request();
+            request.Id = NamedPipeMessages.Notification.Request.Identifier.UpgradeAvailable;
+            request.NewVersion = version;
+
+            this.notificationHandler.SendNotification(request);
         }
     }
 }

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -328,7 +328,7 @@ namespace GVFS.Service
             request.Enlistment = enlistment;
             request.EnlistmentCount = enlistmentCount;
 
-            this.notificationHandler.SendNotification(sessionId, request);
+            this.notificationHandler.SendNotification(request);
         }
 
         private void WriteRegistry(Dictionary<string, RepoRegistration> registry)

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Windows\Mock\WindowsFileSystemVirtualizerTester.cs" />
+    <Compile Include="Windows\ServiceUI\GVFSToastRequestHandlerTests.cs" />
     <Compile Include="Windows\Upgrader\WindowsNuGetUpgraderTests.cs" />
     <Compile Include="Windows\Mock\MockProcessLauncher.cs" />
     <Compile Include="Windows\Mock\MockVirtualizationInstance.cs" />
@@ -157,6 +158,10 @@
     <ProjectReference Include="..\GVFS.Platform.Windows\GVFS.Platform.Windows.csproj">
       <Project>{4ce404e7-d3fc-471c-993c-64615861ea63}</Project>
       <Name>GVFS.Platform.Windows</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GVFS.Service.UI\GVFS.Service.UI.csproj">
+      <Project>{93b403fd-dafb-46c5-9636-b122792a548a}</Project>
+      <Name>GVFS.Service.UI</Name>
     </ProjectReference>
     <ProjectReference Include="..\GVFS.Service\GVFS.Service.Mac.csproj">
       <Project>{03769a07-f216-456b-886b-e07caf6c5e81}</Project>

--- a/GVFS/GVFS.UnitTests.Windows/Windows/ServiceUI/GVFSToastRequestHandlerTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/ServiceUI/GVFSToastRequestHandlerTests.cs
@@ -1,0 +1,111 @@
+﻿using GVFS.Common.NamedPipes;
+using GVFS.Service.UI;
+using GVFS.UnitTests.Mock.Common;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Windows.ServiceUI
+{
+    [TestFixture]
+    public class GVFSToastRequestHandlerTests
+    {
+        private NamedPipeMessages.Notification.Request request;
+        private GVFSToastRequestHandler toastHandler;
+        private Mock<IToastNotifier> mockToastNotifier;
+        private MockTracer tracer;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.tracer = new MockTracer();
+            this.mockToastNotifier = new Mock<IToastNotifier>(MockBehavior.Strict);
+            this.mockToastNotifier.SetupSet(toastNotifier => toastNotifier.UserResponseCallback = It.IsAny<Action<string>>()).Verifiable();
+            this.toastHandler = new GVFSToastRequestHandler(this.mockToastNotifier.Object, this.tracer);
+            this.request = new NamedPipeMessages.Notification.Request();
+        }
+
+        [TestCase]
+        public void UpgradeToastIsActionableAndContainsVersionInfo()
+        {
+            const string version = "1.0.956749.2";
+
+            this.request.Id = NamedPipeMessages.Notification.Request.Identifier.UpgradeAvailable;
+            this.request.NewVersion = version;
+
+            this.VerifyToastMessage(
+                expectedTitle: "New version " + version + " is available",
+                expectedMessage: "click Upgrade button",
+                expectedButtonTitle: "Upgrade",
+                expectedGVFSCmd: "gvfs upgrade --confirm");
+        }
+
+        [TestCase]
+        public void MountFailureToastIsActionableAndContainEnlistmentInfo()
+        {
+            const string enlistmentRoot = "D:\\Work\\OS";
+
+            this.request.Id = NamedPipeMessages.Notification.Request.Identifier.MountFailure;
+            this.request.Enlistment = enlistmentRoot;
+
+            this.VerifyToastMessage(
+                expectedTitle: "VFS For Git Automount",
+                expectedMessage: enlistmentRoot,
+                expectedButtonTitle: "Retry",
+                expectedGVFSCmd: "gvfs mount " + enlistmentRoot);
+        }
+
+        [TestCase]
+        public void MountStartIsNotActionableAndContainsEnlistmentCount()
+        {
+            const int enlistmentCount = 10;
+
+            this.request.Id = NamedPipeMessages.Notification.Request.Identifier.AutomountStart;
+            this.request.EnlistmentCount = enlistmentCount;
+
+            this.VerifyToastMessage(
+                expectedTitle: "VFS For Git Automount",
+                expectedMessage: "mount " + enlistmentCount.ToString() + " VFS For Git repos",
+                expectedButtonTitle: null,
+                expectedGVFSCmd: null);
+        }
+
+        [TestCase]
+        public void UnknownToastRequestGetsIgnored()
+        {
+            this.request.Id = (NamedPipeMessages.Notification.Request.Identifier)10;
+            this.request.EnlistmentCount = 232;
+            this.request.Enlistment = "C:\\OS";
+
+            this.toastHandler.HandleToastRequest(this.tracer, this.request);
+
+            this.mockToastNotifier.Verify(
+                toastNotifier => toastNotifier.Notify(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()),
+                Times.Never());
+        }
+
+        private void VerifyToastMessage(
+            string expectedTitle,
+            string expectedMessage,
+            string expectedButtonTitle,
+            string expectedGVFSCmd)
+        {
+            this.mockToastNotifier.Setup(toastNotifier => toastNotifier.Notify(
+                expectedTitle,
+                It.Is<string>(message => message.Contains(expectedMessage)),
+                expectedButtonTitle,
+                expectedGVFSCmd));
+
+            this.toastHandler.HandleToastRequest(this.tracer, this.request);
+            this.mockToastNotifier.VerifyAll();
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -127,6 +127,13 @@ namespace GVFS.CommandLine
                             this.ServiceName,
                             copySubFolders: true);
 
+                        // service ui
+                        this.CopyAllFiles(
+                            GVFSPlatform.Instance.GetDataRootForGVFS(),
+                            archiveFolderPath,
+                            GVFSConstants.Service.UIName,
+                            copySubFolders: true);
+
                         if (GVFSPlatform.Instance.UnderConstruction.SupportsGVFSUpgrade)
                         {
                             // upgrader


### PR DESCRIPTION
#### Supported notifications
| Notification | Screenshot | Action |
| --- | --- |---|
| Autmount start |<img width="390" alt="Automount_Start" src="https://user-images.githubusercontent.com/378580/64622955-2765c380-d3b6-11e9-9cb0-f929a6e7bb11.png">|This notification is not actionable |
| Mount failure during auto-mount |<img width="389" alt="Automount_Failure" src="https://user-images.githubusercontent.com/378580/64623109-6bf15f00-d3b6-11e9-897d-3553d87cdc06.png">|<img width="752" alt="Automount_Failure_Response" src="https://user-images.githubusercontent.com/378580/64623135-76abf400-d3b6-11e9-80f6-914fa964a7c2.png">|
| Upgrade available | <img width="385" alt="Upgrade_Available" src="https://user-images.githubusercontent.com/378580/64623199-90e5d200-d3b6-11e9-8242-2b9a1d7d288c.png">| <img width="726" alt="Upgrade_Available_Response" src="https://user-images.githubusercontent.com/378580/64623227-9c38fd80-d3b6-11e9-85a3-5e2e838d3dfc.png">|

#### Changes in this PR
- `VFSForGit` installer creates a `Start Menu` shortcut to `GVFS.Service.UI.exe` after successful install. (This shortcut is a requirement for enabling native toasters.)
- `VFSForGit` installer launches `GVFS.Service.UI.exe` in the currently logged-in user context after install
- `GVFS.Service` will launch `GVFS.Service.UI` when a new user logs in.
- `GVFS.Service.UI.exe` will always be running.
- `GVFS.Service.UI.exe` listens for supported notifications. Notifications that cannot be identified are ignored.
- Auto-mount and Upgrade available toasters are actionable. In response these actionable toasters, `GVFS.Service.UI` runs `gvfs mount` and `gvfs upgrade --confirm` (elevated) verbs in a new Command Prompt window.
- `GVFS.Service` waits for a minute before doing upgrade checks, just so that `VFSForGit` installer gets the time to launch `GVFS.Service.UI` that is needed to display the notifications.

#### TODO
- [x] Testing
- [x] Integrate with `GVFS.Service`
- [x] Unit testing
- [x] Update diagnose verb to cat `GVFS.Service.UI` logs