### PR TITLE
restore mixed-case prefetch folder list tests and tidy MirrorProviders

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -44,7 +44,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             "foo.cpp", // Changes to a folder in one test
             "FilenameEncoding",
             "GitCommandsTests",
-            "GVFLT_MultiThreadTest", // Changes case in one test
+            "GVFLT_MultiThreadTest", // Required by DeleteFolderAndChangeBranchToFolderWithDifferentCase test in sparse mode
             "GVFlt_BugRegressionTest",
             "GVFlt_DeleteFileTest",
             "GVFlt_DeleteFolderTest",

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -44,7 +44,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             "foo.cpp", // Changes to a folder in one test
             "FilenameEncoding",
             "GitCommandsTests",
-            "GVFLT_MultiThreadTest",
+            "GVFLT_MultiThreadTest", // Changes case in one test
             "GVFlt_BugRegressionTest",
             "GVFlt_DeleteFileTest",
             "GVFlt_DeleteFolderTest",

--- a/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Mac/MacFileSystemVirtualizer.cs
@@ -11,6 +11,7 @@ namespace MirrorProvider.Mac
         private VirtualizationInstance virtualizationInstance = new VirtualizationInstance();
 
         protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+        protected override StringComparer PathComparer => StringComparer.OrdinalIgnoreCase;
 
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
@@ -243,7 +244,7 @@ namespace MirrorProvider.Mac
             targetBuffer[bytesRead] = 0;
             symLinkTarget = Encoding.UTF8.GetString(targetBuffer);
 
-            if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, StringComparison.OrdinalIgnoreCase))
+            if (symLinkTarget.StartsWith(this.Enlistment.MirrorRoot, PathComparison))
             {
                 // Link target is an absolute path inside the MirrorRoot.  
                 // The target needs to be adjusted to point inside the src root

--- a/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider.Windows/WindowsFileSystemVirtualizer.cs
@@ -13,6 +13,7 @@ namespace MirrorProvider.Windows
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations = new ConcurrentDictionary<Guid, ActiveEnumeration>();
 
         protected override StringComparison PathComparison => StringComparison.OrdinalIgnoreCase;
+        protected override StringComparer PathComparer => StringComparer.OrdinalIgnoreCase;
 
         public override bool TryConvertVirtualizationRoot(string directory, out string error)
         {
@@ -76,7 +77,7 @@ namespace MirrorProvider.Windows
             // what is on disk, and it assumes that both lists are already sorted.
             ActiveEnumeration activeEnumeration = new ActiveEnumeration(
                 this.GetChildItems(relativePath)
-                .OrderBy(file => file.Name, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(file => file.Name, PathComparer)
                 .ToList());
 
             if (!this.activeEnumerations.TryAdd(enumerationId, activeEnumeration))
@@ -272,7 +273,7 @@ namespace MirrorProvider.Windows
 
             string parentDirectory = Path.GetDirectoryName(relativePath);
             string childName = Path.GetFileName(relativePath);
-            if (this.GetChildItems(parentDirectory).Any(child => child.Name.Equals(childName, StringComparison.OrdinalIgnoreCase)))
+            if (this.GetChildItems(parentDirectory).Any(child => child.Name.Equals(childName, PathComparison)))
             {
                 return HResult.Ok;
             }

--- a/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
+++ b/MirrorProvider/MirrorProvider/FileSystemVirtualizer.cs
@@ -10,6 +10,7 @@ namespace MirrorProvider
         protected Enlistment Enlistment { get; private set; }
 
         protected abstract StringComparison PathComparison { get; }
+        protected abstract StringComparer PathComparer { get; }
 
         public abstract bool TryConvertVirtualizationRoot(string directory, out string error);
         public virtual bool TryStartVirtualizationInstance(Enlistment enlistment, out string error)


### PR DESCRIPTION
On case-insensitive filesystems, we can restore the use of non-case-matching mixed-case file and folder paths in several `PrefetchVerbTests`, while retaining case-sensitive exact matches on Linux.

These changes are a follow-up based on PR feedback from @wilbaker on PR #1412 and commit 5c78902.

We also use the `PathComparison` we set in our `MirrorProvider`s to actually perform path comparisons, and add a `PathComparer` for use on Windows in particular.