### PR TITLE
Mac installer preinstall failure

### DIFF
--- a/GVFS/GVFS.Installer.Mac/scripts/preinstall
+++ b/GVFS/GVFS.Installer.Mac/scripts/preinstall
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Unmount all registered repositories before unloading
+# the Kext.
+GVFSBINPATH="/usr/local/vfsforgit/gvfs"
+if [ -f "${GVFSBINPATH}" ]; then
+    unmountCmd="${GVFSBINPATH} service --unmount-all"
+    echo $unmountCmd
+    eval $unmountCmd || exit 1
+fi
+
 KEXTBUNDLEID="org.vfsforgit.PrjFSKext"
 isKextLoadedCmd="/usr/sbin/kextstat -l -b $KEXTBUNDLEID | wc -l"
 isKextLoaded=$(eval $isKextLoadedCmd)
@@ -16,11 +25,4 @@ if [ "$isKextLoaded" -gt 0 ]; then
     unloadCmd="/sbin/kextunload -b $LEGACYKEXTBUNDLEID"
     echo $unloadCmd
     eval $unloadCmd || exit 1
-fi
-
-GVFSBINPATH="/usr/local/vfsforgit/gvfs"
-if [ -f "${GVFSBINPATH}" ]; then
-    unmountCmd="${GVFSBINPATH} service --unmount-all"
-    echo $unmountCmd
-    eval $unmountCmd || exit 1
 fi


### PR DESCRIPTION
#### `gvfs service --unmount-all` used to fail in preinstall script

```
2019-09-04 08:54:21-04 JamesonsWorkMBP installd[688]: ./preinstall: /sbin/kextunload -b org.vfsforgit.PrjFSKext
2019-09-04 08:54:21-04 JamesonsWorkMBP installd[688]: ./preinstall: /usr/local/vfsforgit/gvfs service --unmount-all
2019-09-04 08:54:21-04 JamesonsWorkMBP installd[688]: ./preinstall: Failed to find instance of service class org_vfsforgit_PrjFS
2019-09-04 08:54:21-04 JamesonsWorkMBP installd[688]: ./preinstall: Unable to register with the kernel for offline I/O. Ensure that VFS for Git installed successfully and try again
```

#### Steps To manually repro the problem
```
$ gvfs service --list-mounted
/Users/Ameen/Work/Microsoft/TestRepos/GVFS_7
$ sudo kextunload /Library/Extensions/PrjFSKext.kext
$ gvfs service --list-mounted
Failed to find instance of service class org_vfsforgit_PrjFS
Unable to register with the kernel for offline I/O. Ensure that VFS for Git installed successfully and try again
$ sudo kextload /Library/Extensions/PrjFSKext.kext
$ gvfs service --list-mounted
/Users/Ameen/Work/Microsoft/TestRepos/GVFS_7
```

The script used to unload `org.vfsforgit.PrjFSKext` before un-mounting the registered repos. Causing the failure. All registered repositories should be unmounted before unloading the PrjFS Kext. Updated the order of commands run, in `preinstall` script.