### PR TITLE
Check the disposing flag in Dispose methods

### DIFF
--- a/GVFS/GVFS.Common/GVFSContext.cs
+++ b/GVFS/GVFS.Common/GVFSContext.cs
@@ -28,6 +28,7 @@ namespace GVFS.Common
         public void Dispose()
         {
             this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/GVFS/GVFS.Common/Git/HashingStream.cs
+++ b/GVFS/GVFS.Common/Git/HashingStream.cs
@@ -108,15 +108,18 @@ namespace GVFS.Common.Git
 
         protected override void Dispose(bool disposing)
         {
-            if (this.hash != null)
+            if (disposing)
             {
-                this.hash.Dispose();
-            }
+                if (this.hash != null)
+                {
+                    this.hash.Dispose();
+                }
 
-            if (this.stream != null)
-            {
-                this.stream.Dispose();
-                this.stream = null;
+                if (this.stream != null)
+                {
+                    this.stream.Dispose();
+                    this.stream = null;
+                }
             }
 
             base.Dispose(disposing);

--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -211,12 +211,15 @@ namespace GVFS.Service
 
         protected override void Dispose(bool disposing)
         {
-            this.StopRunning();
-
-            if (this.tracer != null)
+            if (disposing)
             {
-                this.tracer.Dispose();
-                this.tracer = null;
+                this.StopRunning();
+
+                if (this.tracer != null)
+                {
+                    this.tracer.Dispose();
+                    this.tracer = null;
+                }
             }
 
             base.Dispose(disposing);

--- a/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
+++ b/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
@@ -124,10 +124,13 @@ namespace GVFS.Virtualization.Background
 
         protected void Dispose(bool disposing)
         {
-            if (this.backgroundThread != null)
+            if (disposing)
             {
-                this.backgroundThread.Dispose();
-                this.backgroundThread = null;
+                if (this.backgroundThread != null)
+                {
+                    this.backgroundThread.Dispose();
+                    this.backgroundThread = null;
+                }
             }
         }
 


### PR DESCRIPTION
When using `Dispose(bool disposing)`, the disposing flag needs to be checked so that objects that may have already been disposed of through garbage collection will not be used and cause a ObjectDisposedException.  When the disposing flag is `true` it is okay to call dispose on other member objects but when it is `false` it is being disposed through the finalizer by the garbage collector and the member objects may have already been disposed by garbage collection and should not be used.

In most cases in our code we are not following the exact pattern for dispose but it is okay because we are not holding onto unmanaged resources and are not implementing a finalizer to release the unmanaged resources.  

Please see [this article](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose) for the suggested way to implement and use the dispose pattern.