### PR TITLE
diff: use csharp driver for better function headers in .cs files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # Do not normalize any line endings.
 ###############################################################################
 * -text
+*.cs diff=csharp


### PR DESCRIPTION
Update .gitattributes to use the csharp pattern for hunk headers in *.cs files.
This will result in the csharp function name that a change occurs in to be
included in the hunk header.

For example, for commit 351145, this updates the output from:

```
diff --git a/GVFS/GVFS.Common/GVFSContext.cs b/GVFS/GVFS.Common/GVFSContext.cs
index 67636d6f..3e79d7d2 100644
--- a/GVFS/GVFS.Common/GVFSContext.cs
+++ b/GVFS/GVFS.Common/GVFSContext.cs
@@ -28,6 +28,7 @@ namespace GVFS.Common
         public void Dispose()
         {
             this.Dispose(true);
+            GC.SuppressFinalize(this);^M
         }
```

to:

```
diff --git a/GVFS/GVFS.Common/GVFSContext.cs b/GVFS/GVFS.Common/GVFSContext.cs
index 67636d6f..3e79d7d2 100644
--- a/GVFS/GVFS.Common/GVFSContext.cs
+++ b/GVFS/GVFS.Common/GVFSContext.cs
@@ -28,6 +28,7 @@ public GVFSContext(ITracer tracer, PhysicalFileSystem fileSystem, GitRepo reposi
         public void Dispose()
         {
             this.Dispose(true);
+            GC.SuppressFinalize(this);^M
         }
```

