### PR TITLE
Update upgrade messages for platforms that do not support NuGet package verification

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -240,16 +240,19 @@ namespace GVFS.Common
             public UnderConstructionFlags(
                 bool supportsGVFSUpgrade = true,
                 bool supportsGVFSConfig = true,
-                bool supportsNuGetEncryption = true)
+                bool supportsNuGetEncryption = true,
+                bool supportsNuGetVerification = true)
             {
                 this.SupportsGVFSUpgrade = supportsGVFSUpgrade;
                 this.SupportsGVFSConfig = supportsGVFSConfig;
                 this.SupportsNuGetEncryption = supportsNuGetEncryption;
+                this.SupportsNuGetVerification = supportsNuGetVerification;
             }
 
             public bool SupportsGVFSUpgrade { get; }
             public bool SupportsGVFSConfig { get; }
             public bool SupportsNuGetEncryption { get; }
+            public bool SupportsNuGetVerification { get; }
         }
     }
 }

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.Shared.cs
@@ -8,7 +8,7 @@ namespace GVFS.Platform.Mac
     public partial class MacPlatform
     {
         public const string DotGVFSRoot = ".gvfs";
-        public const string UpgradeConfirmMessage = "`sudo gvfs upgrade --confirm`";
+        public const string UpgradeConfirmMessage = "`sudo gvfs upgrade --confirm --no-verify`";
 
         public static string GetDataRootForGVFSImplementation()
         {

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -23,7 +23,8 @@ namespace GVFS.Platform.Mac
              underConstruction: new UnderConstructionFlags(
                 supportsGVFSUpgrade: true,
                 supportsGVFSConfig: true,
-                supportsNuGetEncryption: false))
+                supportsNuGetEncryption: false,
+                supportsNuGetVerification: false))
         {
         }
 

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -23,7 +23,8 @@ namespace GVFS.Platform.POSIX
             underConstruction: new UnderConstructionFlags(
                 supportsGVFSUpgrade: false,
                 supportsGVFSConfig: false,
-                supportsNuGetEncryption: false))
+                supportsNuGetEncryption: false,
+                supportsNuGetVerification: false))
         {
         }
 

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -68,7 +68,7 @@ namespace GVFS.CommandLine
             "no-verify",
             Default = false,
             Required = false,
-            HelpText = "This parameter is reserved for internal use.")]
+            HelpText = "Do not verify NuGet packages after downloading them. Some platforms do not support NuGet verification.")]
         public bool NoVerify { get; set; }
 
         protected override string VerbName

--- a/GVFS/GVFS/CommandLine/UpgradeVerb.cs
+++ b/GVFS/GVFS/CommandLine/UpgradeVerb.cs
@@ -198,6 +198,18 @@ namespace GVFS.CommandLine
                     return false;
                 }
 
+                // If we are on a platform that does not support nuget verification, and user has not
+                // specified the --no-verify flag, then print a helpful message here.
+                if (!GVFSPlatform.Instance.UnderConstruction.SupportsNuGetVerification && !this.NoVerify)
+                {
+                    string packageVerificationNotSupportedMessage = @"
+NuGet package verification is not supported on this platform. In order to run upgrade, you must run upgrade without NuGet package verification.
+To run upgrade without NuGet verification include the --no-verify option.
+";
+                    this.ReportInfoToConsole(packageVerificationNotSupportedMessage);
+                    return false;
+                }
+
                 if (!this.TryRunInstaller(out message))
                 {
                     this.tracer.RelatedError($"{nameof(this.TryRunProductUpgrade)}: Could not launch upgrade tool. {message}");


### PR DESCRIPTION
NuGet package verification is not supported by the NuGet client / net core on some platforms - in particular Linux / macOS. There has been some confusion around the messages we display. This PR is to improve the messaging to reduce confusion. I am open to feedback on the messaging. I listed some of the issues I could see with our current messaging at the bottom. I am also keeping in mind how much work it would be to improve the messages. The current PR is a more tactical change, but I could see that some of the issues might require more in-depth changes (and hence are not addressed in this PR) - but if we feel there is a driving need to update them, let's consider it.

There is a matrix of scenarios for us to consider based on the arguments passed to `gvfs upgrade` and whether it is run with elevated permissions:

| Confirm | NoVerify | Run elevated |
| -------- | -------- | ------------- |
 

With this change, here is the current output for several scenarios:

Scenario 1: `gvfs upgrade` (with or without `--no-verify` argument)

```
$ gvfs upgrade
Checking for GVFS upgrades...Succeeded
New version 0.6.19224.2 is available.

Upgrade will unmount and remount gvfs repos, ensure you are at a stopping point.
When ready, run `sudo gvfs upgrade --confirm --no-verify` to upgrade.
```

Scenario 2: `gvfs upgrade` with `--confirm` argument, but not run elevated. With or without `--no-verify` argument

```
$ gvfs upgrade --confirm
Cannot upgrade GVFS on this machine.

ERROR: The installer needs to be run with elevated permissions.
Run `sudo gvfs upgrade --confirm --no-verify`.
```

Scenario 3: `gvfs upgrade` with confirm argument, run with elevated permissions:

```
$ sudo gvfs upgrade --confirm
Checking for GVFS upgrades...Succeeded
New version 0.6.19224.2 is available.

NuGet package verification is not supported on this platform. In order to run upgrade, you must run upgrade without NuGet package verification.
To run upgrade without NuGet verification include the --no-verify option.
```

Issues:
1) In scenario 2, there are 2 items that prevent the user from upgrading - the command is not run elevated, and the `--no-verify` argument not supplied. We call out that the command needs to be run elevated, and the command we display includes the `--no-verify` option, but we don't otherwise call out the `--no-verify` argument.

2) The command that we recommend to run (`sudo gvfs upgrade --confirm --no-verify`) includes the `--no-verify` argument, but we do not call out what the user should consider before running this command as we do in the output for scenario 3.

3) Scenario 2 includes messaging that the user "Cannot upgrade GVFS on this machine", which is not entirely accurate. They just need to run the command elevated. 
