### PR TITLE
Add sparse set and file option

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSProcess.cs
@@ -104,7 +104,12 @@ namespace GVFS.FunctionalTests.Tools
                 }
             }
 
-            return this.CallGVFS($"sparse {this.enlistmentRoot} {pruneArg} {action} {folderList}", expectedExitCode: shouldSucceed ? SuccessExitCode : ExitCodeShouldNotBeZero);
+            return this.Sparse($"{pruneArg} {action} {folderList}", shouldSucceed);
+        }
+
+        public string Sparse(string arguments, bool shouldSucceed)
+        {
+            return this.CallGVFS($"sparse {this.enlistmentRoot} {arguments}", expectedExitCode: shouldSucceed ? SuccessExitCode : ExitCodeShouldNotBeZero);
         }
 
         public string[] GetSparseFolders()

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -88,10 +88,7 @@ Folders need to be relative to the repos root directory.")
                 return;
             }
 
-            if (!this.OptionsValid())
-            {
-                return;
-            }
+            this.CheckOptions();
 
             using (JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, SparseVerbName))
             {
@@ -281,15 +278,14 @@ Folders need to be relative to the repos root directory.")
             }
         }
 
-        private bool OptionsValid()
+        private void CheckOptions()
         {
             if (!string.IsNullOrEmpty(this.Set) && (
                 !string.IsNullOrEmpty(this.Add) ||
                 !string.IsNullOrEmpty(this.Remove) ||
                 !string.IsNullOrEmpty(this.File)))
             {
-                this.Output.WriteLine("--set not valid with other options.");
-                return false;
+                this.ReportErrorAndExit("--set not valid with other options.");
             }
 
             if (!string.IsNullOrEmpty(this.File) && (
@@ -297,11 +293,8 @@ Folders need to be relative to the repos root directory.")
                 !string.IsNullOrEmpty(this.Remove) ||
                 !string.IsNullOrEmpty(this.Set)))
             {
-                this.Output.WriteLine("--file not valid with other options.");
-                return false;
+                this.ReportErrorAndExit("--file not valid with other options.");
             }
-
-            return true;
         }
 
         private void ListSparseFolders(string enlistmentRoot)

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -26,6 +26,22 @@ Folders need to be relative to the repos root directory.")
         private const char StatusRenameToken = 'R';
 
         [Option(
+            's',
+            "set",
+            Required = false,
+            Default = "",
+            HelpText = "A semicolon-delimited list of repo root relative folders to use as the sparse set for determining what to project. Wildcards are not supported.")]
+        public string Set { get; set; }
+
+        [Option(
+            'f',
+            "file",
+            Required = false,
+            Default = "",
+            HelpText = "Path to a file that will has repo root relative folders to use as the sparse set. One folder per line. Wildcards are not supported.")]
+        public string File { get; set; }
+
+        [Option(
             'a',
             "add",
             Required = false,


### PR DESCRIPTION
This PR adds both the `--set` and `--file` options to the sparse verb.

This will allow the sparse verb to make the projected folders match what is in the set passed in, adding and removing as needed.  `--set` is a `;` separated list of the folders.  `--file` is the path to a file that contains the folders, one per line.

The tests only are testing that the sparse folders are updated properly since there are other tests for checking the file system gets updated correctly.

Resolves #1509 