### PR TITLE
Add disable option to quickly get out of sparse mode

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -14,6 +14,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [TestFixture]
     public class SparseTests : TestsWithEnlistmentPerFixture
     {
+        private static readonly string[] NoSparseFolders = new string[0];
         private FileSystemRunner fileSystem = new SystemIORunner();
         private GVFSProcess gvfsProcess;
         private string mainSparseFolder = Path.Combine("GVFS", "GVFS");
@@ -43,7 +44,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 .Where(x => !x.Contains(Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar))
                 .ToArray();
             directories.ShouldMatchInOrder(this.allDirectories);
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         [TestCase, Order(1)]
@@ -235,7 +236,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string output = this.gvfsProcess.AddSparseFolders(shouldPrune: false, shouldSucceed: false, folders: this.mainSparseFolder);
             output.ShouldContain("sparse was aborted");
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         [TestCase, Order(10)]
@@ -419,7 +420,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string output = this.gvfsProcess.AddSparseFolders(shouldPrune: false, shouldSucceed: false, folders: "Scripts");
             output.ShouldContain("Running git status...Failed", "sparse was aborted");
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         [TestCase, Order(20)]
@@ -461,7 +462,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             string output = this.gvfsProcess.RemoveSparseFolders(folders: this.mainSparseFolder);
             output.ShouldNotContain(ignoreCase: false, unexpectedSubstrings: "Running git status");
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         [TestCase, Order(23)]
@@ -497,11 +498,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             output = this.gvfsProcess.RemoveSparseFolders(folders: this.mainSparseFolder);
             output.ShouldNotContain(ignoreCase: false, unexpectedSubstrings: "Running git status");
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
 
             output = this.gvfsProcess.AddSparseFolders(shouldPrune: false, shouldSucceed: false, folders: "Scripts");
             output.ShouldContain("Running git status...Failed", "sparse was aborted");
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
 
             string statusOutput = GitProcess.Invoke(this.Enlistment.RepoRoot, "status --porcelain -uall");
             statusOutput.ShouldEqual(expecetedStatusOutput, "Status output should not change.");
@@ -588,10 +589,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(30)]
         public void DisableWhenNotInSparseModeShouldBeNoop()
         {
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
             string output = this.gvfsProcess.Sparse("--disable", shouldSucceed: true);
             output.ShouldEqual(string.Empty);
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         private void CheckMainSparseFolder()
@@ -620,11 +621,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.gvfsProcess.AddSparseFolders(path);
             this.ValidateFoldersInSparseList(expectedSparsePath);
             this.gvfsProcess.RemoveSparseFolders(path);
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
             this.gvfsProcess.AddSparseFolders(path);
             this.ValidateFoldersInSparseList(expectedSparsePath);
             this.gvfsProcess.RemoveSparseFolders(expectedSparsePath);
-            this.ValidateFoldersInSparseList(new string[0]);
+            this.ValidateFoldersInSparseList(NoSparseFolders);
         }
 
         private void ValidateFoldersInSparseList(params string[] folders)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -585,6 +585,15 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             output.ShouldContain("--disable not valid with other options.");
         }
 
+        [TestCase, Order(30)]
+        public void DisableWhenNotInSparseModeShouldBeNoop()
+        {
+            this.ValidateFoldersInSparseList(new string[0]);
+            string output = this.gvfsProcess.Sparse("--disable", shouldSucceed: true);
+            output.ShouldEqual(string.Empty);
+            this.ValidateFoldersInSparseList(new string[0]);
+        }
+
         private void CheckMainSparseFolder()
         {
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -573,6 +573,21 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.ValidateFoldersInSparseList("Scripts", "GitCommandsTests");
         }
 
+        [TestCase, Order(30)]
+        public void DisableWithOtherOptionsFails()
+        {
+            string output = this.gvfsProcess.Sparse($"--disable --add test1", shouldSucceed: false);
+            output.ShouldContain("--disable not valid with other options.");
+            output = this.gvfsProcess.Sparse($"--disable --remove test1", shouldSucceed: false);
+            output.ShouldContain("--disable not valid with other options.");
+            output = this.gvfsProcess.Sparse($"--disable --set test1", shouldSucceed: false);
+            output.ShouldContain("--disable not valid with other options.");
+            output = this.gvfsProcess.Sparse($"--disable --file test1", shouldSucceed: false);
+            output.ShouldContain("--disable not valid with other options.");
+            output = this.gvfsProcess.Sparse($"--disable --prune", shouldSucceed: false);
+            output.ShouldContain("--disable not valid with other options.");
+        }
+
         private void CheckMainSparseFolder()
         {
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -17,14 +17,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private FileSystemRunner fileSystem = new SystemIORunner();
         private GVFSProcess gvfsProcess;
         private string mainSparseFolder = Path.Combine("GVFS", "GVFS");
-        private string[] allRootDirectories;
+        private string[] allDirectories;
         private string[] directoriesInMainFolder;
 
         [OneTimeSetUp]
         public void Setup()
         {
             this.gvfsProcess = new GVFSProcess(this.Enlistment);
-            this.allRootDirectories = Directory.GetDirectories(this.Enlistment.RepoRoot, "*", SearchOption.AllDirectories)
+            this.allDirectories = Directory.GetDirectories(this.Enlistment.RepoRoot, "*", SearchOption.AllDirectories)
                 .Where(x => !x.Contains(Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar))
                 .ToArray();
             this.directoriesInMainFolder = Directory.GetDirectories(Path.Combine(this.Enlistment.RepoRoot, this.mainSparseFolder));
@@ -36,16 +36,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "clean -xdf");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "reset --hard");
 
-            foreach (string sparseFolder in this.gvfsProcess.GetSparseFolders())
-            {
-                this.gvfsProcess.RemoveSparseFolders(sparseFolder);
-            }
+            this.gvfsProcess.Sparse("--disable", shouldSucceed: true);
 
             // Remove all sparse folders should make all folders appear again
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot, "*", SearchOption.AllDirectories)
                 .Where(x => !x.Contains(Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar))
                 .ToArray();
-            directories.ShouldMatchInOrder(this.allRootDirectories);
+            directories.ShouldMatchInOrder(this.allDirectories);
             this.ValidateFoldersInSparseList(new string[0]);
         }
 

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -116,11 +116,18 @@ Folders need to be relative to the repos root directory.")
                     List<string> foldersToRemove = new List<string>();
                     List<string> foldersToAdd = new List<string>();
 
-                    if (this.Disable && directories.Count > 0)
+                    if (this.Disable)
                     {
-                        needToChangeProjection = true;
-                        foldersToRemove.AddRange(directories);
-                        directories.Clear();
+                        if (directories.Count > 0)
+                        {
+                            needToChangeProjection = true;
+                            foldersToRemove.AddRange(directories);
+                            directories.Clear();
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
                     else if (!string.IsNullOrEmpty(this.Set) || !string.IsNullOrEmpty(this.File))
                     {

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -73,6 +73,14 @@ Folders need to be relative to the repos root directory.")
             HelpText = "Remove any folders that are not in the list of sparse folders.")]
         public bool Prune { get; set; }
 
+        [Option(
+            'd',
+            "disable",
+            Required = false,
+            Default = false,
+            HelpText = "Disable the sparse feature.  This will remove all folders in the sparse list and start projecting all folders.")]
+        public bool Disable { get; set; }
+
         protected override string VerbName => SparseVerbName;
 
         protected override void Execute(GVFSEnlistment enlistment)

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -87,6 +87,7 @@ Folders need to be relative to the repos root directory.")
         {
             if (this.List || (
                 !this.Prune &&
+                !this.Disable &&
                 string.IsNullOrEmpty(this.Add) &&
                 string.IsNullOrEmpty(this.Remove) &&
                 string.IsNullOrEmpty(this.Set) &&
@@ -288,6 +289,16 @@ Folders need to be relative to the repos root directory.")
 
         private void CheckOptions()
         {
+            if (this.Disable && (
+                this.Prune ||
+                !string.IsNullOrEmpty(this.Set) ||
+                !string.IsNullOrEmpty(this.Add) ||
+                !string.IsNullOrEmpty(this.Remove) ||
+                !string.IsNullOrEmpty(this.File)))
+            {
+                this.ReportErrorAndExit(ReturnCode.GenericError, "--disable not valid with other options.");
+            }
+
             if (!string.IsNullOrEmpty(this.Set) && (
                 !string.IsNullOrEmpty(this.Add) ||
                 !string.IsNullOrEmpty(this.Remove) ||

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -116,7 +116,13 @@ Folders need to be relative to the repos root directory.")
                     List<string> foldersToRemove = new List<string>();
                     List<string> foldersToAdd = new List<string>();
 
-                    if (!string.IsNullOrEmpty(this.Set) || !string.IsNullOrEmpty(this.File))
+                    if (this.Disable && directories.Count > 0)
+                    {
+                        needToChangeProjection = true;
+                        foldersToRemove.AddRange(directories);
+                        directories.Clear();
+                    }
+                    else if (!string.IsNullOrEmpty(this.Set) || !string.IsNullOrEmpty(this.File))
                     {
                         IEnumerable<string> folders = null;
                         if (!string.IsNullOrEmpty(this.Set))
@@ -296,7 +302,7 @@ Folders need to be relative to the repos root directory.")
                 !string.IsNullOrEmpty(this.Remove) ||
                 !string.IsNullOrEmpty(this.File)))
             {
-                this.ReportErrorAndExit(ReturnCode.GenericError, "--disable not valid with other options.");
+                this.ReportErrorAndExit("--disable not valid with other options.");
             }
 
             if (!string.IsNullOrEmpty(this.Set) && (


### PR DESCRIPTION
This PR builds on #1520 changes. [Here is the diff for just these changes](https://github.com/kewillford/VFSForGit/compare/sparse-set...kewillford:sparse-turn-off)

This adds a `--disable` option that isn't valid with other options that will take the list of directories in the sparse table and remove each one.  I thought about adding a `RemoveAll` to the `SparseTable` but decided that it might be helpful to have the paths that were removed in the log file so this uses the code that was already there simply adding each directory to the `foldersToRemove` list.

Changed the tests to use the `--disable` option in the `Teardown`. 

- [x] Add test that uses the option when sparse mode is already off.

Resolves #1502 