### PR TITLE
GitMaintenanceStep: delete commit-graphs folder before rewriting

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -276,6 +276,14 @@ namespace GVFS.Common.Maintenance
             string commitGraphPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graph");
             errorMetadata["TryDeleteFileResult"] = this.Context.FileSystem.TryDeleteFile(commitGraphPath);
 
+            string commitGraphsPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, "info", "commit-graphs");
+            errorMetadata["TryDeleteDirectoryResult"] = this.Context.FileSystem.TryDeleteDirectory(commitGraphsPath, out Exception dirException);
+
+            if (dirException != null)
+            {
+                errorMetadata["TryDeleteDirectoryError"] = dirException.Message;
+            }
+
             GitProcess.Result rewriteResult = this.RunGitCommand((process) => process.WriteCommitGraph(this.Context.Enlistment.GitObjectsRoot, packs), nameof(GitProcess.WriteCommitGraph));
             errorMetadata["RewriteResultExitCode"] = rewriteResult.ExitCode;
 


### PR DESCRIPTION
If "git commit-graph verify" fails, we call the method
LogErrorAndRewritecommitGraph(). This is supposed to get us
into a better state. It appears that it is not doing that
when we have an issue around our incremental commit-graph
format.

Fix that by deleting the commit-graphs folder in addition to
the commit-graph file. Report the status of the call, so we
know if we had such a folder.