### PR TITLE
[releases/shipped] Configure VFS4G pkg installer to always install kext/'VFS For Git.app' regardless of version

### DIFF
--- a/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
+++ b/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
@@ -8,7 +8,7 @@
 		<key>BundleIsRelocatable</key>
 		<false/>
 		<key>BundleIsVersionChecked</key>
-		<true/>
+		<false/>
 		<key>BundleOverwriteAction</key>
 		<string>upgrade</string>
 		<key>RootRelativeBundlePath</key>
@@ -16,7 +16,7 @@
 	</dict>
 	<dict>
 		<key>BundleIsVersionChecked</key>
-		<true/>
+		<false/>
 		<key>BundleOverwriteAction</key>
 		<string>upgrade</string>
 		<key>RootRelativeBundlePath</key>


### PR DESCRIPTION
Cherry pick of #1526 onto releases/shipped

----

Presently, the installer is not actually updating the version of PrjFSKext.kext or the 'VFS For Git.app' on disk because we initially started with a test version of 1 and we now stamp it with our real version numbers (0.6.YYDDD). PackageKit will be 'smart' and not downgrade the version.

You can see this system install.log like so:
2019-08-02 16:17:04-07 nickgra-trashcan installer[1230]: PackageKit: Skipping component "com.microsoft.VFSForGit" (0.6.19213-1.0.0-*) because the version 1.0.0-1.0.0-* is already installed at /Library/Application Support/VFS For Git/VFS For Git.app
2019-09-19 16:35:30-07 nickgra-trashcan installer[1474]: PackageKit: Skipping component "org.vfsforgit.PrjFSKext" (0.6.19262-0.6.0-*) because the version 1.0.0-1.0.0-* is already installed at /Library/Extensions/PrjFSKext.kext.

Ameen caught this issue when testing out upgrade for the latest release, we started hitting issues since we made a backwards incompatible change with the kext. It turns out we haven't been upgrading the kext (or the .app) since we initially released them.

The cleanest fix is in our component plist: configure BundleIsVersionChecked to be false. With this change, I've observed the kext version to roll backwards from 1 to the dev build number (0.2).