### PR TITLE
[POSIX] convert Mac-specific functional tests to POSIX where viable

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -8,6 +8,7 @@
 
         public const string WindowsOnly = "WindowsOnly";
         public const string MacOnly = "MacOnly";
+        public const string POSIXOnly = "POSIXOnly";
 
         public static class MacTODO
         {

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -104,7 +104,7 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             string existingFileBashPath = this.ConvertWinPathToBashPath(existingFilePath);
             string newLinkBashPath = this.ConvertWinPathToBashPath(newLinkFilePath);
 
-            this.RunProcess(string.Format("-c \"ln -s -F '{0}' '{1}'\"", existingFileBashPath, newLinkBashPath));
+            this.RunProcess(string.Format("-c \"ln -s -f '{0}' '{1}'\"", existingFileBashPath, newLinkBashPath));
         }
 
         public override bool FileExists(string path)

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -113,6 +113,7 @@ namespace GVFS.FunctionalTests
             {
                 // Windows excludes.
                 excludeCategories.Add(Categories.MacOnly);
+                excludeCategories.Add(Categories.POSIXOnly);
             }
 
             GVFSTestConfig.DotGVFSRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ".vfsforgit" : ".gvfs";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -825,7 +825,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         // separately from the DeleteIndexFileFails() test case
         // This test is failing on Windows because the CmdRunner succeeds in moving the index file
         [TestCaseSource(typeof(FileSystemRunner), nameof(FileSystemRunner.Runners))]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void MoveIndexFileFails(FileSystemRunner fileSystem)
         {
             string indexFilePath = this.Enlistment.GetVirtualPathTo(Path.Combine(".git", "index"));

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -47,7 +47,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void CloneWithDefaultLocalCacheLocation()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSLockTests.cs
@@ -88,7 +88,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             uint flags);
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
-        private static extern int MacRename(string oldPath, string newPath);
+        private static extern int POSIXRename(string oldPath, string newPath);
 
         private void OverwritingIndexShouldFail(string testFilePath)
         {
@@ -121,7 +121,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
             else
             {
-                return MacRename(oldPath, newPath) == 0;
+                return POSIXRename(oldPath, newPath) == 0;
             }
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SymbolicLinkTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SymbolicLinkTests.cs
@@ -7,8 +7,8 @@ using NUnit.Framework;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    // MacOnly until issue #297 (add SymLink support for Windows) is complete
-    [Category(Categories.MacOnly)]
+    // POSIXOnly until issue #297 (add SymLink support for Windows) is complete
+    [Category(Categories.POSIXOnly)]
     [TestFixture]
     public class SymbolicLinkTests : TestsWithEnlistmentPerFixture
     {

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -559,9 +559,9 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.MoveFolder);
         }
 
-        // MacOnly because Windows does not support file mode
+        // Mac and Linux only because Windows does not support file mode
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void UpdateFileModeOnly()
         {
             const string TestFileName = "test-file-mode";


### PR DESCRIPTION
Where appropriate, convert functional tests marked `MacOnly` into `POSIXOnly` tests which also execute on Linux.

The `rename(2)` function is identical on Linux and Mac, so update its `DllImport` wrapper name to `POSIXRename()` from `MacRename()` in `GVFSLockTests`.

Finally, use generic POSIX options to `ln(1`) in `BashRunner` because the `GitStatusReportsSymLinkChanges()` functional test will fail on Linux otherwise, as `ln -s -F` does not have the same meaning as on BSD/Darwin; the `-F` flag does not imply `-f` on
Linux but instead tries to hard link a directory.  Thus the deletion of the target `testFilePath` in the test does not occur and the test fails.  Instead, we use `ln -s -f` in the `CreateSymbolicLink()` method in `BashRunner` which suffices on both types of systems.
