### PR TITLE
[Linux] minor POSIX and path case comparison fixups

### DIFF
--- a/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
+++ b/GVFS/GVFS.Common/ModifiedPathsDatabase.cs
@@ -126,7 +126,7 @@ namespace GVFS.Common
             string entry = this.NormalizeEntryString(path, isFolder: true);
             foreach (string modifiedPath in this.modifiedPaths)
             {
-                if (modifiedPath.StartsWith(entry, StringComparison.OrdinalIgnoreCase))
+                if (modifiedPath.StartsWith(entry, GVFSPlatform.Instance.Constants.PathComparison))
                 {
                     if (this.modifiedPaths.TryRemove(modifiedPath))
                     {

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/BasicFileSystemTests.cs
@@ -920,7 +920,7 @@ namespace GVFS.FunctionalTests.Tests.LongRunningEnlistment
         }
 
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void RunPythonExecutable()
         {
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout FunctionalTests/PythonExecutable");

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -504,7 +504,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string[] placeholderLines = this.GetPlaceholderDatabaseLines();
             foreach (string path in paths)
             {
-                placeholderLines.ShouldContain(x => x.StartsWith(path + GVFSHelpers.PlaceholderFieldDelimiter, StringComparison.OrdinalIgnoreCase));
+                placeholderLines.ShouldContain(x => x.StartsWith(path + GVFSHelpers.PlaceholderFieldDelimiter, FileSystemHelpers.PathComparison));
             }
         }
 
@@ -513,7 +513,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string[] placeholderLines = this.GetPlaceholderDatabaseLines();
             foreach (string path in paths)
             {
-                placeholderLines.ShouldNotContain(x => x.StartsWith(path + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) || x.Equals(path, StringComparison.OrdinalIgnoreCase));
+                placeholderLines.ShouldNotContain(x => x.StartsWith(path + Path.DirectorySeparatorChar, FileSystemHelpers.PathComparison) || x.Equals(path, FileSystemHelpers.PathComparison));
             }
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -598,10 +598,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void CheckMainSparseFolder()
         {
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
-            Array.Sort(directories, FileSystemHelpers.PathComparer);
             directories.Length.ShouldEqual(2);
-            directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, ".git"));
-            directories[1].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
+            directories.ShouldContain(x => x == Path.Combine(this.Enlistment.RepoRoot, ".git"));
+            directories.ShouldContain(x => x == Path.Combine(this.Enlistment.RepoRoot, "GVFS"));
 
             string folder = this.Enlistment.GetVirtualPathTo(this.mainSparseFolder);
             folder.ShouldBeADirectory(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -598,6 +598,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         private void CheckMainSparseFolder()
         {
             string[] directories = Directory.GetDirectories(this.Enlistment.RepoRoot);
+            Array.Sort(directories, FileSystemHelpers.PathComparer);
             directories.Length.ShouldEqual(2);
             directories[0].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, ".git"));
             directories[1].ShouldEqual(Path.Combine(this.Enlistment.RepoRoot, "GVFS"));


### PR DESCRIPTION
Convert a few recent inadvertent uses of `StringComparison.OrdinalIgnoreCase` in file path comparisons to the relevant OS-specific `PathComparison` helpers.

The array returned by `Directory.GetDirectories()` is not consistently ordered across different platforms, so we use `PathComparer` to sort the array prior to checking its contents in `CheckMainSparseFolder()` in the `SparseTests` functional tests.

We can also mark one recent new functional test, `RunPythonExecutable()`, as `POSIXOnly` since it applies to Linux as well as macOS.