### PR TITLE
[Linux] Use backing root and check min version in dehydrate commands/tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/DiskLayoutVersionTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/DiskLayoutVersionTests.cs
@@ -10,30 +10,7 @@ namespace GVFS.FunctionalTests.Tests
     [Category(Categories.ExtraCoverage)]
     public class DiskLayoutVersionTests : TestsWithEnlistmentPerTestCase
     {
-        private const int WindowsCurrentDiskLayoutMajorVersion = 19;
-        private const int MacCurrentDiskLayoutMajorVersion = 19;
-        private const int WindowsCurrentDiskLayoutMinimumMajorVersion = 7;
-        private const int MacCurrentDiskLayoutMinimumMajorVersion = 18;
         private const int CurrentDiskLayoutMinorVersion = 0;
-        private int currentDiskMajorVersion;
-        private int currentDiskMinimumMajorVersion;
-
-        [SetUp]
-        public override void CreateEnlistment()
-        {
-            base.CreateEnlistment();
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                this.currentDiskMajorVersion = MacCurrentDiskLayoutMajorVersion;
-                this.currentDiskMinimumMajorVersion = MacCurrentDiskLayoutMinimumMajorVersion;
-            }
-            else
-            {
-                this.currentDiskMajorVersion = WindowsCurrentDiskLayoutMajorVersion;
-                this.currentDiskMinimumMajorVersion = WindowsCurrentDiskLayoutMinimumMajorVersion;
-            }
-        }
 
         [TestCase]
         public void MountSucceedsIfMinorVersionHasAdvancedButNotMajorVersion()
@@ -42,7 +19,7 @@ namespace GVFS.FunctionalTests.Tests
             this.Enlistment.UnmountGVFS();
             GVFSHelpers.SaveDiskLayoutVersion(
                 this.Enlistment.DotGVFSRoot,
-                this.currentDiskMajorVersion.ToString(),
+                GVFSHelpers.GetCurrentDiskLayoutMajorVersion().ToString(),
                 (CurrentDiskLayoutMinorVersion + 1).ToString());
             this.Enlistment.TryMountGVFS().ShouldBeTrue("Mount should succeed because only the minor version advanced");
 
@@ -50,7 +27,7 @@ namespace GVFS.FunctionalTests.Tests
             this.Enlistment.UnmountGVFS();
             GVFSHelpers.SaveDiskLayoutVersion(
                 this.Enlistment.DotGVFSRoot,
-                (this.currentDiskMajorVersion + 1).ToString(),
+                (GVFSHelpers.GetCurrentDiskLayoutMajorVersion() + 1).ToString(),
                 CurrentDiskLayoutMinorVersion.ToString());
             this.Enlistment.TryMountGVFS().ShouldBeFalse("Mount should fail because the major version has advanced");
         }
@@ -62,7 +39,7 @@ namespace GVFS.FunctionalTests.Tests
             this.Enlistment.UnmountGVFS();
             GVFSHelpers.SaveDiskLayoutVersion(
                 this.Enlistment.DotGVFSRoot,
-                (this.currentDiskMinimumMajorVersion - 1).ToString(),
+                (GVFSHelpers.GetCurrentDiskLayoutMinimumMajorVersion() - 1).ToString(),
                 CurrentDiskLayoutMinorVersion.ToString());
             this.Enlistment.TryMountGVFS().ShouldBeFalse("Mount should fail because we are before minimum version");
         }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -162,8 +162,12 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             int.TryParse(majorVersion.ShouldNotBeNull(), out majorVersionNum).ShouldEqual(true);
             int.TryParse(minorVersion.ShouldNotBeNull(), out minorVersionNum).ShouldEqual(true);
 
-            GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, (majorVersionNum - 1).ToString(), "0");
-            this.DehydrateShouldFail(new[] { "disk layout version doesn't match current version" }, noStatus: true);
+            int previousMajorVersionNum = majorVersionNum - 1;
+            if (previousMajorVersionNum >= GVFSHelpers.GetCurrentDiskLayoutMinimumMajorVersion())
+            {
+                GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, previousMajorVersionNum.ToString(), "0");
+                this.DehydrateShouldFail(new[] { "disk layout version doesn't match current version" }, noStatus: true);
+            }
 
             GVFSHelpers.SaveDiskLayoutVersion(this.Enlistment.DotGVFSRoot, (majorVersionNum + 1).ToString(), "0");
             this.DehydrateShouldFail(new[] { "Changes to GVFS disk layout do not allow mounting after downgrade." }, noStatus: true);

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -34,6 +34,11 @@ namespace GVFS.FunctionalTests.Tools
         private const string PrjFSLibPath = "libPrjFSLib.dylib";
         private const int PrjFSResultSuccess = 1;
 
+        private const int WindowsCurrentDiskLayoutMajorVersion = 19;
+        private const int MacCurrentDiskLayoutMajorVersion = 19;
+        private const int WindowsCurrentDiskLayoutMinimumMajorVersion = 7;
+        private const int MacCurrentDiskLayoutMinimumMajorVersion = 18;
+
         public static string ConvertPathToGitFormat(string path)
         {
             return path.Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator);
@@ -214,6 +219,30 @@ namespace GVFS.FunctionalTests.Tools
             {
                 uint result = PrjFSUnregisterForOfflineIO();
                 result.ShouldEqual<uint>(PrjFSResultSuccess, $"{nameof(RegisterForOfflineIO)} failed (result = {result})");
+            }
+        }
+
+        public static int GetCurrentDiskLayoutMajorVersion()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MacCurrentDiskLayoutMajorVersion;
+            }
+            else
+            {
+                return WindowsCurrentDiskLayoutMajorVersion;
+            }
+        }
+
+        public static int GetCurrentDiskLayoutMinimumMajorVersion()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MacCurrentDiskLayoutMinimumMajorVersion;
+            }
+            else
+            {
+                return WindowsCurrentDiskLayoutMinimumMajorVersion;
             }
         }
 

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -490,7 +490,7 @@ from a parent of the folders list.
                     }
 
                     // Move the current src folder to the backup location...
-                    if (!this.TryIO(tracer, () => Directory.Move(enlistment.WorkingDirectoryRoot, backupSrc), "Move the src folder", out ioError))
+                    if (!this.TryIO(tracer, () => Directory.Move(enlistment.WorkingDirectoryBackingRoot, backupSrc), "Move the src folder", out ioError))
                     {
                         errorMessage = "Failed to move the src folder: " + ioError + Environment.NewLine;
                         errorMessage += "Make sure you have no open handles or running processes in the src folder";
@@ -498,7 +498,7 @@ from a parent of the folders list.
                     }
 
                     // ... but move the .git folder back to the new src folder so we can preserve objects, refs, logs...
-                    if (!this.TryIO(tracer, () => Directory.CreateDirectory(enlistment.WorkingDirectoryRoot), "Create new src folder", out errorMessage) ||
+                    if (!this.TryIO(tracer, () => Directory.CreateDirectory(enlistment.WorkingDirectoryBackingRoot), "Create new src folder", out errorMessage) ||
                         !this.TryIO(tracer, () => Directory.Move(Path.Combine(backupSrc, ".git"), enlistment.DotGitRoot), "Keep existing .git folder", out errorMessage))
                     {
                         return false;


### PR DESCRIPTION
The `DehydrateVerb` `TryBackupFiles()` method currently fails on Linux due to the inadvertent use of the `WorkingDirectoryRoot` as the source location for the backup.  This is because on Linux the `src/` working directory is fully unavailable when the provider is unmounted.

Instead, by using the `WorkingDirectoryBackingRoot`, which is always available on all platforms (and is equivalent to the `WorkingDirectoryRoot` on Windows and Mac), we can allow most dehydrate tests to succeed on Linux.

Also, the `DehydrateShouldFailOnWrongDiskLayoutVersion()` functional test currently fails and leaves the test suite in a broken state if it attempts to set the disk layout major version number below a platform's minimum supported version.

By checking whether the existing version is higher than the minimum version first, we can proceed with this test only when safe to do so.  To accommodate this check, we move the platform-specific disk layout major version numbers and minimum version numbers into `GVFSHelpers` from `DiskLayoutVersionTests`.