### PR TITLE
When using --set add folders back to directories for checking git status

### DIFF
--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -166,6 +166,13 @@ Folders need to be relative to the repos root directory.")
                         {
                             needToChangeProjection = true;
                             foldersToRemove.AddRange(directories);
+                            directories.Clear();
+                        }
+
+                        // Need to add folders that will be in the projection back into directories for the status check
+                        foreach (string folder in folders)
+                        {
+                            directories.Add(folder);
                         }
                     }
                     else


### PR DESCRIPTION
The set option was removing folder from the directories hashset to know
what folders needed to be removed but the directories hashset was used
in checking status and for pruning so it needs to be the set of folders
that will be in the sparse set after determining the what to add and remove
so that git status and prune will have the correct set of sparse folders.

Fixes #1460 