### PR TITLE
IsFileSystemSupported: cleanup test files on Mac

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -85,6 +85,26 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             enlistment.UnmountAndDeleteAll();
         }
 
+        [TestCase]
+        public void CloneCreatesCorrectFilesInRoot()
+        {
+            GVFSFunctionalTestEnlistment enlistment = GVFSFunctionalTestEnlistment.CloneAndMount(GVFSTestConfig.PathToGVFS);
+            try
+            {
+                string[] files = Directory.GetFiles(enlistment.EnlistmentRoot);
+                files.Length.ShouldEqual(1);
+                files.ShouldContain(x => Path.GetFileName(x).Equals("git.cmd", StringComparison.Ordinal));
+                string[] directories = Directory.GetDirectories(enlistment.EnlistmentRoot);
+                directories.Length.ShouldEqual(2);
+                directories.ShouldContain(x => Path.GetFileName(x).Equals(".gvfs", StringComparison.Ordinal));
+                directories.ShouldContain(x => Path.GetFileName(x).Equals("src", StringComparison.Ordinal));
+            }
+            finally
+            {
+                enlistment.UnmountAndDeleteAll();
+            }
+        }
+
         private void SubfolderCloneShouldFail()
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);

--- a/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
+++ b/GVFS/GVFS.Platform.Mac/MacFileSystem.cs
@@ -32,20 +32,21 @@ namespace GVFS.Platform.Mac
 
         public override bool IsFileSystemSupported(string path, out string error)
         {
-            string lowerCaseFile = Guid.NewGuid().ToString().ToLower();
-            string upperCaseFile = lowerCaseFile.ToUpper();
             error = null;
 
             try
             {
-                File.Create(Path.Combine(path, lowerCaseFile));
-                if (File.Exists(Path.Combine(path, upperCaseFile)))
+                string lowerCaseFilePath = Path.Combine(path, $"casetest{Guid.NewGuid().ToString()}");
+                string upperCaseFilePath = lowerCaseFilePath.ToUpper();
+
+                File.Create(lowerCaseFilePath);
+                if (File.Exists(upperCaseFilePath))
                 {
-                    File.Delete(lowerCaseFile);
+                    File.Delete(lowerCaseFilePath);
                     return true;
                 }
 
-                File.Delete(lowerCaseFile);
+                File.Delete(lowerCaseFilePath);
                 error = "VFS for Git does not support case sensitive filesystems";
                 return false;
             }


### PR DESCRIPTION
IsFileSystemSupported was leaving around test files it uses to
test if the file system is case sensitive.  Fix up the paths it
uses for its tests.