### PR TITLE
Native hooks: Fix build error due to missing std::string declaration

### DIFF
--- a/GVFS/GVFS.NativeHooks.Common/common.h
+++ b/GVFS/GVFS.NativeHooks.Common/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstring>
+#include <string>
 
 #ifdef __APPLE__
 typedef std::string PATH_STRING;


### PR DESCRIPTION
This fixes a build failure when building VFSForGit with Xcode 10 and the macOS 10.14 SDK. std::string should only be used after `#include <string>`.

I noticed the problem while trying to run a full `Scripts/Mac/BuildGVFSForMac.sh` on macOS 10.15 GM, with Xcode 10.2.1 set as the default toolchain. (The CI uses Xcode 9 and the macOS 10.13 SDK, which is fine as we're still targeting 10.13, but we'll presumably eventually move up.)