### PR TITLE
Set git config autoRefreshIndex to true

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1020,6 +1020,27 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        public void ChangeTimestampAndDiff()
+        {
+            // User scenario -
+            // 1. Enlistment's "diff.autoRefreshIndex" config is set to false
+            // 2. A checked out file got into a state where it differs from the git copy
+            // only in its LastWriteTime metadata (no change in file contents.)
+            // Repro steps - This happens when user edits a file, saves it and later decides
+            // to undo the edit and save the file again.
+            // Once in this state, the unchanged file (only its timestamp has changed) shows
+            // up in `git difftool` creating noise. It also shows up in `git diff --raw` command,
+            // (but not in `git status` or `git diff`.)
+
+            // Change the timestamp - The lastwrite time can be close to the time this test method gets
+            // run. Changing (Subtracting) it to the past so there will always be a difference.
+            this.AdjustLastWriteTime(GitCommandsTests.EditFilePath, TimeSpan.FromDays(-10));
+            this.ValidateGitCommand("diff --raw");
+            this.ValidateGitCommand($"checkout {GitCommandsTests.EditFilePath}");
+            this.ValidateGitCommand("status");
+        }
+
+        [TestCase]
         public void UseAlias()
         {
             this.ValidateGitCommand("config --local alias.potato status");

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -4,6 +4,7 @@ using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -347,6 +348,15 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
 
             File.SetAttributes(virtualFile, File.GetAttributes(virtualFile) | FileAttributes.ReadOnly);
             File.SetAttributes(virtualFile, File.GetAttributes(controlFile) | FileAttributes.ReadOnly);
+        }
+
+        protected void AdjustLastWriteTime(string filePath, TimeSpan timestamp)
+        {
+            string virtualFile = Path.Combine(this.Enlistment.RepoRoot, filePath);
+            string controlFile = Path.Combine(this.ControlGitRepo.RootPath, filePath);
+
+            File.SetLastWriteTime(virtualFile, File.GetLastWriteTime(virtualFile).Add(timestamp));
+            File.SetLastWriteTime(controlFile, File.GetLastWriteTime(controlFile).Add(timestamp));
         }
 
         protected void MoveFile(string pathFrom, string pathTo)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -139,7 +139,7 @@ namespace GVFS.CommandLine
                 { "core.hookspath", expectedHooksPath },
                 { GitConfigSetting.CredentialUseHttpPath, "true" },
                 { "credential.validate", "false" },
-                { "diff.autoRefreshIndex", "false" },
+                { "diff.autoRefreshIndex", "true" },
                 { "gc.auto", "0" },
                 { "gui.gcwarning", "false" },
                 { "index.threads", "true" },


### PR DESCRIPTION
- setting the git config autoRefreshIndex to true. This is not needed anymore, because current version of gvfs does not use index.lock. (This change was introduced initially to prevent `git diff` from acquiring index.lock file.)