### PR TITLE
Add sparse prune info

### DIFF
--- a/GVFS/GVFS.Common/ReturnCode.cs
+++ b/GVFS/GVFS.Common/ReturnCode.cs
@@ -8,6 +8,7 @@
         GenericError = 3,
         FilterError = 4,
         NullRequestData = 5,
-        UnableToRegisterForOfflineIO = 6
+        UnableToRegisterForOfflineIO = 6,
+        DehydrateFolderFailures = 7,
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -16,6 +16,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [Category(Categories.ExtraCoverage)]
     public class DehydrateTests : TestsWithEnlistmentPerFixture
     {
+        private const string FolderDehydrateSuccessfulMessage = "folder dehydrate successful.";
         private const int GVFSGenericError = 3;
         private FileSystemRunner fileSystem;
 
@@ -183,7 +184,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string subFolderToEnumerate = Path.Combine(pathToEnumerate, "GVFS");
             this.fileSystem.EnumerateDirectory(subFolderToEnumerate);
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { $"GVFS {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -206,7 +207,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             {
             }
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { $"GVFS {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -229,7 +230,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.EnumerateDirectory(pathToReadFiles);
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { $"GVFS {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -252,7 +253,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { $"GVFS {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -273,7 +274,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteDirectory(pathToDelete);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -- Scripts");
 
-            this.DehydrateShouldSucceed(new[] { "Scripts folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
+            this.DehydrateShouldSucceed(new[] { $"Scripts {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -302,7 +303,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.AppendAllText(fileNotDehydrated2, "Append content");
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"reset --hard");
 
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             this.PlaceholdersShouldNotContain(folderToDehydrate, Path.Combine(folderToDehydrate, "Program.cs"));
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, Path.Combine(folderToDehydrate, "App.config").Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator));
@@ -329,7 +330,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead2);
 
             this.DehydrateShouldSucceed(
-                new[] { $"{folderToDehydrate1} folder dehydrate successful.", $"{folderToDehydrate2} folder dehydrate successful." },
+                new[] { $"{folderToDehydrate1} {FolderDehydrateSuccessfulMessage}", $"{folderToDehydrate2} {FolderDehydrateSuccessfulMessage}" },
                 confirm: true,
                 noStatus: false,
                 foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
@@ -351,7 +352,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead2);
 
             this.DehydrateShouldSucceed(
-                new[] { $"{folderToDehydrate1} folder dehydrate successful.", $"Cannot dehydrate folder '{folderToDehydrate2}': '{folderToDehydrate2}' does not exist." },
+                new[] { $"{folderToDehydrate1} {FolderDehydrateSuccessfulMessage}", $"Cannot dehydrate folder '{folderToDehydrate2}': '{folderToDehydrate2}' does not exist." },
                 confirm: true,
                 noStatus: false,
                 foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
@@ -427,7 +428,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -f HEAD~1");
 
             string folderToDehydrate = "TrailingSlashTests";
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             pathToDelete.ShouldBeADirectory(this.fileSystem);
         }
@@ -440,7 +441,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -a -m \"Delete a directory\"");
 
             string folderToDehydrate = "TrailingSlashTests";
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             pathToDelete.ShouldNotExistOnDisk(this.fileSystem);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout HEAD~1");
@@ -488,7 +489,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed(new[] { "NewFolder folder dehydrate successful" }, confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
+            this.DehydrateShouldSucceed(new[] { $"NewFolder {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
 
             this.Enlistment.UnmountGVFS();
             fileToCreate.ShouldNotExistOnDisk(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -183,7 +183,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string subFolderToEnumerate = Path.Combine(pathToEnumerate, "GVFS");
             this.fileSystem.EnumerateDirectory(subFolderToEnumerate);
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -206,7 +206,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             {
             }
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -229,7 +229,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.EnumerateDirectory(pathToReadFiles);
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -252,7 +252,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed(new[] { "GVFS folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
+            this.DehydrateShouldSucceed(new[] { "GVFS folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "GVFS");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -273,7 +273,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteDirectory(pathToDelete);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -- Scripts");
 
-            this.DehydrateShouldSucceed(new[] { "Scripts folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
+            this.DehydrateShouldSucceed(new[] { "Scripts folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: "Scripts");
             this.Enlistment.UnmountGVFS();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -302,7 +302,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.AppendAllText(fileNotDehydrated2, "Append content");
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"reset --hard");
 
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             this.PlaceholdersShouldNotContain(folderToDehydrate, Path.Combine(folderToDehydrate, "Program.cs"));
             GVFSHelpers.ModifiedPathsShouldNotContain(this.Enlistment, this.fileSystem, Path.Combine(folderToDehydrate, "App.config").Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator));
@@ -329,7 +329,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead2);
 
             this.DehydrateShouldSucceed(
-                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"{folderToDehydrate2} folder successfully dehydrated." },
+                new[] { $"{folderToDehydrate1} folder dehydrate successful.", $"{folderToDehydrate2} folder dehydrate successful." },
                 confirm: true,
                 noStatus: false,
                 foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
@@ -351,7 +351,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.ReadAllText(fileToRead2);
 
             this.DehydrateShouldSucceed(
-                new[] { $"{folderToDehydrate1} folder successfully dehydrated.", $"Cannot dehydrate folder '{folderToDehydrate2}': '{folderToDehydrate2}' does not exist." },
+                new[] { $"{folderToDehydrate1} folder dehydrate successful.", $"Cannot dehydrate folder '{folderToDehydrate2}': '{folderToDehydrate2}' does not exist." },
                 confirm: true,
                 noStatus: false,
                 foldersToDehydrate: string.Join(";", folderToDehydrate1, folderToDehydrate2));
@@ -372,7 +372,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': Must dehydrate parent folder 'GitCommandsTests/'." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -414,7 +414,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderToDehydrate = Path.Combine("GitCommandsTests", "DeleteFileTests");
             this.Enlistment.GetVirtualPathTo(folderToDehydrate).ShouldBeADirectory(this.fileSystem);
 
-            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': parent folder 'GitCommandsTests/' must be dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"Cannot dehydrate folder '{folderToDehydrate}': Must dehydrate parent folder 'GitCommandsTests/'." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
         }
 
         [TestCase]
@@ -427,7 +427,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -f HEAD~1");
 
             string folderToDehydrate = "TrailingSlashTests";
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             pathToDelete.ShouldBeADirectory(this.fileSystem);
         }
@@ -440,7 +440,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -a -m \"Delete a directory\"");
 
             string folderToDehydrate = "TrailingSlashTests";
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder successfully dehydrated." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} folder dehydrate successful." }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
 
             pathToDelete.ShouldNotExistOnDisk(this.fileSystem);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout HEAD~1");
@@ -488,7 +488,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            this.DehydrateShouldSucceed(new[] { "NewFolder folder successfully dehydrated" }, confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
+            this.DehydrateShouldSucceed(new[] { "NewFolder folder dehydrate successful" }, confirm: true, noStatus: false, foldersToDehydrate: "NewFolder");
 
             this.Enlistment.UnmountGVFS();
             fileToCreate.ShouldNotExistOnDisk(this.fileSystem);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -645,7 +645,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             modifiedPath.ShouldBeAFile(this.fileSystem);
 
             output = this.gvfsProcess.Sparse($"--set Scripts --prune", shouldSucceed: true);
-            output.ShouldContain("No folders to update in sparse set.", "Pruning folders...Succeeded");
+            output.ShouldContain("No folders to update in sparse set.", "Found 1 folders to prune.", "Cleaning up folders...Succeeded", "GVFS folder prune successful.");
             this.ValidateFoldersInSparseList("Scripts");
             modifiedPath.ShouldNotExistOnDisk(this.fileSystem);
         }

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -291,13 +291,13 @@ namespace GVFS.Mount
                 string[] folders = request.Folders.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string folder in folders)
                 {
-                    if (this.fileSystemCallbacks.TryDehydrateFolder(folder))
+                    if (this.fileSystemCallbacks.TryDehydrateFolder(folder, out string errorMessage))
                     {
                         response.SuccessfulFolders.Add(folder);
                     }
                     else
                     {
-                        response.FailedFolders.Add(folder);
+                        response.FailedFolders.Add($"{folder}\0{errorMessage}");
                     }
                 }
 

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -297,11 +297,11 @@ namespace GVFS.Virtualization
             return metadata;
         }
 
-        public bool TryDehydrateFolder(string relativePath)
+        public bool TryDehydrateFolder(string relativePath, out string errorMessage)
         {
             List<IPlaceholderData> removedPlaceholders = null;
             List<string> removedModifiedPaths = null;
-            bool successful = false;
+            errorMessage = string.Empty;
 
             try
             {
@@ -309,21 +309,20 @@ namespace GVFS.Virtualization
                 removedPlaceholders = this.placeholderDatabase.RemoveAllEntriesForFolder(relativePath);
                 removedModifiedPaths = this.modifiedPaths.RemoveAllEntriesForFolder(relativePath);
                 FileSystemResult result = this.fileSystemVirtualizer.DehydrateFolder(relativePath);
-                successful = result.Result == FSResult.Ok;
-
-                if (!successful)
+                if (result.Result != FSResult.Ok)
                 {
-                    this.context.Tracer.RelatedError($"{nameof(this.TryDehydrateFolder)} failed with {result.Result}");
+                    errorMessage = $"{nameof(this.TryDehydrateFolder)} failed with {result.Result}";
+                    this.context.Tracer.RelatedError(errorMessage);
                 }
             }
             catch (Exception ex)
             {
+                errorMessage = $"{nameof(this.TryDehydrateFolder)} threw an exception - {ex.Message}";
                 EventMetadata metadata = this.CreateEventMetadata(relativePath, ex);
-                this.context.Tracer.RelatedError(metadata, $"{nameof(this.TryDehydrateFolder)} threw an exception");
-                successful = false;
+                this.context.Tracer.RelatedError(metadata, errorMessage);
             }
 
-            if (!successful)
+            if (!string.IsNullOrEmpty(errorMessage))
             {
                 if (removedPlaceholders != null)
                 {
@@ -353,7 +352,7 @@ namespace GVFS.Virtualization
                 }
             }
 
-            return successful;
+            return string.IsNullOrEmpty(errorMessage);
         }
 
         public void ForceIndexProjectionUpdate(bool invalidateProjection, bool invalidateModifiedPaths)

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -46,6 +46,9 @@ namespace GVFS.CommandLine
             HelpText = "A semicolon (" + FolderListSeparator + ") delimited list of folders to dehydrate. Each folder must be relative to the repository root.")]
         public string Folders { get; set; }
 
+        public string RunningVerbName { get; set; } = DehydrateVerbName;
+        public string DisplayName { get; set; } = DehydrateVerbName;
+
         protected override string VerbName
         {
             get { return DehydrateVerb.DehydrateVerbName; }
@@ -160,10 +163,10 @@ from a parent of the folders list.
 
                 if (fullDehydrate)
                 {
-                    this.WriteMessage(tracer, "Starting dehydration. All of your existing files will be backed up in " + backupRoot);
+                    this.WriteMessage(tracer, $"Starting dehydrate. All of your existing files will be backed up in " + backupRoot);
                 }
 
-                this.WriteMessage(tracer, "WARNING: If you abort the dehydrate after this point, the repo may become corrupt");
+                this.WriteMessage(tracer, $"WARNING: If you abort the {this.RunningVerbName} after this point, the repo may become corrupt");
 
                 this.Output.WriteLine();
 
@@ -206,12 +209,12 @@ from a parent of the folders list.
                         }
                         else
                         {
-                            this.ReportErrorAndExit("Cannot dehydrate: must have a clean git status.");
+                            this.ReportErrorAndExit($"Cannot {this.DisplayName}: must have a clean git status.");
                         }
                     }
                     else
                     {
-                        this.ReportErrorAndExit("No folders to dehydrate.");
+                        this.ReportErrorAndExit($"No folders to {this.DisplayName}.");
                     }
                 }
             }
@@ -243,7 +246,7 @@ from a parent of the folders list.
                             string normalizedPath = GVFSDatabase.NormalizePath(folder);
                             if (!this.IsFolderValid(normalizedPath))
                             {
-                                this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': invalid folder path.");
+                                this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': invalid folder path.");
                             }
                             else
                             {
@@ -251,7 +254,7 @@ from a parent of the folders list.
                                 // dehydration will not do any good with a parent folder there
                                 if (modifiedPaths.ContainsParentFolder(folder, out string parentFolder))
                                 {
-                                    this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': parent folder '{parentFolder}' must be dehydrated.");
+                                    this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': Must {this.DisplayName} parent folder '{parentFolder}'.");
                                 }
                                 else
                                 {
@@ -260,7 +263,7 @@ from a parent of the folders list.
                                     {
                                         if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting '{fullPath}'", out ioError))
                                         {
-                                            this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': removing '{folder}' failed.");
+                                            this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': removing '{folder}' failed.");
                                             this.WriteMessage(tracer, "Ensure no applications are accessing the folder and retry.");
                                             this.WriteMessage(tracer, $"More details: {ioError}");
                                         }
@@ -271,7 +274,7 @@ from a parent of the folders list.
                                     }
                                     else
                                     {
-                                        this.WriteMessage(tracer, $"Cannot dehydrate folder '{folder}': '{folder}' does not exist.");
+                                        this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': '{folder}' does not exist.");
 
                                         // Still add to foldersToDehydrate so that any placeholders or modified paths get cleaned up
                                         foldersToDehydrate.Add(folder);
@@ -285,7 +288,7 @@ from a parent of the folders list.
                 },
                 "Cleaning up folders"))
             {
-                this.ReportErrorAndExit(tracer, "Dehydrate for folders failed.");
+                this.ReportErrorAndExit(tracer, $"{this.DisplayName} for folders failed.");
             }
 
             this.Mount(tracer);
@@ -334,12 +337,12 @@ from a parent of the folders list.
             {
                 foreach (string folder in response.SuccessfulFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder successfully dehydrated.");
+                    this.WriteMessage(tracer, $"{folder} folder {this.DisplayName} successful.");
                 }
 
                 foreach (string folder in response.FailedFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder failed to dehydrate. You may need to reset the working directory by deleting {folder}, running `git reset --hard`, and retry the dehydrate.");
+                    this.WriteMessage(tracer, $"{folder} folder failed to {this.DisplayName}. You may need to reset the working directory by deleting {folder}, running `git reset --hard`, and retry the {this.DisplayName}.");
                 }
             }
         }
@@ -373,10 +376,10 @@ from a parent of the folders list.
         {
             if (!this.NoStatus)
             {
-                this.WriteMessage(tracer, "Running git status before dehydrating to make sure you don't have any pending changes.");
+                this.WriteMessage(tracer, $"Running git status before {this.DisplayName} to make sure you don't have any pending changes.");
                 if (fullDehydrate)
                 {
-                    this.WriteMessage(tracer, "If this takes too long, you can abort and run dehydrate with --no-status to skip this safety check.");
+                    this.WriteMessage(tracer, $"If this takes too long, you can abort and run {this.RunningVerbName} with --no-status to skip this safety check.");
                 }
 
                 this.Output.WriteLine();
@@ -430,7 +433,7 @@ from a parent of the folders list.
                         this.WriteMessage(tracer, "git status reported that you have dirty files");
                         if (fullDehydrate)
                         {
-                            this.WriteMessage(tracer, "Either commit your changes or run dehydrate with --no-status");
+                            this.WriteMessage(tracer, $"Either commit your changes or run {this.RunningVerbName} with --no-status");
                         }
                         else
                         {
@@ -438,7 +441,7 @@ from a parent of the folders list.
                         }
                     }
 
-                    this.ReportErrorAndExit(tracer, "Dehydrate was aborted");
+                    this.ReportErrorAndExit(tracer, $"Aborted {this.DisplayName}");
                     return false;
                 }
                 else

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -47,7 +47,7 @@ namespace GVFS.CommandLine
         public string Folders { get; set; }
 
         public string RunningVerbName { get; set; } = DehydrateVerbName;
-        public string DisplayName { get; set; } = DehydrateVerbName;
+        public string ActionName { get; set; } = DehydrateVerbName;
 
         protected override string VerbName
         {
@@ -163,7 +163,7 @@ from a parent of the folders list.
 
                 if (fullDehydrate)
                 {
-                    this.WriteMessage(tracer, $"Starting dehydrate. All of your existing files will be backed up in " + backupRoot);
+                    this.WriteMessage(tracer, $"Starting {this.RunningVerbName}. All of your existing files will be backed up in " + backupRoot);
                 }
 
                 this.WriteMessage(tracer, $"WARNING: If you abort the {this.RunningVerbName} after this point, the repo may become corrupt");
@@ -209,12 +209,12 @@ from a parent of the folders list.
                         }
                         else
                         {
-                            this.ReportErrorAndExit($"Cannot {this.DisplayName}: must have a clean git status.");
+                            this.ReportErrorAndExit($"Cannot {this.ActionName}: must have a clean git status.");
                         }
                     }
                     else
                     {
-                        this.ReportErrorAndExit($"No folders to {this.DisplayName}.");
+                        this.ReportErrorAndExit($"No folders to {this.ActionName}.");
                     }
                 }
             }
@@ -247,7 +247,7 @@ from a parent of the folders list.
                             string normalizedPath = GVFSDatabase.NormalizePath(folder);
                             if (!this.IsFolderValid(normalizedPath))
                             {
-                                this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': invalid folder path.");
+                                this.WriteMessage(tracer, $"Cannot {this.ActionName} folder '{folder}': invalid folder path.");
                             }
                             else
                             {
@@ -255,7 +255,7 @@ from a parent of the folders list.
                                 // dehydration will not do any good with a parent folder there
                                 if (modifiedPaths.ContainsParentFolder(folder, out string parentFolder))
                                 {
-                                    this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': Must {this.DisplayName} parent folder '{parentFolder}'.");
+                                    this.WriteMessage(tracer, $"Cannot {this.ActionName} folder '{folder}': Must {this.ActionName} parent folder '{parentFolder}'.");
                                 }
                                 else
                                 {
@@ -264,7 +264,7 @@ from a parent of the folders list.
                                     {
                                         if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting '{fullPath}'", out ioError))
                                         {
-                                            this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': removing '{folder}' failed.");
+                                            this.WriteMessage(tracer, $"Cannot {this.ActionName} folder '{folder}': removing '{folder}' failed.");
                                             this.WriteMessage(tracer, "Ensure no applications are accessing the folder and retry.");
                                             this.WriteMessage(tracer, $"More details: {ioError}");
                                             folderErrors.Add($"{folder}\0{ioError}");
@@ -276,7 +276,7 @@ from a parent of the folders list.
                                     }
                                     else
                                     {
-                                        this.WriteMessage(tracer, $"Cannot {this.DisplayName} folder '{folder}': '{folder}' does not exist.");
+                                        this.WriteMessage(tracer, $"Cannot {this.ActionName} folder '{folder}': '{folder}' does not exist.");
 
                                         // Still add to foldersToDehydrate so that any placeholders or modified paths get cleaned up
                                         foldersToDehydrate.Add(folder);
@@ -290,7 +290,7 @@ from a parent of the folders list.
                 },
                 "Cleaning up folders"))
             {
-                this.ReportErrorAndExit(tracer, $"{this.DisplayName} for folders failed.");
+                this.ReportErrorAndExit(tracer, $"{this.ActionName} for folders failed.");
             }
 
             this.Mount(tracer);
@@ -349,12 +349,12 @@ from a parent of the folders list.
             {
                 foreach (string folder in response.SuccessfulFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder {this.DisplayName} successful.");
+                    this.WriteMessage(tracer, $"{folder} folder {this.ActionName} successful.");
                 }
 
                 foreach (string folder in response.FailedFolders)
                 {
-                    this.WriteMessage(tracer, $"{folder} folder failed to {this.DisplayName}. You may need to reset the working directory by deleting {folder}, running `git reset --hard`, and retry the {this.DisplayName}.");
+                    this.WriteMessage(tracer, $"{folder} folder failed to {this.ActionName}. You may need to reset the working directory by deleting {folder}, running `git reset --hard`, and retry the {this.ActionName}.");
                     folderErrors.Add(folder);
                 }
             }
@@ -389,7 +389,7 @@ from a parent of the folders list.
         {
             if (!this.NoStatus)
             {
-                this.WriteMessage(tracer, $"Running git status before {this.DisplayName} to make sure you don't have any pending changes.");
+                this.WriteMessage(tracer, $"Running git status before {this.ActionName} to make sure you don't have any pending changes.");
                 if (fullDehydrate)
                 {
                     this.WriteMessage(tracer, $"If this takes too long, you can abort and run {this.RunningVerbName} with --no-status to skip this safety check.");
@@ -454,7 +454,7 @@ from a parent of the folders list.
                         }
                     }
 
-                    this.ReportErrorAndExit(tracer, $"Aborted {this.DisplayName}");
+                    this.ReportErrorAndExit(tracer, $"Aborted {this.ActionName}");
                     return false;
                 }
                 else

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -24,6 +24,8 @@ namespace GVFS.CommandLine
         public GVFSVerb(bool validateOrigin = true)
         {
             this.Output = Console.Out;
+
+            // Currently stderr is only being used for machine readable output for failures in sparse --prune
             this.ErrorOutput = Console.Error;
             this.ReturnCode = ReturnCode.Success;
             this.validateOriginURL = validateOrigin;
@@ -901,6 +903,8 @@ You can specify a URL, a name of a configured cache server, or the special names
                     }
                     else
                     {
+                        // If a parent verb is redirecting the output of its child, include a reminder
+                        // that the child verb's activity was recorded in its own log file
                         metadata.Add("Output", $"Check {new TVerb().VerbName} logs for output");
                     }
 

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -24,6 +24,7 @@ namespace GVFS.CommandLine
         public GVFSVerb(bool validateOrigin = true)
         {
             this.Output = Console.Out;
+            this.ErrorOutput = Console.Error;
             this.ReturnCode = ReturnCode.Success;
             this.validateOriginURL = validateOrigin;
             this.ServiceName = GVFSConstants.Service.ServiceName;
@@ -92,6 +93,7 @@ namespace GVFS.CommandLine
         }
 
         public TextWriter Output { get; set; }
+        public TextWriter ErrorOutput { get; set; }
 
         public ReturnCode ReturnCode { get; private set; }
 

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -895,14 +895,18 @@ You can specify a URL, a name of a configured cache server, or the special names
                             configureVerb?.Invoke(verb);
                         });
 
-                    tracer.RelatedEvent(
-                        EventLevel.Informational,
-                        typeof(TVerb).Name,
-                        new EventMetadata
-                        {
-                            { "Output", commandOutput?.ToString() },
-                            { "ReturnCode", returnCode }
-                        });
+                    EventMetadata metadata = new EventMetadata();
+                    if (commandOutput != null)
+                    {
+                        metadata.Add("Output", commandOutput.ToString());
+                    }
+                    else
+                    {
+                        metadata.Add("Output", $"Check {new TVerb().VerbName} logs for output");
+                    }
+
+                    metadata.Add("ReturnCode", returnCode);
+                    tracer.RelatedEvent(EventLevel.Informational, typeof(TVerb).Name, metadata);
 
                     return returnCode;
                 }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -262,7 +262,7 @@ Folders need to be relative to the repos root directory.")
                     verb =>
                     {
                         verb.RunningVerbName = this.VerbName;
-                        verb.DisplayName = PruneOptionName;
+                        verb.ActionName = PruneOptionName;
                         verb.Confirmed = true;
                         verb.Folders = string.Join(FolderListSeparator, directoriesToDehydrate);
                     },

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -289,13 +289,16 @@ Folders need to be relative to the repos root directory.")
                 foreach (string directory in fileSystem.EnumerateDirectories(folderToEnumerate))
                 {
                     string enlistmentRootRelativeFolderPath = GVFSDatabase.NormalizePath(directory.Substring(rootPath.Length));
-                    if (sparseFolders.Any(x => x.StartsWith(enlistmentRootRelativeFolderPath + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison)))
+                    if (!enlistmentRootRelativeFolderPath.Equals(GVFSConstants.DotGit.Root, GVFSPlatform.Instance.Constants.PathComparison))
                     {
-                        foldersToEnumerate.Enqueue(directory);
-                    }
-                    else if (!sparseFolders.Contains(enlistmentRootRelativeFolderPath))
-                    {
-                        foldersOutsideSparse.Add(enlistmentRootRelativeFolderPath);
+                        if (sparseFolders.Any(x => x.StartsWith(enlistmentRootRelativeFolderPath + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison)))
+                        {
+                            foldersToEnumerate.Enqueue(directory);
+                        }
+                        else if (!sparseFolders.Contains(enlistmentRootRelativeFolderPath))
+                        {
+                            foldersOutsideSparse.Add(enlistmentRootRelativeFolderPath);
+                        }
                     }
                 }
             }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -256,20 +256,16 @@ Folders need to be relative to the repos root directory.")
 
             if (directoriesToDehydrate.Length > 0)
             {
-                if (!this.ShowStatusWhileRunning(
-                    () =>
+                ReturnCode verbReturnCode = this.ExecuteGVFSVerb<DehydrateVerb>(
+                    tracer,
+                    verb =>
                     {
-                        ReturnCode verbReturnCode = this.ExecuteGVFSVerb<DehydrateVerb>(
-                            tracer,
-                            verb =>
-                            {
-                                verb.Confirmed = true;
-                                verb.Folders = string.Join(FolderListSeparator, directoriesToDehydrate);
-                            });
-
-                        return verbReturnCode == ReturnCode.Success;
+                        verb.Confirmed = true;
+                        verb.Folders = string.Join(FolderListSeparator, directoriesToDehydrate);
                     },
-                    "Pruning folders"))
+                    this.Output);
+
+                if (verbReturnCode != ReturnCode.Success)
                 {
                     this.ReportErrorAndExit(tracer, "Failed to prune.");
                 }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -270,7 +270,7 @@ Folders need to be relative to the repos root directory.")
 
                 if (verbReturnCode != ReturnCode.Success)
                 {
-                    this.ReportErrorAndExit(tracer, $"Failed to {PruneOptionName}.");
+                    this.ReportErrorAndExit(tracer, verbReturnCode, $"Failed to {PruneOptionName}. Exit Code: {verbReturnCode}");
                 }
             }
         }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -24,6 +24,7 @@ Folders need to be relative to the repos root directory.")
         private const string FolderListSeparator = ";";
         private const char StatusPathSeparatorToken = '\0';
         private const char StatusRenameToken = 'R';
+        private const string PruneOptionName = "prune";
 
         [Option(
             's',
@@ -67,7 +68,7 @@ Folders need to be relative to the repos root directory.")
 
         [Option(
             'p',
-            "prune",
+            PruneOptionName,
             Required = false,
             Default = false,
             HelpText = "Remove any folders that are not in the list of sparse folders.")]
@@ -247,12 +248,12 @@ Folders need to be relative to the repos root directory.")
                     directoriesToDehydrate = this.GetDirectoriesOutsideSparse(enlistment.WorkingDirectoryBackingRoot, sparseTable);
                     return true;
                 },
-                "Finding folders to prune"))
+                $"Finding folders to {PruneOptionName}"))
             {
-                this.ReportErrorAndExit(tracer, "Failed to prune.");
+                this.ReportErrorAndExit(tracer, $"Failed to {PruneOptionName}.");
             }
 
-            this.WriteMessage(tracer, $"Found {directoriesToDehydrate.Length} folders to prune.");
+            this.WriteMessage(tracer, $"Found {directoriesToDehydrate.Length} folders to {PruneOptionName}.");
 
             if (directoriesToDehydrate.Length > 0)
             {
@@ -260,6 +261,8 @@ Folders need to be relative to the repos root directory.")
                     tracer,
                     verb =>
                     {
+                        verb.RunningVerbName = this.VerbName;
+                        verb.DisplayName = PruneOptionName;
                         verb.Confirmed = true;
                         verb.Folders = string.Join(FolderListSeparator, directoriesToDehydrate);
                     },
@@ -267,7 +270,7 @@ Folders need to be relative to the repos root directory.")
 
                 if (verbReturnCode != ReturnCode.Success)
                 {
-                    this.ReportErrorAndExit(tracer, "Failed to prune.");
+                    this.ReportErrorAndExit(tracer, $"Failed to {PruneOptionName}.");
                 }
             }
         }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -240,7 +240,20 @@ Folders need to be relative to the repos root directory.")
 
         private void PruneFoldersOutsideSparse(ITracer tracer, Enlistment enlistment, SparseTable sparseTable)
         {
-            string[] directoriesToDehydrate = this.GetDirectoriesOutsideSparse(enlistment.WorkingDirectoryBackingRoot, sparseTable);
+            string[] directoriesToDehydrate = new string[0];
+            if (!this.ShowStatusWhileRunning(
+                () =>
+                {
+                    directoriesToDehydrate = this.GetDirectoriesOutsideSparse(enlistment.WorkingDirectoryBackingRoot, sparseTable);
+                    return true;
+                },
+                "Finding folders to prune"))
+            {
+                this.ReportErrorAndExit(tracer, "Failed to prune.");
+            }
+
+            this.WriteMessage(tracer, $"Found {directoriesToDehydrate.Length} folders to prune.");
+
             if (directoriesToDehydrate.Length > 0)
             {
                 if (!this.ShowStatusWhileRunning(


### PR DESCRIPTION
This changes adds more information to the user's console output to see what is happening when prune is running.

The one thing I don't really like is that there will be an entry in the sparse log file
```
DehydrateVerb {"Output":null,"ReturnCode":0}
```
since there isn't a `StringBuilder commandOutput` that is capturing the output to write to the logs.
There is a entire log file for the dehydrate that has all the log information though so maybe this is okay.  I could also remove the `"Output":null,` and just have the `ReturnCode` in this case or maybe put the information about the verb that was ran and to look in the logs for that verb.

Updated to have this in the sparse log:
```
DehydrateVerb {"Output":"Check dehydrate logs for output","ReturnCode":0}
```
Also thought about having all the information in the sparse log but that would require more extensive changes by having the base class create the tracer for the verb and all the derived class use that tracer.  Seems that change would be outside the scope of these changes though.
