### PR TITLE
Functional test failures on Server 2016

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
@@ -63,7 +63,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string alias = nameof(this.GitAliasNamedAfterKnownCommandAcquiresLock);
 
             int pid;
-            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: 3000);
+            int tenSeconds = 10 * 1000;
+            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: tenSeconds);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "config --local alias." + alias + " status");
             ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, alias, removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
@@ -75,7 +76,8 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string alias = nameof(this.GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock);
 
             int pid;
-            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: 3000);
+            int tenSeconds = 10 * 1000;
+            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: tenSeconds);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "config --local alias." + alias + " rebase");
             ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(
                 Path.Combine(this.Enlistment.RepoRoot, "GVFS"),

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GitReadAndGitLockTests.cs
@@ -14,6 +14,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     public class GitReadAndGitLockTests : TestsWithEnlistmentPerFixture
     {
         private const string ExpectedStatusWaitingText = @"Waiting for 'GVFS.FunctionalTests.LockHolder'";
+        private const int AcquireGVFSLockTimeout = 10 * 1000;
         private FileSystemRunner fileSystem;
 
         public GitReadAndGitLockTests()
@@ -63,8 +64,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string alias = nameof(this.GitAliasNamedAfterKnownCommandAcquiresLock);
 
             int pid;
-            int tenSeconds = 10 * 1000;
-            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: tenSeconds);
+            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: AcquireGVFSLockTimeout);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "config --local alias." + alias + " status");
             ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, alias, removeWaitingMessages: false);
             statusWait.Errors.ShouldContain(ExpectedStatusWaitingText);
@@ -76,8 +76,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string alias = nameof(this.GitAliasInSubfolderNamedAfterKnownCommandAcquiresLock);
 
             int pid;
-            int tenSeconds = 10 * 1000;
-            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: tenSeconds);
+            GitHelpers.AcquireGVFSLock(this.Enlistment, out pid, resetTimeout: AcquireGVFSLockTimeout);
             GitHelpers.CheckGitCommandAgainstGVFSRepo(this.Enlistment.RepoRoot, "config --local alias." + alias + " rebase");
             ProcessResult statusWait = GitHelpers.InvokeGitAgainstGVFSRepo(
                 Path.Combine(this.Enlistment.RepoRoot, "GVFS"),

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -188,7 +188,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // Regex to extract the total number of files and percentage they represent (should always be 100)
             // "Total files in HEAD commit:           <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Total files in HEAD commit:\s*([\d,]+)\s*\|\s*(\d+)\s*%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedTotalFiles).ShouldBeTrue();
             int.TryParse(lineMatch.Groups[2].Value, out int outputtedTotalFilePercent).ShouldBeTrue();
@@ -201,7 +201,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // Regex to extract the total number of fast files and percentage they represent
             // "Files managed by VFS for Git (fast):    <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by VFS for Git \(fast\):\s*([\d,]+)\s*\|\s*(\d+)\s*%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedFastFiles).ShouldBeTrue();
             int.TryParse(lineMatch.Groups[2].Value, out int outputtedFastFilesPercent).ShouldBeTrue();
@@ -214,7 +214,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // Regex to extract the total number of slow files and percentage they represent
             // "Files managed by git (slow):                <count> | <percentage>%"
-            Match lineMatch = Regex.Match(outputLine, @"^Files managed by Git:\s*([\d,]+)\s*\|\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Files managed by Git:\s*([\d,]+)\s*\|\s*(\d+)\s*%$");
 
             int.TryParse(lineMatch.Groups[1].Value, NumberStyles.AllowThousands, CultureInfo.CurrentCulture.NumberFormat, out int outputtedSlowFiles).ShouldBeTrue();
             int.TryParse(lineMatch.Groups[2].Value, out int outputtedSlowFilesPercent).ShouldBeTrue();
@@ -227,7 +227,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             // Regex to extract the total hydration percentage of the enlistment
             // "Total hydration percentage:            <percentage>%
-            Match lineMatch = Regex.Match(outputLine, @"^Total hydration percentage:\s*(\d+)%$");
+            Match lineMatch = Regex.Match(outputLine, @"^Total hydration percentage:\s*(\d+)\s*%$");
 
             int.TryParse(lineMatch.Groups[1].Value, out int outputtedTotalHydration).ShouldBeTrue();
 

--- a/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
+++ b/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
@@ -4,6 +4,8 @@ namespace GVFS.Platform.Windows
 {
     public class HResultExtensions
     {
+        public const int GenericProjFSError = -2147024579; // returned by ProjFS::DeleteFile() on Win server 2016 while deleting a partial file
+
         private const int FacilityNtBit = 0x10000000; // FACILITY_NT_BIT
         private const int FacilityWin32 = 7;          // FACILITY_WIN32
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -104,6 +104,9 @@ namespace GVFS.Platform.Windows
                 case HResult.VirtualizationInvalidOp:
                     return FSResult.VirtualizationInvalidOperation;
 
+                case (HResult)HResultExtensions.GenericProjFSError:
+                    return FSResult.GenericProjFSError;
+
                 default:
                     return FSResult.IOError;
             }

--- a/GVFS/GVFS.Virtualization/FileSystem/FSResult.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FSResult.cs
@@ -9,5 +9,6 @@
         FileOrPathNotFound,
         IoReparseTagNotHandled,
         VirtualizationInvalidOperation,
+        GenericProjFSError,
     }
 }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1780,19 +1780,31 @@ namespace GVFS.Virtualization.Projection
 
                 default:
                     {
-                        string gitPath;
-                        this.AddFileToUpdateDeletePlaceholderFailureReport(deleteOperation, placeholder, out gitPath);
                         this.ScheduleBackgroundTaskForFailedUpdateDeletePlaceholder(placeholder, deleteOperation);
                         this.AddParentFoldersToListToKeep(parentKey, folderPlaceholdersToKeep);
 
                         metadata = CreateEventMetadata();
                         metadata.Add("deleteOperation", deleteOperation);
                         metadata.Add("virtualPath", placeholder.Path);
-                        metadata.Add("gitPath", gitPath);
                         metadata.Add("result.Result", result.ToString());
                         metadata.Add("result.RawResult", result.RawResult);
                         metadata.Add("failureReason", failureReason.ToString());
-                        this.context.Tracer.RelatedWarning(metadata, "UpdateOrDeletePlaceholder: did not succeed");
+
+                        bool logOnly = result.Result == FSResult.GenericProjFSError && failureReason == UpdateFailureReason.DirtyData;
+                        if (logOnly)
+                        {
+                            metadata.Add("backgroundCount", this.backgroundFileSystemTaskRunner.Count);
+                            metadata.Add(TracingConstants.MessageKey.InfoMessage, "UpdateOrDeletePlaceholder: attempted an invalid operation");
+                            this.context.Tracer.RelatedEvent(EventLevel.Informational, "UpdatePlaceholders_InvalidOperation", metadata);
+                        }
+                        else
+                        {
+                            string gitPath = null;
+                            this.AddFileToUpdateDeletePlaceholderFailureReport(deleteOperation, placeholder, out gitPath);
+
+                            metadata.Add("gitPath", gitPath);
+                            this.context.Tracer.RelatedWarning(metadata, "UpdateOrDeletePlaceholder: did not succeed");
+                        }
                     }
 
                     break;


### PR DESCRIPTION
### Issue
GVFS Functional tests fail on Windows server 2016.

Example failure log:
```Failed : GVFS.FunctionalTests.Tests.GitCommands.UpdateIndexTests(None).UpdateIndexWithCacheInfo()
2019-10-21T22:07:06.3542872Z reset --hard -q HEAD Errors Lines
2019-10-21T22:07:06.3543090Z reset --hard -q HEAD Errors Lines counts do not match. was: 2 expected: 0
2019-10-21T22:07:06.3543366Z Extra: GVFS was unable to delete the following files. To recover, close all handles to the files and run these commands:
2019-10-21T22:07:06.3543615Z Extra:     git clean -f Protocol.md
2019-10-21T22:07:06.3543923Z Items are not in the same order: 'GVFS was unable to delete the following files. To recover, close all handles to the files and run these commands:,    git clean -f Protocol.md' vs. ''
2019-10-21T22:07:06.3544368Z    at GVFS.Tests.Should.EnumerableShouldExtensions.ShouldMatchInOrder[T](IEnumerable`1 group, IEnumerable`1 expectedValues, Func`3 equals, String message) in C:\agent\_work\13\s\GVFS\GVFS.Tests\Should\EnumerableShouldExtensions.cs:line 124
2019-10-21T22:07:06.3544840Z    at GVFS.FunctionalTests.Tools.GitHelpers.ErrorsShouldMatch(String command, ProcessResult expectedResult, ProcessResult actualResult) in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Tools\GitHelpers.cs:line 192
2019-10-21T22:07:06.3545281Z    at GVFS.FunctionalTests.Tests.GitCommands.GitRepoTests.RunGitCommand(String command, Boolean ignoreErrors, Boolean checkStatus) in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Tests\GitCommands\GitRepoTests.cs:line 253
2019-10-21T22:07:06.3545721Z    at GVFS.FunctionalTests.Tests.GitCommands.GitRepoTests.TestValidationAndCleanup(Boolean ignoreCase) in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Tests\GitCommands\GitRepoTests.cs:line 174
2019-10-21T22:07:06.3546122Z    at GVFS.FunctionalTests.Tests.GitCommands.GitRepoTests.TearDownForTest() in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Tests\GitCommands\GitRepoTests.cs:line 159
```

### Steps to repro
```
gvfs clone "https://gvfs.visualstudio.com/ci/_git/ForTests" "FT1" --branch "FunctionalTests/20180214" --local-cache-path "GvfsCacheDirectory"
cd ".\FT1\src"
git update-index --cacheinfo 100644 "583f1a56db7cc884d54534c5d9c56b93a1e00a2b" Protocol.md
git status
git reset --hard -q HEAD
gvfs unmount
```

### Cause
The issue is caused by a change in the behavior of `WindowsFileSystemVirtualizer::Delete()` API. While deleting a `partial` file placeholder, the API returns `-2147024579` on Server 2016 and `-2147024511` on other OS versions. Client treats the return codes differently.

`-2147024511`: Client expects this in certain scenarios. It logs the event and proceeds.

`-2147024579`: Client considers this to be a failure while deleting placeholder file. It includes the file in placeholder failure report, that is send back to `git` command when `gvfs lock` held by the command is released. The report appears in the console and causes the FT to fail.

### Changes in this PR
This PR updates `WindowsFileSystemVirtualizer` to map both the above error codes to `VirtualizationInvalidOperation`. `VFSForGit` now treats them as being the same.