### PR TITLE
dehydrate: skip installing hooks when re-mounting

### DIFF
--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -385,6 +385,24 @@ from a parent of the folders list.
             }
         }
 
+        private void Mount(ITracer tracer)
+        {
+            if (!this.ShowStatusWhileRunning(
+                () =>
+                {
+                    return this.ExecuteGVFSVerb<MountVerb>(
+                        tracer,
+                        verb =>
+                        {
+                            verb.SkipInstallHooks = true;
+                        }) == ReturnCode.Success;
+                },
+                "Mounting"))
+            {
+                this.ReportErrorAndExit(tracer, "Failed to mount.");
+            }
+        }
+
         private bool CheckGitStatus(ITracer tracer, GVFSEnlistment enlistment, bool fullDehydrate)
         {
             if (!this.NoStatus)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -943,19 +943,6 @@ You can specify a URL, a name of a configured cache server, or the special names
                 }
             }
 
-            protected void Mount(ITracer tracer)
-            {
-                if (!this.ShowStatusWhileRunning(
-                    () =>
-                    {
-                        return this.ExecuteGVFSVerb<MountVerb>(tracer) == ReturnCode.Success;
-                    },
-                    "Mounting"))
-                {
-                    this.ReportErrorAndExit(tracer, "Failed to mount.");
-                }
-            }
-
             private void InitializeCachePathsFromRepoMetadata(
                 ITracer tracer,
                 GVFSEnlistment enlistment)

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -36,6 +36,7 @@ namespace GVFS.CommandLine
 
         public bool SkipMountedCheck { get; set; }
         public bool SkipVersionCheck { get; set; }
+        public bool SkipInstallHooks { get; set; }
         public CacheServerInfo ResolvedCacheServer { get; set; }
         public ServerGVFSConfig DownloadedGVFSConfig { get; set; }
 
@@ -89,7 +90,7 @@ namespace GVFS.CommandLine
                 GitRepo gitRepo = new GitRepo(tracer, enlistment, fileSystem);
                 GVFSContext context = new GVFSContext(tracer, fileSystem, gitRepo, enlistment);
 
-                if (!HooksInstaller.InstallHooks(context, out errorMessage))
+                if (!this.SkipInstallHooks && !HooksInstaller.InstallHooks(context, out errorMessage))
                 {
                     this.ReportErrorAndExit("Error installing hooks: " + errorMessage);
                 }


### PR DESCRIPTION
Resolves #1565 

There is no need to copy the hooks when mounting as part of
dehydrate.  Additionally, this copy can cause problems if
'gvfs dehydrate' is called as part of a post-command hook.