### PR TITLE
Ensure git-credential cmds are run with correct wrkdir

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -173,7 +173,7 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            Result result = this.InvokeGitOutsideEnlistment(
+            Result result = this.InvokeGitAgainstDotGitFolder(
                 GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
                 null);
@@ -200,7 +200,7 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            Result result = this.InvokeGitOutsideEnlistment(
+            Result result = this.InvokeGitAgainstDotGitFolder(
                 GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
                 null);


### PR DESCRIPTION
Ensure that all git-credential commands are run with the correct working
directory. Currently only 'fill' is invoked against the .git directory
and the 'reject' and 'approve' commands are invoked outside the
repository.

The result of this mismatch means that if the user has a local
configuration entry set, for say credential.usehttppath, then the
behaviour for locating credentials will be different between read and
modification operations.

Fixes #1568
