### PR TITLE
LooseObjectsStep: simply code for getting directory paths

### DIFF
--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -52,8 +52,7 @@ namespace GVFS.Common.Maintenance
 
                 if (GitObjects.IsLooseObjectsDirectory(directoryName))
                 {
-                    string dirPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, directoryPath);
-                    List<DirectoryItemInfo> dirItems = this.Context.FileSystem.ItemsInDirectory(dirPath).ToList();
+                    List<DirectoryItemInfo> dirItems = this.Context.FileSystem.ItemsInDirectory(directoryPath).ToList();
                     count += dirItems.Count;
                     size += dirItems.Sum(item => item.Length);
                 }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -280,7 +280,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
             {
                 foreach (MockDirectory subDirectory in directory.Directories.Values)
                 {
-                    yield return subDirectory.Name;
+                    yield return subDirectory.FullName;
                 }
             }
         }


### PR DESCRIPTION
The code in CountLooseObjects can be simplified by avoiding
an unnecessary Path.Combine.

Additionally, fix a bug in the MockFileSystem where EnumerateDirectories
was not returning the full paths of directories and it should.