### PR TITLE
Update Git to have proper version number

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20191106.1</GitPackageVersion>
+    <GitPackageVersion>2.20191106.5</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
The previous installer was generated without the `v2.24.0.vfs.1.1` tag, which caused the Git version generation to fail. That is the only change between the `.1` and `.2` builds.

[Here is the build line with the version number.](https://dev.azure.com/gvfs/ci/_build/results?buildId=17360&view=logs&j=00af5505-930d-50dd-3844-b167e8b4bb13&t=6ec846bc-101e-588c-b676-9b550d603286&l=27)