### PR TITLE
[Not to Merge] Win server 2016 FT fixes (6)

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -5,6 +5,7 @@
         public const string ExtraCoverage = "ExtraCoverage";
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
+        public const string WinServer16Disabled = "WinServer16Disabled";
 
         // Linux uses a separate device mount for its repository, and so is unable to rename(2) inodes
         // in or out of the repository filesystem; attempts to do so fail with errno set to EXDEV.

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -114,6 +114,7 @@ namespace GVFS.FunctionalTests
                 // Windows excludes.
                 excludeCategories.Add(Categories.MacOnly);
                 excludeCategories.Add(Categories.POSIXOnly);
+                excludeCategories.Add(Categories.WinServer16Disabled);
             }
 
             GVFSTestConfig.DotGVFSRoot = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ".vfsforgit" : ".gvfs";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MoveRenameFolderTests.cs
@@ -128,7 +128,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
         {
             string fileContents = "Test contents for MoveFullFolderToFullFolderInDotGitFolder";
             string testFileName = "MoveFullFolderToFullFolderInDotGitFolder.txt";
-            string oldFolderPath = this.Enlistment.GetVirtualPathTo("MoveFullFolderToFullFolderInDotGitFolder");
+            string oldFolderPath = this.Enlistment.GetVirtualPathTo("MoveSourceFolder");
             oldFolderPath.ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.CreateDirectory(oldFolderPath);
             oldFolderPath.ShouldBeADirectory(this.fileSystem);
@@ -137,7 +137,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             this.fileSystem.WriteAllText(oldFilePath, fileContents);
             oldFilePath.ShouldBeAFile(this.fileSystem).WithContents(fileContents);
 
-            string newFolderName = "NewMoveFullFolderToFullFolderInDotGitFolder";
+            string newFolderName = "MoveTargetFolder";
             string newFolderPath = this.Enlistment.GetVirtualPathTo(".git", newFolderName);
             newFolderPath.ShouldNotExistOnDisk(this.fileSystem);
             this.fileSystem.CreateDirectory(newFolderPath);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
@@ -60,6 +60,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(2)]
+        [Category(Categories.WinServer16Disabled)]
         public void RepackAllToOnePack()
         {
             // Create new pack(s) by prefetching blobs for a folder.
@@ -88,6 +89,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase, Order(3)]
+        [Category(Categories.WinServer16Disabled)]
         public void ExpireAllButOneAndKeep()
         {
             string prefetchPack = Directory.GetFiles(this.PackRoot, "prefetch-*.pack")


### PR DESCRIPTION
Fixing FT failure - 
```
1) Failed : GVFS.FunctionalTests.Tests.EnlistmentPerFixture.MoveRenameFolderTests(GVFS.FunctionalTests.FileSystemRunners.CmdRunner).MoveFullFolderToFullFolderInDotGitFolder()
  Directory C:\Repos\GVFSFunctionalTests\enlistment\728d0dda6e8a4229bb80\src\.git\NewMoveFullFolderToFullFolderInDotGitFolder\Should does not exist
  Expected: True
  But was:  False
   at GVFS.Tests.Should.ValueShouldExtensions.ShouldEqual[T](T actualValue, T expectedValue, String message) in C:\agent\_work\13\s\GVFS\GVFS.Tests\Should\ValueShouldExtensions.cs:line 34
   at GVFS.FunctionalTests.Should.FileSystemShouldExtensions.DirectoryAdapter..ctor(String path, FileSystemRunner runner) in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Should\FileSystemShouldExtensions.cs:line 140
   at GVFS.FunctionalTests.Should.FileSystemShouldExtensions.ShouldBeADirectory(String path, FileSystemRunner runner) in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Should\FileSystemShouldExtensions.cs:line 46
   at GVFS.FunctionalTests.Tests.EnlistmentPerFixture.MoveRenameFolderTests.MoveFullFolderToFullFolderInDotGitFolder() in C:\agent\_work\13\s\GVFS\GVFS.FunctionalTests\Tests\EnlistmentPerFixture\MoveRenameFolderTests.cs:line 149
```

Issue -

- `CMD.EXE Move` command fails with error - "The filename or extension is too long"
  while moving this directory "MoveFullFolderToFullFolderInDotGitFolder". The
  error causes MoveRenameFolderTests to fail when run with CmdRunner (other file system runners succeed.) This seems to be an issue with `Move` command on 2016. Renamed the directory to a shorter name.