### PR TITLE
Create shared cache folders with the same ACLs as repo folders

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -12,7 +12,7 @@ namespace GVFS.Common.FileSystem
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
-        void CreateDirectoryAccessibleByAuthUsers(string directoryPath);
+        bool TryCreateDirectoryAccessibleByAuthUsers(string directoryPath, out string error, ITracer tracer = null);
         bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error);
         bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error);
         bool IsFileSystemSupported(string path, out string error);

--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -12,6 +12,7 @@ namespace GVFS.Common.FileSystem
         bool HydrateFile(string fileName, byte[] buffer);
         bool IsExecutable(string filePath);
         bool IsSocket(string filePath);
+        void CreateDirectoryAccessibleByAuthUsers(string directoryPath);
         bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error);
         bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error);
         bool IsFileSystemSupported(string path, out string error);

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -213,12 +213,10 @@ namespace GVFS.Common
             this.BlobSizesRoot = blobSizesRoot;
         }
 
-        public bool TryCreateEnlistmentFolders()
+        public bool TryCreateEnlistmentSubFolders()
         {
             try
             {
-                Directory.CreateDirectory(this.EnlistmentRoot);
-                GVFSPlatform.Instance.InitializeEnlistmentACLs(this.EnlistmentRoot);
                 Directory.CreateDirectory(this.WorkingDirectoryRoot);
                 this.CreateHiddenDirectory(this.DotGVFSRoot);
             }

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -73,7 +73,6 @@ namespace GVFS.Common
         public abstract string GetOSVersionInformation();
         public abstract string GetDataRootForGVFS();
         public abstract string GetDataRootForGVFSComponent(string componentName);
-        public abstract void InitializeEnlistmentACLs(string enlistmentPath);
         public abstract bool IsElevated();
         public abstract string GetCurrentUser();
         public abstract string GetUserIdFromLoginSessionId(int sessionId, ITracer tracer);

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -56,7 +56,13 @@ namespace GVFS.Common
             {
                 // A lock is required because FileBasedDictionary is not multi-process safe, neither is the act of adding a new cache
                 string lockPath = Path.Combine(localCacheRoot, MappingFile + ".lock");
-                GVFSPlatform.Instance.FileSystem.CreateDirectoryAccessibleByAuthUsers(localCacheRoot);
+
+                string createDirectoryError;
+                if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryAccessibleByAuthUsers(localCacheRoot, out createDirectoryError, tracer))
+                {
+                    errorMessage = $"Failed to create '{localCacheRoot}': {createDirectoryError}";
+                    return false;
+                }
 
                 using (FileBasedLock mappingLock = GVFSPlatform.Instance.CreateFileBasedLock(
                     this.fileSystem,

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -56,7 +56,11 @@ namespace GVFS.Common
             {
                 // A lock is required because FileBasedDictionary is not multi-process safe, neither is the act of adding a new cache
                 string lockPath = Path.Combine(localCacheRoot, MappingFile + ".lock");
-                this.fileSystem.CreateDirectory(localCacheRoot);
+
+                // Create any missing parent directories of localCacheRoot with default permissions/ACLs
+                // before creating localCacheRoot itself
+                this.fileSystem.CreateDirectory(Path.GetDirectoryName(localCacheRoot));
+                GVFSPlatform.Instance.FileSystem.CreateDirectoryAccessibleByAuthUsers(localCacheRoot);
 
                 using (FileBasedLock mappingLock = GVFSPlatform.Instance.CreateFileBasedLock(
                     this.fileSystem,

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -56,10 +56,6 @@ namespace GVFS.Common
             {
                 // A lock is required because FileBasedDictionary is not multi-process safe, neither is the act of adding a new cache
                 string lockPath = Path.Combine(localCacheRoot, MappingFile + ".lock");
-
-                // Create any missing parent directories of localCacheRoot with default permissions/ACLs
-                // before creating localCacheRoot itself
-                this.fileSystem.CreateDirectory(Path.GetDirectoryName(localCacheRoot));
                 GVFSPlatform.Instance.FileSystem.CreateDirectoryAccessibleByAuthUsers(localCacheRoot);
 
                 using (FileBasedLock mappingLock = GVFSPlatform.Instance.CreateFileBasedLock(

--- a/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXFileSystem.cs
@@ -54,6 +54,11 @@ namespace GVFS.Platform.POSIX
 
         public abstract bool IsSocket(string fileName);
 
+        public void CreateDirectoryAccessibleByAuthUsers(string directoryPath)
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
         public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
         {
             throw new NotImplementedException();

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -183,10 +183,6 @@ namespace GVFS.Platform.POSIX
             return result;
         }
 
-        public override void InitializeEnlistmentACLs(string enlistmentPath)
-        {
-        }
-
         public override string GetGVFSServiceNamedPipeName(string serviceName)
         {
             // Pipes are stored as files on POSIX, use a rooted pipe name

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -117,6 +117,30 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
+        /// <summary>
+        /// Creates the specified directory (and its ancestors) if they do not
+        /// already exist.
+        ///
+        /// If the specified directory does not exist this method:
+        ///
+        ///  - Creates the directory and its ancestors
+        ///  - Adjusts the ACLs of 'directoryPath' (the ancestors' ACLs are not
+        ///    modified).
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        /// <remarks>
+        /// The following permissions are typically present on deskop and missing on Server.
+        /// These are the permissions added by this method.
+        ///
+        ///   ACCESS_ALLOWED_ACE_TYPE: NT AUTHORITY\Authenticated Users
+        ///          [OBJECT_INHERIT_ACE]
+        ///          [CONTAINER_INHERIT_ACE]
+        ///          [INHERIT_ONLY_ACE]
+        ///        DELETE
+        ///        GENERIC_EXECUTE
+        ///        GENERIC_WRITE
+        ///        GENERIC_READ
+        /// </remarks>
         public void CreateDirectoryAccessibleByAuthUsers(string directoryPath)
         {
             if (Directory.Exists(directoryPath))
@@ -124,37 +148,12 @@ namespace GVFS.Platform.Windows
                 return;
             }
 
-            // Create the ancestors of the specified path with the default ACLs
-            string parentPath = Path.GetDirectoryName(directoryPath);
-            Directory.CreateDirectory(parentPath);
-
-            // Create a temporary directory and read its ACLs.  This allows us to call
-            // Directory.CreateDirectorywith both the proper inherited ACLs, and the ACLs we want to add.
-            string tempDir = Path.Combine(parentPath, $"gvfs_{Path.GetRandomFileName()}");
-            Directory.CreateDirectory(tempDir);
-            DirectorySecurity directorySecurity;
-            try
-            {
-                directorySecurity = Directory.GetAccessControl(tempDir);
-            }
-            finally
-            {
-                Directory.Delete(tempDir);
-            }
-
-            // The following permissions are typically present on deskop and missing on Server
-            //
-            //   ACCESS_ALLOWED_ACE_TYPE: NT AUTHORITY\Authenticated Users
-            //          [OBJECT_INHERIT_ACE]
-            //          [CONTAINER_INHERIT_ACE]
-            //          [INHERIT_ONLY_ACE]
-            //        DELETE
-            //        GENERIC_EXECUTE
-            //        GENERIC_WRITE
-            //        GENERIC_READ
+            // Create the directory first and then adjust the ACLs as needed
+            Directory.CreateDirectory(directoryPath);
 
             // Use AccessRuleFactory rather than creating a FileSystemAccessRule because the NativeMethods.FileAccess flags
             // we're specifying are not valid for the FileSystemRights parameter of the FileSystemAccessRule constructor
+            DirectorySecurity directorySecurity = Directory.GetAccessControl(directoryPath);
             AccessRule authenticatedUsersAccessRule = directorySecurity.AccessRuleFactory(
                 new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null),
                 unchecked((int)(NativeMethods.FileAccess.DELETE | NativeMethods.FileAccess.GENERIC_EXECUTE | NativeMethods.FileAccess.GENERIC_WRITE | NativeMethods.FileAccess.GENERIC_READ)),
@@ -166,7 +165,7 @@ namespace GVFS.Platform.Windows
             // The return type of the AccessRuleFactory method is the base class, AccessRule, but the return value can be cast safely to the derived class.
             // https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemsecurity.accessrulefactory(v=vs.110).aspx
             directorySecurity.AddAccessRule((FileSystemAccessRule)authenticatedUsersAccessRule);
-            Directory.CreateDirectory(directoryPath, directorySecurity);
+            Directory.SetAccessControl(directoryPath, directorySecurity);
         }
 
         public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -117,6 +117,58 @@ namespace GVFS.Platform.Windows
             return false;
         }
 
+        public void CreateDirectoryAccessibleByAuthUsers(string directoryPath)
+        {
+            if (Directory.Exists(directoryPath))
+            {
+                return;
+            }
+
+            // Create the ancestors of the specified path with the default ACLs
+            string parentPath = Path.GetDirectoryName(directoryPath);
+            Directory.CreateDirectory(parentPath);
+
+            // Create a temporary directory and read its ACLs.  This allows us to call
+            // Directory.CreateDirectorywith both the proper inherited ACLs, and the ACLs we want to add.
+            string tempDir = Path.Combine(parentPath, $"gvfs_{Path.GetRandomFileName()}");
+            Directory.CreateDirectory(tempDir);
+            DirectorySecurity directorySecurity;
+            try
+            {
+                directorySecurity = Directory.GetAccessControl(tempDir);
+            }
+            finally
+            {
+                Directory.Delete(tempDir);
+            }
+
+            // The following permissions are typically present on deskop and missing on Server
+            //
+            //   ACCESS_ALLOWED_ACE_TYPE: NT AUTHORITY\Authenticated Users
+            //          [OBJECT_INHERIT_ACE]
+            //          [CONTAINER_INHERIT_ACE]
+            //          [INHERIT_ONLY_ACE]
+            //        DELETE
+            //        GENERIC_EXECUTE
+            //        GENERIC_WRITE
+            //        GENERIC_READ
+
+            // Use AccessRuleFactory rather than creating a FileSystemAccessRule because the NativeMethods.FileAccess flags
+            // we're specifying are not valid for the FileSystemRights parameter of the FileSystemAccessRule constructor
+            AccessRule authenticatedUsersAccessRule = directorySecurity.AccessRuleFactory(
+                new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null),
+                unchecked((int)(NativeMethods.FileAccess.DELETE | NativeMethods.FileAccess.GENERIC_EXECUTE | NativeMethods.FileAccess.GENERIC_WRITE | NativeMethods.FileAccess.GENERIC_READ)),
+                true,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow);
+
+            // The return type of the AccessRuleFactory method is the base class, AccessRule, but the return value can be cast safely to the derived class.
+            // https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemsecurity.accessrulefactory(v=vs.110).aspx
+            directorySecurity.AddAccessRule((FileSystemAccessRule)authenticatedUsersAccessRule);
+            Directory.CreateDirectory(directoryPath, directorySecurity);
+        }
+
         public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
         {
             try

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -97,33 +97,6 @@ namespace GVFS.Platform.Windows
             return true;
         }
 
-        public override void InitializeEnlistmentACLs(string enlistmentPath)
-        {
-            // The following permissions are typically present on deskop and missing on Server
-            //
-            //   ACCESS_ALLOWED_ACE_TYPE: NT AUTHORITY\Authenticated Users
-            //          [OBJECT_INHERIT_ACE]
-            //          [CONTAINER_INHERIT_ACE]
-            //          [INHERIT_ONLY_ACE]
-            //        DELETE
-            //        GENERIC_EXECUTE
-            //        GENERIC_WRITE
-            //        GENERIC_READ
-            DirectorySecurity rootSecurity = Directory.GetAccessControl(enlistmentPath);
-            AccessRule authenticatedUsersAccessRule = rootSecurity.AccessRuleFactory(
-                new SecurityIdentifier(WellKnownSidType.AuthenticatedUserSid, null),
-                unchecked((int)(NativeMethods.FileAccess.DELETE | NativeMethods.FileAccess.GENERIC_EXECUTE | NativeMethods.FileAccess.GENERIC_WRITE | NativeMethods.FileAccess.GENERIC_READ)),
-                true,
-                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
-                PropagationFlags.None,
-                AccessControlType.Allow);
-
-            // The return type of the AccessRuleFactory method is the base class, AccessRule, but the return value can be cast safely to the derived class.
-            // https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemsecurity.accessrulefactory(v=vs.110).aspx
-            rootSecurity.AddAccessRule((FileSystemAccessRule)authenticatedUsersAccessRule);
-            Directory.SetAccessControl(enlistmentPath, rootSecurity);
-        }
-
         public override string GetOSVersionInformation()
         {
             StringBuilder sb = new StringBuilder();

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -132,11 +132,6 @@ namespace GVFS.UnitTests.Mock.Common
             return this.GetUpgradeProtectedDataDirectory();
         }
 
-        public override void InitializeEnlistmentACLs(string enlistmentPath)
-        {
-            throw new NotSupportedException();
-        }
-
         public override bool IsConsoleOutputRedirectedToFile()
         {
             throw new NotSupportedException();

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -45,7 +45,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
-        public void CreateDirectoryAccessibleByAuthUsers(string directoryPath)
+        public bool TryCreateDirectoryAccessibleByAuthUsers(string directoryPath, out string error, ITracer tracer = null)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -45,6 +45,11 @@ namespace GVFS.UnitTests.Mock.FileSystem
             throw new NotSupportedException();
         }
 
+        public void CreateDirectoryAccessibleByAuthUsers(string directoryPath)
+        {
+            throw new NotSupportedException();
+        }
+
         public bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error)
         {
             throw new NotSupportedException();

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -127,7 +127,11 @@ namespace GVFS.CommandLine
                     {
                         // Create the enlistment root explicitly with CreateDirectoryAccessibleByAuthUsers before calling
                         // AddLogFileEventListener to ensure that elevated and non-elevated users have access to the root.
-                        GVFSPlatform.Instance.FileSystem.CreateDirectoryAccessibleByAuthUsers(enlistment.EnlistmentRoot);
+                        string createDirectoryError;
+                        if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryAccessibleByAuthUsers(enlistment.EnlistmentRoot, out createDirectoryError))
+                        {
+                            this.ReportErrorAndExit($"Failed to create '{enlistment.EnlistmentRoot}': {createDirectoryError}");
+                        }
 
                         tracer.AddLogFileEventListener(
                             GVFSEnlistment.GetNewGVFSLogFileName(enlistment.GVFSLogsRoot, GVFSConstants.LogFileTypes.Clone),
@@ -377,7 +381,7 @@ namespace GVFS.CommandLine
 
                     if (!enlistment.TryCreateEnlistmentSubFolders())
                     {
-                        string error = "Could not create enlistment directory";
+                        string error = "Could not create enlistment directories";
                         tracer.RelatedError(error);
                         return new Result(error);
                     }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -127,8 +127,6 @@ namespace GVFS.CommandLine
                     {
                         // Create the enlistment root explicitly with CreateDirectoryAccessibleByAuthUsers before calling
                         // AddLogFileEventListener to ensure that elevated and non-elevated users have access to the root.
-                        // But first create the ancestors of the enlistment root with the default ACLs (in case they're not on disk already)
-                        Directory.CreateDirectory(Path.GetDirectoryName(enlistment.EnlistmentRoot));
                         GVFSPlatform.Instance.FileSystem.CreateDirectoryAccessibleByAuthUsers(enlistment.EnlistmentRoot);
 
                         tracer.AddLogFileEventListener(


### PR DESCRIPTION
Resolves #1115 

The changes in this commit address the ACL problems that can
occur on Windows Server when a shared cache created by an
elevated VFS4G process is used by a non-elevated process.

By adding Authenticated Users to the shared cache ACLs we ensure
that the permissions of the shared cache will be consistent with
those used in the repo itself.

**NOTE**

This changes only fix scenarios where directories are being created for the first time.  They do not address:

- VFS4G re-creating the local cache after it's been deleted (#1579)
- Fixing up existing repos/caches (#1580)