### PR TITLE
Mac: EndpointSecurity MirrorProvider-like prototype

### DIFF
--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
@@ -1,0 +1,300 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4A6A654B22C227CA00E207E2 /* libEndpointSecurity.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */; };
+		4A6A654F22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4A6A653D22C227BA00E207E2 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		4A6A653F22C227BA00E207E2 /* EndpointSecurityMirror */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = EndpointSecurityMirror; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libEndpointSecurity.tbd; path = usr/lib/libEndpointSecurity.tbd; sourceTree = SDKROOT; };
+		4A6A654C22C22E9500E207E2 /* EndpointSecurityMirror.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EndpointSecurityMirror.entitlements; sourceTree = "<group>"; };
+		4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EndpointSecurityMirror.cpp; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4A6A653C22C227BA00E207E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A6A654B22C227CA00E207E2 /* libEndpointSecurity.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4A6A653622C227BA00E207E2 = {
+			isa = PBXGroup;
+			children = (
+				4A6A654122C227BA00E207E2 /* EndpointSecurityMirror */,
+				4A6A654022C227BA00E207E2 /* Products */,
+				4A6A654922C227CA00E207E2 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		4A6A654022C227BA00E207E2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4A6A653F22C227BA00E207E2 /* EndpointSecurityMirror */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4A6A654122C227BA00E207E2 /* EndpointSecurityMirror */ = {
+			isa = PBXGroup;
+			children = (
+				4A6A654C22C22E9500E207E2 /* EndpointSecurityMirror.entitlements */,
+				4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */,
+			);
+			path = EndpointSecurityMirror;
+			sourceTree = "<group>";
+		};
+		4A6A654922C227CA00E207E2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4A6A653E22C227BA00E207E2 /* EndpointSecurityMirror */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4A6A654622C227BA00E207E2 /* Build configuration list for PBXNativeTarget "EndpointSecurityMirror" */;
+			buildPhases = (
+				4A6A653B22C227BA00E207E2 /* Sources */,
+				4A6A653C22C227BA00E207E2 /* Frameworks */,
+				4A6A653D22C227BA00E207E2 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EndpointSecurityMirror;
+			productName = EndpointSecurityMirror;
+			productReference = 4A6A653F22C227BA00E207E2 /* EndpointSecurityMirror */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4A6A653722C227BA00E207E2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = "Microsoft Corporation";
+				TargetAttributes = {
+					4A6A653E22C227BA00E207E2 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+				};
+			};
+			buildConfigurationList = 4A6A653A22C227BA00E207E2 /* Build configuration list for PBXProject "EndpointSecurityMirror" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 4A6A653622C227BA00E207E2;
+			productRefGroup = 4A6A654022C227BA00E207E2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4A6A653E22C227BA00E207E2 /* EndpointSecurityMirror */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4A6A653B22C227BA00E207E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A6A654F22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4A6A654422C227BA00E207E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		4A6A654522C227BA00E207E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		4A6A654722C227BA00E207E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = EndpointSecurityMirror/EndpointSecurityMirror.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PLT8TQHCAJ;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		4A6A654822C227BA00E207E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = EndpointSecurityMirror/EndpointSecurityMirror.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PLT8TQHCAJ;
+				ENABLE_HARDENED_RUNTIME = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4A6A653A22C227BA00E207E2 /* Build configuration list for PBXProject "EndpointSecurityMirror" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A6A654422C227BA00E207E2 /* Debug */,
+				4A6A654522C227BA00E207E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4A6A654622C227BA00E207E2 /* Build configuration list for PBXNativeTarget "EndpointSecurityMirror" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A6A654722C227BA00E207E2 /* Debug */,
+				4A6A654822C227BA00E207E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4A6A653722C227BA00E207E2 /* Project object */;
+}

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4A6A654B22C227CA00E207E2 /* libEndpointSecurity.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */; };
 		4A6A654F22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */; };
+		4A6A656922C4C33200E207E2 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6A656822C4C32B00E207E2 /* libbsm.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,6 +29,8 @@
 		4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libEndpointSecurity.tbd; path = usr/lib/libEndpointSecurity.tbd; sourceTree = SDKROOT; };
 		4A6A654C22C22E9500E207E2 /* EndpointSecurityMirror.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EndpointSecurityMirror.entitlements; sourceTree = "<group>"; };
 		4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EndpointSecurityMirror.cpp; sourceTree = "<group>"; };
+		4A6A655022C4A9E000E207E2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4A6A656822C4C32B00E207E2 /* libbsm.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbsm.tbd; path = usr/lib/libbsm.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -36,6 +39,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A6A654B22C227CA00E207E2 /* libEndpointSecurity.tbd in Frameworks */,
+				4A6A656922C4C33200E207E2 /* libbsm.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,6 +68,7 @@
 			children = (
 				4A6A654C22C22E9500E207E2 /* EndpointSecurityMirror.entitlements */,
 				4A6A654E22C4A8BE00E207E2 /* EndpointSecurityMirror.cpp */,
+				4A6A655022C4A9E000E207E2 /* README.md */,
 			);
 			path = EndpointSecurityMirror;
 			sourceTree = "<group>";
@@ -71,6 +76,7 @@
 		4A6A654922C227CA00E207E2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4A6A656822C4C32B00E207E2 /* libbsm.tbd */,
 				4A6A654A22C227CA00E207E2 /* libEndpointSecurity.tbd */,
 			);
 			name = Frameworks;

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.pbxproj
@@ -108,7 +108,7 @@
 		4A6A653722C227BA00E207E2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1110;
 				ORGANIZATIONNAME = "Microsoft Corporation";
 				TargetAttributes = {
 					4A6A653E22C227BA00E207E2 = {
@@ -259,10 +259,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = EndpointSecurityMirror/EndpointSecurityMirror.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PLT8TQHCAJ;
 				ENABLE_HARDENED_RUNTIME = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = org.vfsforgit.mirrorprovider.endpointsecurityprototype;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -271,10 +273,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = EndpointSecurityMirror/EndpointSecurityMirror.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PLT8TQHCAJ;
 				ENABLE_HARDENED_RUNTIME = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = org.vfsforgit.mirrorprovider.endpointsecurityprototype;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:EndpointSecurityMirror.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/xcshareddata/xcschemes/EndpointSecurityMirror.xcscheme
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/xcshareddata/xcschemes/EndpointSecurityMirror.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1110"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/xcshareddata/xcschemes/EndpointSecurityMirror.xcscheme
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror.xcodeproj/xcshareddata/xcschemes/EndpointSecurityMirror.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A6A653E22C227BA00E207E2"
+               BuildableName = "EndpointSecurityMirror"
+               BlueprintName = "EndpointSecurityMirror"
+               ReferencedContainer = "container:EndpointSecurityMirror.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A6A653E22C227BA00E207E2"
+            BuildableName = "EndpointSecurityMirror"
+            BlueprintName = "EndpointSecurityMirror"
+            ReferencedContainer = "container:EndpointSecurityMirror.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A6A653E22C227BA00E207E2"
+            BuildableName = "EndpointSecurityMirror"
+            BlueprintName = "EndpointSecurityMirror"
+            ReferencedContainer = "container:EndpointSecurityMirror.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -194,7 +194,15 @@ static void HandleSecurityEvent(
 		
 			es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
 		}
+        else
+        {
+            fprintf(stderr, "Unexpected event type: %u\n", message->event_type);
+        }
 	}
+    else
+    {
+        fprintf(stderr, "Unexpected action type: %u, event type: %u\n", message->action_type, message->event_type);
+    }
 }
 
 static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* message)

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -229,7 +229,7 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 
 			string sourcePath = SourcePathForTargetFile(eventPath.c_str());
 			// NOTE: if you increase this beyond 60000ms (1 minute) the process ends up being killed
-			unsigned delay_ms = random() % 60000u;
+			unsigned delay_ms = 0;//random() % 60000u;
 			printf("Hydrating '%s' -> '%s' for process %u (%s), with %u ms delay\n", sourcePath.c_str(), eventPath.c_str(), audit_token_to_pid(messageCopy->proc.audit_token), FilenameFromPath(messageCopy->proc.file.path.data), delay_ms);
 			usleep(delay_ms * 1000u);
 			int result = copyfile(sourcePath.c_str(), eventPath.c_str(), nullptr /* state */, COPYFILE_DATA);
@@ -311,7 +311,7 @@ static const char* CopyfileStageString(int stage)
 static int RecursiveEnumerationCopyfileStatusCallback(
 	int what, int stage, copyfile_state_t state, const char* src, const char* dst, void* ctx)
 {
-	printf("copyfile callback: what = %s, stage = %s, src = '%s', dst = '%s'\n", CopyfileWhatString(what), CopyfileStageString(stage), src, dst);
+	//printf("copyfile callback: what = %s, stage = %s, src = '%s', dst = '%s'\n", CopyfileWhatString(what), CopyfileStageString(stage), src, dst);
 	
 	if (what == COPYFILE_RECURSE_FILE && stage == COPYFILE_FINISH)
 	{

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -193,7 +193,8 @@ static void HandleSecurityEvent(
 					    || 0 == strcmp("mds", processFilename))
 					{
 						//printf("Denying crawler process %u (%s) access to empty file '%s'\n", audit_token_to_pid(message->proc.audit_token), processFilename, eventPath);
-						es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+						es_respond_result_t result = es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+						assert(result == ES_RESPOND_RESULT_SUCCESS);
 						unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
 						if (count != 1)
 						{
@@ -209,7 +210,8 @@ static void HandleSecurityEvent(
 				else
 				{
 					fprintf(stderr, "File tagged as empty found outside target directory: '%s'\n", eventPath);
-					es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+					es_respond_result_t result = es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+					assert(result == ES_RESPOND_RESULT_SUCCESS);
 					unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
 					if (count != 1)
 					{
@@ -229,7 +231,8 @@ static void HandleSecurityEvent(
 			{
 				printf("In-flight authorisation requests pending: %u\n", count - 1);
 			}
-			es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
+			es_respond_result_t result = es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
+			assert(result == ES_RESPOND_RESULT_SUCCESS);
 		}
         else
         {
@@ -270,7 +273,8 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 				{
 					printf("In-flight authorisation requests pending: %u\n", count - 1);
 				}
-				es_respond_flags_result(client, messageCopy, 0x7fffffff, false /* don't cache */);
+				es_respond_result_t result = es_respond_flags_result(client, messageCopy, 0x7fffffff, false /* don't cache */);
+				assert(result == ES_RESPOND_RESULT_SUCCESS);
 				return;
 			}
 
@@ -301,7 +305,8 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 			{
 				printf("In-flight authorisation requests pending: %u\n", count - 1);
 			}
-			es_respond_flags_result(client, messageCopy, responseFlags, false /* don't cache */);
+			es_respond_result_t response_result = es_respond_flags_result(client, messageCopy, responseFlags, false /* don't cache */);
+			assert(response_result == ES_RESPOND_RESULT_SUCCESS);
 			uint64_t responseMachTime = mach_absolute_time();
 			uint64_t responseMachDuration = responseMachTime - messageCopy->mach_time;
 			int64_t responseMachDeadlineDelta = responseMachTime - messageCopy->deadline;
@@ -330,7 +335,8 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 				es_message_t* waitingMessage = waitingMessages.back();
 				waitingMessages.pop_back();
 				
-				es_respond_flags_result(client, waitingMessage, responseFlags, false /* don't cache */);
+				es_respond_result_t response_result = es_respond_flags_result(client, waitingMessage, responseFlags, false /* don't cache */);
+				assert(response_result == ES_RESPOND_RESULT_SUCCESS);
 				free(waitingMessage);
 				unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
 				if (count != 1)

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -182,13 +182,13 @@ static void HandleSecurityEvent(
 		if (message->event_type == ES_EVENT_TYPE_AUTH_OPEN)
 		{
 			char xattrBuffer[16];
-			const char* eventPath = message->event.open.file.path.data;
+            const char* eventPath = message->event.open.file->path.data;
 			ssize_t xattrBytes = getxattr(eventPath, EmptyFileXattr, xattrBuffer, sizeof(xattrBuffer), 0 /* offset */, 0 /* options */);
 			if (xattrBytes >= 0)
 			{
 				if (PathLiesWithinTarget(eventPath))
 				{
-					const char* processFilename = FilenameFromPath(message->proc.file.path.data);
+					const char* processFilename = FilenameFromPath(eventPath);
 					if (0 == strcmp("mdworker_shared", processFilename)
 					    || 0 == strcmp("mds", processFilename))
 					{
@@ -277,7 +277,7 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 			string sourcePath = SourcePathForTargetFile(eventPath.c_str());
 			// NOTE: if you increase this beyond 60000ms (1 minute) the process ends up being killed
 			unsigned delay_ms = 0;//random() % 60000u;
-			printf("Hydrating '%s' -> '%s' for process %u (%s), with %u ms delay\n", sourcePath.c_str(), eventPath.c_str(), audit_token_to_pid(messageCopy->proc.audit_token), FilenameFromPath(messageCopy->proc.file.path.data), delay_ms);
+			//printf("Hydrating '%s' -> '%s' for process %u (%s), with %u ms delay\n", sourcePath.c_str(), eventPath.c_str(), audit_token_to_pid(messageCopy->proc.audit_token), FilenameFromPath(messageCopy->proc.file.path.data), delay_ms);
 			usleep(delay_ms * 1000u);
 			int result = copyfile(sourcePath.c_str(), eventPath.c_str(), nullptr /* state */, COPYFILE_DATA);
 			

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -1,0 +1,257 @@
+#include <copyfile.h>
+#include <EndpointSecurity/EndpointSecurity.h>
+#include <cstdio>
+#include <dispatch/dispatch.h>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/errno.h>
+#include <string>
+#include <cstdlib>
+
+using std::string;
+
+static constexpr const char* EmptyFileXattr = "org.vfsforgit.endpointsecuritymirror.emptyfile";
+
+static es_client_t* client = nullptr;
+
+static void HandleSecurityEvent(
+	es_client_t* _Nonnull client, const es_message_t* _Nonnull message);
+static int RecursiveEnumerationCopyfileStatusCallback(
+	int what, int stage, copyfile_state_t state, const char * src, const char * dst, void * ctx);
+
+static string s_sourcePrefix, s_targetPrefix;
+
+// Helper function that automatically fills out the event_count in es_subscribe calls
+template <typename... ARGS>
+bool ESSubscribe(es_client_t* _Nonnull client, ARGS... events)
+{
+  return es_subscribe(client, sizeof...(events), events...);
+}
+
+static const char* FilenameFromPath(const char* path)
+{
+	const char* lastSlash = std::strrchr(path, '/');
+	if (lastSlash == nullptr)
+	{
+		return path;
+	}
+	else
+	{
+		return lastSlash + 1;
+	}
+}
+
+int main(int argc, const char* argv[])
+{
+	if (argc < 3)
+	{
+		fprintf(stderr, "Run as: %s <source directory> <target directory>\n", FilenameFromPath(argv[0]));
+		return 1;
+	}
+	
+	const char* const sourceDir = argv[1];
+	struct stat sourceDirStat = {};
+	if (0 != stat(sourceDir, &sourceDirStat))
+	{
+		perror("stat() on source directory failed");
+		return 1;
+	}
+	
+	if (!S_ISDIR(sourceDirStat.st_mode))
+	{
+		fprintf(stderr, "Source (%s) is not a directory.\n", sourceDir);
+		return 1;
+	}
+
+
+	es_new_client_result_t result = es_new_client(
+		&client,
+		^(es_client_t* _Nonnull client, const es_message_t* _Nonnull message)
+		{
+			HandleSecurityEvent(client, message);
+		});
+	if (result != ES_NEW_CLIENT_RESULT_SUCCESS)
+	{
+		fprintf(stderr, "es_new_client failed, error = %u\n", result);
+		return 1;
+	}
+
+
+	const char* const targetDir = argv[2];
+	int targetDirFD = open(targetDir, O_DIRECTORY | O_RDONLY);
+	if (targetDirFD < 0)
+	{
+		if (errno == ENOENT)
+		{
+			// target directory does not exist, create it and enumerate
+			/*
+			if (0 != mkdir(targetDir, sourceDirStat.st_mode))
+			{
+				perror("mkdir() of target failed");
+				return 1;
+			}
+			if (0 != chown(targetDir, sourceDirStat.st_uid, sourceDirStat.st_gid))
+			{
+				perror("chown() of target failed");
+				return 1;
+			}
+			 */
+
+			copyfile_state_t copyState = copyfile_state_alloc();
+			copyfile_state_set(copyState, COPYFILE_STATE_STATUS_CB, reinterpret_cast<void*>(&RecursiveEnumerationCopyfileStatusCallback));
+			int result = copyfile(sourceDir, targetDir, copyState, COPYFILE_METADATA | COPYFILE_RECURSIVE);
+			if (result != 0)
+			{
+				perror("copyfile() for enumeration failed");
+			}
+		}
+		else
+		{
+			perror("open() on target directory failed");
+			return 1;
+		}
+	}
+	
+	char* absoluteSourceDir = realpath(sourceDir, nullptr);
+	s_sourcePrefix = absoluteSourceDir;
+	free(absoluteSourceDir);
+	if (s_sourcePrefix[s_sourcePrefix.length() - 1] != '/')
+		s_sourcePrefix.append("/");
+	
+	char* absoluteTargetDir = realpath(targetDir, nullptr);
+	s_targetPrefix = absoluteTargetDir;
+	free(absoluteTargetDir);
+	if (s_targetPrefix[s_targetPrefix.length() - 1] != '/')
+		s_targetPrefix.append("/");
+
+
+	printf("Starting up with source '%s', target '%s'\n", s_sourcePrefix.c_str(), s_targetPrefix.c_str());
+	es_clear_cache(client);
+	
+	
+	if (!ESSubscribe(client, ES_EVENT_TYPE_AUTH_OPEN))
+	{
+		fprintf(stderr, "es_subscribe failed\n");
+		return 1;
+	}
+	
+	dispatch_main();
+}
+
+
+static bool PathLiesWithinTarget(const char* path)
+{
+	return 0 == strncmp(s_targetPrefix.c_str(), path, s_targetPrefix.length());
+}
+
+static string SourcePathForTargetFile(const char* targetPath)
+{
+	return s_sourcePrefix + (targetPath + s_targetPrefix.length());
+}
+
+static void HandleSecurityEvent(
+	es_client_t* _Nonnull client, const es_message_t* _Nonnull message)
+{
+	if (message->action_type == ES_ACTION_TYPE_AUTH)
+	{
+		if (message->event_type == ES_EVENT_TYPE_AUTH_OPEN)
+		{
+			char xattrBuffer[16];
+			const char* eventPath = message->event.open.file.path;
+			ssize_t xattrBytes = getxattr(eventPath, EmptyFileXattr, xattrBuffer, sizeof(xattrBuffer), 0 /* offset */, 0 /* options */);
+			if (xattrBytes >= 0)
+			{
+				if (PathLiesWithinTarget(eventPath))
+				{
+					string sourcePath = SourcePathForTargetFile(eventPath);
+					
+					printf("Hydrating '%s' -> '%s'\n", sourcePath.c_str(), eventPath);
+					int result = copyfile(sourcePath.c_str(), eventPath, nullptr /* state */, COPYFILE_DATA);
+					if (result == 0)
+					{
+						result = removexattr(eventPath, EmptyFileXattr, 0 /* options */);
+						if (result != 0)
+						{
+							perror("removexattr failed");
+						}
+					}
+					else
+					{
+						perror("hydration copyfile failed");
+						es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+						return;
+					}
+				}
+				else
+				{
+					fprintf(stderr, "File tagged as empty found outside target directory: '%s'\n", eventPath);
+					es_respond_flags_result(client, message, 0x0, false /* don't cache */);
+					return;
+				}
+			}
+			else if (errno != ENOATTR)
+			{
+				perror("getxattr failed");
+			}
+		
+			es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
+		}
+	}
+}
+
+static const char* CopyfileWhatString(int what)
+{
+	switch (what)
+	{
+  case COPYFILE_RECURSE_FILE:
+		return "COPYFILE_RECURSE_FILE";
+	case COPYFILE_RECURSE_DIR:
+		return "COPYFILE_RECURSE_DIR";
+	case COPYFILE_RECURSE_DIR_CLEANUP:
+		return "COPYFILE_RECURSE_DIR_CLEANUP";
+	case COPYFILE_RECURSE_ERROR:
+		return "COPYFILE_RECURSE_ERROR";
+  default:
+    return "???";
+	}
+}
+
+static const char* CopyfileStageString(int stage)
+{
+	switch (stage)
+	{
+  case COPYFILE_START:
+    return "COPYFILE_START";
+	case COPYFILE_FINISH:
+		return "COPYFILE_FINISH";
+	case COPYFILE_ERR:
+		return "COPYFILE_ERR";
+  default:
+    return "???";
+	}
+}
+
+static int RecursiveEnumerationCopyfileStatusCallback(
+	int what, int stage, copyfile_state_t state, const char* src, const char* dst, void* ctx)
+{
+	printf("copyfile callback: what = %s, stage = %s, src = '%s', dst = '%s'\n", CopyfileWhatString(what), CopyfileStageString(stage), src, dst);
+	
+	if (what == COPYFILE_RECURSE_FILE && stage == COPYFILE_FINISH)
+	{
+		struct stat destStat = {};
+		if (0 != stat(dst, &destStat))
+		{
+			perror("stat() on destination failed");
+		}
+		else
+		{
+			if (0 != setxattr(dst, EmptyFileXattr, "", 0 /* size */, 0 /* offset */, 0 /* options */))
+			{
+				perror("setxattr failed: ");
+			}
+		}
+	}
+	return COPYFILE_CONTINUE;
+}
+

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -207,6 +207,7 @@ static void HandleSecurityEvent(
 					}
 					else
 					{
+						printf("Hydration event to '%s' caused by '%s'\n", eventPath, processFilename);
 						HydrateFileOrAwaitHydration(eventPath, message);
 					}
 					return;
@@ -315,11 +316,13 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 			uint64_t responseMachDuration = responseMachTime - messageCopy->mach_time;
 			int64_t responseMachDeadlineDelta = responseMachTime - messageCopy->deadline;
 	
-			printf("Hydrating '%s' done; response took %llu µs, %lld µs %s deadline\n",
+			printf("Hydrating '%s' done; response took %llu µs, %lld µs %s deadline; triggered by access from process %d ('%s')\n",
 				eventPath.c_str(),
 				usecFromMachDuration(responseMachDuration),
 				std::abs(usecFromMachDuration(responseMachDeadlineDelta)),
-				responseMachDeadlineDelta <= 0 ? "before" : "after");
+				responseMachDeadlineDelta <= 0 ? "before" : "after",
+				audit_token_to_pid(messageCopy->process->audit_token),
+				messageCopy->process ? messageCopy->process->executable->path.data : "[NULL]");
 
 			free(messageCopy);
 			

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -188,9 +188,13 @@ static void HandleSecurityEvent(
 			{
 				if (PathLiesWithinTarget(eventPath))
 				{
-					const char* processFilename = FilenameFromPath(eventPath);
-					if (0 == strcmp("mdworker_shared", processFilename)
-					    || 0 == strcmp("mds", processFilename))
+					const char* processFilename =
+						(message->process && message->process->executable && message->process->executable->path.data)
+						? FilenameFromPath(message->process->executable->path.data)
+						: nullptr;
+					if (processFilename != nullptr &&
+							(0 == strcmp("mdworker_shared", processFilename)
+					     || 0 == strcmp("mds", processFilename)))
 					{
 						//printf("Denying crawler process %u (%s) access to empty file '%s'\n", audit_token_to_pid(message->proc.audit_token), processFilename, eventPath);
 						es_respond_result_t result = es_respond_flags_result(client, message, 0x0, false /* don't cache */);

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -337,7 +337,7 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 				audit_token_to_pid(messageCopy->process->audit_token),
 				messageCopy->process ? messageCopy->process->executable->path.data : "[NULL]");
 
-			free(messageCopy);
+			es_free_message(messageCopy);
 			
 			vector<es_message_t*> waitingMessages;
 			
@@ -357,7 +357,8 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 				
 				es_respond_result_t response_result = es_respond_flags_result(client, waitingMessage, responseFlags, false /* don't cache */);
 				assert(response_result == ES_RESPOND_RESULT_SUCCESS);
-				free(waitingMessage);
+				es_free_message(waitingMessage);
+				
 				unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
 				if (count != 1)
 				{

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.cpp
@@ -20,11 +20,24 @@ using std::mutex;
 using std::unordered_map;
 using std::vector;
 using std::atomic_uint;
+using std::extent;
 
 typedef std::lock_guard<mutex> Guard;
 
-static pid_t selfpid;
+// Local function declarations
 
+static void HandleSecurityEvent(
+	es_client_t* _Nonnull client, const es_message_t* _Nonnull message);
+static int RecursiveEnumerationCopyfileStatusCallback(
+	int what, int stage, copyfile_state_t state, const char * src, const char * dst, void * ctx);
+static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* message);
+static void HydrateFile(string eventPath, es_message_t* message);
+static const char* CopyfileWhatString(int what) __attribute__((unused));
+static const char* CopyfileStageString(int stage) __attribute__((unused));
+
+// Global/static variable definitions
+
+static pid_t selfpid;
 static constexpr const char* EmptyFileXattr = "org.vfsforgit.endpointsecuritymirror.emptyfile";
 
 static es_client_t* client = nullptr;
@@ -32,23 +45,12 @@ static dispatch_queue_t s_hydrationQueue = nullptr;
 static mutex s_hydrationMutex;
 static unordered_map<string, vector<es_message_t*>> s_waitingFileHydrationMessages;
 
-static void HandleSecurityEvent(
-	es_client_t* _Nonnull client, const es_message_t* _Nonnull message);
-static int RecursiveEnumerationCopyfileStatusCallback(
-	int what, int stage, copyfile_state_t state, const char * src, const char * dst, void * ctx);
-
 static string s_sourcePrefix, s_targetPrefix;
 
 static atomic_uint s_pendingAuthCount(0);
 static mach_timebase_info_data_t s_machTimebase;
 
-// Helper function that automatically fills out the event_count in es_subscribe calls
-template <typename... ARGS>
-es_return_t ESSubscribe(es_client_t* _Nonnull client, ARGS... events)
-{
-	es_event_type_t requestedEvents[sizeof...(events)] = { events... };
-  return es_subscribe(client, requestedEvents, sizeof...(events));
-}
+// Helper functions
 
 static uint64_t usecFromMachDuration(uint64_t machDuration)
 {
@@ -74,10 +76,57 @@ static const char* FilenameFromPath(const char* path)
 	}
 }
 
+static bool PathLiesWithinTarget(const char* path)
+{
+	return 0 == strncmp(s_targetPrefix.c_str(), path, s_targetPrefix.length());
+}
+
+static string SourcePathForTargetFile(const char* targetPath)
+{
+	return s_sourcePrefix + (targetPath + s_targetPrefix.length());
+}
+
+
+// Helper function for making "what" argument to copyfile callback human-readable
+static const char* CopyfileWhatString(int what)
+{
+	switch (what)
+	{
+  case COPYFILE_RECURSE_FILE:
+		return "COPYFILE_RECURSE_FILE";
+	case COPYFILE_RECURSE_DIR:
+		return "COPYFILE_RECURSE_DIR";
+	case COPYFILE_RECURSE_DIR_CLEANUP:
+		return "COPYFILE_RECURSE_DIR_CLEANUP";
+	case COPYFILE_RECURSE_ERROR:
+		return "COPYFILE_RECURSE_ERROR";
+  default:
+    return "???";
+	}
+}
+
+// Helper function for making "stage" argument to copyfile callback human-readable
+static const char* CopyfileStageString(int stage)
+{
+	switch (stage)
+	{
+  case COPYFILE_START:
+    return "COPYFILE_START";
+	case COPYFILE_FINISH:
+		return "COPYFILE_FINISH";
+	case COPYFILE_ERR:
+		return "COPYFILE_ERR";
+  default:
+    return "???";
+	}
+}
+
+//
+
 int main(int argc, const char* argv[])
 {
 	selfpid = getpid();
-	mach_timebase_info(&s_machTimebase);
+	mach_timebase_info(&s_machTimebase); // required for subsequent mach time <-> nsec/usec conversions
 	
 	if (argc < 3)
 	{
@@ -85,8 +134,11 @@ int main(int argc, const char* argv[])
 		return 1;
 	}
 	
+	// The dispatch queue used for processing hydration requests.
+	// Note: concurrent, i.e. multithreaded.
 	s_hydrationQueue = dispatch_queue_create("org.vfsforgit.endpointsecuritymirror.hydrationqueue", DISPATCH_QUEUE_CONCURRENT);
 	
+	// Sanity check on the mirror source: must exist, must be a directory
 	const char* const sourceDir = argv[1];
 	struct stat sourceDirStat = {};
 	if (0 != stat(sourceDir, &sourceDirStat))
@@ -101,30 +153,23 @@ int main(int argc, const char* argv[])
 		return 1;
 	}
 
-
-	es_new_client_result_t result = es_new_client(
-		&client,
-		^(es_client_t* _Nonnull client, const es_message_t* _Nonnull message)
-		{
-			std::atomic_fetch_add(&s_pendingAuthCount, 1u);
-			HandleSecurityEvent(client, message);
-		});
-	if (result != ES_NEW_CLIENT_RESULT_SUCCESS)
-	{
-		fprintf(stderr, "es_new_client failed, error = %u\n", result);
-		return 1;
-	}
-
-
+	// If the target directory exists, assume it has already been populated with
+	// placeholders. If not, perform recursive enumeration.
 	const char* const targetDir = argv[2];
 	int targetDirFD = open(targetDir, O_DIRECTORY | O_RDONLY);
 	if (targetDirFD < 0)
 	{
 		if (errno == ENOENT)
 		{
-			// target directory does not exist, create it and enumerate
 			copyfile_state_t copyState = copyfile_state_alloc();
+			// This callback function will be called multiple times on every directory
+			// and file encountered during recursive descent into the source directory
+			// Check copyfile manpage for details.
+			// We use the callback to set the EmptyFileXattr xattr and truncate
+			// the file to the correct length.
 			copyfile_state_set(copyState, COPYFILE_STATE_STATUS_CB, reinterpret_cast<void*>(&RecursiveEnumerationCopyfileStatusCallback));
+			// Note that the COPYFILE_DATA flag is NOT set; this would copy the file
+			// contents, but we want empty placeholders.
 			int result = copyfile(sourceDir, targetDir, copyState, COPYFILE_METADATA | COPYFILE_RECURSIVE | COPYFILE_NOFOLLOW_SRC | COPYFILE_NOFOLLOW_DST);
 			if (result != 0)
 			{
@@ -137,7 +182,13 @@ int main(int argc, const char* argv[])
 			return 1;
 		}
 	}
+	else
+	{
+		close(targetDirFD);
+	}
 	
+	// Ensure we have paths with trailing slashes for both source and target, so
+	// that simple string prefix tests will suffice from here on out.
 	char* absoluteSourceDir = realpath(sourceDir, nullptr);
 	s_sourcePrefix = absoluteSourceDir;
 	free(absoluteSourceDir);
@@ -152,30 +203,34 @@ int main(int argc, const char* argv[])
 
 
 	printf("Starting up with source '%s', target '%s'\n", s_sourcePrefix.c_str(), s_targetPrefix.c_str());
-	es_clear_cache(client);
+
+	// Perform the EndpointSecurity start-up:
+	// Create client object, clear cache, and subscribe to events we're interested in.
+	es_new_client_result_t result = es_new_client(
+		&client,
+		^(es_client_t* _Nonnull client, const es_message_t* _Nonnull message)
+		{
+			std::atomic_fetch_add(&s_pendingAuthCount, 1u);
+			HandleSecurityEvent(client, message);
+		});
+	if (result != ES_NEW_CLIENT_RESULT_SUCCESS)
+	{
+		fprintf(stderr, "es_new_client failed, error = %u\n", result);
+		return 1;
+	}
+
+	es_clear_cache(client); // This may no longer be necessary; without it, early macOS 10.15 betas would drop events.
 	
-	
-	if (ES_RETURN_SUCCESS != ESSubscribe(client, ES_EVENT_TYPE_AUTH_OPEN))
+	es_event_type_t subscribe_events[] = { ES_EVENT_TYPE_AUTH_OPEN };
+	if (ES_RETURN_SUCCESS != es_subscribe(client, subscribe_events, extent<decltype(subscribe_events)>::value))
 	{
 		fprintf(stderr, "es_subscribe failed\n");
 		return 1;
 	}
 	
+	// Handle events until process is killed
 	dispatch_main();
 }
-
-
-static bool PathLiesWithinTarget(const char* path)
-{
-	return 0 == strncmp(s_targetPrefix.c_str(), path, s_targetPrefix.length());
-}
-
-static string SourcePathForTargetFile(const char* targetPath)
-{
-	return s_sourcePrefix + (targetPath + s_targetPrefix.length());
-}
-
-static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* message);
 
 static void HandleSecurityEvent(
 	es_client_t* _Nonnull client, const es_message_t* _Nonnull message)
@@ -201,6 +256,10 @@ static void HandleSecurityEvent(
 				ssize_t xattrBytes = getxattr(eventPath, EmptyFileXattr, xattrBuffer, sizeof(xattrBuffer), 0 /* offset */, 0 /* options */);
 				if (xattrBytes >= 0)
 				{
+					// If we end up here, the event path lies within the mirror target,
+					// and the file is empty and thus needs hydrating before the open()
+					// call may proceed.
+				
 					const char* processFilename =
 						(message->process && message->process->executable && message->process->executable->path.data)
 						? FilenameFromPath(message->process->executable->path.data)
@@ -209,6 +268,8 @@ static void HandleSecurityEvent(
 							(0 == strcmp("mdworker_shared", processFilename)
 					     || 0 == strcmp("mds", processFilename)))
 					{
+						// Don't allow crawler processes to hydrate, so fail the open() call.
+						
 						//printf("Denying crawler process %u (%s) access to empty file '%s'\n", audit_token_to_pid(message->proc.audit_token), processFilename, eventPath);
 						es_respond_result_t result = es_respond_flags_result(client, message, 0x0, false /* don't cache */);
 						assert(result == ES_RESPOND_RESULT_SUCCESS);
@@ -220,6 +281,7 @@ static void HandleSecurityEvent(
 					}
 					else
 					{
+						// Request hydration
 						printf("Hydration event to '%s' caused by '%s'\n", eventPath, processFilename);
 						HydrateFileOrAwaitHydration(eventPath, message);
 					}
@@ -227,7 +289,7 @@ static void HandleSecurityEvent(
 				}
 				else
 				{
-					//fprintf(stderr, "File tagged as empty found outside target directory: '%s'\n", eventPath);
+					// File already hydrated
 					es_respond_result_t result = es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
 					assert(result == ES_RESPOND_RESULT_SUCCESS);
 					unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
@@ -252,10 +314,10 @@ static void HandleSecurityEvent(
 			es_respond_result_t result = es_respond_flags_result(client, message, 0x7fffffff, false /* don't cache */);
 			assert(result == ES_RESPOND_RESULT_SUCCESS);
 		}
-        else
-        {
-            fprintf(stderr, "Unexpected event type: %u\n", message->event_type);
-        }
+		else
+		{
+			fprintf(stderr, "Unexpected event type: %u\n", message->event_type);
+		}
 	}
 	else
 	{
@@ -281,6 +343,14 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 	else
 	{
 		dispatch_async(s_hydrationQueue, ^{
+			HydrateFile(eventPath, messageCopy);
+		});
+	}
+}
+			
+static void HydrateFile(string eventPath, es_message_t* messageCopy)
+{
+	// Re-check xattr, file might already be hydrated. (defend against TOCTOU)
 			char xattrBuffer[16];
 			ssize_t xattrBytes = getxattr(eventPath.c_str(), EmptyFileXattr, xattrBuffer, sizeof(xattrBuffer), 0 /* offset */, 0 /* options */);
 			if (xattrBytes < 0)
@@ -297,12 +367,22 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 			}
 
 			string sourcePath = SourcePathForTargetFile(eventPath.c_str());
+			
+			// This can be used for simulating slow hydrations:
 			// NOTE: if you increase this beyond 60000ms (1 minute) the process ends up being killed
 			unsigned delay_ms = 0;//random() % 60000u;
 			//printf("Hydrating '%s' -> '%s' for process %u (%s), with %u ms delay\n", sourcePath.c_str(), eventPath.c_str(), audit_token_to_pid(messageCopy->proc.audit_token), FilenameFromPath(messageCopy->proc.file.path.data), delay_ms);
 			usleep(delay_ms * 1000u);
+			
+			// Enumeration copied metadata, hydration copies data
 			int result = copyfile(sourcePath.c_str(), eventPath.c_str(), nullptr /* state */, COPYFILE_DATA);
 			
+			// This bitfield is required for responding to the open() authorisation.
+			// Not 100% sure what the bits stand for, but they are probably the
+			// FREAD/FWRITE flags, and the various O_* constants you can pass to open()
+			// Note that this value may be cached, so we need to authorise any option
+			// bits we might want to allow even if they are not requested for this
+			// specific open() call (in messageCopy->event.open.fflag)
 			uint32_t responseFlags = 0x7fffffff;
 			if (result == 0)
 			{
@@ -315,16 +395,23 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 			else
 			{
 				perror("hydration copyfile failed");
-				responseFlags = 0x0;
+				responseFlags = 0x0; // This means deny the open() call
 			}
 			
+			// Sanity counter we use to ensure every auth callback is matched by a es_respond_flags_result()
 			unsigned count = std::atomic_fetch_sub(&s_pendingAuthCount, 1u);
 			if (count != 1)
 			{
+				// This will occasionally print something when there are multiple callbacks outstanding.
+				// No indication of problems if the actual count keeps hovering around 1.
 				printf("In-flight authorisation requests pending: %u\n", count - 1);
 			}
+			
+			// Tell ES to allow the open() call where this hydration request originated.
 			es_respond_result_t response_result = es_respond_flags_result(client, messageCopy, responseFlags, false /* don't cache */);
 			assert(response_result == ES_RESPOND_RESULT_SUCCESS);
+			
+			// Calculation of remaining time to deadline (so we can see how close we are to having our process killed)
 			uint64_t responseMachTime = mach_absolute_time();
 			uint64_t responseMachDuration = responseMachTime - messageCopy->mach_time;
 			int64_t responseMachDeadlineDelta = responseMachTime - messageCopy->deadline;
@@ -339,9 +426,12 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 
 			es_free_message(messageCopy);
 			
+			
+			// Now respond in the same way to any other open() calls waiting for this file to be hydrated.
 			vector<es_message_t*> waitingMessages;
 			
 			{
+				// Atomically remove the list of waiting messages from the global map indexed by filename
 				Guard lock(s_hydrationMutex);
 			 	s_waitingFileHydrationMessages[eventPath].swap(waitingMessages);
 			 	s_waitingFileHydrationMessages.erase(eventPath);
@@ -365,40 +455,6 @@ static void HydrateFileOrAwaitHydration(string eventPath, const es_message_t* me
 					printf("In-flight authorisation requests pending: %u\n", count - 1);
 				}
 			}
-		});
-	}
-}
-
-static const char* CopyfileWhatString(int what)
-{
-	switch (what)
-	{
-  case COPYFILE_RECURSE_FILE:
-		return "COPYFILE_RECURSE_FILE";
-	case COPYFILE_RECURSE_DIR:
-		return "COPYFILE_RECURSE_DIR";
-	case COPYFILE_RECURSE_DIR_CLEANUP:
-		return "COPYFILE_RECURSE_DIR_CLEANUP";
-	case COPYFILE_RECURSE_ERROR:
-		return "COPYFILE_RECURSE_ERROR";
-  default:
-    return "???";
-	}
-}
-
-static const char* CopyfileStageString(int stage)
-{
-	switch (stage)
-	{
-  case COPYFILE_START:
-    return "COPYFILE_START";
-	case COPYFILE_FINISH:
-		return "COPYFILE_FINISH";
-	case COPYFILE_ERR:
-		return "COPYFILE_ERR";
-  default:
-    return "???";
-	}
 }
 
 static int RecursiveEnumerationCopyfileStatusCallback(

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.entitlements
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/EndpointSecurityMirror.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.endpoint-security.client</key>
+	<true/>
+</dict>
+</plist>

--- a/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/README.md
+++ b/ProjFS.Mac/EndpointSecurityPrototype/EndpointSecurityMirror/README.md
@@ -1,0 +1,13 @@
+#  EndpointSecurity Mirror Provider Prototype
+
+This uses the new EndpointSecurity API in macOS 10.15 Catalina to detect accesses to empty placeholder files and hydrates them on demand.
+
+Requires root privileges to run. I don't recommend running it in a debugger, as this can end up locking up the system.
+
+To run:
+
+    sudo ./EndpointSecurityMirror path/to/source-directory path/to/mirror/target-directory
+    
+Paths can be relative. If the target does not exist, its parent directory must exist; in this case the target directory will be recursively enumerated (filled with empty placeholders).
+
+There is very little error handling at the moment. Empty placeholders are marked using the `org.vfsforgit.endpointsecuritymirror.emptyfile` xattr. If such a file is opened by a process while this provider is running, the provider will aim to hydrate it before allowing the other process to continue.


### PR DESCRIPTION
This is an experimental implementation of a provider similar to MirrorProvider which uses the new EndpointSecurity API from macOS 10.15 Catalina. It is intended as an example for using the API as a possible future option for implementing a VFSForGit provider or file system watcher.

The prototype allows specifying a source directory and a target directory (which initially should not yet exist); the source directory is lazily replicated into the target by means of empty placeholder files whose contents are copied from their respective source equivalent on read or write access.

The EndpointSecurity API unfortunately does not offer the necessary events to fully replicate MirrorProvider; specifically, there is no blocking event for accesses to directories, so on-demand directory enumeration is not possible. As a result, all empty placeholder files must be created recursively during cloning.

The key EndpointSecurity event type for hydrating placeholders is `ES_EVENT_TYPE_AUTH_OPEN`, and this is the main functionality the prototype is built around.

Another critical limitation of the EndpointSecurity API is the hard time limit of 60 seconds. Particularly if file hydration hits the network, it can be impossible to complete the request within that time frame. The hard time limit therefore makes the API unsuitable for that type of application.

The remaining possible application for the EndpointSecurity API is to watch for file modifications and creation. For this, the various `ES_EVENT_TYPE_NOTIFY_*` events are indeed suitable.