### PR TITLE
GVFSVerb: explicitly disable new config settings

### DIFF
--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -155,6 +155,9 @@ namespace GVFS.CommandLine
                 { "receive.autogc", "false" },
                 { "reset.quiet", "true" },
                 { "status.deserializePath", gitStatusCachePath },
+                { "feature.manyFiles", "false" },
+                { "feature.experimental", "false" },
+                { "fetch.writeCommitGraph", "false" },
             };
 
             if (!TrySetConfig(enlistment, requiredSettings, isRequired: true))


### PR DESCRIPTION
In Git 2.24.0, some new config settings were created. Disable them
locally in VFS for Git repos in case a user has set them globally.

The feature.* config settings change the defaults for some other
config settings. We already monitor config settings pretty carefully,
so let's disable these.

The fetch.writeCommitGraph setting choses to write a commit-graph
file at the end of each `git fetch` call. We already build the
commit-graph file in the background AND put it in the shared cache
instead of the local Git repo.