### PR TITLE
Move config & upgrader files to ProgramFiles

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -39,7 +39,10 @@ namespace GVFS.Common.FileSystem
             directory.Delete();
         }
 
-        public virtual void CopyDirectoryRecursive(string srcDirectoryPath, string dstDirectoryPath)
+        public virtual void CopyDirectoryRecursive(
+            string srcDirectoryPath,
+            string dstDirectoryPath,
+            HashSet<string> excludeDirectories = null)
         {
             DirectoryInfo srcDirectory = new DirectoryInfo(srcDirectoryPath);
 
@@ -55,7 +58,13 @@ namespace GVFS.Common.FileSystem
 
             foreach (DirectoryInfo subDirectory in srcDirectory.EnumerateDirectories())
             {
-                this.CopyDirectoryRecursive(subDirectory.FullName, Path.Combine(dstDirectoryPath, subDirectory.Name));
+                if (excludeDirectories == null || !excludeDirectories.Contains(subDirectory.FullName))
+                {
+                    this.CopyDirectoryRecursive(
+                        subDirectory.FullName,
+                        Path.Combine(dstDirectoryPath, subDirectory.Name),
+                        excludeDirectories);
+                }
             }
         }
 

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -71,8 +71,10 @@ namespace GVFS.Common
         public abstract NamedPipeServerStream CreatePipeByName(string pipeName);
 
         public abstract string GetOSVersionInformation();
-        public abstract string GetDataRootForGVFS();
-        public abstract string GetDataRootForGVFSComponent(string componentName);
+        public abstract string GetSecureDataRootForGVFS();
+        public abstract string GetSecureDataRootForGVFSComponent(string componentName);
+        public abstract string GetCommonAppDataRootForGVFS();
+        public abstract string GetLogsDirectoryForGVFSComponent(string componentName);
         public abstract bool IsElevated();
         public abstract string GetCurrentUser();
         public abstract string GetUserIdFromLoginSessionId(int sessionId, ITracer tracer);

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -179,7 +179,13 @@ namespace GVFS.Common
             error = null;
             try
             {
-                this.fileSystem.CopyDirectoryRecursive(currentPath, upgradeApplicationDirectory);
+                // Copying C:\Program Files\GVFS to inside of C:\Program Files\GVFS\ProgramData\GVFS.Upgrade\Tools
+                // directory causes a cycle(at some point we start copying C:\Program Files\GVFS\ProgramData\GVFS.Upgrade
+                // and its contents into C:\Program Files\GVFS\ProgramData\GVFS.Upgrade\Tools). The exclusion below is
+                // added to avoid this loop.
+               HashSet<string> directoriesToExclude = new HashSet<string>();
+                directoriesToExclude.Add(GVFSPlatform.Instance.GetSecureDataRootForGVFS());
+                this.fileSystem.CopyDirectoryRecursive(currentPath, upgradeApplicationDirectory, directoriesToExclude);
             }
             catch (UnauthorizedAccessException e)
             {

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -144,8 +144,9 @@ namespace GVFS.FunctionalTests
                 GVFSServiceProcess.InstallService();
 
                 string statusCacheVersionTokenPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.Create),
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolderOption.Create),
                     "GVFS",
+                    "ProgramData",
                     "GVFS.Service",
                     "EnableGitStatusCacheToken.dat");
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -29,8 +29,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         {
             this.fileSystem = new SystemIORunner();
             this.upgradeDownloadsDirectory = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.Create),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolderOption.Create),
                 "GVFS",
+                "ProgramData",
                 "GVFS.Upgrade",
                 "Downloads");
         }

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Mac.cs
@@ -4,11 +4,6 @@ namespace GVFS.Hooks.HooksPlatform
 {
     public static partial class GVFSHooksPlatform
     {
-        public static string GetDataRootForGVFS()
-        {
-            return MacPlatform.GetDataRootForGVFSImplementation();
-        }
-
         public static string GetUpgradeHighestAvailableVersionDirectory()
         {
             return MacPlatform.GetUpgradeHighestAvailableVersionDirectoryImplementation();

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.Windows.cs
@@ -37,11 +37,6 @@ namespace GVFS.Hooks.HooksPlatform
             return WindowsFileSystem.TryGetNormalizedPathImplementation(path, out normalizedPath, out errorMessage);
         }
 
-        public static string GetDataRootForGVFS()
-        {
-            return WindowsPlatform.GetDataRootForGVFSImplementation();
-        }
-
         public static string GetUpgradeHighestAvailableVersionDirectory()
         {
             return WindowsPlatform.GetUpgradeHighestAvailableVersionDirectoryImplementation();

--- a/GVFS/GVFS.Platform.Mac/MacPlatform.cs
+++ b/GVFS/GVFS.Platform.Mac/MacPlatform.cs
@@ -61,14 +61,26 @@ namespace GVFS.Platform.Mac
             return string.IsNullOrWhiteSpace(result.Output) ? result.Errors : result.Output;
         }
 
-        public override string GetDataRootForGVFS()
+        public override string GetSecureDataRootForGVFS()
         {
+            // On the Mac, unlike Windows, there is no separate secure data root directory.
             return MacPlatform.GetDataRootForGVFSImplementation();
         }
 
-        public override string GetDataRootForGVFSComponent(string componentName)
+        public override string GetSecureDataRootForGVFSComponent(string componentName)
         {
+            // On the Mac, unlike Windows, there is no separate secure data root directory.
             return MacPlatform.GetDataRootForGVFSComponentImplementation(componentName);
+        }
+
+        public override string GetCommonAppDataRootForGVFS()
+        {
+            return this.GetSecureDataRootForGVFS();
+        }
+
+        public override string GetLogsDirectoryForGVFSComponent(string componentName)
+        {
+            return Path.Combine(this.GetCommonAppDataRootForGVFS(), componentName);
         }
 
         public override bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)

--- a/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
+++ b/GVFS/GVFS.Platform.POSIX/POSIXPlatform.cs
@@ -187,7 +187,7 @@ namespace GVFS.Platform.POSIX
         {
             // Pipes are stored as files on POSIX, use a rooted pipe name
             // in the same location as the service to keep full control of the location of the file
-            return this.GetDataRootForGVFSComponent(serviceName) + ".pipe";
+            return this.GetSecureDataRootForGVFSComponent(serviceName) + ".pipe";
         }
 
         public override bool IsConsoleOutputRedirectedToFile()

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -75,16 +75,32 @@ namespace GVFS.Platform.Windows
             return "GVFS_" + enlistmentRoot.ToUpper().Replace(':', '_');
         }
 
-        public static string GetDataRootForGVFSImplementation()
+        public static string GetSecureDataRootForGVFSImplementation()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolderOption.Create),
+                 "GVFS",
+                 "ProgramData");
+        }
+
+        public static string GetCommonAppDataRootForGVFSImplementation()
         {
             return Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.Create),
                 "GVFS");
         }
 
-        public static string GetDataRootForGVFSComponentImplementation(string componentName)
+        public static string GetLogsDirectoryForGVFSComponentImplementation(string componentName)
         {
-            return Path.Combine(GetDataRootForGVFSImplementation(), componentName);
+            return Path.Combine(
+                GetCommonAppDataRootForGVFSImplementation(),
+                componentName,
+                "Logs");
+        }
+
+        public static string GetSecureDataRootForGVFSComponentImplementation(string componentName)
+        {
+            return Path.Combine(GetSecureDataRootForGVFSImplementation(), componentName);
         }
 
         public static bool IsConsoleOutputRedirectedToFileImplementation()
@@ -114,7 +130,7 @@ namespace GVFS.Platform.Windows
 
         public static string GetUpgradeProtectedDataDirectoryImplementation()
         {
-            return Path.Combine(GetDataRootForGVFSImplementation(), ProductUpgraderInfo.UpgradeDirectoryName);
+            return Path.Combine(GetSecureDataRootForGVFSImplementation(), ProductUpgraderInfo.UpgradeDirectoryName);
         }
 
         public static string GetUpgradeHighestAvailableVersionDirectoryImplementation()

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -40,7 +40,7 @@ namespace GVFS.Platform.Windows
         {
             get
             {
-                string servicePath = GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.ServiceName);
+                string servicePath = GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(GVFSConstants.Service.ServiceName);
                 string gvfsDirectory = Path.GetDirectoryName(servicePath);
 
                 return Path.Combine(gvfsDirectory, LocalGVFSConfig.FileName);
@@ -118,14 +118,24 @@ namespace GVFS.Platform.Windows
             return sb.ToString();
         }
 
-        public override string GetDataRootForGVFS()
+        public override string GetSecureDataRootForGVFS()
         {
-            return WindowsPlatform.GetDataRootForGVFSImplementation();
+            return WindowsPlatform.GetSecureDataRootForGVFSImplementation();
         }
 
-        public override string GetDataRootForGVFSComponent(string componentName)
+        public override string GetSecureDataRootForGVFSComponent(string componentName)
         {
-            return WindowsPlatform.GetDataRootForGVFSComponentImplementation(componentName);
+            return WindowsPlatform.GetSecureDataRootForGVFSComponentImplementation(componentName);
+        }
+
+        public override string GetCommonAppDataRootForGVFS()
+        {
+            return WindowsPlatform.GetCommonAppDataRootForGVFSImplementation();
+        }
+
+        public override string GetLogsDirectoryForGVFSComponent(string componentName)
+        {
+            return WindowsPlatform.GetLogsDirectoryForGVFSComponentImplementation(componentName);
         }
 
         public override void StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args)
@@ -325,7 +335,9 @@ namespace GVFS.Platform.Windows
 
         public override string GetUpgradeLogDirectoryParentDirectory()
         {
-            return this.GetUpgradeProtectedDataDirectory();
+            return Path.Combine(
+               this.GetCommonAppDataRootForGVFS(),
+               ProductUpgraderInfo.UpgradeDirectoryName);
         }
 
         public override string GetSystemInstallerLogPath()
@@ -352,7 +364,7 @@ namespace GVFS.Platform.Windows
 
         public override bool IsGitStatusCacheSupported()
         {
-            return File.Exists(Path.Combine(GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.ServiceName), GVFSConstants.GitStatusCache.EnableGitStatusCacheTokenFile));
+            return File.Exists(Path.Combine(GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(GVFSConstants.Service.ServiceName), GVFSConstants.GitStatusCache.EnableGitStatusCacheTokenFile));
         }
 
         public override FileBasedLock CreateFileBasedLock(

--- a/GVFS/GVFS.Service.UI/Program.cs
+++ b/GVFS/GVFS.Service.UI/Program.cs
@@ -14,7 +14,7 @@ namespace GVFS.Service.UI
             using (JsonTracer tracer = new JsonTracer("Microsoft.Git.GVFS.Service.UI", "Service.UI"))
             {
                 string error;
-                string serviceUILogDirectory = GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.UIName);
+                string serviceUILogDirectory = GVFSPlatform.Instance.GetLogsDirectoryForGVFSComponent(GVFSConstants.Service.UIName);
                 if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryWithAdminAndUserModifyPermissions(serviceUILogDirectory, out error))
                 {
                     EventMetadata metadata = new EventMetadata();

--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -50,7 +50,7 @@ namespace GVFS.Service
                 this.repoRegistry = new RepoRegistry(
                     this.tracer,
                     new PhysicalFileSystem(),
-                    this.serviceDataLocation,
+                    Path.Combine(GVFSPlatform.Instance.GetCommonAppDataRootForGVFS(), this.serviceName),
                     new GVFSMountProcess(this.tracer),
                     this.notificationHandler);
                 this.repoRegistry.Upgrade();
@@ -179,9 +179,7 @@ namespace GVFS.Service
                 this.serviceName = serviceName.Substring(ServiceNameArgPrefix.Length);
             }
 
-            string serviceLogsDirectoryPath = Path.Combine(
-                    GVFSPlatform.Instance.GetDataRootForGVFSComponent(this.serviceName),
-                    GVFSConstants.Service.LogDirectory);
+            string serviceLogsDirectoryPath = GVFSPlatform.Instance.GetLogsDirectoryForGVFSComponent(this.serviceName);
 
             // Create the logs directory explicitly *before* creating a log file event listener to ensure that it
             // and its ancestor directories are created with the correct ACLs.
@@ -193,7 +191,7 @@ namespace GVFS.Service
 
             try
             {
-                this.serviceDataLocation = GVFSPlatform.Instance.GetDataRootForGVFSComponent(this.serviceName);
+                this.serviceDataLocation = GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(this.serviceName);
                 this.CreateAndConfigureProgramDataDirectories();
                 this.Start();
             }
@@ -255,7 +253,7 @@ namespace GVFS.Service
         {
             try
             {
-                string statusCacheVersionTokenPath = Path.Combine(GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.ServiceName), GVFSConstants.GitStatusCache.EnableGitStatusCacheTokenFile);
+                string statusCacheVersionTokenPath = Path.Combine(GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(GVFSConstants.Service.ServiceName), GVFSConstants.GitStatusCache.EnableGitStatusCacheTokenFile);
                 if (File.Exists(statusCacheVersionTokenPath))
                 {
                     this.tracer.RelatedInfo($"CheckEnableGitStatusCache: EnableGitStatusCacheToken file already exists at {statusCacheVersionTokenPath}.");
@@ -330,7 +328,7 @@ namespace GVFS.Service
 
             // Special rules for the upgrader logs, as non-elevated users need to be be able to write
             this.CreateAndConfigureLogDirectory(ProductUpgraderInfo.GetLogDirectoryPath());
-            this.CreateAndConfigureLogDirectory(GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.UIName));
+            this.CreateAndConfigureLogDirectory(GVFSPlatform.Instance.GetLogsDirectoryForGVFSComponent(GVFSConstants.Service.UIName));
         }
 
         private void CreateAndConfigureLogDirectory(string path)

--- a/GVFS/GVFS.Service/Program.Mac.cs
+++ b/GVFS/GVFS.Service/Program.Mac.cs
@@ -37,9 +37,7 @@ namespace GVFS.Service
 
             GVFSPlatform gvfsPlatform = GVFSPlatform.Instance;
 
-            string logFilePath = Path.Combine(
-                gvfsPlatform.GetDataRootForGVFSComponent(serviceName),
-                GVFSConstants.Service.LogDirectory);
+            string logFilePath = GVFSPlatform.Instance.GetLogsDirectoryForGVFSComponent(serviceName);
             Directory.CreateDirectory(logFilePath);
 
             tracer.AddLogFileEventListener(
@@ -47,7 +45,7 @@ namespace GVFS.Service
                 EventLevel.Informational,
                 Keywords.Any);
 
-            string serviceDataLocation = gvfsPlatform.GetDataRootForGVFSComponent(serviceName);
+            string serviceDataLocation = gvfsPlatform.GetSecureDataRootForGVFSComponent(serviceName);
             RepoRegistry repoRegistry = new RepoRegistry(
                 tracer,
                 new PhysicalFileSystem(),

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -94,17 +94,27 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override string GetDataRootForGVFS()
+        public override string GetSecureDataRootForGVFS()
         {
-            // TODO: Update this method to return non existant file path.
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                "GVFS");
+            return "mock:\\dataRoot";
         }
 
-        public override string GetDataRootForGVFSComponent(string componentName)
+        public override string GetSecureDataRootForGVFSComponent(string componentName)
         {
-            return Path.Combine(this.GetDataRootForGVFS(), componentName);
+            return Path.Combine(this.GetSecureDataRootForGVFS(), componentName);
+        }
+
+        public override string GetCommonAppDataRootForGVFS()
+        {
+            return this.GetSecureDataRootForGVFS();
+        }
+
+        public override string GetLogsDirectoryForGVFSComponent(string componentName)
+        {
+            return Path.Combine(
+                this.GetCommonAppDataRootForGVFS(),
+                componentName,
+                "Logs");
         }
 
         public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly)
@@ -114,7 +124,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public override string GetUpgradeProtectedDataDirectory()
         {
-            return this.GetDataRootForGVFSComponent(ProductUpgraderInfo.UpgradeDirectoryName);
+            return this.GetSecureDataRootForGVFSComponent(ProductUpgraderInfo.UpgradeDirectoryName);
         }
 
         public override string GetUpgradeLogDirectoryParentDirectory()

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -122,14 +122,20 @@ namespace GVFS.CommandLine
 
                         // service
                         this.CopyAllFiles(
-                            GVFSPlatform.Instance.GetDataRootForGVFS(),
+                            GVFSPlatform.Instance.GetCommonAppDataRootForGVFS(),
+                            archiveFolderPath,
+                            this.ServiceName,
+                            copySubFolders: true);
+
+                        this.CopyAllFiles(
+                            GVFSPlatform.Instance.GetSecureDataRootForGVFS(),
                             archiveFolderPath,
                             this.ServiceName,
                             copySubFolders: true);
 
                         // service ui
                         this.CopyAllFiles(
-                            GVFSPlatform.Instance.GetDataRootForGVFS(),
+                            GVFSPlatform.Instance.GetCommonAppDataRootForGVFS(),
                             archiveFolderPath,
                             GVFSConstants.Service.UIName,
                             copySubFolders: true);
@@ -160,7 +166,7 @@ namespace GVFS.CommandLine
 
                         if (GVFSPlatform.Instance.UnderConstruction.SupportsGVFSConfig)
                         {
-                            this.CopyFile(GVFSPlatform.Instance.GetDataRootForGVFS(), archiveFolderPath, LocalGVFSConfig.FileName);
+                            this.CopyFile(GVFSPlatform.Instance.GetSecureDataRootForGVFS(), archiveFolderPath, LocalGVFSConfig.FileName);
                         }
 
                         if (!GVFSPlatform.Instance.TryCopyPanicLogs(archiveFolderPath, out string errorMessage))

--- a/GVFS/GVFS/CommandLine/LogVerb.cs
+++ b/GVFS/GVFS/CommandLine/LogVerb.cs
@@ -62,9 +62,7 @@ namespace GVFS.CommandLine
                 this.DisplayMostRecent(gvfsLogsRoot, GVFSConstants.LogFileTypes.Repair);
                 this.DisplayMostRecent(gvfsLogsRoot, GVFSConstants.LogFileTypes.Sparse);
 
-                string serviceLogsRoot = Path.Combine(
-                    GVFSPlatform.Instance.GetDataRootForGVFSComponent(GVFSConstants.Service.ServiceName),
-                    GVFSConstants.Service.LogDirectory);
+                string serviceLogsRoot = GVFSPlatform.Instance.GetLogsDirectoryForGVFSComponent(GVFSConstants.Service.ServiceName);
                 this.DisplayMostRecent(serviceLogsRoot, GVFSConstants.LogFileTypes.Service);
 
                 this.DisplayMostRecent(ProductUpgraderInfo.GetLogDirectoryPath(), GVFSConstants.LogFileTypes.UpgradePrefix);


### PR DESCRIPTION
- Changed GVFSDataRoot on Windows platform to
  "C:\Program Files\GVFS\ProgramData".
- Created new LogsDataRoot. LogsDataRoot is unchanged on all platforms.
- gvfs config file now gets created in the new GVFSDataRoot directory.
- Updated installer to copy gvfs.config file from old location to new.
- Updated diagnose verb to use new LogsDataRoot.

Fixes #1585

#TODO (Separate PR): Gather feedback on whether to keep (or remove) code that sets ACLs on DataRoot and LogsRoot directories.