### PR TITLE
Fix upgrade timer crash

### DIFF
--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -218,7 +218,10 @@ namespace GVFS.Service
 
                     info.RecordHighestAvailableVersion(highestAvailableVersion: newerVersion);
 
-                    this.DisplayUpgradeAvailableToast(newerVersion.ToString());
+                    if (newerVersion != null)
+                    {
+                        this.DisplayUpgradeAvailableToast(newerVersion.ToString());
+                    }
                 }
                 catch (Exception ex) when (
                     ex is IOException ||


### PR DESCRIPTION
- When no upgrade is available, product upgrader returns null for newer version. Added null check before using version.

(Cherry picking service crash bug fix to `releases/shipped`)
