### PR TITLE
WindowsGitHooksInstaller: allow configuring hooks in local git config

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -99,26 +99,22 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         public void MountMergesLocalPrePostHooksConfig()
         {
             // Create some dummy pre/post command hooks
-            string dummyPreCommandHookBin = Path.Combine(this.Enlistment.EnlistmentRoot, "DummyPreCommandHook.bat");
-            this.fileSystem.WriteAllText(dummyPreCommandHookBin, "@echo off && exit 0");
-
-            string dummyPostCommandHookBin = Path.Combine(this.Enlistment.EnlistmentRoot, "DummyPostCommandHook.bat");
-            this.fileSystem.WriteAllText(dummyPreCommandHookBin, "@echo off && exit 0");
+            string dummyCommandHookBin = "cmd.exe /c exit 0";
 
             // Confirm git is not already using the dummy hooks
             string localGitPreCommandHooks = this.Enlistment.GetVirtualPathTo(".git", "hooks", "pre-command.hooks");
-            localGitPreCommandHooks.ShouldBeAFile(this.fileSystem).WithContents().Contains(dummyPreCommandHookBin).ShouldBeFalse();
+            localGitPreCommandHooks.ShouldBeAFile(this.fileSystem).WithContents().Contains(dummyCommandHookBin).ShouldBeFalse();
 
             string localGitPostCommandHooks = this.Enlistment.GetVirtualPathTo(".git", "hooks", "post-command.hooks");
-            localGitPreCommandHooks.ShouldBeAFile(this.fileSystem).WithContents().Contains(dummyPostCommandHookBin).ShouldBeFalse();
+            localGitPreCommandHooks.ShouldBeAFile(this.fileSystem).WithContents().Contains(dummyCommandHookBin).ShouldBeFalse();
 
             this.Enlistment.UnmountGVFS();
 
             // Create dummy-<pre/post>-command.hooks and set them in the local git config
             string dummyPreCommandHooksConfig = Path.Combine(this.Enlistment.EnlistmentRoot, "dummy-pre-command.hooks");
-            this.fileSystem.WriteAllText(dummyPreCommandHooksConfig, dummyPreCommandHookBin);
+            this.fileSystem.WriteAllText(dummyPreCommandHooksConfig, dummyCommandHookBin);
             string dummyOostCommandHooksConfig = Path.Combine(this.Enlistment.EnlistmentRoot, "dummy-post-command.hooks");
-            this.fileSystem.WriteAllText(dummyOostCommandHooksConfig, dummyPostCommandHookBin);
+            this.fileSystem.WriteAllText(dummyOostCommandHooksConfig, dummyCommandHookBin);
 
             // Configure the hooks locally
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"config gvfs.clone.default-pre-command {dummyPreCommandHooksConfig}");
@@ -134,14 +130,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 .WithContents()
                 .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             mergedPreCommandHooksLines.Length.ShouldEqual(2);
-            mergedPreCommandHooksLines[0].ShouldEqual(dummyPreCommandHookBin);
+            mergedPreCommandHooksLines[0].ShouldEqual(dummyCommandHookBin);
 
             string[] mergedPostCommandHooksLines = localGitPostCommandHooks
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents()
                 .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
             mergedPreCommandHooksLines.Length.ShouldEqual(2);
-            mergedPreCommandHooksLines[1].ShouldEqual(dummyPostCommandHookBin);
+            mergedPreCommandHooksLines[1].ShouldEqual(dummyCommandHookBin);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -129,14 +129,14 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents()
                 .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            mergedPreCommandHooksLines.Length.ShouldEqual(2);
+            mergedPreCommandHooksLines.Length.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPreCommandHooksLines)}");
             mergedPreCommandHooksLines[0].ShouldEqual(dummyCommandHookBin);
 
             string[] mergedPostCommandHooksLines = localGitPostCommandHooks
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents()
                 .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            mergedPreCommandHooksLines.Length.ShouldEqual(2);
+            mergedPreCommandHooksLines.Length.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPostCommandHooksLines)}");
             mergedPreCommandHooksLines[1].ShouldEqual(dummyCommandHookBin);
         }
 

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -6,8 +6,10 @@ using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
@@ -125,19 +127,23 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             // .git\hooks\<pre/post>-command.hooks should now contain our local dummy hook
             // The dummy pre-command hooks should appear first, and the post-command hook should appear last
-            string[] mergedPreCommandHooksLines = localGitPreCommandHooks
+            List<string> mergedPreCommandHooksLines = localGitPreCommandHooks
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents()
-                .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            mergedPreCommandHooksLines.Length.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPreCommandHooksLines)}");
+                .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => !line.StartsWith("#"))
+                .ToList();
+            mergedPreCommandHooksLines.Count.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPreCommandHooksLines)}");
             mergedPreCommandHooksLines[0].ShouldEqual(dummyCommandHookBin);
 
-            string[] mergedPostCommandHooksLines = localGitPostCommandHooks
+            List<string> mergedPostCommandHooksLines = localGitPostCommandHooks
                 .ShouldBeAFile(this.fileSystem)
                 .WithContents()
-                .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-            mergedPreCommandHooksLines.Length.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPostCommandHooksLines)}");
-            mergedPreCommandHooksLines[1].ShouldEqual(dummyCommandHookBin);
+                .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => !line.StartsWith("#"))
+                .ToList();
+            mergedPostCommandHooksLines.Count.ShouldEqual(2, $"Expected 2 lines, actual: {string.Join("\n", mergedPostCommandHooksLines)}");
+            mergedPostCommandHooksLines[1].ShouldEqual(dummyCommandHookBin);
         }
 
         [TestCase]

--- a/GVFS/GVFS.Platform.Windows/WindowsGitHooksInstaller.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsGitHooksInstaller.cs
@@ -43,7 +43,8 @@ namespace GVFS.Platform.Windows
             string filename;
             string[] defaultHooksLines = { };
 
-            if (configProcess.TryGetFromConfig(configSettingName, forceOutsideEnlistment: true, value: out filename) && filename != null)
+            // Pass false for forceOutsideEnlistment to allow hooks to be configured at the per-repo level
+            if (configProcess.TryGetFromConfig(configSettingName, forceOutsideEnlistment: false, value: out filename) && filename != null)
             {
                 filename = filename.Trim(' ', '\n');
                 defaultHooksLines = File.ReadAllLines(filename);


### PR DESCRIPTION
Resolves #1563 

Prior to the changes in this commit gvfs.clone.default-pre-command
and gvfs.clone.default-pre-command would only be read from the system
and global git configs.  This meant that users were unable to config
custom pre/post command hooks at a per-repo level.

With this change InvokeGitAgainstDotGitFolder when reading the above
config values, and using InvokeGitAgainstDotGitFolder will give us
the standard git config behavior of local config "winning" over a
system or global config.