### PR TITLE
HandleDehydrateFolders: update index using reset

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -466,6 +466,11 @@ namespace GVFS.Common.Git
             return this.InvokeGitInWorkingDirectoryRoot("checkout -f " + target, useReadObjectHook: false);
         }
 
+        public Result Reset(string target, string paths)
+        {
+            return this.InvokeGitInWorkingDirectoryRoot($"reset {target} {paths}", useReadObjectHook: false);
+        }
+
         public Result Status(bool allowObjectDownloads, bool useStatusCache, bool showUntracked = false)
         {
             string command = "status";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -407,7 +407,13 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem.DeleteDirectory(secondFolderToDelete.VirtualPath);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -a -m \"Delete directories\"");
 
+            folderToDelete.VirtualPath.ShouldNotExistOnDisk(this.fileSystem);
+            secondFolderToDelete.VirtualPath.ShouldNotExistOnDisk(this.fileSystem);
+
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -f HEAD~1");
+
+            folderToDelete.VirtualPath.ShouldBeADirectory(this.fileSystem);
+            secondFolderToDelete.VirtualPath.ShouldBeADirectory(this.fileSystem);
 
             this.DehydrateShouldSucceed(
                 new[]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/DehydrateTests.cs
@@ -396,18 +396,31 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        public void FolderDehydratePreviouslyDeletedFolder()
+        public void FolderDehydratePreviouslyDeletedFolders()
         {
             string folderToDehydrate = "TrailingSlashTests";
             TestPath folderToDelete = new TestPath(this.Enlistment, folderToDehydrate);
+            string secondFolderToDehydrate = "FilenameEncoding";
+            TestPath secondFolderToDelete = new TestPath(this.Enlistment, secondFolderToDehydrate);
+
             this.fileSystem.DeleteDirectory(folderToDelete.VirtualPath);
-            GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -a -m \"Delete a directory\"");
+            this.fileSystem.DeleteDirectory(secondFolderToDelete.VirtualPath);
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -a -m \"Delete directories\"");
 
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout -f HEAD~1");
 
-            this.DehydrateShouldSucceed(new[] { $"{folderToDehydrate} {FolderDehydrateSuccessfulMessage}" }, confirm: true, noStatus: false, foldersToDehydrate: folderToDehydrate);
+            this.DehydrateShouldSucceed(
+                new[]
+                {
+                    $"{folderToDehydrate} {FolderDehydrateSuccessfulMessage}",
+                    $"{secondFolderToDehydrate} {FolderDehydrateSuccessfulMessage}",
+                },
+                confirm: true,
+                noStatus: false,
+                foldersToDehydrate: new[] { folderToDehydrate, secondFolderToDehydrate });
 
             folderToDelete.VirtualPath.ShouldBeADirectory(this.fileSystem);
+            secondFolderToDelete.VirtualPath.ShouldBeADirectory(this.fileSystem);
         }
 
         [TestCase]

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -469,8 +469,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
             // Modify a file that's in the sparse set
+            string modifiedFileContents = "New Contents";
             string modifiedPath = Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS", "Program.cs");
-            this.fileSystem.WriteAllText(modifiedPath, "New Contents");
+            this.fileSystem.WriteAllText(modifiedPath, modifiedFileContents);
+            string expecetedStatusOutput = GitProcess.Invoke(this.Enlistment.RepoRoot, "status --porcelain -uall");
 
             // Remove and prune folderToCreateFileIn
             string output = this.gvfsProcess.RemoveSparseFolders(shouldPrune: true, folders: folderToCreateFileIn);
@@ -481,6 +483,11 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             string folderPath = Path.Combine(this.Enlistment.RepoRoot, folderToCreateFileIn);
             folderPath.ShouldNotExistOnDisk(this.fileSystem);
             fileToCreate.ShouldNotExistOnDisk(this.fileSystem);
+
+            // Confirm the changes to the modified file are preserved and that status does not change
+            modifiedPath.ShouldBeAFile(this.fileSystem).WithContents(modifiedFileContents);
+            string statusOutput = GitProcess.Invoke(this.Enlistment.RepoRoot, "status --porcelain -uall");
+            statusOutput.ShouldEqual(expecetedStatusOutput, "Status output should not change.");
         }
 
         [TestCase, Order(23)]

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -300,7 +300,10 @@ from a parent of the folders list.
 
             this.Mount(tracer);
 
-            this.SendDehydrateMessage(tracer, enlistment, folderErrors, foldersToDehydrate.ToArray());
+            if (foldersToDehydrate.Count > 0)
+            {
+                this.SendDehydrateMessage(tracer, enlistment, folderErrors, foldersToDehydrate);
+            }
 
             if (folderErrors.Count > 0)
             {
@@ -327,7 +330,7 @@ from a parent of the folders list.
             return true;
         }
 
-        private void SendDehydrateMessage(ITracer tracer, GVFSEnlistment enlistment, List<string> folderErrors, string[] folders)
+        private void SendDehydrateMessage(ITracer tracer, GVFSEnlistment enlistment, List<string> folderErrors, List<string> folders)
         {
             NamedPipeMessages.DehydrateFolders.Response response = null;
 


### PR DESCRIPTION
Resolves #1603

Use `git reset <paths>` rather than `git checkout -f` (or `git checkout
-f <paths>`) because:

 - `git reset <paths>` will not overwrite modified files (like
   `checkout -f` would).
 - `reset` will update the index for paths that are outside of
   ModifiedPaths.dat (unlike `checkout -f <paths>`).

We need the index to be updated because when a folder is dehydrated
it is removed from ModifiedPaths.dat and we need to make sure its
entries in the index are updated.