### PR TITLE
sparse: check for not recursive matches when finding dirty files

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -485,7 +485,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             // Remove and prune folderToCreateFileIn
             string output = this.gvfsProcess.RemoveSparseFolders(shouldPrune: true, folders: folderToCreateFileIn);
             output.ShouldContain("Running git status...Succeeded");
-            this.ValidateFoldersInSparseList(this.mainSparseFolder);
+            this.ValidateFoldersInSparseList(this.mainSparseFolder, additionalSparseFolder);
 
             // Confirm the prune succeeded
             string folderPath = Path.Combine(this.Enlistment.RepoRoot, folderToCreateFileIn);

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/SparseTests.cs
@@ -455,23 +455,31 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase, Order(22)]
         public void ModifiedFileInSparseSetShouldAllowPrune()
         {
-            this.gvfsProcess.AddSparseFolders(this.mainSparseFolder);
-            this.ValidateFoldersInSparseList(this.mainSparseFolder);
+            string additionalSparseFolder = Path.Combine("GVFS", "GVFS.Tests", "Should");
+            this.gvfsProcess.AddSparseFolders(this.mainSparseFolder, additionalSparseFolder);
+            this.ValidateFoldersInSparseList(this.mainSparseFolder, additionalSparseFolder);
 
             // Ensure that folderToCreateFileIn is on disk so that there's something to prune
             string folderToCreateFileIn = Path.Combine("GVFS", "GVFS.Common");
-            this.gvfsProcess.AddSparseFolders(this.mainSparseFolder, folderToCreateFileIn);
-            this.ValidateFoldersInSparseList(this.mainSparseFolder, folderToCreateFileIn);
+            this.gvfsProcess.AddSparseFolders(this.mainSparseFolder, additionalSparseFolder, folderToCreateFileIn);
+            this.ValidateFoldersInSparseList(this.mainSparseFolder, additionalSparseFolder, folderToCreateFileIn);
 
             string fileToCreate = Path.Combine(this.Enlistment.RepoRoot, folderToCreateFileIn, "newfile.txt");
             this.fileSystem.WriteAllText(fileToCreate, "New Contents");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add .");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m Test");
 
-            // Modify a file that's in the sparse set
+            // Modify a file that's in the sparse set (recursively)
             string modifiedFileContents = "New Contents";
-            string modifiedPath = Path.Combine(this.Enlistment.RepoRoot, "GVFS", "GVFS", "Program.cs");
+            string modifiedPath = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS", "Program.cs");
+            modifiedPath.ShouldBeAFile(this.fileSystem);
             this.fileSystem.WriteAllText(modifiedPath, modifiedFileContents);
+
+            // Modify a file that is in the sparse set (via a non-recursive parent)
+            string secondModifiedPath = this.Enlistment.GetVirtualPathTo("GVFS", "GVFS.Tests", "NUnitRunner.cs");
+            secondModifiedPath.ShouldBeAFile(this.fileSystem);
+            this.fileSystem.WriteAllText(secondModifiedPath, modifiedFileContents);
+
             string expecetedStatusOutput = GitProcess.Invoke(this.Enlistment.RepoRoot, "status --porcelain -uall");
 
             // Remove and prune folderToCreateFileIn
@@ -486,6 +494,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
             // Confirm the changes to the modified file are preserved and that status does not change
             modifiedPath.ShouldBeAFile(this.fileSystem).WithContents(modifiedFileContents);
+            secondModifiedPath.ShouldBeAFile(this.fileSystem).WithContents(modifiedFileContents);
             string statusOutput = GitProcess.Invoke(this.Enlistment.RepoRoot, "status --porcelain -uall");
             statusOutput.ShouldEqual(expecetedStatusOutput, "Status output should not change.");
         }

--- a/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
+++ b/GVFS/GVFS.UnitTests.Windows/GVFS.UnitTests.Windows.csproj
@@ -114,6 +114,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Windows\CommandLine\SparseVerbTests.cs" />
     <Compile Include="Windows\Mock\WindowsFileSystemVirtualizerTester.cs" />
     <Compile Include="Windows\ServiceUI\GVFSToastRequestHandlerTests.cs" />
     <Compile Include="Windows\Upgrader\WindowsNuGetUpgraderTests.cs" />

--- a/GVFS/GVFS.UnitTests.Windows/Windows/CommandLine/SparseVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/CommandLine/SparseVerbTests.cs
@@ -1,0 +1,114 @@
+﻿using GVFS.CommandLine;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GVFS.UnitTests.Windows.Windows.CommandLine
+{
+    [TestFixture]
+    public class SparseVerbTests
+    {
+        // Shorter name for readability
+        private static char dirSep = Path.DirectorySeparatorChar;
+
+        [TestCase]
+        public void PathCoveredBySparseFolders_RootPaths()
+        {
+            string rootPaths = $"a.txt{SparseVerb.StatusPathSeparatorToken}b.txt{SparseVerb.StatusPathSeparatorToken}c.txt{SparseVerb.StatusPathSeparatorToken}";
+
+            ConfirmAllPathsCovered(rootPaths, new HashSet<string>());
+            ConfirmAllPathsCovered(rootPaths, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A" });
+            ConfirmAllPathsCovered(rootPaths, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B{dirSep}C" });
+        }
+
+        [TestCase]
+        public void PathCoveredBySparseFolders_RecursivelyCoveredPaths()
+        {
+            StringBuilder rootPaths = new StringBuilder();
+            rootPaths.Append($"A/a.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"A/B/B.txt{SparseVerb.StatusPathSeparatorToken}");
+
+            ConfirmAllPathsCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A" });
+            ConfirmAllPathsCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B{dirSep}C" });
+
+            // Root entries should always be covered
+            rootPaths.Append($"d.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"e.txt{SparseVerb.StatusPathSeparatorToken}");
+
+            ConfirmAllPathsCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A" });
+            ConfirmAllPathsCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B{dirSep}C" });
+
+            rootPaths.Append($"B/C/e.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"B/C/F/g.txt{SparseVerb.StatusPathSeparatorToken}");
+            ConfirmAllPathsCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B{dirSep}C" });
+        }
+
+        [TestCase]
+        public void PathCoveredBySparseFolders_NonRecursivelyCoveredPaths()
+        {
+            StringBuilder rootPaths = new StringBuilder();
+            rootPaths.Append($"A/B/B.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"A/C.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"A/D/E/C.txt{SparseVerb.StatusPathSeparatorToken}");
+
+            ConfirmAllPathsCovered(
+                rootPaths.ToString(),
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    $"A{dirSep}B{dirSep}C{dirSep}D",
+                    $"A{dirSep}D{dirSep}E{dirSep}F{dirSep}G"
+                });
+
+            // Root entries should always be covered
+            rootPaths.Append($"d.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"e.txt{SparseVerb.StatusPathSeparatorToken}");
+
+            ConfirmAllPathsCovered(
+                rootPaths.ToString(),
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    $"A{dirSep}B{dirSep}C{dirSep}D",
+                    $"A{dirSep}D{dirSep}E{dirSep}F{dirSep}G"
+                });
+        }
+
+        [TestCase]
+        public void PathCoveredBySparseFolders_PathsNotCovered()
+        {
+            StringBuilder rootPaths = new StringBuilder();
+            rootPaths.Append($"A/B/B.txt{SparseVerb.StatusPathSeparatorToken}");
+            rootPaths.Append($"A/D/E/C.txt{SparseVerb.StatusPathSeparatorToken}");
+
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { $"A{dirSep}C" });
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B" });
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B", $"C{dirSep}D" });
+        }
+
+        private static void ConfirmAllPathsCovered(string paths, HashSet<string> sparseSet)
+        {
+            CheckIfPathsCovered(paths, sparseSet, shouldBeCovered: true);
+        }
+
+        private static void ConfirmAllPathsNotCovered(string paths, HashSet<string> sparseSet)
+        {
+            CheckIfPathsCovered(paths, sparseSet, shouldBeCovered: false);
+        }
+
+        private static void CheckIfPathsCovered(string paths, HashSet<string> sparseSet, bool shouldBeCovered)
+        {
+            int index = 0;
+            while (index < paths.Length - 1)
+            {
+                int nextSeparatorIndex = paths.IndexOf(SparseVerb.StatusPathSeparatorToken, index);
+                string expectedGitPath = paths.Substring(index, nextSeparatorIndex - index);
+                SparseVerb.PathCoveredBySparseFolders(ref index, paths, sparseSet, out string gitPath).ShouldEqual(shouldBeCovered);
+                index.ShouldEqual(nextSeparatorIndex + 1);
+                gitPath.ShouldEqual(expectedGitPath);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests.Windows/Windows/CommandLine/SparseVerbTests.cs
+++ b/GVFS/GVFS.UnitTests.Windows/Windows/CommandLine/SparseVerbTests.cs
@@ -23,7 +23,7 @@ namespace GVFS.UnitTests.Windows.Windows.CommandLine
 
             ConfirmAllPathsCovered(rootPaths, EmptySparseSet);
             ConfirmAllPathsCovered(rootPaths, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A" });
-            ConfirmAllPathsCovered(rootPaths, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B\\C" });
+            ConfirmAllPathsCovered(rootPaths, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", @"B\C" });
         }
 
         [TestCase]
@@ -34,7 +34,7 @@ namespace GVFS.UnitTests.Windows.Windows.CommandLine
             rootPaths.Append($"A/B/B.txt{StatusPathSeparatorToken}");
 
             HashSet<string> singleFolderSparseSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A" };
-            HashSet<string> twoFolderSparseSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", $"B\\C" };
+            HashSet<string> twoFolderSparseSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "A", @"B\C" };
 
             ConfirmAllPathsCovered(rootPaths.ToString(), singleFolderSparseSet);
             ConfirmAllPathsCovered(rootPaths.ToString(), twoFolderSparseSet);
@@ -63,8 +63,8 @@ namespace GVFS.UnitTests.Windows.Windows.CommandLine
                 rootPaths.ToString(),
                 new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    $"A\\B\\C\\D",
-                    $"A\\D\\E\\F\\G"
+                    @"A\B\C\D",
+                    @"A\D\E\F\G"
                 });
 
             // Root entries should always be covered
@@ -75,8 +75,8 @@ namespace GVFS.UnitTests.Windows.Windows.CommandLine
                 rootPaths.ToString(),
                 new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    $"A\\B\\C\\D",
-                    $"A\\D\\E\\F\\G"
+                    @"A\B\C\D",
+                    @"A\D\E\F\G"
                 });
         }
 
@@ -88,9 +88,9 @@ namespace GVFS.UnitTests.Windows.Windows.CommandLine
             rootPaths.Append($"A/D/E/C.txt{StatusPathSeparatorToken}");
 
             ConfirmAllPathsNotCovered(rootPaths.ToString(), EmptySparseSet);
-            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { $"A\\C" });
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { @"A\C" });
             ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B" });
-            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B", $"C\\D" });
+            ConfirmAllPathsNotCovered(rootPaths.ToString(), new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B", @"C\D" });
         }
 
         private static void ConfirmAllPathsCovered(string paths, HashSet<string> sparseSet)

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -93,12 +93,16 @@ Folders need to be relative to the repos root directory.")
 
         protected override string VerbName => SparseVerbName;
 
-        internal static bool PathCoveredBySparseFolders(ref int index, string statusOutput, HashSet<string> sparseFolders, out string gitPath)
+        internal static string GetNextGitPath(ref int index, string statusOutput)
         {
             int endOfPathIndex = statusOutput.IndexOf(StatusPathSeparatorToken, index);
-            gitPath = statusOutput.Substring(index, endOfPathIndex - index);
+            string gitPath = statusOutput.Substring(index, endOfPathIndex - index);
             index = endOfPathIndex + 1;
+            return gitPath;
+        }
 
+        internal static bool PathCoveredBySparseFolders(string gitPath, HashSet<string> sparseFolders)
+        {
             string filePath = gitPath.Replace(GVFSConstants.GitPathSeparator, Path.DirectorySeparatorChar);
             if (sparseFolders.Any(x => filePath.StartsWith(x + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison)))
             {
@@ -662,15 +666,16 @@ Folders need to be relative to the repos root directory.")
                 bool isRename = statusOutput[index] == StatusRenameToken || statusOutput[index + 1] == StatusRenameToken;
                 index = index + 3;
 
-                string gitPath;
-                if (!PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
+                string gitPath = GetNextGitPath(ref index, statusOutput);
+                if (!PathCoveredBySparseFolders(gitPath, sparseFolders))
                 {
                     uncoveredPaths.Add(gitPath);
                 }
 
                 if (isRename)
                 {
-                    if (!PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
+                    gitPath = GetNextGitPath(ref index, statusOutput);
+                    if (!PathCoveredBySparseFolders(gitPath, sparseFolders))
                     {
                         uncoveredPaths.Add(gitPath);
                     }

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -22,9 +22,9 @@ Folders need to be relative to the repos root directory.")
     ]
     public class SparseVerb : GVFSVerb.ForExistingEnlistment
     {
+        internal const char StatusPathSeparatorToken = '\0';
         private const string SparseVerbName = "sparse";
         private const string FolderListSeparator = ";";
-        private const char StatusPathSeparatorToken = '\0';
         private const char StatusRenameToken = 'R';
         private const string PruneOptionName = "prune";
 
@@ -92,6 +92,44 @@ Folders need to be relative to the repos root directory.")
         public bool Disable { get; set; }
 
         protected override string VerbName => SparseVerbName;
+
+        internal static bool PathCoveredBySparseFolders(ref int index, string statusOutput, HashSet<string> sparseFolders, out string gitPath)
+        {
+            int endOfPathIndex = statusOutput.IndexOf(StatusPathSeparatorToken, index);
+            gitPath = statusOutput.Substring(index, endOfPathIndex - index);
+            index = endOfPathIndex + 1;
+
+            string filePath = gitPath.Replace(GVFSConstants.GitPathSeparator, Path.DirectorySeparatorChar);
+            if (sparseFolders.Any(x => filePath.StartsWith(x + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison)))
+            {
+                // Path is covered by a recursive entry
+                return true;
+            }
+
+            int pathSeparatorIndex = filePath.LastIndexOf(Path.DirectorySeparatorChar);
+            if (pathSeparatorIndex < 0)
+            {
+                // Path is in the root, and root entries are always in the sparse set
+                return true;
+            }
+
+            // Get the parent path (including the path separator)
+            string parentPath = filePath.Substring(startIndex: 0, length: pathSeparatorIndex + 1);
+            if (sparseFolders.Any(x => x.StartsWith(parentPath, GVFSPlatform.Instance.Constants.PathComparison)))
+            {
+                // Path is a child of a non-recursive entry
+                //
+                // Example:
+                //  - Sparse set: A\B\C
+                //  - filePath: A\B\d.txt
+                //
+                // This file is in the sparse set because its parent ("A\B\") is an ancestory of a recursive
+                // entry ("A\B\C\") in the sparse set
+                return true;
+            }
+
+            return false;
+        }
 
         protected override void Execute(GVFSEnlistment enlistment)
         {
@@ -625,14 +663,14 @@ Folders need to be relative to the repos root directory.")
                 index = index + 3;
 
                 string gitPath;
-                if (!this.PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
+                if (!PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
                 {
                     uncoveredPaths.Add(gitPath);
                 }
 
                 if (isRename)
                 {
-                    if (!this.PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
+                    if (!PathCoveredBySparseFolders(ref index, statusOutput, sparseFolders, out gitPath))
                     {
                         uncoveredPaths.Add(gitPath);
                     }
@@ -640,15 +678,6 @@ Folders need to be relative to the repos root directory.")
             }
 
             return uncoveredPaths;
-        }
-
-        private bool PathCoveredBySparseFolders(ref int index, string statusOutput, HashSet<string> sparseFolders, out string gitPath)
-        {
-            int endOfPathIndex = statusOutput.IndexOf(StatusPathSeparatorToken, index);
-            gitPath = statusOutput.Substring(index, endOfPathIndex - index);
-            string filePath = gitPath.Replace(GVFSConstants.GitPathSeparator, Path.DirectorySeparatorChar);
-            index = endOfPathIndex + 1;
-            return sparseFolders.Any(x => filePath.StartsWith(x + Path.DirectorySeparatorChar, GVFSPlatform.Instance.Constants.PathComparison));
         }
 
         private void WriteMessage(ITracer tracer, string message)

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -22,9 +22,9 @@ Folders need to be relative to the repos root directory.")
     ]
     public class SparseVerb : GVFSVerb.ForExistingEnlistment
     {
-        internal const char StatusPathSeparatorToken = '\0';
         private const string SparseVerbName = "sparse";
         private const string FolderListSeparator = ";";
+        private const char StatusPathSeparatorToken = '\0';
         private const char StatusRenameToken = 'R';
         private const string PruneOptionName = "prune";
 
@@ -123,7 +123,7 @@ Folders need to be relative to the repos root directory.")
                 //  - Sparse set: A\B\C
                 //  - filePath: A\B\d.txt
                 //
-                // This file is in the sparse set because its parent ("A\B\") is an ancestory of a recursive
+                // This file is in the sparse set because its parent ("A\B\") is an ancestor of a recursive
                 // entry ("A\B\C\") in the sparse set
                 return true;
             }

--- a/GVFS/GVFS/Properties/AssemblyInfo.cs
+++ b/GVFS/GVFS/Properties/AssemblyInfo.cs
@@ -21,3 +21,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("32220664-594c-4425-b9a0-88e0be2f3d2a")]
+
+[assembly: InternalsVisibleTo("GVFS.UnitTests")]
+[assembly: InternalsVisibleTo("GVFS.UnitTests.Windows")]


### PR DESCRIPTION
Resolves #1604

The previous file path matching was only matching against recursive
sparse paths, and incorrectly flagging children of non-recursive folders
as dirty.  This matching has been updated to match both recursive and
non-recursive parents, and unit tests were added to validate the
matching behavior.