### PR TITLE
[master] PostFetchStep: do not immediately delete expired commit-graph files

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -538,7 +538,9 @@ namespace GVFS.Common.Git
         /// </summary>
         public Result WriteCommitGraph(string objectDir, List<string> packs)
         {
-            string command = "commit-graph write --stdin-packs --split --size-multiple=4 --object-dir \"" + objectDir + "\"";
+            // Do not expire commit-graph files that have been modified in the last hour.
+            // This will prevent deleting any commit-graph files that are currently in the commit-graph-chain.
+            string command = $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time={1 * 60 * 60} --object-dir \"{objectDir}\"";
             return this.InvokeGitInWorkingDirectoryRoot(
                 command,
                 useReadObjectHook: true,

--- a/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
@@ -18,7 +18,7 @@ namespace GVFS.UnitTests.Maintenance
         private MockGitProcess gitProcess;
         private GVFSContext context;
 
-        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --split --size-multiple=4 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time=3600 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
         private string CommitGraphVerifyCommand => $"commit-graph verify --shallow --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
 
         [TestCase]


### PR DESCRIPTION
We have noticed a lot of "cannot find all commit-graph files" errors,
more than is reasonable for simply hard-drive failures. Likely there is
an issue with how Git is comparing the paths of the commit-graph files
it is queueing for deletion and the ones it plans to keep, related to
how we use the --object-dir parameter.

The commit-graph code in Git will "touch" all the files that are
currently in the commit-graph-chain, so as long as we pass a non-zero
expire time, that will prevent us from deleting the files that are
still in the chain despite the path difference.

This is a faster fix than fixing Git first.

Cc: @jrbriggs, @wilbaker this may be worth taking into `milestones/162`.