### PR TITLE
[Linux] functional test backing root and DotGVFSRoot fixes

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -96,7 +96,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
                 files.ShouldContain(x => Path.GetFileName(x).Equals("git.cmd", StringComparison.Ordinal));
                 string[] directories = Directory.GetDirectories(enlistment.EnlistmentRoot);
                 directories.Length.ShouldEqual(2);
-                directories.ShouldContain(x => Path.GetFileName(x).Equals(".gvfs", StringComparison.Ordinal));
+                directories.ShouldContain(x => Path.GetFileName(x).Equals(GVFSTestConfig.DotGVFSRoot, StringComparison.Ordinal));
                 directories.ShouldContain(x => Path.GetFileName(x).Equals("src", StringComparison.Ordinal));
             }
             finally

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/MountTests.cs
@@ -74,9 +74,9 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
                 this.Enlistment.UnmountGVFS();
 
-                GitProcess.Invoke(this.Enlistment.RepoRoot, "config --unset core.hookspath");
+                GitProcess.Invoke(this.Enlistment.RepoBackingRoot, "config --unset core.hookspath");
                 string.IsNullOrWhiteSpace(
-                    GitProcess.Invoke(this.Enlistment.RepoRoot, "config core.hookspath"))
+                    GitProcess.Invoke(this.Enlistment.RepoBackingRoot, "config core.hookspath"))
                     .ShouldBeTrue();
 
                 this.Enlistment.MountGVFS();


### PR DESCRIPTION
This PR includes two minor edits to enable the functional test suite on Linux: first, we replace one use of a `.gvfs` string constant in the functional tests which was added in 9fc6bc1, in order to align with the changes made in 8348777.  This allows the `CloneTests` to pass on Linux where `.vfsforgit` is used instead of `.gvfs`.

And second, the `MountSetsCoreHooksPath()` functional test performs an unmount step before resetting Git's configurations, and while this actually does succeed on Linux as it stands, the `src/` `RepoRoot` directory is entirely empty while its unmounted, so to be consistent, use the backing root instead.