### PR TITLE
GVFSVerb: use flags for core.gvfs

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20191211.2</GitPackageVersion>
+    <GitPackageVersion>2.20191217.3</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -36,6 +36,60 @@ namespace GVFS.CommandLine
             this.InitializeDefaultParameterValues();
         }
 
+        [Flags]
+        private enum GitCoreGVFSFlags
+        {
+            // GVFS_SKIP_SHA_ON_INDEX
+            // Disables the calculation of the sha when writing the index
+            SkipShaOnIndex = 1 << 0,
+
+            // GVFS_BLOCK_COMMANDS
+            // Blocks git commands that are not allowed in a GVFS/Scalar repo
+            BlockCommands = 1 << 1,
+
+            // GVFS_MISSING_OK
+            // Normally git write-tree ensures that the objects referenced by the
+            // directory exist in the object database.This option disables this check.
+            MissingOk = 1 << 2,
+
+            // GVFS_NO_DELETE_OUTSIDE_SPARSECHECKOUT
+            // When marking entries to remove from the index and the working
+            // directory this option will take into account what the
+            // skip-worktree bit was set to so that if the entry has the
+            // skip-worktree bit set it will not be removed from the working
+            // directory.  This will allow virtualized working directories to
+            // detect the change to HEAD and use the new commit tree to show
+            // the files that are in the working directory.
+            NoDeleteOutsideSparseCheckout = 1 << 3,
+
+            // GVFS_FETCH_SKIP_REACHABILITY_AND_UPLOADPACK
+            // While performing a fetch with a virtual file system we know
+            // that there will be missing objects and we don't want to download
+            // them just because of the reachability of the commits.  We also
+            // don't want to download a pack file with commits, trees, and blobs
+            // since these will be downloaded on demand.  This flag will skip the
+            // checks on the reachability of objects during a fetch as well as
+            // the upload pack so that extraneous objects don't get downloaded.
+            FetchSkipReachabilityAndUploadPack = 1 << 4,
+
+            // 1 << 5 has been deprecated
+
+            // GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS
+            // With a virtual file system we only know the file size before any
+            // CRLF or smudge/clean filters processing is done on the client.
+            // To prevent file corruption due to truncation or expansion with
+            // garbage at the end, these filters must not run when the file
+            // is first accessed and brought down to the client. Git.exe can't
+            // currently tell the first access vs subsequent accesses so this
+            // flag just blocks them from occurring at all.
+            BlockFiltersAndEolConversions = 1 << 6,
+
+            // GVFS_PREFETCH_DURING_FETCH
+            // While performing a `git fetch` command, use the gvfs-helper to
+            // perform a "prefetch" of commits and trees.
+            PrefetchDuringFetch = 1 << 7,
+        }
+
         public abstract string EnlistmentRootPathParameter { get; set; }
 
         [Option(
@@ -117,6 +171,15 @@ namespace GVFS.CommandLine
                 gitStatusCachePath = Paths.ConvertPathToGitFormat(gitStatusCachePath);
             }
 
+            string coreGVFSFlags = Convert.ToInt32(
+                GitCoreGVFSFlags.SkipShaOnIndex |
+                GitCoreGVFSFlags.BlockCommands |
+                GitCoreGVFSFlags.MissingOk |
+                GitCoreGVFSFlags.NoDeleteOutsideSparseCheckout |
+                GitCoreGVFSFlags.FetchSkipReachabilityAndUploadPack |
+                GitCoreGVFSFlags.BlockFiltersAndEolConversions)
+                .ToString();
+
             // These settings are required for normal GVFS functionality.
             // They will override any existing local configuration values.
             //
@@ -144,7 +207,7 @@ namespace GVFS.CommandLine
                 { "core.fscache", "true" },
 
                 // Turns on all special gvfs logic. https://github.com/microsoft/git/blob/be5e0bb969495c428e219091e6976b52fb33b301/gvfs.h
-                { "core.gvfs", "true" },
+                { "core.gvfs", coreGVFSFlags },
 
                 // Use 'multi-pack-index' builtin instead of 'midx' to match upstream implementation
                 { "core.multiPackIndex", "true" },


### PR DESCRIPTION
The core.gvfs config option can take a boolen "true" to turn on
all options, but also an integer to show a bitmask of important
flags. For the first time, we have a new flag that we may not
want to enable right away: GVFS_PREFETCH_DURING_FETCH.

This flag will make the `git fetch` builtin run a `git gvfs-helper prefetch`
command. Until that hardens a bit, we do not want VFS for Git users
to use that code path.

Update Git to include this option.