### PR TITLE
Add $ to make string interpolated

### DIFF
--- a/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/GVFS/GVFS.Common/NuGetUpgrade/NuGetFeed.cs
@@ -116,7 +116,7 @@ namespace GVFS.Common.NuGetUpgrade
             {
                 if (downloadResourceResult.Status != DownloadResourceResultStatus.Available)
                 {
-                    throw new Exception("Download of NuGet package failed. DownloadResult Status: {downloadResourceResult.Status}");
+                    throw new Exception($"Download of NuGet package failed. DownloadResult Status: {downloadResourceResult.Status}");
                 }
 
                 using (FileStream fileStream = File.Create(downloadPath))


### PR DESCRIPTION
I happened to notice this whilst browsing the source code to see an example of how the Nuget CLient packages are used.

I assume it's a mistake, so created a pull request. If it's not, please close.