### PR TITLE
sparse: allow dehydrate to continue if a directory delete fails

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -13,7 +13,7 @@ namespace GVFS.Common.FileSystem
     {
         public const int DefaultStreamBufferSize = 8192;
 
-        public virtual void DeleteDirectory(string path, bool recursive = true)
+        public virtual void DeleteDirectory(string path, bool recursive = true, bool ignoreDirectoryDeleteExceptions = false)
         {
             if (!Directory.Exists(path))
             {
@@ -32,11 +32,21 @@ namespace GVFS.Common.FileSystem
 
                 foreach (DirectoryInfo subDirectory in directory.GetDirectories())
                 {
-                    this.DeleteDirectory(subDirectory.FullName);
+                    this.DeleteDirectory(subDirectory.FullName, recursive, ignoreDirectoryDeleteExceptions);
                 }
             }
 
-            directory.Delete();
+            try
+            {
+                directory.Delete();
+            }
+            catch (Exception)
+            {
+                if (!ignoreDirectoryDeleteExceptions)
+                {
+                    throw;
+                }
+            }
         }
 
         public virtual void CopyDirectoryRecursive(

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -40,7 +40,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         /// </summary>
         public bool DeleteNonExistentFileThrowsException { get; set; }
 
-        public override void DeleteDirectory(string path, bool recursive = true)
+        public override void DeleteDirectory(string path, bool recursive = true, bool ignoreDirectoryDeleteExceptions = false)
         {
             if (!recursive)
             {

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystemWithCallbacks.cs
@@ -48,7 +48,7 @@ namespace GVFS.UnitTests.Mock.FileSystem
         {
         }
 
-        public override void DeleteDirectory(string path, bool recursive = true)
+        public override void DeleteDirectory(string path, bool recursive = true, bool ignoreDirectoryDeleteExceptions = false)
         {
             throw new InvalidOperationException("DeleteDirectory has not been implemented.");
         }

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -267,7 +267,9 @@ from a parent of the folders list.
                                     string fullPath = Path.Combine(enlistment.WorkingDirectoryBackingRoot, folder);
                                     if (this.fileSystem.DirectoryExists(fullPath))
                                     {
-                                        if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath), $"Deleting '{fullPath}'", out ioError))
+                                        // Since directories are deleted last and will be empty at that point we can skip errors
+                                        // while trying to delete it and leave the empty directory and continue to dehydrate
+                                        if (!this.TryIO(tracer, () => this.fileSystem.DeleteDirectory(fullPath, ignoreDirectoryDeleteExceptions: true), $"Deleting '{fullPath}'", out ioError))
                                         {
                                             this.WriteMessage(tracer, $"Cannot {this.ActionName} folder '{folder}': removing '{folder}' failed.");
                                             this.WriteMessage(tracer, "Ensure no applications are accessing the folder and retry.");


### PR DESCRIPTION
When the code gets to the point of deleting the directory it is empty
and it will not hurt anything leaving it on disk.  This also more
closely matches what git does when changing the sparse-checkout since
it ignores errors when trying to delete empty directories.

Todo:
- [x] Write a dehydrate functional test that will cause an error on the directory delete if possible.