### PR TITLE
build: fix the build error related to dotnet core version

### DIFF
--- a/Scripts/RestorePackages.bat
+++ b/Scripts/RestorePackages.bat
@@ -13,8 +13,8 @@ IF NOT EXIST %nuget% (
   powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %nuget%"
 )
 
-%nuget% restore %VFS_SRCDIR%\GVFS.sln || exit /b 1
-
 dotnet restore %VFS_SRCDIR%\GVFS.sln /p:Configuration=%SolutionConfiguration% /p:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140" --packages %VFS_PACKAGESDIR% || exit /b 1
+
+%nuget% restore %VFS_SRCDIR%\GVFS.sln || exit /b 1
 
 ENDLOCAL


### PR DESCRIPTION
Not sure why this fixes the "The project was restored using
Microsoft.NETCore.App version X, but with current settings, version Y
would be used instead" error. Maybe the nuget restore was doing something
to have it use a different version.