### PR TITLE
Update Git to v2.26.0

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20200221.5</GitPackageVersion>
+    <GitPackageVersion>2.20200323.8</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -5,7 +5,6 @@ using GVFS.FunctionalTests.Tools;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -204,6 +203,7 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         {
             this.Enlistment = GVFSFunctionalTestEnlistment.CloneAndMount(GVFSTestConfig.PathToGVFS, commitish: commitish);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "config advice.statusUoption false");
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "config core.editor true");
             this.ControlGitRepo = ControlGitRepo.Create(commitish);
             this.ControlGitRepo.Initialize();
         }

--- a/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/ControlGitRepo.cs
@@ -1,7 +1,5 @@
-﻿using GVFS.FunctionalTests.FileSystemRunners;
-using System;
+﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace GVFS.FunctionalTests.Tools
 {
@@ -52,6 +50,7 @@ namespace GVFS.FunctionalTests.Tools
             Directory.CreateDirectory(this.RootPath);
             GitProcess.Invoke(this.RootPath, "init");
             GitProcess.Invoke(this.RootPath, "config core.autocrlf false");
+            GitProcess.Invoke(this.RootPath, "config core.editor true");
             GitProcess.Invoke(this.RootPath, "config merge.stat false");
             GitProcess.Invoke(this.RootPath, "config merge.renames false");
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");

--- a/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
@@ -123,6 +123,7 @@ namespace GVFS.FunctionalTests.Tools
 
             Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
             environmentVariables["GIT_QUIET"] = "true";
+            environmentVariables["GIT_COMMITTER_DATE"] = "Thu Feb 16 10:07:35 2017 -0700";
 
             ProcessResult expectedResult = GitProcess.InvokeProcess(controlRepoRoot, command, environmentVariables);
             ProcessResult actualResult = GitHelpers.InvokeGitAgainstGVFSRepo(gvfsRepoRoot, command, environmentVariables);


### PR DESCRIPTION
See microsoft/git#251 for details.

This required an update to our test infrastructure. The rebase merge backend changed in a way that it would now open an editor during `git rebase --continue`, causing a test to wait for `vim` to close. Set the editor to be a no-op. This also changes the output to include the commit oid, so use `GIT_COMMITTER_TIME` to be a constant to keep the commits the same.