### PR TITLE
Fix commit-graph expiration

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20200323.8</GitPackageVersion>
+    <GitPackageVersion>2.20200402.1</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -16,6 +16,7 @@ namespace GVFS.Common.Git
 
         private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false);
         private static bool failedToSetEncoding = false;
+        private static string expireTimeDateString;
 
         /// <summary>
         /// Lock taken for duration of running executingProcess.
@@ -78,6 +79,19 @@ namespace GVFS.Common.Git
             if (this.workingDirectoryRoot != null)
             {
                 this.dotGitRoot = Path.Combine(this.workingDirectoryRoot, GVFSConstants.DotGit.Root);
+            }
+        }
+
+        public static string ExpireTimeDateString
+        {
+            get
+            {
+                if (expireTimeDateString == null)
+                {
+                    expireTimeDateString = DateTime.Now.Subtract(TimeSpan.FromDays(1)).ToShortDateString();
+                }
+
+                return expireTimeDateString;
             }
         }
 
@@ -540,7 +554,7 @@ namespace GVFS.Common.Git
         {
             // Do not expire commit-graph files that have been modified in the last hour.
             // This will prevent deleting any commit-graph files that are currently in the commit-graph-chain.
-            string command = $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time={1 * 60 * 60} --object-dir \"{objectDir}\"";
+            string command = $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time={ExpireTimeDateString} --object-dir \"{objectDir}\"";
             return this.InvokeGitInWorkingDirectoryRoot(
                 command,
                 useReadObjectHook: true,

--- a/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
@@ -18,7 +18,7 @@ namespace GVFS.UnitTests.Maintenance
         private MockGitProcess gitProcess;
         private GVFSContext context;
 
-        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time=3600 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --stdin-packs --split --size-multiple=4 --expire-time={GitProcess.ExpireTimeDateString} --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
         private string CommitGraphVerifyCommand => $"commit-graph verify --shallow --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
 
         [TestCase]


### PR DESCRIPTION
Wow, this was really not working as expected.

See microsoft/git#255 for how broken the `--expire-time` argument was.

Fix this by using the fixed argument and passing a datetime instead of an offset by seconds. This will provide a longer window for old commit-graph files, but apparently we've been leaving turd files around for a long time without anyone noticing.