### PR TITLE
[WIP] Track folder changes to update USN journal

### DIFF
--- a/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderCollection.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common.Database
 
         HashSet<string> GetAllFilePaths();
 
-        void AddPartialFolder(string path);
+        void AddPartialFolder(string path, string sha);
         void AddExpandedFolder(string path);
         void AddPossibleTombstoneFolder(string path);
 

--- a/GVFS/GVFS.Common/Database/IPlaceholderData.cs
+++ b/GVFS/GVFS.Common/Database/IPlaceholderData.cs
@@ -6,7 +6,7 @@
     public interface IPlaceholderData
     {
         string Path { get; }
-        string Sha { get; }
+        string Sha { get; set; }
         bool IsFolder { get; }
         bool IsExpandedFolder { get; }
         bool IsPossibleTombstoneFolder { get; }

--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -117,7 +117,7 @@ namespace GVFS.Common.Database
                 }
                 else
                 {
-                    this.AddPartialFolder(data.Path);
+                    this.AddPartialFolder(data.Path, data.Sha);
                 }
             }
             else
@@ -136,9 +136,9 @@ namespace GVFS.Common.Database
             this.Insert(new PlaceholderData() { Path = path, PathType = PlaceholderData.PlaceholderType.File, Sha = sha });
         }
 
-        public void AddPartialFolder(string path)
+        public void AddPartialFolder(string path, string sha)
         {
-            this.Insert(new PlaceholderData() { Path = path, PathType = PlaceholderData.PlaceholderType.PartialFolder });
+            this.Insert(new PlaceholderData() { Path = path, PathType = PlaceholderData.PlaceholderType.PartialFolder, Sha = sha });
         }
 
         public void AddExpandedFolder(string path)

--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -270,6 +270,7 @@ namespace GVFS.Common
             private int deleteFolderPlacehoderAttempted;
             private int folderPlaceholdersDeleted;
             private int folderPlaceholdersPathNotFound;
+            private int folderPlaceholdersShaUpdate;
             private long parseGitIndexTimeMs;
             private long projectionWriteLockHeldMs;
 
@@ -299,7 +300,8 @@ namespace GVFS.Common
                 long writeAndFlushMs,
                 int deleteFolderPlacehoderAttempted,
                 int folderPlaceholdersDeleted,
-                int folderPlaceholdersPathNotFound)
+                int folderPlaceholdersPathNotFound,
+                int folderPlaceholdersShaUpdate)
             {
                 this.placeholderTotalUpdateTimeMs = durationMs;
                 this.placeholderUpdateFilesTimeMs = updateFilesMs;
@@ -308,6 +310,7 @@ namespace GVFS.Common
                 this.deleteFolderPlacehoderAttempted = deleteFolderPlacehoderAttempted;
                 this.folderPlaceholdersDeleted = folderPlaceholdersDeleted;
                 this.folderPlaceholdersPathNotFound = folderPlaceholdersPathNotFound;
+                this.folderPlaceholdersShaUpdate = folderPlaceholdersShaUpdate;
             }
 
             public void RecordProjectionWriteLockHeld(long durationMs)
@@ -350,6 +353,7 @@ namespace GVFS.Common
                 metadata.Add("UpdateFolderPlaceholdersMS", this.placeholderUpdateFoldersTimeMs);
                 metadata.Add("DeleteFolderPlacehoderAttempted", this.deleteFolderPlacehoderAttempted);
                 metadata.Add("FolderPlaceholdersDeleted", this.folderPlaceholdersDeleted);
+                metadata.Add("FolderPlaceholdersShaUpdate", this.folderPlaceholdersShaUpdate);
                 metadata.Add("FolderPlaceholdersPathNotFound", this.folderPlaceholdersPathNotFound);
                 metadata.Add("PlaceholdersWriteAndFlushMS", this.placeholderWriteAndFlushTimeMs);
                 metadata.Add("ProjectionWriteLockHeldMs", this.projectionWriteLockHeldMs);

--- a/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
+++ b/GVFS/GVFS.Common/LegacyPlaceholderListDatabase.cs
@@ -83,7 +83,7 @@ namespace GVFS.Common
             this.AddAndFlush(path, sha);
         }
 
-        public void AddPartialFolder(string path)
+        public void AddPartialFolder(string path, string sha)
         {
             this.AddAndFlush(path, PartialFolderValue);
         }
@@ -390,7 +390,7 @@ namespace GVFS.Common
             }
 
             public string Path { get; }
-            public string Sha { get; }
+            public string Sha { get; set; }
 
             public bool IsFolder
             {

--- a/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
+++ b/GVFS/GVFS.FunctionalTests.Windows/GVFS.FunctionalTests.Windows.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Windows\Tests\WindowsDiskLayoutUpgradeTests.cs" />
     <Compile Include="Windows\Tests\JunctionAndSubstTests.cs" />
+    <Compile Include="Windows\Tests\WindowsFolderUsnUpdate.cs" />
     <Compile Include="Windows\Tests\WindowsTombstoneTests.cs" />
     <Compile Include="Windows\Tests\WindowsUpdatePlaceholderTests.cs" />
     <Compile Include="Windows\Tests\WindowsFileSystemTests.cs" />

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFolderUsnUpdate.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFolderUsnUpdate.cs
@@ -1,0 +1,93 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Tests.EnlistmentPerFixture;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace GVFS.FunctionalTests.Windows.Windows.Tests
+{
+    [TestFixture]
+    [Category(Categories.WindowsOnly)]
+    [Category(Categories.GitCommands)]
+    public class WindowsFolderUsnUpdate : TestsWithEnlistmentPerFixture
+    {
+        private const string StartingCommit = "ad87b3877c8fa6bebbe62330354f5c535875c4dd";
+        private const string CommitWithChanges = "e6d047cf65f4a384568b7a451530e18410bc8a12";
+        private FileSystemRunner fileSystem;
+
+        public WindowsFolderUsnUpdate()
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        [TestCase]
+        public void CheckoutUpdatesFolderUsnJournal()
+        {
+            this.GitCheckoutCommitId(StartingCommit);
+            this.GitStatusShouldBeClean(StartingCommit);
+
+            FolderPathUsn[] pathsToCheck = new FolderPathUsn[]
+            {
+                new FolderPathUsn(Path.Combine(this.Enlistment.RepoRoot, "Test_ConflictTests", "AddedFiles"), this.fileSystem),
+                new FolderPathUsn(Path.Combine(this.Enlistment.RepoRoot, "Test_ConflictTests", "DeletedFiles"), this.fileSystem),
+                new FolderPathUsn(Path.Combine(this.Enlistment.RepoRoot, "Test_ConflictTests", "ModifiedFiles"), this.fileSystem),
+            };
+
+            this.GitCheckoutCommitId(CommitWithChanges);
+            this.GitStatusShouldBeClean(CommitWithChanges);
+
+            foreach (FolderPathUsn folderPath in pathsToCheck)
+            {
+                folderPath.ValidateUsnChange();
+            }
+        }
+
+        private static string UsnFolderId(string path)
+        {
+            ProcessResult result = ProcessHelper.Run("fsutil", $"usn readdata \"{path}\"");
+            Match match = Regex.Match(result.Output, @"^Usn\s+:\s(\w+)", RegexOptions.Multiline);
+            if (match.Success)
+            {
+                return match.Value;
+            }
+
+            return string.Empty;
+        }
+
+        private void GitStatusShouldBeClean(string commitId)
+        {
+            GitHelpers.CheckGitCommandAgainstGVFSRepo(
+                this.Enlistment.RepoRoot,
+                "status",
+                "HEAD detached at " + commitId,
+                "nothing to commit, working tree clean");
+        }
+
+        private void GitCheckoutCommitId(string commitId)
+        {
+            GitHelpers.InvokeGitAgainstGVFSRepo(this.Enlistment.RepoRoot, "checkout " + commitId).Errors.ShouldContain("HEAD is now at " + commitId);
+        }
+
+        private class FolderPathUsn
+        {
+            private readonly string path;
+            private readonly string originalUsn;
+
+            public FolderPathUsn(string path, FileSystemRunner fileSystem)
+            {
+                this.path = path;
+                fileSystem.EnumerateDirectory(path);
+                this.originalUsn = UsnFolderId(path);
+            }
+
+            public void ValidateUsnChange()
+            {
+                string usnAfter = UsnFolderId(this.path);
+                usnAfter.ShouldNotEqual(this.originalUsn);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFolderUsnUpdate.cs
+++ b/GVFS/GVFS.FunctionalTests.Windows/Windows/Tests/WindowsFolderUsnUpdate.cs
@@ -12,6 +12,7 @@ namespace GVFS.FunctionalTests.Windows.Windows.Tests
     [TestFixture]
     [Category(Categories.WindowsOnly)]
     [Category(Categories.GitCommands)]
+    [Ignore("fsutil requires WSL be enabled.  Need to find a way to enable for builds or a different way to get the USN for the folder.")]
     public class WindowsFolderUsnUpdate : TestsWithEnlistmentPerFixture
     {
         private const string StartingCommit = "ad87b3877c8fa6bebbe62330354f5c535875c4dd";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/DiskLayoutUpgradeTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerTestCase/DiskLayoutUpgradeTests.cs
@@ -88,7 +88,7 @@ D GVFS{Path.DirectorySeparatorChar}GVFS.Tests{Path.DirectorySeparatorChar}Proper
 
         protected string PartialFolderPlaceholderString(params string[] pathParts)
         {
-            return $"{Path.Combine(pathParts)}{GVFSHelpers.PlaceholderFieldDelimiter}{PlaceholderTablePartialFolderPathType}{GVFSHelpers.PlaceholderFieldDelimiter}";
+            return $"{Path.Combine(pathParts)}{GVFSHelpers.PlaceholderFieldDelimiter}{PlaceholderTablePartialFolderPathType}{GVFSHelpers.PlaceholderFieldDelimiter}{TestConstants.PartialFolderPlaceholderDatabaseValue}{GVFSHelpers.PlaceholderFieldDelimiter}";
         }
 
         protected void ValidatePersistedVersionMatchesCurrentVersion()

--- a/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitHelpers.cs
@@ -91,7 +91,7 @@ namespace GVFS.FunctionalTests.Tools
                 IEnumerable<string> filteredErrorLines = errorLines.Where(line =>
                 {
                     if (string.IsNullOrWhiteSpace(line) ||
-                        (removeUpgradeMessages && line.StartsWith("A new version of GVFS is available.")) ||
+                        (removeUpgradeMessages && line.StartsWith("A new version of VFS for Git is available.")) ||
                         (removeWaitingMessages && line.StartsWith("Waiting for ")))
                     {
                         return false;

--- a/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/PlaceholderTableTests.cs
@@ -382,7 +382,7 @@ namespace GVFS.UnitTests.Common.Database
         public void AddPartialFolder()
         {
             this.TestPlaceholdersInsert(
-                placeholders => placeholders.AddPartialFolder(DefaultPath),
+                placeholders => placeholders.AddPartialFolder(DefaultPath, sha: null),
                 DefaultPath,
                 PathTypePartialFolder,
                 sha: null);
@@ -393,7 +393,7 @@ namespace GVFS.UnitTests.Common.Database
         public void AddPartialFolderThrowsGVFSDatabaseException()
         {
             GVFSDatabaseException ex = Assert.Throws<GVFSDatabaseException>(() => this.TestPlaceholdersInsert(
-                placeholders => placeholders.AddPartialFolder(DefaultPath),
+                placeholders => placeholders.AddPartialFolder(DefaultPath, sha: null),
                 DefaultPath,
                 PathTypePartialFolder,
                 sha: null,

--- a/GVFS/GVFS.UnitTests/Common/LegacyPlaceholderDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LegacyPlaceholderDatabaseTests.cs
@@ -87,7 +87,7 @@ namespace GVFS.UnitTests.Common
             using (LegacyPlaceholderListDatabase dut1 = CreatePlaceholderListDatabase(fs, string.Empty))
             {
                 dut1.AddFile(InputGitIgnorePath, InputGitIgnoreSHA);
-                dut1.AddPartialFolder("partialFolder");
+                dut1.AddPartialFolder("partialFolder", sha: null);
                 dut1.AddFile(InputGitAttributesPath, InputGitAttributesSHA);
                 dut1.AddExpandedFolder("expandedFolder");
                 dut1.AddFile(InputThirdFilePath, InputThirdFileSHA);

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -136,7 +136,7 @@ namespace GVFS.UnitTests.Virtualization
             mockPlaceholderDb.Setup(x => x.AddFile("test.txt", "1111122222333334444455555666667777788888")).Callback(() => ++filePlaceholderCount);
             mockPlaceholderDb.Setup(x => x.AddFile("test.txt", "2222233333444445555566666777778888899999")).Callback(() => ++filePlaceholderCount);
             mockPlaceholderDb.Setup(x => x.AddFile("test.txt", "3333344444555556666677777888889999900000")).Callback(() => ++filePlaceholderCount);
-            mockPlaceholderDb.Setup(x => x.AddPartialFolder("foo")).Callback(() => ++folderPlaceholderCount);
+            mockPlaceholderDb.Setup(x => x.AddPartialFolder("foo", null)).Callback(() => ++folderPlaceholderCount);
             mockPlaceholderDb.Setup(x => x.GetFilePlaceholdersCount()).Returns(() => filePlaceholderCount);
             mockPlaceholderDb.Setup(x => x.GetFolderPlaceholdersCount()).Returns(() => folderPlaceholderCount);
             Mock<ISparseCollection> mockSparseDb = new Mock<ISparseCollection>(MockBehavior.Strict);

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
@@ -1,9 +1,11 @@
-﻿using GVFS.Common.Git;
+﻿using GVFS.Common;
+using GVFS.Common.Git;
 using GVFS.Common.Tracing;
 using GVFS.Virtualization.BlobSize;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 
 namespace GVFS.Virtualization.Projection
@@ -46,6 +48,26 @@ namespace GVFS.Virtualization.Projection
                         FolderData folderData = (FolderData)this.ChildEntries[i];
                         folderData.Include();
                     }
+                }
+            }
+
+            public string HashedFileShas()
+            {
+                byte[] sha = new byte[20];
+                using (HashAlgorithm hash = SHA1.Create())
+                {
+                    for (int i = 0; i < this.ChildEntries.Count; i++)
+                    {
+                        if (!this.ChildEntries[i].IsFolder)
+                        {
+                            FileData fileData = (FileData)this.ChildEntries[i];
+                            fileData.Sha.ToBuffer(sha);
+                            hash.TransformBlock(sha, 0, 20, null, 0);
+                        }
+                    }
+
+                    hash.TransformFinalBlock(new byte[0], 0, 0);
+                    return SHA1Util.HexStringFromBytes(hash.Hash);
                 }
             }
 

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -1248,6 +1248,7 @@ namespace GVFS.Virtualization.Projection
                 int deleteFolderPlaceholderAttempted = 0;
                 int folderPlaceholdersDeleted = 0;
                 int folderPlaceholdersPathNotFound = 0;
+                int folderPlaceholdersShaUpdate = 0;
 
                 // A hash of the placeholders is only required if the platform expands directories
                 // This is using a in memory HashSet for speed in processing
@@ -1315,6 +1316,8 @@ namespace GVFS.Virtualization.Projection
                             string newFolderSha = folderData.HashedFileShas();
                             if (folderPlaceholder.Sha != newFolderSha)
                             {
+                                ++folderPlaceholdersShaUpdate;
+
                                 // Write and delete a file so USN journal will have the folder as being changed
                                 string tempFilePath = Path.Combine(this.context.Enlistment.WorkingDirectoryRoot, folderPlaceholder.Path, ".vfs_usn_folder_update.tmp");
                                 if (this.context.FileSystem.TryWriteAllText(tempFilePath, "TEMP FILE FOR USN FOLDER MODIFICATION"))
@@ -1359,7 +1362,8 @@ namespace GVFS.Virtualization.Projection
                     millisecondsWriteAndFlush,
                     deleteFolderPlaceholderAttempted,
                     folderPlaceholdersDeleted,
-                    folderPlaceholdersPathNotFound);
+                    folderPlaceholdersPathNotFound,
+                    folderPlaceholdersShaUpdate);
             }
         }
 


### PR DESCRIPTION
BuildXL was having issues detecting that a folder had changes when the projection changed because VFSForGit was simply updating its in memory projection and not doing anything with the file system that would trigger and update to the USN. It would hand back the new items in the directory when projfs would ask for the items for enumeration the next time an enumeration happened.

This change is to make the folder get a new USN when VFSForGit determines that a folder has changed.  This is done by keeping a SHA1 hash of all the SHAs of the files that are in the projection and when the projection changes calculate the new SHA for the folder and compare with what it had before.  If it changed then write and delete a file in the folder to trigger the USN update.

Something to note. We don't need any upgrade step because we are already storing the SHA for the folder in the placeholder database but it is currently `null` for all folders so the first time there is a projection change it will cause all the folders to get the calculated SHA for the folder and update the placeholder database. 

Todos:
- [x] Error handling
- [x] Functional tests
- [x] Check Memory and Performance
- [x] Give version to BuildXL to test with

