### PR TITLE
RepoRegistry: ignore non-existent repos

### DIFF
--- a/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/GetActiveRepoListHandler.cs
@@ -2,6 +2,7 @@ using GVFS.Common;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace GVFS.Service.Handlers
@@ -68,6 +69,11 @@ namespace GVFS.Service.Handlers
 
         private bool IsValidRepo(string repoRoot)
         {
+            if (!Directory.Exists(repoRoot))
+            {
+                return false;
+            }
+
             string gitBinPath = GVFSPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
 
             string hooksVersion = null;

--- a/GVFS/GVFS.Service/IRepoRegistry.cs
+++ b/GVFS/GVFS.Service/IRepoRegistry.cs
@@ -8,7 +8,7 @@ namespace GVFS.Service
         bool TryDeactivateRepo(string repoRoot, out string errorMessage);
         bool TryGetActiveRepos(out List<RepoRegistration> repoList, out string errorMessage);
         bool TryRemoveRepo(string repoRoot, out string errorMessage);
-        void AutoMountRepos(string userId, int sessionId);
+        void AutoMountRepos(string userId, int sessionId, bool checkDirectoryExists = true);
         void TraceStatus();
     }
 }

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -171,7 +171,7 @@ namespace GVFS.Service
             return false;
         }
 
-        public void AutoMountRepos(string userId, int sessionId)
+        public void AutoMountRepos(string userId, int sessionId, bool checkDirectoryExists = true)
         {
             using (ITracer activity = this.tracer.StartActivity("AutoMount", EventLevel.Informational))
             {
@@ -179,6 +179,11 @@ namespace GVFS.Service
                 foreach (RepoRegistration repo in activeRepos)
                 {
                     // TODO #1089: We need to respect the elevation level of the original mount
+                    if (checkDirectoryExists && !Directory.Exists(repo.EnlistmentRoot))
+                    {
+                        continue;
+                    }
+
                     if (!this.repoMounter.MountRepository(repo.EnlistmentRoot, sessionId))
                     {
                         this.SendNotification(

--- a/GVFS/GVFS.UnitTests/Service/Mac/MacServiceTests.cs
+++ b/GVFS/GVFS.UnitTests/Service/Mac/MacServiceTests.cs
@@ -1,7 +1,5 @@
 ﻿using GVFS.Common;
-using GVFS.Common.FileSystem;
 using GVFS.Common.NamedPipes;
-using GVFS.Platform.Mac;
 using GVFS.Service;
 using GVFS.Service.Handlers;
 using GVFS.UnitTests.Mock.Common;
@@ -38,7 +36,7 @@ namespace GVFS.UnitTests.Service.Mac
         public void ServiceStartTriggersAutoMountForCurrentUser()
         {
             Mock<IRepoRegistry> repoRegistry = new Mock<IRepoRegistry>(MockBehavior.Strict);
-            repoRegistry.Setup(r => r.AutoMountRepos(ExpectedActiveUserId.ToString(), ExpectedSessionId));
+            repoRegistry.Setup(r => r.AutoMountRepos(ExpectedActiveUserId.ToString(), ExpectedSessionId, true));
             repoRegistry.Setup(r => r.TraceStatus());
 
             GVFSService service = new GVFSService(
@@ -86,7 +84,7 @@ namespace GVFS.UnitTests.Service.Mac
                 repoMounterMock.Object,
                 null);
 
-            repoRegistry.AutoMountRepos(ExpectedActiveUserId.ToString(), ExpectedSessionId);
+            repoRegistry.AutoMountRepos(ExpectedActiveUserId.ToString(), ExpectedSessionId, checkDirectoryExists: false);
 
             repoMounterMock.VerifyAll();
         }


### PR DESCRIPTION
The 'gvfs mount' command will send a message over the named pipe to
deactivate a repo. This marks it with "IsActive = false" so we don't
try to mount it at service startup. However, a repo can be deleted
and then there is no way to send this message again.

Instead, ignore repositories where the enlistment root does not
exist. Don't remove it from the registry, since there may be a
subtle reason why it is not visible from the service (such as a
removed USB drive).

Resolves #1651.