### PR TITLE
Update Git to include v2.26.1

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20200402.1</GitPackageVersion>
+    <GitPackageVersion>2.20200414.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
Re-pushed to include the correct version number after pushing the `v2.26.1.vfs.1.1` tag.