### PR TITLE
ProjFSFilter: Be more robust to missing PowerShell

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -679,9 +679,16 @@ namespace GVFS.Platform.Windows
 
         private static ProcessResult GetProjFSOptionalFeatureStatus()
         {
-            return CallPowershellCommand(
-                "$var=(Get-WindowsOptionalFeature -Online -FeatureName " + OptionalFeatureName + ");  if($var -eq $null){exit " +
-                (int)ProjFSInboxStatus.NotInbox + "}else{if($var.State -eq 'Enabled'){exit " + (int)ProjFSInboxStatus.Enabled + "}else{exit " + (int)ProjFSInboxStatus.Disabled + "}}");
+            try
+            {
+                return CallPowershellCommand(
+                    "$var=(Get-WindowsOptionalFeature -Online -FeatureName " + OptionalFeatureName + ");  if($var -eq $null){exit " +
+                    (int)ProjFSInboxStatus.NotInbox + "}else{if($var.State -eq 'Enabled'){exit " + (int)ProjFSInboxStatus.Enabled + "}else{exit " + (int)ProjFSInboxStatus.Disabled + "}}");
+            }
+            catch (Exception)
+            {
+                return new ProcessResult(string.Empty, "Failed. Possible that powershell does not exist on system", 1);
+            }
         }
 
         private static EventMetadata CreateEventMetadata(Exception e = null)


### PR DESCRIPTION
A user had issues and we started a support line. Their diagnose log
had _thousands_ of service logs. These were all failing with this call
stack pointing to the method changed here:

```
System.ComponentModel.Win32Exception (0x80004005): The system cannot find the file specified
 at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at GVFS.Common.ProcessHelper.StartProcess(Process executingProcess)
    at GVFS.Common.ProcessHelper.Run(ProcessStartInfo processInfo, String errorMsgDelimeter, Object executionLock)
     at GVFS.Platform.Windows.ProjFSFilter.IsGVFSUpgradeSupported() in E:\\A\\_work\\822\\s\\GVFS\\GVFS.Platform.Windows\\ProjFSFilter.cs:line 371 
       at GVFS.Upgrader.InstallerPreRunChecker.IsGVFSUpgradeAllowed(String& consoleError) 
        at GVFS.Upgrader.InstallerPreRunChecker.TryRunPreUpgradeChecks(String& consoleError) 
          at GVFS.Service.ProductUpgradeTimer.TimerCallback(Object unusedState) in E:\\A\\_work\\822\\s\\GVFS\\GVFS.Service\\ProductUpgradeTimer.cs:line 168
```

The only explanation I can think of is that PowerShell is not
available on their system!