### PR TITLE
Update Git to v2.27.0

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20200420.2</GitPackageVersion>
+    <GitPackageVersion>2.20200601.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -667,7 +667,7 @@ namespace GVFS.Common.Git
 
         public Result MultiPackIndexRepack(string gitObjectDirectory, string batchSize)
         {
-            return this.InvokeGitAgainstDotGitFolder($"-c pack.threads=1 multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize} --no-progress");
+            return this.InvokeGitAgainstDotGitFolder($"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize} --no-progress");
         }
 
         public Process GetGitProcess(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, bool redirectStandardError, string gitObjectsDirectory)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetMixedTests.cs
@@ -79,19 +79,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        public void ResetMixedOnlyAddedThenCheckoutWithConflicts()
-        {
-            this.ValidateGitCommand("checkout " + GitRepoTests.ConflictTargetBranch);
-            this.ValidateGitCommand("reset --mixed HEAD~1");
-
-            // This will reset all the files except the files that were added
-            // and are untracked to make sure we error out with those using sparse-checkout
-            this.ValidateGitCommand("checkout -f");
-            this.ValidateGitCommand("checkout " + GitRepoTests.ConflictSourceBranch);
-            this.FilesShouldMatchCheckoutOfTargetBranch();
-        }
-
-        [TestCase]
         public void ResetMixedAndCheckoutFile()
         {
             this.ControlGitRepo.Fetch("FunctionalTests/20170602");

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -26,7 +26,7 @@ namespace GVFS.UnitTests.Maintenance
         private string ExpireCommand => $"multi-pack-index expire --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --no-progress";
         private string VerifyCommand => $"-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --no-progress";
         private string WriteCommand => $"-c core.multiPackIndex=true multi-pack-index write --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --no-progress";
-        private string RepackCommand => $"-c pack.threads=1 multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=2g --no-progress";
+        private string RepackCommand => $"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=2g --no-progress";
 
         [TestCase]
         public void PackfileMaintenanceIgnoreTimeRestriction()


### PR DESCRIPTION
See microsoft/git#271.

Updates necessary here:

* The `multi-pack-index` builtin started honoring `repack.packKeptObjects`, which is `false` by default. We want to repack the `.keep` pack because that is just the most-recent prefetch pack-file. We don't expire it, but we want to repack it.

* The `sparse-checkout` code changed some error messages and behavior, so the `reset --mixed` tests no longer reflect an exact behavior match to vanilla Git (without sparse-checkout). Since VFS for Git dynamically sparsifies, we can't exactly match the behavior in the control repo.