### PR TITLE
ProductUpgradeTimer: remove unacceptable Environment.Exit()

### DIFF
--- a/GVFS/GVFS.Service/ProductUpgradeTimer.cs
+++ b/GVFS/GVFS.Service/ProductUpgradeTimer.cs
@@ -223,21 +223,11 @@ namespace GVFS.Service
                         this.DisplayUpgradeAvailableToast(newerVersion.ToString());
                     }
                 }
-                catch (Exception ex) when (
-                    ex is IOException ||
-                    ex is UnauthorizedAccessException ||
-                    ex is NotSupportedException)
+                catch (Exception ex)
                 {
                     this.tracer.RelatedWarning(
                         CreateEventMetadata(ex),
                         "Exception encountered recording highest available version");
-                }
-                catch (Exception ex)
-                {
-                    this.tracer.RelatedError(
-                        CreateEventMetadata(ex),
-                        "Unhanlded exception encountered recording highest available version");
-                    Environment.Exit((int)ReturnCode.GenericError);
                 }
             }
         }


### PR DESCRIPTION
A user reported an issue via the Teams channel. Looking at the diagnose logs I saw that the user's `GVFS.Service` was restarting in a loop with an exception tracking down to this `Environment.Exit()` call.

It's completely unacceptable to exit here, as it kills the service and then it restarts. Better to have no upgrades than to let this continue.

The cause of this exception was a missing executable when checking `ProjFS.IsGVFSUpgradeSupported()`, which seems to call PowerShell. The only reason the stack would have a `Win32Exception` with "The system cannot find the file specified" is that `powershell.exe` is not on the `PATH`, which was fixed in #1658.