### PR TITLE
Docs: more troubleshooting and FAQs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,3 +32,40 @@ undergoing a rename to VFS for Git. While the rename is in progress, the
 code, protocol, built executables, and releases may still refer to the old
 GVFS name. See https://github.com/Microsoft/VFSForGit/projects/4 for the
 latest status of the rename effort.
+
+### Why only Windows? Wasn't there a macOS version coming?
+
+We were working hard to deliver a macOS version, and there are still many
+remnants of that effort in the codebase. We were heavily dependent upon the
+macOS KAUTH kernel extensions to provide equivalent functionality of ProjFS on
+Windows. Unfortunately, [Apple deprecated this feature in Catalina](https://developer.apple.com/support/kernel-extensions/).
+All of the recommended alternatives were either not appropriate for our
+scenario or were not fast enough.
+
+We transitioned our large repository strategy to focus on using
+[`git sparse-checkout`](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/)
+instead of filesystem virtualization. We then forked the VFS for Git
+codebase to create [Scalar](https://github.com/microsoft/scalar). Those
+investments in a cross-platform tool paid off since Scalar could launch
+quickly.
+
+### Why are you abandoning VFS for Git?
+
+We will continue supporting VFS for Git as long as there is a need for it.
+Through our experience, we have found that it is appropriate for only a very
+small number of extremely large repos. For instance, the Windows OS repository
+will depend on VFS for Git for the foreseeable future, and we will continue
+supporting them. This includes updating VFS for Git with new versions of Git.
+
+The basic issue with VFS for Git is that users who don’t know exactly what’s
+going on will frequently get into bad states, such as populating too much of
+their working directory or not properly enabling the ProjFS feature (this is
+a larger problem for users using older versions of Windows). The Windows OS
+team developed a lot of tribal knowledge for how to avoid known issues with
+VFS for Git.
+
+We prefer users adopting Scalar because that is where we are investing most
+of our engineering efforts. The system is simpler and has a better “offramp”
+onto core Git, if one decides that they want to get there. We are also
+investing in making the Git client do more of the heavy lifting and reducing
+how much is really a “Scalar” feature and how much is just a Git feature.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,55 @@ to actually perform the upgrade, if you wish.
 Common Issues
 -------------
 
+We are constantly improving VFS for Git to prevent known issues from
+reoccurring. Please make sure you are on the latest version using `gvfs upgrade`
+before raising an issue. Please also keep your version of Windows updated
+as that is the only way to get updates to the ProjFS filesystem driver.
+
+### TRY THIS FIRST: `gvfs repair`
+
+Some known issues can get your enlistment out of a bad state. Running
+`gvfs repair` will detect known issues and the output will mention if the
+issue is actionable or not. Then, `gvfs repair --confirm` will actually
+make the changes it thinks are necessary.
+
+If `gvfs repair` detects a problem but says it cannot fix the problem,
+then that's an excellent message to include when creating an issue.
+
+### TRY THIS NEXT: `gvfs unmount`, `gvfs mount`, or restart
+
+Sometimes the `GVFS.Mount` process gets in a bad state and simply needs to
+restart to auto-heal. Since VFS for Git also interacts directly with the
+ProjFS filesystem driver, sometimes a system restart can help.
+
+### Mismatched Git version
+
+**Symptom:** Enlistment fails to mount with an error such as
+
+```
+Warning: Installed git version <X> does not match supported version of <Y>
+```
+
+**Fix:** VFS for Git is tightly coupled to
+[a custom version of Git](https://github.com/microsoft/git). This error
+happens when the installed version of Git does not match the one that was
+included in the VFS for Git installer. Please download and install the
+matching version of Git from
+[the VFS for Git releases page](https://github.com/microsoft/vfsforgit/releases).
+
+### 404 Errors, or "The Git repository with name or identifier X does not exist..."
+
+If your `gvfs clone <url>` command fails with this error, then check if you
+can access `<url>` in a web browser. If you cannot see the repository in the
+web, then you do not have permissions to read that repository. These issues
+cannot be resolved by the VFS for Git team and must be done by your repository
+administrators.
+
+If you _can_ see the repository in the web, then likely you have a stale
+credential in your credential manager that needs updating. VFS for Git
+_should_ attempt to renew your credential. If it does not, then go to
+Windows Credential Manager and delete the Git credential for that URL.
+
 ### ProjFS Installation Issue
 
 **Symptoms:**
@@ -77,7 +126,8 @@ Check the value of `State:` in the output to see if inbox ProjFS is enabled.
     - `gvfs mount` repo
 
 If the above steps do not resolve the issue, and the user is on Windows
-Server, ensure they have the latest version of GVFS installed.
+Server, ensure they have
+[the latest version of GVFS installed](https://github.com/microsoft/vfsforgit/releases).
 
 ### Unable to Move/Rename directories inside GVFS repository.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,8 @@ as that is the only way to get updates to the ProjFS filesystem driver.
 
 ### TRY THIS FIRST: `gvfs repair`
 
-Some known issues can get your enlistment out of a bad state. Running
+Some known issues can get your enlistment into a bad state. Running
+
 `gvfs repair` will detect known issues and the output will mention if the
 issue is actionable or not. Then, `gvfs repair --confirm` will actually
 make the changes it thinks are necessary.


### PR DESCRIPTION
More progress towards #1665:

1. Add some troubleshooting steps from the private wiki and recent issues.
2. Add FAQs around macOS port and Scalar.

The release process needs to be documented, but it includes private info so that will happen in a private repo.