### PR TITLE
[HOTFIX] ProductUpgrader: be extra careful about a copy loop

### DIFF
--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -183,7 +183,7 @@ namespace GVFS.Common
                 // directory causes a cycle(at some point we start copying C:\Program Files\GVFS\ProgramData\GVFS.Upgrade
                 // and its contents into C:\Program Files\GVFS\ProgramData\GVFS.Upgrade\Tools). The exclusion below is
                 // added to avoid this loop.
-               HashSet<string> directoriesToExclude = new HashSet<string>();
+               HashSet<string> directoriesToExclude = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 string secureDataRoot = GVFSPlatform.Instance.GetSecureDataRootForGVFS();
                 directoriesToExclude.Add(secureDataRoot);

--- a/GVFS/GVFS.Common/ProductUpgrader.cs
+++ b/GVFS/GVFS.Common/ProductUpgrader.cs
@@ -184,7 +184,14 @@ namespace GVFS.Common
                 // and its contents into C:\Program Files\GVFS\ProgramData\GVFS.Upgrade\Tools). The exclusion below is
                 // added to avoid this loop.
                HashSet<string> directoriesToExclude = new HashSet<string>();
-                directoriesToExclude.Add(GVFSPlatform.Instance.GetSecureDataRootForGVFS());
+
+                string secureDataRoot = GVFSPlatform.Instance.GetSecureDataRootForGVFS();
+                directoriesToExclude.Add(secureDataRoot);
+                directoriesToExclude.Add(upgradeApplicationDirectory);
+
+                this.tracer.RelatedInfo($"Copying contents of '{currentPath}' to '{upgradeApplicationDirectory}',"
+                                        + $"excluding '{upgradeApplicationDirectory}' and '{secureDataRoot}'");
+
                 this.fileSystem.CopyDirectoryRecursive(currentPath, upgradeApplicationDirectory, directoriesToExclude);
             }
             catch (UnauthorizedAccessException e)


### PR DESCRIPTION
The `ProductUpgrader` makes a backup of the `C:\Program Files\GVFS` folder before running the install, as a mechanism for backing out a failed upgrade. However, it copies that data into `C:\Program Files\GVFS\ProgramData\GVFS.Upgrade\Tools`, which can create a copy loop! This affected an actual user.

I'm not sure why this affects that one user but not another. In addition to adding more defensive programming (adding the target of the copy to the list of exclusions), I also added some extra tracing so we can see how these strings differ on this machine.

See #1672 for the master PR.