### PR TITLE
Config: disable status.submoduleSummary

### DIFF
--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -300,7 +300,12 @@ namespace GVFS.CommandLine
 
                 // Configure git to use our serialize status file - make git use the serialized status file rather than compute the status by
                 // parsing the index file and going through the files to determine changes.
-                { "status.deserializePath", gitStatusCachePath }
+                { "status.deserializePath", gitStatusCachePath },
+
+                // The GVFS Protocol forbids submodules, so prevent a user's
+                // global config of "status.submoduleSummary=true" from causing
+                // extreme slowness in "git status"
+                { "status.submoduleSummary", "false" },
             };
 
             if (!TrySetConfig(enlistment, requiredSettings, isRequired: true))


### PR DESCRIPTION
The GVFS protocol does not support submodules, so disable the
status.submoduleSummary config setting. A user had this enabled
in their global config, but that caused "git status" to be much
slower. When enabled, this runs two "git submodule" subprocesses,
which are very slow.

I investigated disabling these subprocesses in Git when the repo
has no submodules, but it needs to run the processes to check for
untracked submodules. Thus, there is no efficient way to detect
that submodules exist or not in advance.