### PR TITLE
PreCommandHook: don't lock pack-objects

### DIFF
--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -347,6 +347,7 @@ namespace GVFS.Hooks
                 case "merge-base":
                 case "multi-pack-index":
                 case "name-rev":
+                case "pack-objects":
                 case "push":
                 case "remote":
                 case "rev-list":
@@ -362,7 +363,7 @@ namespace GVFS.Hooks
                     return false;
 
                 /*
-                 * There are several git commands that are "unsupoorted" in virtualized (VFS4G)
+                 * There are several git commands that are "unsupported" in virtualized (VFS4G)
                  * enlistments that are blocked by git. Usually, these are blocked before they acquire
                  * a GVFSLock, but the submodule command is different, and is blocked after acquiring the
                  * GVFS lock. This can cause issues if another action is attempting to create placeholders.


### PR DESCRIPTION
We have a short list of Git commands that are known to be safe to run in parallel because they do not update the index. This list did not include `git pack-objects`. This is blocking some legitimate use of the tool.