### PR TITLE
[Release] BuildGVFSForWindows.bat: use nuget on PATH when possible

### DIFF
--- a/MirrorProvider/Scripts/Windows/Build.bat
+++ b/MirrorProvider/Scripts/Windows/Build.bat
@@ -4,10 +4,9 @@ SET SRC=%~dp0\..\..\..
 SET ROOT=%SRC%\..
 SET SLN=%SRC%\MirrorProvider\MirrorProvider.sln
 
-SET nuget="%ROOT%\.tools\nuget.exe"
-IF NOT EXIST %nuget% (
-  mkdir %nuget%\..
-  powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %nuget%"
+FOR /F "tokens=* USEBACKQ" %%F IN (`where nuget.exe`) DO (
+	SET nuget=%%F
+	ECHO Found nuget.exe at '%%F'
 )
 
 %nuget% restore %SLN%

--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,7 @@ If you'd like to build your own VFS for Git Windows installer:
     * .NET Core runtime
     * Windows 10 SDK (10.0.10240.0)
 * Install the .NET Core 2.1 SDK (https://www.microsoft.com/net/download/dotnet-core/2.1)
+* Install [`nuget.exe`](https://www.nuget.org/downloads)
 * Create a folder to clone into, e.g. `C:\Repos\VFSForGit`
 * Clone this repo into the `src` subfolder, e.g. `C:\Repos\VFSForGit\src`
 * Run `\src\Scripts\BuildGVFSForWindows.bat`

--- a/Scripts/BuildGVFSForWindows.bat
+++ b/Scripts/BuildGVFSForWindows.bat
@@ -8,10 +8,14 @@ IF "%2"=="" (SET "GVFSVersion=0.2.173.2") ELSE (SET "GVFSVersion=%2")
 
 SET SolutionConfiguration=%Configuration%.Windows
 
-SET nuget="%VFS_TOOLSDIR%\nuget.exe"
+FOR /F "tokens=* USEBACKQ" %%F IN (`where nuget.exe`) DO (
+	SET nuget=%%F
+	ECHO Found nuget.exe at '%%F'
+)
+
 IF NOT EXIST %nuget% (
-  mkdir %nuget%\..
-  powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %nuget%"
+	ECHO ERROR: Could not find nuget.exe on the PATH
+	exit /b 10
 )
 
 :: Acquire vswhere to find dev15 installations reliably.
@@ -27,7 +31,7 @@ IF NOT EXIST "c:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0" (
 
 :: Use vswhere to find the latest VS installation with the msbuild component.
 :: See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
-for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Workload.NetCoreTools Microsoft.Net.Core.Component.SDK.2.1 -find MSBuild\**\Bin\amd64\MSBuild.exe`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.Net.Core.Component.SDK.2.1 -find MSBuild\**\Bin\amd64\MSBuild.exe`) do (
  set msbuild="%%i"
 )
 

--- a/Scripts/RestorePackages.bat
+++ b/Scripts/RestorePackages.bat
@@ -7,10 +7,9 @@ IF "%1"=="" (SET "Configuration=Debug") ELSE (SET "Configuration=%1")
  
 SET SolutionConfiguration=%Configuration%.Windows
 
-SET nuget="%VFS_TOOLSDIR%\nuget.exe"
-IF NOT EXIST %nuget% (
-  mkdir %nuget%\..
-  powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %nuget%"
+FOR /F "tokens=* USEBACKQ" %%F IN (`where nuget.exe`) DO (
+	SET nuget=%%F
+	ECHO Found nuget.exe at '%%F'
 )
 
 dotnet restore %VFS_SRCDIR%\GVFS.sln /p:Configuration=%SolutionConfiguration% /p:VCTargetsPath="C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140" --packages %VFS_PACKAGESDIR% || exit /b 1


### PR DESCRIPTION
Our release build is failing because we cannot download nuget due to TLS
1.2 changes. But we already require nuget.exe in an earlier step of the
build.

Require nuget.exe to be on the PATH, and update Readme.me accordingly.