### PR TITLE
GVFS.SignFiles.csproj: include more DLLs for signing

### DIFF
--- a/GVFS/GVFS.SignFiles/GVFS.SignFiles.csproj
+++ b/GVFS/GVFS.SignFiles/GVFS.SignFiles.csproj
@@ -48,7 +48,11 @@
       $(BuildOutputDir)\GVFS.VirtualFileSystemHook.Windows\bin\$(Platform)\$(Configuration)\GVFS.VirtualFileSystemHook.exe;
       $(BuildOutputDir)\GVFS.PostIndexChangedHook.Windows\bin\$(Platform)\$(Configuration)\GVFS.PostIndexChangedHook.exe;
       $(BuildOutputDir)\GVFS.Upgrader\bin\$(Platform)\$(Configuration)\net461\GVFS.Upgrader.exe;
-      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.exe;">
+      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.exe;
+      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.Common.dll;
+      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.GvFlt.dll;
+      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.Platform.Windows.dll;
+      $(BuildOutputDir)\GVFS.Windows\bin\$(Platform)\$(Configuration)\GVFS.Virtualization.dll;">
       <Authenticode>Microsoft400</Authenticode>
       <InProject>false</InProject>
     </FilesToSign>


### PR DESCRIPTION
It appears that during our build, we send some DLLs for signing, but the
versions we send have already been copied to other projects. Thus, we
ship versions of those DLLs that are unsigned.

Add extra versions of the DLLs that are currently being signed, except
include them in the GVFS.Windows project that is likely where they are
being copied as part of the build.