### PR TITLE
Update Git to include GCM Core update

### DIFF
--- a/GVFS/GVFS.Build/GVFS.props
+++ b/GVFS/GVFS.Build/GVFS.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <GVFSVersion>0.2.173.2</GVFSVersion>
-    <GitPackageVersion>2.20201020.1</GitPackageVersion>
+    <GitPackageVersion>2.20201209.2</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
This actually updates to a better build:

1. It has a new tag `v2.29.0.vfs.0.1`.
2. It was created after `git-for-windows/build-extra` updated with the new GCM Core package.