### PR TITLE
Add dismount command line option...

### DIFF
--- a/GVFS/GVFS/CommandLine/DismountVerb.cs
+++ b/GVFS/GVFS/CommandLine/DismountVerb.cs
@@ -1,0 +1,10 @@
+﻿using CommandLine;
+
+namespace GVFS.CommandLine
+{
+    [Verb(DismountVerb.DismountVerbName, HelpText = "Dismount a GVFS virtual repo")]
+    public class DismountVerb: UnmountVerb
+    {
+        private const string DismountVerbName = "dismount";
+    }
+}

--- a/GVFS/GVFS/GVFS.Windows.csproj
+++ b/GVFS/GVFS/GVFS.Windows.csproj
@@ -127,6 +127,7 @@
     <Compile Include="CommandLine\MountVerb.cs" />
     <Compile Include="CommandLine\PrefetchVerb.cs" />
     <Compile Include="CommandLine\SparseVerb.cs" />
+    <Compile Include="CommandLine\DismountVerb.cs" />
     <Compile Include="CommandLine\UpgradeVerb.cs" />
     <Compile Include="RepairJobs\BackgroundOperationDatabaseRepairJob.cs" />
     <Compile Include="RepairJobs\BlobSizeDatabaseRepairJob.cs" />

--- a/GVFS/GVFS/Program.cs
+++ b/GVFS/GVFS/Program.cs
@@ -26,6 +26,7 @@ namespace GVFS
                 typeof(ConfigVerb),
                 typeof(DehydrateVerb),
                 typeof(DiagnoseVerb),
+                typeof(DismountVerb),
                 typeof(LogVerb),
                 typeof(SparseVerb),
                 typeof(MountVerb),


### PR DESCRIPTION
This addresses issue #1708 by simply adding a dismount verb that derives from "unmount" to add "dismount" to the command line options thereby making the command line options more friendly to use for those who prefer the English correct "dismount" to "unmount".

