### PR TITLE
Adding winget workflow

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -1,0 +1,41 @@
+name: "release-winget"
+on:
+  release:
+    types: [released]
+  push:
+    branches:
+      - ldennington/add-release-workflow
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - id: update-winget
+      name: Update winget repository
+      uses: mjcheetham/update-winget@v1.1
+      with:
+        id: Microsoft.VFSforGit
+        token: ${{ secrets.WINGET_TOKEN }}   
+        releaseAsset: SetupGVFS.([0-9.]*)\.exe
+        repo: ldennington/winget-playground
+        manifestText: |
+          PackageIdentifier: {{id}}
+          PackageVersion: {{version}}
+          PackageName: VFS for Git
+          Publisher: Microsoft Corporation
+          Moniker: vfs-for-git
+          PackageUrl: https://aka.ms/vfs-for-git
+          Tags: [ "vfs for git", "vfs-for-git", "vfsforgit", "gvfs" ]
+          License: Copyright (C) Microsoft Corporation
+          ShortDescription: Virtual File System for Git - a tool to scale Git for monorepo scenarios.
+          Installers:
+          - Architecture: x64
+            InstallerUrl: {{url}}
+            InstallerType: inno
+            InstallerSha256: {{sha256}}
+          PackageLocale: en-US
+          ManifestType: singleton
+          ManifestVersion: 1.0.0
+        alwaysUsePullRequest: true
+        releaseRepo: 'microsoft/VFSForGit'
+        releaseTag: 'v1.0.21085.9'

--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -2,9 +2,6 @@ name: "release-winget"
 on:
   release:
     types: [released]
-  push:
-    branches:
-      - ldennington/add-release-workflow
 
 jobs:
   release:
@@ -12,12 +9,11 @@ jobs:
     steps:
     - id: update-winget
       name: Update winget repository
-      uses: mjcheetham/update-winget@v1.1
+      uses: mjcheetham/update-winget@v1.2
       with:
         id: Microsoft.VFSforGit
         token: ${{ secrets.WINGET_TOKEN }}   
         releaseAsset: SetupGVFS.([0-9.]*)\.exe
-        repo: ldennington/winget-playground
         manifestText: |
           PackageIdentifier: {{id}}
           PackageVersion: {{version}}
@@ -37,5 +33,3 @@ jobs:
           ManifestType: singleton
           ManifestVersion: 1.0.0
         alwaysUsePullRequest: true
-        releaseRepo: 'microsoft/VFSForGit'
-        releaseTag: 'v1.0.21085.9'


### PR DESCRIPTION
Adding a shiny new workflow to publish releases to winget! 🥳

I validated this workflow locally by successfully opening a [PR](https://github.com/ldennington/winget-playground/pull/6) against my winget-playground repo and running `winget validate` to ensure the generated manifest adheres to winget's required schema. Any feedback on the fields I've included or suggestions for additional fields/values are welcome!