### PR TITLE
Fix winget tag specification

### DIFF
--- a/.github/workflows/release-winget.yaml
+++ b/.github/workflows/release-winget.yaml
@@ -21,7 +21,11 @@ jobs:
           Publisher: Microsoft Corporation
           Moniker: vfs-for-git
           PackageUrl: https://aka.ms/vfs-for-git
-          Tags: [ "vfs for git", "vfs-for-git", "vfsforgit", "gvfs" ]
+          Tags:
+          - vfs for git
+          - vfs-for-git
+          - vfsforgit
+          - gvfs
           License: Copyright (C) Microsoft Corporation
           ShortDescription: Virtual File System for Git - a tool to scale Git for monorepo scenarios.
           Installers:


### PR DESCRIPTION
According to a [recent PR](https://github.com/microsoft/winget-pkgs/pull/18410), the recommended format for winget tags has changed. Updating our manifest according to the new specification.