### PR TITLE
"winget install microsoft-git" finds entries in msstore

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ To install, use [`winget`](https://github.com/microsoft/winget) to install the
 using:
 
 ```
-winget install microsoft-git
+winget install -s winget microsoft-git
 winget install gvfs
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -29,8 +29,8 @@ To install, use [`winget`](https://github.com/microsoft/winget) to install the
 using:
 
 ```
-winget install -s winget microsoft-git
-winget install gvfs
+winget install --id Microsoft.Git
+winget install --id Microsoft.VFSforGit
 ```
 
 You will need to continue using the `microsoft/git` version of Git, and it


### PR DESCRIPTION
To address this: using the id parameter we can make sure it will always install this package.

Original Content:
Adding the source parameter will make sure that the install command will actually install from winget