### PR TITLE
*.csproj: update MicroBuild package names

### DIFF
--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" ExcludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Installers/GVFS.Installers.csproj
+++ b/GVFS/GVFS.Installers/GVFS.Installers.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Tools.InnoSetup" Version="5.5.9" />
     <PackageReference Include="GitForWindows.GVFS.Installer" Version="$(GitPackageVersion)" />
     <PackageReference Include="GitForWindows.GVFS.Portable" Version="$(GitPackageVersion)" />
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" ExcludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Payload/GVFS.Payload.csproj
+++ b/GVFS/GVFS.Payload/GVFS.Payload.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="GVFS.ProjFS" Version="2019.411.1" />
     <PackageReference Include="GVFS.VCRuntime" Version="0.2.0-build" />
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" ExcludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Necessary for new singing build changes.

See [this GCM PR](https://github.com/GitCredentialManager/git-credential-manager/pull/533) for a similar change.