### PR TITLE
file.Delete() if file.Exists

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -27,7 +27,10 @@ namespace GVFS.Common.FileSystem
                 foreach (FileInfo file in directory.GetFiles())
                 {
                     file.Attributes = FileAttributes.Normal;
-                    file.Delete();
+                    if(file.Exists)
+                    {
+                        file.Delete();
+                    }
                 }
 
                 foreach (DirectoryInfo subDirectory in directory.GetDirectories())


### PR DESCRIPTION
If some other process is deleting files at the same time, this fails the entire operation even though the intended action of files to be deleted has been successful.