### PR TITLE
dependencies: resolve dependabot alerts

### DIFF
--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.278" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,13 +18,11 @@
 
   <Target Name="_GenerateConstantsFile" BeforeTargets="BeforeCompile">
     <!-- Generate GVFS constants file with the minimum Git version -->
-    <GenerateGVFSConstants MinimumGitVersion="$(MinimumGitVersion)"
-                           LibGit2FileName="$(libgit2_filename)"
-                           OutputFile="$(IntermediateOutputPath)GVFSConstants.g.cs" />
+    <GenerateGVFSConstants MinimumGitVersion="$(MinimumGitVersion)" LibGit2FileName="$(libgit2_filename)" OutputFile="$(IntermediateOutputPath)GVFSConstants.g.cs" />
     <!-- Add the generated file to the list of file writes for MSBuild to keep track of for clean-up -->
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)GVFSConstants.g.cs" />
-      <FileWrites Include="$(IntermediateOutputPath)GVFSConstants.g.cs"/>
+      <FileWrites Include="$(IntermediateOutputPath)GVFSConstants.g.cs" />
     </ItemGroup>
   </Target>
 

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
-    <PackageReference Include="NuGet.Commands" Version="4.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.278" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="Microsoft.Database.Collections.Generic" Version="1.9.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
   </ItemGroup>
 

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="Microsoft.Database.Collections.Generic" Version="1.9.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
   </ItemGroup>

--- a/GVFS/GVFS.GVFlt/GVFS.GVFlt.csproj
+++ b/GVFS/GVFS.GVFlt/GVFS.GVFlt.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/GVFS/GVFS.Service/GVFS.Service.csproj
+++ b/GVFS/GVFS.Service/GVFS.Service.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Service/GVFS.Service.csproj
+++ b/GVFS/GVFS.Service/GVFS.Service.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 

--- a/GVFS/GVFS.Virtualization/GVFS.Virtualization.csproj
+++ b/GVFS/GVFS.Virtualization/GVFS.Virtualization.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade/remove the following packages to resolve dependabot alerts:

1. `NuGet.Commands`
2. `Newtonsoft.Json`
3. `SharpZipLib`