### PR TITLE
index-parser: get the time in a cheaper way

### DIFF
--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.GitIndexParser.cs
@@ -238,8 +238,8 @@ namespace GVFS.Virtualization.Projection
                 uint entryCount = this.ReadFromIndexHeader();
 
                 // Don't want to flood the logs on large indexes so only log every 500ms
-                const int LoggingTicksThreshold = 5000000;
-                long nextLogTicks = DateTime.UtcNow.Ticks + LoggingTicksThreshold;
+                const int LoggingTicksThreshold = 500;
+                int nextLogTicks = Environment.TickCount + LoggingTicksThreshold;
 
                 SortedFolderEntries.InitializePools(tracer, entryCount);
                 LazyUTF8String.InitializePools(tracer, entryCount);
@@ -329,10 +329,11 @@ namespace GVFS.Virtualization.Projection
                         return result;
                     }
 
-                    if (DateTime.UtcNow.Ticks > nextLogTicks)
+                    int curTicks = Environment.TickCount;
+                    if (curTicks - nextLogTicks > 0)
                     {
                         tracer.RelatedInfo($"{i}/{entryCount} index entries parsed.");
-                        nextLogTicks = DateTime.UtcNow.Ticks + LoggingTicksThreshold;
+                        nextLogTicks = curTicks + LoggingTicksThreshold;
                     }
                 }
 


### PR DESCRIPTION
DateTime.UtcNow spends a lot of time getting a very precise system time, including leap seconds and interpolation through
QueryPerformanceCounter.

Use Environment.TickCount (milliseconds since boot) instead, since that just retrieves a value in shared memory that the kernel keeps up to date. This value is still suitable for controlling how much log output index parsing produces.

This UtcNow call consumes 15% of the time under GitIndexParser.ParseIndex.

See the UtcNow implementation at:
See https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/DateTime.Windows.cs.