### PR TITLE
fix: #1802 confirm cached credential before rejecting

### DIFF
--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -5,6 +5,7 @@ using GVFS.UnitTests.Mock.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace GVFS.UnitTests.Mock.Git
@@ -91,7 +92,7 @@ namespace GVFS.UnitTests.Mock.Git
                 return new Result(string.Empty, string.Empty, Result.GenericFailureCode);
             }
 
-            Predicate<CommandInfo> commandMatchFunction =
+            Func<CommandInfo, bool> commandMatchFunction =
                 (CommandInfo commandInfo) =>
                 {
                     if (commandInfo.MatchPrefix)
@@ -104,7 +105,7 @@ namespace GVFS.UnitTests.Mock.Git
                     }
                 };
 
-            CommandInfo matchedCommand = this.expectedCommandInfos.Find(commandMatchFunction);
+            CommandInfo matchedCommand = this.expectedCommandInfos.Last(commandMatchFunction);
             matchedCommand.ShouldNotBeNull("Unexpected command: " + command);
 
             return matchedCommand.Result();


### PR DESCRIPTION
**Issue**
When GCM is in OAuth mode, rejecting the credential is equivalent to a sign-out request, which means the next attempt to get a credential will always cause a pop-up. See #1802 

** Changes **
Before rejecting a credential try getting the credential from GCM again.
If GCM still returns the same credential, then tell GCM to reject it.
If GCM returns a different credential, don't attempt to reject the previous one - just return and let the caller try the new credential instead.