### PR TITLE
Point GVFS.Service to the correct executable when C:\Program exists

### DIFF
--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -221,8 +221,12 @@ begin
   WizardForm.StatusLabel.Caption := 'Installing GVFS.Service.';
   WizardForm.ProgressGauge.Style := npbstMarquee;
 
+  // Spaces after the equal signs are REQUIRED.
+  // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
-    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath="{app}\GVFS.Service.exe" start=auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
+    // We must add additional quotes to the binPath to ensure that they survive argument parsing.
+    // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
+    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       begin
         if Exec(ExpandConstant('{sys}\SC.EXE'), 'failure GVFS.Service reset= 30 actions= restart/10/restart/5000//1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
           begin


### PR DESCRIPTION
An issue was reported to our team where someone was unable to `gvfs clone` a repo. The error message they received was `Could not execute 'C:\Program Files\GVFS\GVFS.Hooks.exe'. CreateProcess error (193)`.
 
After investigation, we discovered that GVFS.Service was stopped and could not be started with the same error. Eventually, we root-caused it to a rogue `C:\Program` file. When this file was deleted, GVFS.Service started up and the repo clone succeeded.
 
To properly resolve paths with spaces in them, quotes must be added. The installer already attempted to do this, but the quotes it added around the `binPath` would get stripped away during argument parsing.
Adding another set of quotes properly retains the quotes until it gets to sc.exe.
 
Without this change, the "path to executable" is not quoted:
![path-to-executable-unquoted](https://github.com/microsoft/VFSForGit/assets/2766036/4e55e042-838b-46bf-865f-775620a542fc)
 
With this change, the path is now quoted:
![path-to-executable-quoted](https://github.com/microsoft/VFSForGit/assets/2766036/64aa7b79-c82b-41e8-b350-18b3c0bb14b9)

This is consistent with other services that run out of paths with spaces in them, e.g. Logi Options+, Visual Studio Installer Elevation.
 
**Validation**
1. Stop GVFS.Service.
2. In an admin PowerShell window, `New-Item -Path C:\Program -ItemType File`.
3. Attempt to start GVFS.Service. This should fail.
4. Attempt to clone a GVFS repo. This should fail.
5. Delete the file.
6. Uninstall VFS for Git.
7. Add back the file.
8. Attempt to install a version that has the quotes fix. This should succeed.
10. Attempt to clone a GVFS repo. This should succeed.