### PR TITLE
Revert "GVFSVerb: Use OAuth credentials by default"

### DIFF
--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -312,11 +312,6 @@ namespace GVFS.CommandLine
 
                 // Disable the builtin FS Monitor in case it was enabled globally.
                 { "core.useBuiltinFSMonitor", "false" },
-
-                // Set the GCM credential method to use OAuth tokens.
-                // See https://github.com/git-ecosystem/git-credential-manager/blob/release/docs/configuration.md#credentialazreposcredentialtype
-                // for more information.
-                { "credential.azreposCredentialType", "oauth" },
             };
 
             if (!TrySetConfig(enlistment, requiredSettings, isRequired: true))


### PR DESCRIPTION
This reverts commit cbd0cefb9cc87744286fde23632860354f5c62ee. This commit was introduced in #1803 based on a comment I made recommending "faster adoption" but that was a mistake. When the release was shipped to `winget` yesterday, this led to breaks in some pipeline environments.

Using this authentication mode by default is breaking some automated scenarios on build agents that use "gvfs clone". Removing the new default is a fast measure to fix these users, while a longer-term consideration for increasing adoption of OAuth can be done at a later date with the proper parties engaged.