### PR TITLE
Update dependencies

### DIFF
--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />
   </ItemGroup>
 

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.278" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />

--- a/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
+++ b/GVFS/GVFS.FunctionalTests.LockHolder/GVFS.FunctionalTests.LockHolder.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Installers/GVFS.Installers.csproj
+++ b/GVFS/GVFS.Installers/GVFS.Installers.csproj
@@ -12,7 +12,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tools.InnoSetup" Version="5.5.9" />
+    <PackageReference Include="Tools.InnoSetup" Version="6.2.1" />
     <PackageReference Include="GitForWindows.GVFS.Installer" Version="$(GitPackageVersion)" />
     <PackageReference Include="GitForWindows.GVFS.Portable" Version="$(GitPackageVersion)" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />

--- a/GVFS/GVFS.Mount/GVFS.Mount.csproj
+++ b/GVFS/GVFS.Mount/GVFS.Mount.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
   </ItemGroup>
 
 </Project>

--- a/GVFS/GVFS/GVFS.csproj
+++ b/GVFS/GVFS/GVFS.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Version.props
+++ b/Version.props
@@ -18,7 +18,7 @@
        including taking version numbers 2.X.Y from upstream and updating .W if we have any
        hotfixes to microsoft/git.
     -->
-    <GitPackageVersion>2.20211115.1</GitPackageVersion>
+    <GitPackageVersion>2.20220414.4</GitPackageVersion>
     <MinimumGitVersion>v2.31.0.vfs.0.1</MinimumGitVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
In reaction to Component Detection pointing out two more issues where dependencies are missing legal information, this PR updates the dependencies (all of them, including the two pointed out by Component Detection) to their latest stable versions.

This includes updating the InnoSetup dependency to a newer version, the LibGit2Sharp dependency to a newer version, and all remaining dependencies to their latest stable versions.


