### PR TITLE
Handle nested failures in HttpRequestException

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# especially
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,25 +42,25 @@ jobs:
       run: src\scripts\CreateBuildArtifacts.bat ${{ matrix.configuration }} artifacts
 
     - name: Upload functional tests drop
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FunctionalTests_${{ matrix.configuration }}
         path: artifacts\GVFS.FunctionalTests
 
     - name: Upload FastFetch drop
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FastFetch_${{ matrix.configuration }}
         path: artifacts\FastFetch
 
     - name: Upload installers
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Installers_${{ matrix.configuration }}
         path: artifacts\GVFS.Installers
 
     - name: Upload NuGet packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: NuGetPackages_${{ matrix.configuration }}
         path: artifacts\NuGetPackages
@@ -76,13 +76,13 @@ jobs:
 
     steps:
     - name: Download installers
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: Installers_${{ matrix.configuration }}
         path: install
 
     - name: Download functional tests drop
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: FunctionalTests_${{ matrix.configuration }}
         path: ft
@@ -101,7 +101,7 @@ jobs:
 
     - name: Upload installation logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: InstallationLogs_${{ matrix.configuration }}
         path: install\logs
@@ -115,14 +115,14 @@ jobs:
 
     - name: Upload functional test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FunctionalTests_Results_${{ matrix.configuration }}
         path: TestResult.xml
 
     - name: Upload Git trace2 output
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: GitTrace2_${{ matrix.configuration }}
         path: C:\temp\git-trace2.log


### PR DESCRIPTION
`HttpClientHandler` will automatically resubmit an HTTP request that fails in certain circumstances. One such circumstance is when `UseDefaultCredentials` is set to true, alternative credentials were provided on the request, and the request failed with 401 Unauthorized, then it will resubmit using the default credentials. If an exception is thrown when getting the default credentials that exception is not handled, but is wrapped in HttpRequestExceptionand thrown by `SendAsync` instead of returning the original response with the failing status code. [Source](https://referencesource.microsoft.com/#System/net/System/Net/HttpWebRequest.cs,5535)

When this happens in GVFS, the result is that GVFS does not recognize the failure as being authentication related, so it does not refresh the credential. Instead, it loops through all its retries, and eventually fails the request. This is typically visible to users as a file system exception (e.g. file not found) if the GVFS trigger was accessing a virtual file or other operation on an individual file, or various errors (including "this repository requires the GVFS protocol") for a git pull. The symptoms will continue for the user until they remount the GVFS enlistment, which forces GVFS to refresh its credential.

This pull request adds an exception handler for HttpRequestException to `client.SendAsync`, which attempts to find the original failed response embedded in the inner exception properties. If it does so, it logs a warning and continues processing using the original failed response, which will trigger the logic for handling the various possible status codes. If it can't extract the original failed response, then it will let the exception bubble up.