### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# especially
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,25 +42,25 @@ jobs:
       run: src\scripts\CreateBuildArtifacts.bat ${{ matrix.configuration }} artifacts
 
     - name: Upload functional tests drop
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FunctionalTests_${{ matrix.configuration }}
         path: artifacts\GVFS.FunctionalTests
 
     - name: Upload FastFetch drop
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FastFetch_${{ matrix.configuration }}
         path: artifacts\FastFetch
 
     - name: Upload installers
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Installers_${{ matrix.configuration }}
         path: artifacts\GVFS.Installers
 
     - name: Upload NuGet packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: NuGetPackages_${{ matrix.configuration }}
         path: artifacts\NuGetPackages
@@ -76,13 +76,13 @@ jobs:
 
     steps:
     - name: Download installers
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: Installers_${{ matrix.configuration }}
         path: install
 
     - name: Download functional tests drop
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: FunctionalTests_${{ matrix.configuration }}
         path: ft
@@ -101,7 +101,7 @@ jobs:
 
     - name: Upload installation logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: InstallationLogs_${{ matrix.configuration }}
         path: install\logs
@@ -115,14 +115,14 @@ jobs:
 
     - name: Upload functional test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FunctionalTests_Results_${{ matrix.configuration }}
         path: TestResult.xml
 
     - name: Upload Git trace2 output
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: GitTrace2_${{ matrix.configuration }}
         path: C:\temp\git-trace2.log


### PR DESCRIPTION
I just noticed that the PR build of https://github.com/microsoft/VFSForGit/pull/1816 failed because of the `actions/upload-artifact@v2` problem I had encountered elsewhere already. The fix is easy: update to the latest version.