### PR TITLE
Allow mounting on ReFS volumes

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -378,14 +378,14 @@ namespace GVFS.Platform.Windows
 
             string pathRoot = Path.GetPathRoot(normalizedEnlistmentRootPath);
             DriveInfo rootDriveInfo = DriveInfo.GetDrives().FirstOrDefault(x => x.Name == pathRoot);
-            string requiredFormat = "NTFS";
+            string[] requiredFormats = new[] { "NTFS", "ReFS" };
             if (rootDriveInfo == null)
             {
-                warning = $"Unable to ensure that '{normalizedEnlistmentRootPath}' is an {requiredFormat} volume.";
+                warning = $"Unable to ensure that '{normalizedEnlistmentRootPath}' is an {string.Join(" or ", requiredFormats)} volume.";
             }
-            else if (!string.Equals(rootDriveInfo.DriveFormat, requiredFormat, StringComparison.OrdinalIgnoreCase))
+            else if (!requiredFormats.Any(requiredFormat => string.Equals(rootDriveInfo.DriveFormat, requiredFormat, StringComparison.OrdinalIgnoreCase)))
             {
-                error = $"Error: Currently only {requiredFormat} volumes are supported.  Ensure repo is located into an {requiredFormat} volume.";
+                error = $"Only {string.Join(" and ", requiredFormats)} volumes are supported.  Ensure your repo is located in an {string.Join(" or ", requiredFormats)} volume.";
                 return false;
             }
 


### PR DESCRIPTION
ReFS is the underlying filesystem that Dev Drives use and should be supported.

VFS for Git let ReFS drives through fine under https://github.com/microsoft/VFSForGit/releases/tag/v1.0.24074.1. I'm not sure why the volume check did not error out, but _something_ changed and after installing the latest prereleases, existing enlistments on Dev Drives are now blocked. They should not be.

(git bisect did not find the issue, nor did I expect it to given this code path did not change)