### PR TITLE
scripts/Build.bat: specify nuget pkg install dir

### DIFF
--- a/scripts/Build.bat
+++ b/scripts/Build.bat
@@ -43,7 +43,7 @@ IF NOT EXIST "%NUGET_EXEC%" (
 
 REM Acquire vswhere to find VS installations reliably
 SET VSWHERE_VER=2.6.7
-"%NUGET_EXEC%" install vswhere -Version %VSWHERE_VER% || exit /b 1
+"%NUGET_EXEC%" install vswhere -Version %VSWHERE_VER% -OutputDirectory %VFS_PACKAGESDIR% || exit /b 1
 SET VSWHERE_EXEC="%VFS_PACKAGESDIR%\vswhere.%VSWHERE_VER%\tools\vswhere.exe"
 
 REM Assumes default installation location for Windows 10 SDKs


### PR DESCRIPTION
The Build.bat script installs the vswhere package in order to locate MSBuild if it is not already found on the %PATH%, however it does not correctly make use of the %VFS_PACKAGESDIR% directory that should house all the packages used in the build process (such as the GVFS.ProjFS package).

Correct the script by adding the -OutputDirectory argument to the nuget install command for vswhere.