### PR TITLE
Fix ownership when cloning elevated

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/IPlatformFileSystem.cs
@@ -18,5 +18,6 @@ namespace GVFS.Common.FileSystem
         bool TryCreateDirectoryWithAdminAndUserModifyPermissions(string directoryPath, out string error);
         bool TryCreateOrUpdateDirectoryToAdminModifyPermissions(ITracer tracer, string directoryPath, out string error);
         bool IsFileSystemSupported(string path, out string error);
+        void EnsureDirectoryIsOwnedByCurrentUser(string workingDirectoryRoot);
     }
 }

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -217,7 +217,7 @@ namespace GVFS.Common
         {
             try
             {
-                Directory.CreateDirectory(this.WorkingDirectoryRoot);
+                GVFSPlatform.Instance.FileSystem.EnsureDirectoryIsOwnedByCurrentUser(this.WorkingDirectoryRoot);
                 this.CreateHiddenDirectory(this.DotGVFSRoot);
             }
             catch (IOException)

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -70,5 +70,10 @@ namespace GVFS.UnitTests.Mock.FileSystem
             error = null;
             return true;
         }
+
+        public void EnsureDirectoryIsOwnedByCurrentUser(string workingDirectoryRoot)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -716,6 +716,17 @@ git %*
                 return new Result(error);
             }
 
+            try
+            {
+                GVFSPlatform.Instance.FileSystem.EnsureDirectoryIsOwnedByCurrentUser(enlistmentToInit.DotGitRoot);
+            }
+            catch (IOException e)
+            {
+                string error = string.Format("Could not ensure .git directory is owned by current user: {0}", e.Message);
+                tracer.RelatedError(error);
+                return new Result(error);
+            }
+
             GitProcess.Result remoteAddResult = new GitProcess(enlistmentToInit).RemoteAdd("origin", enlistmentToInit.RepoUrl);
             if (remoteAddResult.ExitCodeIsFailure)
             {


### PR DESCRIPTION
On Windows, if the current user is elevated then any directories created will be owned by the Administrators group. This can cause problems later on in non-elevated contexts due to git's "dubious ownership" check. Git for Windows does not currently consider a non-elevated admin to be the owner of a directory owned by the Administrators group, though a fix is in progress in the microsoft fork of git. Libgit2(sharp) also does not have this fix. Also, the GVFS service which automounts repositories runs under the SYSTEM account, which would still fail the check even if that fix were in place.

This commit changes the ownership of the .git directory and the working directory to the current user when cloning.