### PR TITLE
Remove old unused upgrader methods and dependencies

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -87,8 +87,6 @@ namespace GVFS.Common
         public abstract bool TryGetGVFSHooksVersion(out string hooksVersion, out string error);
         public abstract bool TryInstallGitCommandHooks(GVFSContext context, string executingDirectory, string hookName, string commandHookPath, out string errorMessage);
 
-        public abstract bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error);
-
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly);
 
         public abstract bool IsConsoleOutputRedirectedToFile();

--- a/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
+++ b/GVFS/GVFS.Platform.Windows/GVFS.Platform.Windows.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Database.Collections.Generic" Version="1.9.4" />
     <PackageReference Include="Microsoft.Database.Isam" Version="1.9.4" />
     <PackageReference Include="Microsoft.Windows.ProjFS" Version="1.1.19156.1" />
-    <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
-using System.Management.Automation;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.ServiceProcess;
@@ -292,30 +291,6 @@ namespace GVFS.Platform.Windows
             }
 
             return true;
-        }
-
-        public override bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error)
-        {
-            using (PowerShell powershell = PowerShell.Create())
-            {
-                powershell.AddScript($"Get-AuthenticodeSignature -FilePath {path}");
-
-                Collection<PSObject> results = powershell.Invoke();
-                if (powershell.HadErrors || results.Count <= 0)
-                {
-                    subject = null;
-                    issuer = null;
-                    error = $"Powershell Get-AuthenticodeSignature failed, could not verify authenticode for {path}.";
-                    return false;
-                }
-
-                Signature signature = results[0].BaseObject as Signature;
-                bool isValid = signature.Status == SignatureStatus.Valid;
-                subject = signature.SignerCertificate.SubjectName.Name;
-                issuer = signature.SignerCertificate.IssuerName.Name;
-                error = isValid == false ? signature.StatusMessage : null;
-                return isValid;
-            }
         }
 
         public override string GetCurrentUser()

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -59,11 +59,6 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotSupportedException();
         }
 
-        public override bool TryVerifyAuthenticodeSignature(string path, out string subject, out string issuer, out string error)
-        {
-            throw new NotImplementedException();
-        }
-
         public override string GetNamedPipeName(string enlistmentRoot)
         {
             return "GVFS_Mock_PipeName";


### PR DESCRIPTION
Remove some of the unused methods left behind after the auto upgrader was shut down. Also remove the no longer needed dependencies.