### PR TITLE
Update and futureproofing of ConfigureVisualStudio

### DIFF
--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -236,7 +236,7 @@ namespace GVFS.Platform.Windows
                  * revisited in the future if VS changes how it stores this. */
                 var vsVersions = Registry.CurrentUser.OpenSubKey(VSRegistryKeyRoot)
                     ?.GetSubKeyNames()
-                    .Where(name => float.TryParse(name, out var version) && version >= 15.0)
+                    .Where(name => Version.TryParse(name, out var version) && version.Major >= 15)
                     .ToArray() ?? Array.Empty<string>();
 
                 foreach (string version in vsVersions)


### PR DESCRIPTION
Visual Studio contains a copy of mingit that it will use for Git operations in its UI (Team Explorer, etc.), which can be overridden by a registry key.

Previously, gvfs mount would set the registry key to point to the user's installed version of git (presumably the .vfs fork), but it only set the registry key for versions 15.0 and 16.0 of Visual Studio.

This commit instead looks for registry keys for versions of Visual Studio at least 15.0, in the same format as the known keys, and sets the key for them.

The current version of Visual Studio is 17.0, and this is fix is confirmed to work for it.

With luck this will also work for future versions of Visual Studio, but there's no guarantee of that.