### PR TITLE
Disable version block when running development version

### DIFF
--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -57,7 +57,16 @@ namespace GVFS.Common
 
         public static bool IsDevelopmentVersion()
         {
-            Version currentVersion = new Version(ProcessHelper.GetCurrentProcessVersion());
+            string version = ProcessHelper.GetCurrentProcessVersion();
+            /* When debugging local version with VS, the version will include +{commitId} suffix, 
+             * which is not valid for Version class. */
+            var plusIndex = version.IndexOf('+');
+            if (plusIndex >= 0)
+            {
+                version = version.Substring(0, plusIndex);
+            }
+
+            Version currentVersion = new Version(version);
 
             return currentVersion.Major == 0;
         }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -926,8 +926,14 @@ You can specify a URL, a name of a configured cache server, or the special names
 
             using (ITracer activity = tracer.StartActivity("ValidateGVFSVersion", EventLevel.Informational))
             {
-                Version currentVersion = new Version(ProcessHelper.GetCurrentProcessVersion());
+                if (ProcessHelper.IsDevelopmentVersion())
+                {
+                    /* Development Version will start with 0 and include a "+{commitID}" suffix
+                     * so it won't ever be valid, but it needs to be able to run so we can test it. */
+                    return true;
+                }
 
+                Version currentVersion = new Version(ProcessHelper.GetCurrentProcessVersion());
                 IEnumerable<ServerGVFSConfig.VersionRange> allowedGvfsClientVersions =
                     config != null
                     ? config.AllowedGVFSClientVersions


### PR DESCRIPTION
Whenever I test changes I've been disabling this version check, then reverting it before creating a pull request.
It would be nice not to have to do that for testing.