### PR TITLE
Disable precommand hooks during configuration loading when mounting

### DIFF
--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -83,7 +83,8 @@ namespace GVFS.UnitTests.Mock.Git
             Action<StreamWriter> writeStdIn,
             Action<string> parseStdOutLine,
             int timeoutMs,
-            string gitObjectsDirectory = null)
+            string gitObjectsDirectory = null,
+            bool usePrecommandHook = true)
         {
             this.CommandsRun.Add(command);
 


### PR DESCRIPTION
If something is wrong with the precommand hooks configuration (such as if GVFS was previously installed at a different directory, and the configuration still points to the old directory) then GVFS mount fails early, before it has a chance to fix the hooks configuration, because the hook runs and fails when looking up the required configuration.

This PR disables the precommand hook when loading the configuration required to fix the hooks configuration on mount.