### PR TITLE
Make hooks location check consistent

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -143,7 +143,6 @@ namespace GVFS.Common
 
             public abstract string GVFSExecutableName { get; }
 
-            public abstract string ProgramLocaterCommand { get; }
 
             /// <summary>
             /// Different platforms can have different requirements

--- a/GVFS/GVFS.Platform.Windows/WindowsGitInstallation.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsGitInstallation.cs
@@ -19,7 +19,7 @@ namespace GVFS.Platform.Windows
                 return File.Exists(gitBinPath);
             }
 
-            return ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GitProcessName) != null;
+            return !string.IsNullOrEmpty(GetInstalledGitBinPath());
         }
 
         public string GetInstalledGitBinPath()

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -258,14 +258,14 @@ namespace GVFS.Platform.Windows
         {
             error = null;
             hooksVersion = null;
-            string hooksPath = ProcessHelper.GetProgramLocation(GVFSPlatform.Instance.Constants.ProgramLocaterCommand, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
-            if (hooksPath == null)
+            string hooksPath = Path.Combine(ProcessHelper.GetCurrentProcessLocation(), GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            if (hooksPath == null || !File.Exists(hooksPath))
             {
                 error = "Could not find " + GVFSPlatform.Instance.Constants.GVFSHooksExecutableName;
                 return false;
             }
 
-            FileVersionInfo hooksFileVersionInfo = FileVersionInfo.GetVersionInfo(Path.Combine(hooksPath, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName));
+            FileVersionInfo hooksFileVersionInfo = FileVersionInfo.GetVersionInfo(hooksPath);
             hooksVersion = hooksFileVersionInfo.ProductVersion;
             return true;
         }
@@ -442,11 +442,6 @@ namespace GVFS.Platform.Windows
             public override string GVFSExecutableName
             {
                 get { return "GVFS" + this.ExecutableExtension; }
-            }
-
-            public override string ProgramLocaterCommand
-            {
-                get { return "where"; }
             }
 
             public override HashSet<string> UpgradeBlockingProcesses

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -222,11 +222,6 @@ namespace GVFS.UnitTests.Mock.Common
                 get { return "MockGVFS" + this.ExecutableExtension; }
             }
 
-            public override string ProgramLocaterCommand
-            {
-                get { return "MockWhere"; }
-            }
-
             public override HashSet<string> UpgradeBlockingProcesses
             {
                 get { return new HashSet<string>(this.PathComparer) { "GVFS", "GVFS.Mount", "git", "wish", "bash" }; }


### PR DESCRIPTION
When checking that GVFS.Hooks.exe matches the version of GVFS.exe, GVFS is currently using where.exe to find GVFS.Hooks.exe on the path. However, when actually running GVFS.Hooks.exe, it uses the file that is in the same directory as GVFS.exe.

This PR removes usage of where.exe for consistency, instead using the directory of gvfs.exe to locate GVFS.Hooks.exe in all cases.

Combined with !1835, this change fixes an error case when a user uninstalls GVFS then reinstalls into a different directory, where existing clones still point to the old directory and will hit errors when mounting.

