### PR TITLE
Fix std handle forwarding

### DIFF
--- a/GVFS/GitHooksLoader/GitHooksLoader.cpp
+++ b/GVFS/GitHooksLoader/GitHooksLoader.cpp
@@ -112,9 +112,6 @@ int ExecuteHook(const std::wstring &applicationName, wchar_t *hookName, int argc
     PROCESS_INFORMATION pi;
     ZeroMemory(&si, sizeof(si));
     si.cb = sizeof(si);
-    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
-    si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
-    si.dwFlags = STARTF_USESTDHANDLES;
 
     ZeroMemory(&pi, sizeof(pi));
 
@@ -135,7 +132,7 @@ int ExecuteHook(const std::wstring &applicationName, wchar_t *hookName, int argc
         NULL,           // Process handle not inheritable
         NULL,           // Thread handle not inheritable
         TRUE,           // Set handle inheritance to TRUE
-        CREATE_NO_WINDOW, // Process creation flags
+        NULL,           // Process creation flags
         NULL,           // Use parent's environment block
         NULL,           // Use parent's starting directory 
         &si,            // Pointer to STARTUPINFO structure


### PR DESCRIPTION
Currently, GitHooksLoader.exe does not forward any output from the hooks that it is configured to run. This is different from the expected git hooks behavior, and it also does not appear to be intentional - stdout and stderr are explicitly configured to be forwarded, but the CREATE_NO_WINDOW flag prevents that from happening. There are also outputs in GVFS.Hooks.exe (which in most cases is the only hook called by this) that are clearly expected to be visible to the user, but are not.

This PR removes CREATE_NO_WINDOW so that standard handles are forwarded. It also removes the explicit forwarding of stdout and stderr, which has the effect that stdin is also forwarded. I'm not aware of any reasons we wouldn't want to forward stdin - without it, if a configured hook expects user input then it will just hang.