### PR TITLE
Use quotes around default GVFS.Hooks.exe configuration

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -28,7 +28,8 @@ namespace GVFS.Common.FileSystem
         public static string MergeHooksData(string[] defaultHooksLines, string filename, string hookName)
         {
             IEnumerable<string> valuableHooksLines = defaultHooksLines.Where(line => !string.IsNullOrEmpty(line.Trim()));
-            string absolutePathToHooksExecutable = Path.Combine(ExecutingDirectory, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            /* Wrap in quotes to handle spaces in the path */
+            string absolutePathToHooksExecutable = $"\"{Path.Combine(ExecutingDirectory, GVFSPlatform.Instance.Constants.GVFSHooksExecutableName)}\"";
 
             if (valuableHooksLines.Contains(GVFSPlatform.Instance.Constants.GVFSHooksExecutableName, GVFSPlatform.Instance.Constants.PathComparer))
             {

--- a/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
+++ b/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerTests.cs
@@ -16,9 +16,7 @@ namespace GVFS.UnitTests.CommandLine
     {
         private const string Filename = "hooksfile";
         private readonly string expectedAbsoluteGvfsHookPath =
-            Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                GVFSPlatform.Instance.Constants.GVFSHooksExecutableName);
+            $"\"{Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), GVFSPlatform.Instance.Constants.GVFSHooksExecutableName)}\"";
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]


### PR DESCRIPTION
The default install location on Windows is in `C:\Program Files\VFS for Git`. When configuring the hook for GVFS.Hooks.exe the absolute path is recorded in pre-command.hooks and post-command.hooks.

GitHooksLoader.exe will read that line verbatim and try to execute it using CreateProcess. This typically works, but it checks for executable files at "C:\Program", "C:\Program.exe", "C:\Program Files\VFS", "C:\Program Files\VFS.exe" etc before resolving to the correct executable.

If a user has a file at C:\Program, then the pre-command hook will try to run it instead, typically failing and blocking all git/gvfs operations.

This pull request puts quotes around the absolute path of GVFS.Hooks.exe when configuring the pre/post command hooks, so that CreateProcess will resolve immediately to the correct executable instead of checking partial paths.