### PR TITLE
GitAuthentication.cs: suppress CodeQL alert about cert validation

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -233,7 +233,7 @@ namespace GVFS.Common.Git
             {
                 if (this.GitSsl != null && !this.GitSsl.ShouldVerify)
                 {
-                    httpClientHandler.ServerCertificateCustomValidationCallback =
+                    httpClientHandler.ServerCertificateCustomValidationCallback = // CodeQL [SM02184] TLS verification can be disabled by Git itself, so this is just mirroring a feature already exposed.
                         (httpRequestMessage, c, cetChain, policyErrors) =>
                         {
                             return true;


### PR DESCRIPTION
Suppress the CodeQL alert about the code tha respects Git's https.sslVerify setting. This is a feature of Git that is mirrored in VFS for Git's behaviour.