### PR TITLE
Index prefetch packs in parallel

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -580,7 +580,11 @@ namespace GVFS.Common.Git
 
         public Result IndexPack(string packfilePath, string idxOutputPath)
         {
-            return this.InvokeGitAgainstDotGitFolder($"index-pack -o \"{idxOutputPath}\" \"{packfilePath}\"");
+            /* Git's default thread count is Environment.ProcessorCount / 2, with a maximum of 20.
+             * Testing shows that we can get a 5% decrease in gvfs clone time for large repositories by using more threads, but
+             * we won't go over ProcessorCount or 20. */
+            var threadCount = Math.Min(Environment.ProcessorCount, 20);
+            return this.InvokeGitAgainstDotGitFolder($"index-pack --threads={threadCount} -o \"{idxOutputPath}\" \"{packfilePath}\"");
         }
 
         /// <summary>


### PR DESCRIPTION
#1840 required local indexing of pack files (an expensive task for large repositories) to `gvfs clone`. This pull request improves the performance of pack file indexing by:
1. Launching `git index-pack` instances asynchronously during prefetch, and
2. Specifying a number of threads equal to processor count to `git index-pack`, overriding the git default of half the processor count.

The prefetch API will usually return one large pack file comprising most of the commits and trees, followed by several smaller pack files representing the new commits and trees since the last maintenance job consolidated the main pack file.

`git index-pack` begins with a single-threaded task to index the objects in the pack file, followed by a multi-threaded task to resolve the deltas. With these changes, the smaller incremental pack files are typically indexed in full while the primary pack file is still in its single-threaded phase, and the primary pack file's multi-threaded phase is marginally faster.

In testing, these changes reduced clone time for a large repository by 15-30%.