### PR TITLE
Distrust received pack indexes (behind config flag, with perf fixes)

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -37,6 +37,10 @@ namespace GVFS.Common
             public const string GVFSTelemetryPipe = GitConfig.GVFSPrefix + "telemetry-pipe";
             public const string IKey = GitConfig.GVFSPrefix + "ikey";
             public const string HooksExtension = ".hooks";
+
+            /* Intended to be a temporary config to allow testing of distrusting pack indexes from cache server
+             * before it is enabled by default. */
+            public const string TrustPackIndexes = GVFSPrefix + "trust-pack-indexes";
         }
 
         public static class LocalGVFSConfig

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -406,7 +406,6 @@ namespace GVFS.Common.Git
                     gitProcess = new GitProcess(this.Enlistment);
                 }
 
-
                 GitProcess.Result result = gitProcess.IndexPack(packfilePath, tempIdxPath);
                 if (result.ExitCodeIsFailure)
                 {

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -706,64 +706,53 @@ namespace GVFS.Common.Git
 
                     bytesDownloaded += packLength;
 
-                    // We will try to build an index if the server does not send one
-                    if (pack.IndexStream == null)
+                    // We can't trust the index file from the server, so we will always build our own.
+                    // We still need to consume and handle any exceptions from the index stream though.
+                    var canContinue = true;
+                    GitProcess.Result result;
+                    if (this.TryBuildIndex(activity, packTempPath, out result, gitProcess))
                     {
-                        GitProcess.Result result;
-                        if (!this.TryBuildIndex(activity, packTempPath, out result, gitProcess))
-                        {
-                            if (packFlushTask != null)
-                            {
-                                packFlushTask.Wait();
-                            }
-
-                            // Move whatever has been successfully downloaded so far
-                            Exception moveException;
-                            this.TryFlushAndMoveTempPacks(tempPacks, ref latestTimestamp, out moveException);
-
-                            return new RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult(null, true);
-                        }
-
                         tempPacks.Add(new TempPrefetchPackAndIdx(pack.Timestamp, packName, packTempPath, packFlushTask, idxName, idxTempPath, idxFlushTask: null));
+                        if (pack.IndexStream != null)
+                        {
+                            try
+                            {
+                                bytesDownloaded += pack.IndexStream.Length;
+                                if (pack.IndexStream.CanSeek)
+                                {
+                                    pack.IndexStream.Seek(0, SeekOrigin.End);
+                                }
+                                else
+                                {
+                                    pack.IndexStream.CopyTo(Stream.Null);
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                canContinue = false;
+                                EventMetadata metadata = CreateEventMetadata(e);
+                                activity.RelatedWarning(metadata, "Failed to read to end of index stream");
+                            }
+                        }
                     }
                     else
                     {
-                        Task indexFlushTask;
-                        if (this.TryWriteTempFile(activity, pack.IndexStream, idxTempPath, out indexLength, out indexFlushTask))
-                        {
-                            tempPacks.Add(new TempPrefetchPackAndIdx(pack.Timestamp, packName, packTempPath, packFlushTask, idxName, idxTempPath, indexFlushTask));
-                        }
-                        else
-                        {
-                            bytesDownloaded += indexLength;
-
-                            // Try to build the index manually, then retry the prefetch
-                            GitProcess.Result result;
-                            if (this.TryBuildIndex(activity, packTempPath, out result, gitProcess))
-                            {
-                                // If we were able to recreate the failed index
-                                // we can start the prefetch at the next timestamp
-                                tempPacks.Add(new TempPrefetchPackAndIdx(pack.Timestamp, packName, packTempPath, packFlushTask, idxName, idxTempPath, idxFlushTask: null));
-                            }
-                            else
-                            {
-                                if (packFlushTask != null)
-                                {
-                                    packFlushTask.Wait();
-                                }
-                            }
-
-                            // Move whatever has been successfully downloaded so far
-                            Exception moveException;
-                            this.TryFlushAndMoveTempPacks(tempPacks, ref latestTimestamp, out moveException);
-
-                            // The download stream will not be in a good state if the index download fails.
-                            // So we have to restart the prefetch
-                            return new RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult(null, true);
-                        }
+                        canContinue = false;
                     }
 
-                    bytesDownloaded += indexLength;
+                    if (!canContinue)
+                    {
+                        if (packFlushTask != null)
+                        {
+                            packFlushTask.Wait();
+                        }
+
+                        // Move whatever has been successfully downloaded so far
+                        Exception moveException;
+                        this.TryFlushAndMoveTempPacks(tempPacks, ref latestTimestamp, out moveException);
+
+                        return new RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult(null, true);
+                    }
                 }
 
                 Exception exception = null;

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -580,7 +580,11 @@ namespace GVFS.Common.Git
 
         public Result IndexPack(string packfilePath, string idxOutputPath)
         {
-            return this.InvokeGitAgainstDotGitFolder($"index-pack -o \"{idxOutputPath}\" \"{packfilePath}\"");
+            /* Git's default thread count is Environment.ProcessorCount / 2, with a maximum of 20.
+             * Testing shows that we can get a 5% decrease in gvfs clone time for large repositories by using more threads, but
+             * we won't go over ProcessorCount or 20. */
+            var threadCount = Math.Min(Environment.ProcessorCount, 20);
+            return this.InvokeGitAgainstDotGitFolder($"index-pack --threads={threadCount} -o \"{idxOutputPath}\" \"{packfilePath}\"");
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request contains 4 things:
1. #1840  to index packs locally, which was reverted due to unexpected performance issues
2. #1843 to increase parallelization when indexing packs, which was abandoned due to #1840 being reverted
3. Added a new configuration "gvfs.trust-pack-indexes", which defaults to true. The new behavior is only used when this is set to false.
This is intended to be a temporary configuration setting, to be removed (or defaulted to false) once more mitigations have been completed for the performance.
4. `git index-pack` is changed from running in the GVFS enlistment to running outside the enlistment. This was the reason for the unexpected performance issues. 
It was expected that the first prefetch on a new clone would take longer due to indexing the pack locally; however users who deleted their prefetch cache (but not the rest of the cache or local loose objects) in order to re-fetch it with local indexing enabled experienced many times longer delays than expected, because `git index-pack` reads all the existing pack indexes and loose objects and considers them when indexing a pack in order to support validating that all referenced objects exist - even when the command-line options to act on nonexistent references are not enabled. Since we aren't using --validate or its variants, we can run `git index-pack` outside the enlistment to avoid this issue.