### PR TITLE
Prefetch in background when cloning if pack indexes are not trusted

### DIFF
--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -109,5 +109,18 @@ namespace GVFS.Common
         {
             return new GitProcess(this);
         }
+
+        public bool GetTrustPackIndexesConfig()
+        {
+            var gitProcess = this.CreateGitProcess();
+            bool trustPackIndexes = true;
+            if (gitProcess.TryGetFromConfig(GVFSConstants.GitConfig.TrustPackIndexes, forceOutsideEnlistment: false, out var valueString)
+                && bool.TryParse(valueString, out var trustPackIndexesConfig))
+            {
+                trustPackIndexes = trustPackIndexesConfig;
+            }
+
+            return trustPackIndexes;
+        }
     }
 }

--- a/GVFS/GVFS.Common/Git/GitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GitObjects.cs
@@ -135,12 +135,7 @@ namespace GVFS.Common.Git
                  * pack file and an index file that do not match.
                  * Eventually we will make this the default, but it has a high performance cost for the first prefetch after
                  * cloning a large repository, so it must be explicitly enabled for now. */
-                bool trustPackIndexes = true;
-                if (gitProcess.TryGetFromConfig(GVFSConstants.GitConfig.TrustPackIndexes, forceOutsideEnlistment: false, out var valueString)
-                    && bool.TryParse(valueString, out var trustPackIndexesConfig))
-                {
-                    trustPackIndexes = trustPackIndexesConfig;
-                }
+                bool trustPackIndexes = this.Enlistment.GetTrustPackIndexesConfig();
                 metadata.Add("trustPackIndexes", trustPackIndexes);
 
                 long requestId = HttpRequestor.GetNewRequestId();


### PR DESCRIPTION
Since prefetch can be quite long for large repos if pack indexes from the server are not trusted (ie need to be built locally after the pack files are downloaded), start prefetch as a separate background process in that case.

See also #1848 for making more history operations usable while the prefetch is still running.