### PR TITLE
Enforce minimum Windows API set, and loosen SDK requirement checks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,15 @@
     <OutDir>$(ProjectOutPath)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectOutPath)intermediate\$(Platform)\$(Configuration)\</IntDir>
     <GeneratedIncludePath>$(IntDir)include\</GeneratedIncludePath>
+    <!--
+      Make sure that we don't accidentally use Windows APIs only available after
+      Windows 10 build 16299 (aka '1709', 'RS3', and 'Fall Creators Update').
+      The minimum Windows version that includes the final design of the
+      Projected File System (ProjFS) APIs was actually Windows 10 version 1809
+      (build 17763), but VFS for Git also supports using the older design of the
+      ProjFS APIs from that version.
+    -->
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
 </Project>

--- a/scripts/Build.bat
+++ b/scripts/Build.bat
@@ -46,12 +46,6 @@ SET VSWHERE_VER=2.6.7
 "%NUGET_EXEC%" install vswhere -Version %VSWHERE_VER% -OutputDirectory %VFS_PACKAGESDIR% || exit /b 1
 SET VSWHERE_EXEC="%VFS_PACKAGESDIR%\vswhere.%VSWHERE_VER%\tools\vswhere.exe"
 
-REM Assumes default installation location for Windows 10 SDKs
-IF NOT EXIST "C:\Program Files (x86)\Windows Kits\10\Include\10.0.16299.0" (
-    ECHO ERROR: Could not find Windows 10 SDK Version 16299
-    EXIT /B 1
-)
-
 REM Use vswhere to find the latest VS installation with the MSBuild component
 REM See https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
 FOR /F "tokens=* USEBACKQ" %%F IN (`%VSWHERE_EXEC% -all -prerelease -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe`) DO (


### PR DESCRIPTION
VFS for Git requires the Windows Projected File System ('ProjFS') to function, which was first introduced, in its non-final API design, with Windows 10 build 16299 (aka '1709', 'Redstone 3', 'Fall Creators Update').

Since 240f73ee5b987fa4e400251229582b64b3924d56, we now use the latest installed version of the Windows SDK to build the native projects. To prevent accidental use of APIs introduced after 16299, we should set the `TargetPlatformMinVersion` property to 10.0.16299.0.

Whilst we are here, we should also remove the now overzealous checks for the specific Windows SDK in the Build.bat script.

Note that the GitHub `windows-2025` runner does _not advertise_ that it has Windows SDK build 16299 installed, but it must do for the current builds to work.