### PR TITLE
GVFS.Installers: update Inno Setup compiler

### DIFF
--- a/GVFS/GVFS.Installers/GVFS.Installers.csproj
+++ b/GVFS/GVFS.Installers/GVFS.Installers.csproj
@@ -12,7 +12,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tools.InnoSetup" Version="6.3.1" />
+    <PackageReference Include="Tools.InnoSetup" Version="6.4.3" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" ExcludeAssets="none" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrade to 6.4.3, which is the latest available in nuget.org.

We are encountering an issue where the ASLR relocation data is being stripped from the setup and uninstaller binaries, which was fixed in 6.3.3, in July 2024:

https://github.com/jrsoftware/issrc/commit/f85c584f9ebfc360d9aa9a7d924f9958f8fea352