### PR TITLE
ci: avoid unnecessary builds and test runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
     steps:
     - name: Look for prior successful runs
       id: check
+      if: github.event.inputs.git_version == ''
       uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
@@ -72,6 +73,7 @@ jobs:
             for (const run of runs.workflow_runs.sort(demoteInProgressToEnd)) {
               if (head_sha !== run.head_sha && tree_id !== run.head_commit?.tree_id) continue
               if (context.runId === run.id) continue // do not wait for the current run to finish ;-)
+              if (run.event === 'workflow_dispatch') continue // skip runs that were started manually: they can override the Git version
 
               if (run.status === 'in_progress') {
                 // poll until the run is done


### PR DESCRIPTION
Sadly, VFSforGit's CI and PR builds are not exactly cheap. Not only in terms of combined runtime (where VFSforGit's 3 hours 45 minutes is not even close runner-up to [`git/git`'s 8.5 hours (!!!)](https://github.com/git/git/actions/runs/17628515153/usage). A Functional Test job typically runs for 35 minutes to test on x86_64, and an even worse 1 hour and 15 minutes on arm64. The wall-clock time for a CI or PR build of VFSforGit therefore weighs around 1 hour and 20 minutes.

This hurts a lot when trying to fast-track a change from a PR targeting `master` to a full VFSforGit release because not only does the entire build run _again_ on the (tree-same) `master` after merging, the next step (thanks to the original VFSforGit maintainer's decision to go for a Git Flow-like setup) requires the build to run _a third-time_ on the (also tree-same) PR merge commit.

Let's try to reuse build and test results from previous, successful runs on what is essentially the same code.