### PR TITLE
Run the Functional Tests in parallel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -280,3 +280,17 @@ jobs:
       if: always() && steps.skip.outputs.result != 'true'
       shell: cmd
       run: install\info.bat
+
+  ft_results:
+    runs-on: ubuntu-latest # quickest runners
+    name: Functional Tests
+    needs: [functional_test]
+
+    strategy:
+      matrix:
+        configuration: [ Debug, Release ]
+        architecture: [ x86_64, arm64 ]
+
+    steps:
+      - name: Success! # for easier identification of successful runs in the Checks Required for Pull Requests
+        run: echo "All functional test jobs successful for ${{ matrix.configuration }} / ${{ matrix.architecture }}!"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -294,3 +294,12 @@ jobs:
     steps:
       - name: Success! # for easier identification of successful runs in the Checks Required for Pull Requests
         run: echo "All functional test jobs successful for ${{ matrix.configuration }} / ${{ matrix.architecture }}!"
+
+  result:
+    runs-on: ubuntu-latest
+    name: Build, Unit and Functional Tests Successful
+    needs: [functional_test]
+
+    steps:
+      - name: Success! # for easier identification of successful runs in the Checks Required for Pull Requests
+        run: echo "Workflow run is successful!"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -205,6 +205,7 @@ jobs:
       matrix:
         configuration: [ Debug, Release ]
         architecture: [ x86_64, arm64 ]
+        nr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] # 10 parallel jobs to speed up the tests
       fail-fast: false # most failures are flaky tests, no need to stop the other jobs from succeeding
 
     steps:
@@ -250,7 +251,7 @@ jobs:
       if: always() && steps.skip.outputs.result != 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: InstallationLogs_${{ matrix.configuration }}_${{ matrix.architecture }}
+        name: InstallationLogs_${{ matrix.configuration }}_${{ matrix.architecture }}-${{ matrix.nr }}
         path: install\logs
 
     - name: Run functional tests
@@ -259,20 +260,20 @@ jobs:
       run: |
         SET PATH=C:\Program Files\VFS for Git;%PATH%
         SET GIT_TRACE2_PERF=C:\temp\git-trace2.log
-        ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci
+        ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci --slice=${{ matrix.nr }},10
 
     - name: Upload functional test results
       if: always() && steps.skip.outputs.result != 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: FunctionalTests_Results_${{ matrix.configuration }}_${{ matrix.architecture }}
+        name: FunctionalTests_Results_${{ matrix.configuration }}_${{ matrix.architecture }}-${{ matrix.nr }}
         path: TestResult.xml
 
     - name: Upload Git trace2 output
       if: always() && steps.skip.outputs.result != 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: GitTrace2_${{ matrix.configuration }}_${{ matrix.architecture }}
+        name: GitTrace2_${{ matrix.configuration }}_${{ matrix.architecture }}-${{ matrix.nr }}
         path: C:\temp\git-trace2.log
 
     - name: ProjFS details (post-test)

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -89,6 +89,25 @@ namespace GVFS.FunctionalTests
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
 
+            (uint, uint)? testSlice = null;
+            string testSliceArg = runner.GetCustomArgWithParam("--slice");
+            if (testSliceArg != null)
+            {
+                // split `testSliceArg` on a comma and parse the two values as uints
+                string[] parts = testSliceArg.Split(',');
+                uint sliceNumber;
+                uint totalSlices;
+                if (parts.Length != 2 ||
+                    !uint.TryParse(parts[0], out sliceNumber) ||
+                    !uint.TryParse(parts[1], out totalSlices) ||
+                    totalSlices == 0 ||
+                    sliceNumber >= totalSlices)
+                {
+                    throw new Exception("Invalid argument to --slice. Expected format: X,Y where X is the slice number and Y is the total number of slices");
+                }
+                testSlice = (sliceNumber, totalSlices);
+            }
+
             GVFSTestConfig.DotGVFSRoot = ".gvfs";
 
             GVFSTestConfig.RepoToClone =
@@ -96,7 +115,7 @@ namespace GVFS.FunctionalTests
                 ?? Properties.Settings.Default.RepoToClone;
 
             RunBeforeAnyTests();
-            Environment.ExitCode = runner.RunTests(includeCategories, excludeCategories);
+            Environment.ExitCode = runner.RunTests(includeCategories, excludeCategories, testSlice);
 
             if (Debugger.IsAttached)
             {

--- a/GVFS/GVFS.Tests/NUnitRunner.cs
+++ b/GVFS/GVFS.Tests/NUnitRunner.cs
@@ -1,8 +1,10 @@
 ﻿using NUnitLite;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace GVFS.Tests
 {
@@ -42,10 +44,106 @@ namespace GVFS.Tests
             }
         }
 
-        public int RunTests(ICollection<string> includeCategories, ICollection<string> excludeCategories)
+        public void PrepareTestSlice(string filters, (uint, uint) testSlice)
+        {
+            IEnumerable<string> args = this.args.Concat(new[] { "--explore" });
+            if (filters.Length > 0)
+            {
+                args = args.Concat(new[] { "--where", filters });
+            }
+
+            // Temporarily redirect Console.Out to capture the output of --explore
+            var stringWriter = new StringWriter();
+            var originalOut = Console.Out;
+
+            string[] list;
+            try
+            {
+                Console.SetOut(stringWriter);
+                int exploreResult = new AutoRun(Assembly.GetEntryAssembly()).Execute(args.ToArray());
+                if (exploreResult != 0)
+                {
+                    throw new Exception("--explore failed with " + exploreResult);
+                }
+
+                list = stringWriter.ToString().Split(new[] { "\n" }, StringSplitOptions.None);
+            }
+            finally
+            {
+                Console.SetOut(originalOut); // Ensure we restore Console.Out
+            }
+
+            // Sort the test cases into roughly equal-sized buckets;
+            // Care must be taken to ensure that all test cases for a given
+            // EnlistmentPerFixture class go into the same bucket, as they
+            // may very well be dependent on each other.
+
+            // First, create the buckets
+            List<string>[] buckets = new List<string>[testSlice.Item2];
+            // There is no PriorityQueue in .NET Framework; Emulate one via
+            // a sorted set that contains tuples of (bucket index, bucket size).
+            var priorityQueue = new SortedSet<(int, int)>(
+                    Comparer<(int, int)>.Create((x, y) =>
+                    {
+                        if (x.Item2 != y.Item2)
+                        {
+                            return x.Item2.CompareTo(y.Item2);
+                        }
+                        return x.Item1.CompareTo(y.Item1);
+                    }));
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = new List<string>();
+                priorityQueue.Add((i, buckets[i].Count));
+            }
+
+            // Now distribute the tests into the buckets
+            Regex perFixtureRegex = new Regex(
+                @"^.*\.EnlistmentPerFixture\..+\.",
+                // @"^.*\.",
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            for (uint i = 0; i < list.Length; i++)
+            {
+                var test = list[i].Trim();
+                if (!test.StartsWith("GVFS.")) continue;
+
+                var bucket = priorityQueue.Min;
+                priorityQueue.Remove(bucket);
+
+                buckets[bucket.Item1].Add(test);
+
+                // Ensure that EnlistmentPerFixture tests of the same class are all in the same bucket
+                var match = perFixtureRegex.Match(test);
+                if (match.Success)
+                {
+                    string prefix = match.Value;
+                    while (i + 1 < list.Length && list[i + 1].StartsWith(prefix))
+                    {
+                        buckets[bucket.Item1].Add(list[++i].Trim());
+                    }
+                }
+
+                bucket.Item2 = buckets[bucket.Item1].Count;
+                priorityQueue.Add(bucket);
+            }
+
+            // Write the respective bucket's contents to a file
+            string listFile = $"GVFS_test_slice_{testSlice.Item1}_of_{testSlice.Item2}.txt";
+            File.WriteAllLines(listFile, buckets[testSlice.Item1]);
+            Console.WriteLine($"Wrote {buckets[testSlice.Item1].Count} test cases to {listFile}");
+
+            this.args.Add($"--testlist={listFile}");
+        }
+
+        public int RunTests(ICollection<string> includeCategories, ICollection<string> excludeCategories, (uint, uint)? testSlice = null)
         {
             string filters = GetFiltersArgument(includeCategories, excludeCategories);
-            if (filters.Length > 0)
+
+            if (testSlice.HasValue && testSlice.Value.Item2 != 1)
+            {
+                this.PrepareTestSlice(filters, testSlice.Value);
+            }
+            else if (filters.Length > 0)
             {
                 this.args.Add("--where");
                 this.args.Add(filters);


### PR DESCRIPTION
From time to time, the Functional Tests fail, and re-running "fixes" the failures, i.e. those tests are flaky. When that happens, we have to invest a lot of time into the re-run: currently 35 minutes for the x86_64 jobs and 1 hour 15 minutes for the ARM64 ones. That's unwelcome friction.

Let's follow the playbook of git/git which runs its test suite (which, due to the heavy over-use of Bash scripting, is very, very slow on Windows) in parallel on Windows, slicing up the tests so that the individual test slices take roughly the same amount of time to run.

This PR is stacked on top of #1866 and will need its (empty) tip commit to be dropped to force GitHub to update the PR correctly (i.e. no longer show the commits of #1866 once they are merged).