### PR TITLE
ci: fix skipping logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
                 }
               }
 
-              if (run.status === 'success') return run.html_url
+              if (run.status === 'completed' && run.conclusion === 'success') return run.html_url
             }
             return ''
           } catch (e) {


### PR DESCRIPTION
In https://github.com/microsoft/VFSForGit/pull/1866 I introduced logic to skip builds and tests when a previous workflow run already succeeded for the same commit.

However, the original revision of that Pull Request tried something _even more_ elaborate, and when I dropped that elaborate logic (because it is a bit fragile), I made a mistake in the replacement logic.

The `run.status` can never be `success`, it can be `completed` and _`run.conclusion`_ can be `success`. So let's test for that instead ;-)