### PR TITLE
Directory.Build.props: don't include commit ID in version

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,12 @@
   <!-- Define common properties that rely on SDK/props-defined properties -->
   <PropertyGroup>
     <Version>$(GVFSVersion)</Version>
+
+    <!--
+      We parse this version into System.Version in several places;
+      we should strip the commit ID from the attribute.
+      -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <!-- Include custom MSBuild targets/tasks -->


### PR DESCRIPTION
Since .NET SDK 8, the Informational Version attribute includes the commit ID of the current HEAD at build time. The product code relies on this value to be System.Version-compliant, so we should opt out of this new behaviour.

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link