### PR TITLE
Fix `gvfs clone` version check when revision is included in the version string

### DIFF
--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -58,17 +58,7 @@ namespace GVFS.Common
         public static bool IsDevelopmentVersion()
         {
             string version = ProcessHelper.GetCurrentProcessVersion();
-            /* When debugging local version with VS, the version will include +{commitId} suffix, 
-             * which is not valid for Version class. */
-            var plusIndex = version.IndexOf('+');
-            if (plusIndex >= 0)
-            {
-                version = version.Substring(0, plusIndex);
-            }
-
-            Version currentVersion = new Version(version);
-
-            return currentVersion.Major == 0;
+            return version.Equals("0.2.173.2") || version.StartsWith("0.2.173.2+");
         }
 
         public static string GetProgramLocation(string programLocaterCommand, string processName)

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -933,7 +933,11 @@ You can specify a URL, a name of a configured cache server, or the special names
                     return true;
                 }
 
-                Version currentVersion = new Version(ProcessHelper.GetCurrentProcessVersion());
+                string recordedVersion = ProcessHelper.GetCurrentProcessVersion();
+                // Work around the default behavior in .NET SDK 8 where the revision ID
+                // is appended after a '+' character, which cannot be parsed by `System.Version`.
+                int plus = recordedVersion.IndexOf('+');
+                Version currentVersion = new Version(plus < 0 ? recordedVersion : recordedVersion.Substring(0, plus));
                 IEnumerable<ServerGVFSConfig.VersionRange> allowedGvfsClientVersions =
                     config != null
                     ? config.AllowedGVFSClientVersions


### PR DESCRIPTION
As reported by @tyrielv, `gvfs clone` would fail with https://github.com/microsoft/VFSForGit/releases/tag/v1.0.25260.1 when the repository to clone specifies a minimal VFSforGit version in its `gvfs/config` endpoint. The reason is that with the version bump from .NET SDK v3 to v9, the version string included in the assembly now contains the suffix `+<commit-SHA>`, which cannot be parsed by `System.Version`:

```
Cannot clone @ C:\path: System.FormatException: Input string was not in a correct format.
   at System.Version.VersionResult.SetFailure(ParseFailureKind failure, String argument)
   at System.Version.TryParseComponent(String component, String componentName, VersionResult& result, Int32& parsedComponent)
   at System.Version.TryParseVersion(String version, VersionResult& result)
   at System.Version.Parse(String input)
   at System.Version..ctor(String version)
   at GVFS.CommandLine.GVFSVerb.TryValidateGVFSVersion(GVFSEnlistment enlistment, ITracer tracer, ServerGVFSConfig config, String& errorMessage, Boolean& errorIsFatal)
   at GVFS.CommandLine.GVFSVerb.ValidateClientVersions(ITracer tracer, GVFSEnlistment enlistment, ServerGVFSConfig gvfsConfig, Boolean showWarnings)
   at GVFS.CommandLine.CloneVerb.Execute()
```

@mjcheetham provided a quick work-around in #1870 to opt out of the new behavior and report the version _without_ that suffix again; Here is a PR that prepares the code to handle such versions gracefully, to open up the door to opt back in to the new behavior (and let `gvfs version` report an even more informative output than right now).