### PR TITLE
ReadObjectHook: suppress false positive

### DIFF
--- a/GVFS/GVFS.ReadObjectHook/main.cpp
+++ b/GVFS/GVFS.ReadObjectHook/main.cpp
@@ -84,13 +84,13 @@ int main(int, char *argv[])
     DisableCRLFTranslationOnStdPipes();
 
     packet_txt_read(packet_buffer, sizeof(packet_buffer));
-    if (strcmp(packet_buffer, "git-read-object-client"))
+    if (strcmp(packet_buffer, "git-read-object-client")) // CodeQL [SM01932] `packet_txt_read()` either NUL-terminates or `die()`s
     {
         die(ReadObjectHookErrorReturnCode::ErrorReadObjectProtocol, "Bad welcome message\n");
     }
 
     packet_txt_read(packet_buffer, sizeof(packet_buffer));
-    if (strcmp(packet_buffer, "version=1"))
+    if (strcmp(packet_buffer, "version=1")) // CodeQL [SM01932] `packet_txt_read()` either NUL-terminates or `die()`s
     {
         die(ReadObjectHookErrorReturnCode::ErrorReadObjectProtocol, "Bad version\n");
     }
@@ -105,7 +105,7 @@ int main(int, char *argv[])
     packet_flush();
 
     packet_txt_read(packet_buffer, sizeof(packet_buffer));
-    if (strcmp(packet_buffer, "capability=get"))
+    if (strcmp(packet_buffer, "capability=get")) // CodeQL [SM01932] `packet_txt_read()` either NUL-terminates or `die()`s
     {
         die(ReadObjectHookErrorReturnCode::ErrorReadObjectProtocol, "Bad capability\n");
     }
@@ -125,13 +125,13 @@ int main(int, char *argv[])
     while (1)
     {
         packet_txt_read(packet_buffer, sizeof(packet_buffer));
-        if (strcmp(packet_buffer, "command=get"))
+        if (strcmp(packet_buffer, "command=get")) // CodeQL [SM01932] `packet_txt_read()` either NUL-terminates or `die()`s
         {
             die(ReadObjectHookErrorReturnCode::ErrorReadObjectProtocol, "Bad command\n");
         }
 
         len = packet_txt_read(packet_buffer, sizeof(packet_buffer));
-        if ((len != SHA1_LENGTH + 5) || strncmp(packet_buffer, "sha1=", 5))
+        if ((len != SHA1_LENGTH + 5) || strncmp(packet_buffer, "sha1=", 5)) // CodeQL [SM01932] `packet_txt_read()` either NUL-terminates or `die()`s
         {
             die(ReadObjectHookErrorReturnCode::ErrorReadObjectProtocol, "Bad sha1 in get command\n");
         }


### PR DESCRIPTION
Currently, CodeQL mis-identifies a couple instances of the usually-legitimate "User-controlled data may not be null terminated" problem.

In these instances, CodeQL thinks that `packet_txt_read()` fails to NUL-terminate (not actually "null"... tsk, tsk) the string. But it totally does! Here is the current definition of that function:

	size_t packet_txt_read(char *buf, size_t count, FILE *stream)
	{
		size_t len;

		len = packet_bin_read(buf, count, stream);
		if (len && buf[len - 1] == '\n')
		{
			len--;
		}

		buf[len] = 0;
		return len;
	}

The `buf[len] = 0` statement guarantees that the string is NUL-terminated.