### PR TITLE
Handle errors on background prefetch start

### DIFF
--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -6,9 +6,11 @@ using GVFS.Common.Http;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace GVFS.CommandLine
@@ -240,15 +242,24 @@ namespace GVFS.CommandLine
 
                         else
                         {
-                            Process.Start(new ProcessStartInfo(
-                                fileName: "gvfs",
-                                arguments: "prefetch --commits")
+                            try
                             {
-                                UseShellExecute = true,
-                                WindowStyle = ProcessWindowStyle.Hidden,
-                                WorkingDirectory = enlistment.EnlistmentRoot
-                            });
-                            this.Output.WriteLine("\r\nPrefetch of commit graph has been started as a background process. Git operations involving history may be slower until prefetch has completed.\r\n");
+                                string gvfsExecutable = Assembly.GetExecutingAssembly().Location;
+                                Process.Start(new ProcessStartInfo(
+                                    fileName: gvfsExecutable,
+                                    arguments: "prefetch --commits")
+                                    {
+                                        UseShellExecute = true,
+                                        WindowStyle = ProcessWindowStyle.Hidden,
+                                        WorkingDirectory = enlistment.EnlistmentRoot
+                                    });
+                                this.Output.WriteLine("\r\nPrefetch of commit graph has been started as a background process. Git operations involving history may be slower until prefetch has completed.\r\n");
+                            }
+                            catch (Win32Exception ex)
+                            {
+                                this.Output.WriteLine("\r\nError starting prefetch: " + ex.Message);
+                                this.Output.WriteLine("Run 'gvfs prefetch --commits' from within your enlistment to prefetch the commit graph.");
+                            }
                         }
                     }
 


### PR DESCRIPTION
In some environments "gvfs" may not be properly resolved by the shell when running the background prefetch process, so this change uses the current process path instead.

If the background prefetch process fails to start, the error is now displayed to the user with remediation steps and clone continues to the next step.