### PR TITLE
Suppress false positives about Git's usage of SHA-1

### DIFF
--- a/GVFS/GVFS.Common/Git/HashingStream.cs
+++ b/GVFS/GVFS.Common/Git/HashingStream.cs
@@ -17,7 +17,7 @@ namespace GVFS.Common.Git
         {
             this.stream = stream;
 
-            this.hash = SHA1.Create();
+            this.hash = SHA1.Create(); // CodeQL [SM02196] SHA-1 is acceptable here because this is Git's hashing algorithm, not used for cryptographic purposes
             this.hashResult = null;
             this.hash.Initialize();
             this.closed = false;

--- a/GVFS/GVFS.Common/SHA1Util.cs
+++ b/GVFS/GVFS.Common/SHA1Util.cs
@@ -21,7 +21,7 @@ namespace GVFS.Common
         {
             byte[] bytes = Encoding.UTF8.GetBytes(s);
 
-            using (SHA1 sha1 = SHA1.Create())
+            using (SHA1 sha1 = SHA1.Create()) // CodeQL [SM02196] SHA-1 is acceptable here because this is Git's hashing algorithm, not used for cryptographic purposes
             {
                 return sha1.ComputeHash(bytes);
             }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.FolderData.cs
@@ -54,7 +54,7 @@ namespace GVFS.Virtualization.Projection
 
             public string HashedChildrenNamesSha()
             {
-                using (HashAlgorithm hash = SHA1.Create())
+                using (HashAlgorithm hash = SHA1.Create()) // CodeQL [SM02196] SHA-1 is acceptable here because this is Git's hashing algorithm, not used for cryptographic purposes
                 {
                     for (int i = 0; i < this.ChildEntries.Count; i++)
                     {


### PR DESCRIPTION
Git uses SHA-1 as its hashing algorithm, and therefore VFSforGit must use the same.