### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,7 @@
 
   <!-- Managed project properties -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <LangVersion>latest</LangVersion>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PlatformTarget>x64</PlatformTarget>
     <BaseOutputPath>$(ProjectOutPath)bin\</BaseOutputPath>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <!-- Serialization -->
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
 
     <!-- Storage -->
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="2.2.4" />
@@ -42,7 +42,6 @@
     -->
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="System.IO.Pipes.AccessControl" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/GVFS/GVFS.Common/FileBasedDictionary.cs
+++ b/GVFS/GVFS.Common/FileBasedDictionary.cs
@@ -1,9 +1,9 @@
-﻿using GVFS.Common.FileSystem;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace GVFS.Common
 {
@@ -120,7 +120,7 @@ namespace GVFS.Common
         {
             try
             {
-                KeyValuePair<TKey, TValue> kvp = JsonConvert.DeserializeObject<KeyValuePair<TKey, TValue>>(line);
+                KeyValuePair<TKey, TValue> kvp = GVFSJsonOptions.Deserialize<KeyValuePair<TKey, TValue>>(line);
                 key = kvp.Key;
                 value = kvp.Value;
             }
@@ -140,7 +140,7 @@ namespace GVFS.Common
         {
             try
             {
-                key = JsonConvert.DeserializeObject<TKey>(line);
+                key = GVFSJsonOptions.Deserialize<TKey>(line);
             }
             catch (JsonException ex)
             {
@@ -162,7 +162,7 @@ namespace GVFS.Common
         {
             foreach (KeyValuePair<TKey, TValue> kvp in this.data)
             {
-                yield return this.FormatAddLine(JsonConvert.SerializeObject(kvp).Trim());
+                yield return this.FormatAddLine(GVFSJsonOptions.Serialize(kvp).Trim());
             }
         }
     }

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -2,9 +2,9 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 
 namespace GVFS.Common
@@ -270,7 +270,7 @@ namespace GVFS.Common
                         tracer.RelatedError($"{nameof(WaitUntilMounted)}: {errorMessage}");
                         return false;
                     }
-                    catch (JsonReaderException e)
+                    catch (JsonException e)
                     {
                         errorMessage = string.Format("Failed to parse response from GVFS.Mount.\n {0}", e);
                         tracer.RelatedError($"{nameof(WaitUntilMounted)}: {errorMessage}");

--- a/GVFS/GVFS.Common/GVFSJsonOptions.cs
+++ b/GVFS/GVFS.Common/GVFSJsonOptions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.Json;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Shared JsonSerializerOptions and helpers for the GVFS codebase.
+    /// PropertyNameCaseInsensitive preserves backward compatibility with
+    /// Newtonsoft.Json's default case-insensitive deserialization.
+    /// </summary>
+    public static class GVFSJsonOptions
+    {
+        public static readonly JsonSerializerOptions Default = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new VersionConverter(), new Tracing.EventMetadataConverter() },
+        };
+
+        /// <summary>
+        /// Serialize using the compile-time type. Use when <typeparamref name="T"/>
+        /// is the concrete type (not a base class with derived properties).
+        /// </summary>
+        public static string Serialize<T>(T value)
+        {
+            return JsonSerializer.Serialize(value, Default);
+        }
+
+        /// <summary>
+        /// Serialize using the runtime type. Use when calling from a base-class
+        /// method where compile-time type would lose derived-class properties
+        /// (e.g., BaseResponse&lt;T&gt;.ToMessage()).
+        /// </summary>
+        public static string Serialize(object value, Type inputType)
+        {
+            return JsonSerializer.Serialize(value, inputType, Default);
+        }
+
+        public static T Deserialize<T>(string json)
+        {
+            return JsonSerializer.Deserialize<T>(json, Default);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/Http/CacheServerInfo.cs
+++ b/GVFS/GVFS.Common/Http/CacheServerInfo.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace GVFS.Common.Http
 {

--- a/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
@@ -1,8 +1,8 @@
-﻿using GVFS.Common.Tracing;
-using Newtonsoft.Json;
+using GVFS.Common.Tracing;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 
 namespace GVFS.Common.Http
@@ -66,10 +66,10 @@ namespace GVFS.Common.Http
                         try
                         {
                             string configString = response.RetryableReadToEnd();
-                            ServerGVFSConfig config = JsonConvert.DeserializeObject<ServerGVFSConfig>(configString);
+                            ServerGVFSConfig config = GVFSJsonOptions.Deserialize<ServerGVFSConfig>(configString);
                             return new RetryWrapper<ServerGVFSConfig>.CallbackResult(config);
                         }
-                        catch (JsonReaderException e)
+                        catch (JsonException e)
                         {
                             return new RetryWrapper<ServerGVFSConfig>.CallbackResult(e, shouldRetry: false);
                         }

--- a/GVFS/GVFS.Common/Http/GitObjectsHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/GitObjectsHttpRequestor.cs
@@ -1,8 +1,8 @@
-﻿using GVFS.Common.Git;
+using GVFS.Common.Git;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -81,7 +81,7 @@ namespace GVFS.Common.Http
                         }
 
                         string objectSizesString = response.RetryableReadToEnd();
-                        List<GitObjectSize> objectSizes = JsonConvert.DeserializeObject<List<GitObjectSize>>(objectSizesString);
+                        List<GitObjectSize> objectSizes = GVFSJsonOptions.Deserialize<List<GitObjectSize>>(objectSizesString);
                         return new RetryWrapper<List<GitObjectSize>>.CallbackResult(objectSizes);
                     }
                 });
@@ -343,8 +343,8 @@ namespace GVFS.Common.Http
 
         public class GitObjectSize
         {
-            public readonly string Id;
-            public readonly long Size;
+            public string Id { get; set; }
+            public long Size { get; set; }
 
             [JsonConstructor]
             public GitObjectSize(string id, long size)

--- a/GVFS/GVFS.Common/InternalVerbParameters.cs
+++ b/GVFS/GVFS.Common/InternalVerbParameters.cs
@@ -1,4 +1,3 @@
-﻿using Newtonsoft.Json;
 
 namespace GVFS.Common
 {
@@ -23,12 +22,12 @@ namespace GVFS.Common
 
         public static InternalVerbParameters FromJson(string json)
         {
-            return JsonConvert.DeserializeObject<InternalVerbParameters>(json);
+            return GVFSJsonOptions.Deserialize<InternalVerbParameters>(json);
         }
 
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this);
+            return GVFSJsonOptions.Serialize(this);
         }
     }
 }

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -46,12 +45,12 @@ namespace GVFS.Common.NamedPipes
 
                 public static Response FromJson(string json)
                 {
-                    return JsonConvert.DeserializeObject<Response>(json);
+                    return GVFSJsonOptions.Deserialize<Response>(json);
                 }
 
                 public string ToJson()
                 {
-                    return JsonConvert.SerializeObject(this);
+                    return GVFSJsonOptions.Serialize(this);
                 }
             }
         }
@@ -203,6 +202,10 @@ namespace GVFS.Common.NamedPipes
 
             public class Request
             {
+                public Request()
+                {
+                }
+
                 public Request(string backupFolderPath, string folders)
                 {
                     this.Folders = folders;
@@ -211,21 +214,27 @@ namespace GVFS.Common.NamedPipes
 
                 public static Request FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Request>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Request>(message.Body);
                 }
 
-                public string Folders { get; }
+                public string Folders { get; set; }
 
-                public string BackupFolderPath { get; }
+                public string BackupFolderPath { get; set; }
 
                 public Message CreateMessage()
                 {
-                    return new Message(Dehydrate, JsonConvert.SerializeObject(this));
+                    return new Message(Dehydrate, GVFSJsonOptions.Serialize(this));
                 }
             }
 
             public class Response
             {
+                public Response()
+                {
+                    this.SuccessfulFolders = new List<string>();
+                    this.FailedFolders = new List<string>();
+                }
+
                 public Response(string result)
                 {
                     this.Result = result;
@@ -233,18 +242,18 @@ namespace GVFS.Common.NamedPipes
                     this.FailedFolders = new List<string>();
                 }
 
-                public string Result { get; }
-                public List<string> SuccessfulFolders { get; }
-                public List<string> FailedFolders { get; }
+                public string Result { get; set; }
+                public List<string> SuccessfulFolders { get; set; }
+                public List<string> FailedFolders { get; set; }
 
                 public static Response FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
                 }
 
                 public Message CreateMessage()
                 {
-                    return new Message(this.Result, JsonConvert.SerializeObject(this));
+                    return new Message(this.Result, GVFSJsonOptions.Serialize(this));
                 }
             }
         }
@@ -259,7 +268,7 @@ namespace GVFS.Common.NamedPipes
             {
                 public Request(List<string> packIndexes)
                 {
-                    this.PackIndexList = JsonConvert.SerializeObject(packIndexes);
+                    this.PackIndexList = GVFSJsonOptions.Serialize(packIndexes);
                 }
 
                 public Request(Message message)
@@ -324,12 +333,12 @@ namespace GVFS.Common.NamedPipes
 
                 public static Request FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Request>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Request>(message.Body);
                 }
 
                 public Message ToMessage()
                 {
-                    return new Message(Header, JsonConvert.SerializeObject(this));
+                    return new Message(Header, GVFSJsonOptions.Serialize(this));
                 }
             }
         }
@@ -342,19 +351,19 @@ namespace GVFS.Common.NamedPipes
 
             public static UnregisterRepoRequest FromMessage(Message message)
             {
-                return JsonConvert.DeserializeObject<UnregisterRepoRequest>(message.Body);
+                return GVFSJsonOptions.Deserialize<UnregisterRepoRequest>(message.Body);
             }
 
             public Message ToMessage()
             {
-                return new Message(Header, JsonConvert.SerializeObject(this));
+                return new Message(Header, GVFSJsonOptions.Serialize(this));
             }
 
             public class Response : BaseResponse<UnregisterRepoRequest>
             {
                 public static Response FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
                 }
             }
         }
@@ -368,19 +377,19 @@ namespace GVFS.Common.NamedPipes
 
             public static RegisterRepoRequest FromMessage(Message message)
             {
-                return JsonConvert.DeserializeObject<RegisterRepoRequest>(message.Body);
+                return GVFSJsonOptions.Deserialize<RegisterRepoRequest>(message.Body);
             }
 
             public Message ToMessage()
             {
-                return new Message(Header, JsonConvert.SerializeObject(this));
+                return new Message(Header, GVFSJsonOptions.Serialize(this));
             }
 
             public class Response : BaseResponse<RegisterRepoRequest>
             {
                 public static Response FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
                 }
             }
         }
@@ -393,19 +402,19 @@ namespace GVFS.Common.NamedPipes
 
             public static EnableAndAttachProjFSRequest FromMessage(Message message)
             {
-                return JsonConvert.DeserializeObject<EnableAndAttachProjFSRequest>(message.Body);
+                return GVFSJsonOptions.Deserialize<EnableAndAttachProjFSRequest>(message.Body);
             }
 
             public Message ToMessage()
             {
-                return new Message(Header, JsonConvert.SerializeObject(this));
+                return new Message(Header, GVFSJsonOptions.Serialize(this));
             }
 
             public class Response : BaseResponse<EnableAndAttachProjFSRequest>
             {
                 public static Response FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
                 }
             }
         }
@@ -416,12 +425,12 @@ namespace GVFS.Common.NamedPipes
 
             public static GetActiveRepoListRequest FromMessage(Message message)
             {
-                return JsonConvert.DeserializeObject<GetActiveRepoListRequest>(message.Body);
+                return GVFSJsonOptions.Deserialize<GetActiveRepoListRequest>(message.Body);
             }
 
             public Message ToMessage()
             {
-                return new Message(Header, JsonConvert.SerializeObject(this));
+                return new Message(Header, GVFSJsonOptions.Serialize(this));
             }
 
             public class Response : BaseResponse<GetActiveRepoListRequest>
@@ -430,7 +439,7 @@ namespace GVFS.Common.NamedPipes
 
                 public static Response FromMessage(Message message)
                 {
-                    return JsonConvert.DeserializeObject<Response>(message.Body);
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
                 }
             }
         }
@@ -444,7 +453,7 @@ namespace GVFS.Common.NamedPipes
 
             public Message ToMessage()
             {
-                return new Message(Header, JsonConvert.SerializeObject(this));
+                return new Message(Header, GVFSJsonOptions.Serialize(this, this.GetType()));
             }
         }
     }

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -1,10 +1,9 @@
-﻿using GVFS.Common.FileSystem;
+using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Prefetch.Git;
 using GVFS.Common.Prefetch.Pipeline;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -140,8 +139,8 @@ namespace GVFS.Common.Prefetch
                 lastPrefetchArgs.TryGetValue(PrefetchArgs.Folders, out string lastFoldersString) &&
                 lastPrefetchArgs.TryGetValue(PrefetchArgs.Hydrate, out string lastHydrateString))
             {
-                string newFilesString = JsonConvert.SerializeObject(files);
-                string newFoldersString = JsonConvert.SerializeObject(folders);
+                string newFilesString = GVFSJsonOptions.Serialize(files);
+                string newFoldersString = GVFSJsonOptions.Serialize(folders);
                 bool isNoop =
                     commitId == lastCommitId &&
                     hydrateFilesAfterDownload.ToString() == lastHydrateString &&
@@ -587,8 +586,8 @@ namespace GVFS.Common.Prefetch
                     new[]
                     {
                         new KeyValuePair<string, string>(PrefetchArgs.CommitId, targetCommit),
-                        new KeyValuePair<string, string>(PrefetchArgs.Files, JsonConvert.SerializeObject(this.FileList)),
-                        new KeyValuePair<string, string>(PrefetchArgs.Folders, JsonConvert.SerializeObject(this.FolderList)),
+                        new KeyValuePair<string, string>(PrefetchArgs.Files, GVFSJsonOptions.Serialize(this.FileList)),
+                        new KeyValuePair<string, string>(PrefetchArgs.Folders, GVFSJsonOptions.Serialize(this.FolderList)),
                         new KeyValuePair<string, string>(PrefetchArgs.Hydrate, hydrate.ToString()),
                     });
             }

--- a/GVFS/GVFS.Common/ServerGVFSConfig.cs
+++ b/GVFS/GVFS.Common/ServerGVFSConfig.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace GVFS.Common
 {
@@ -13,7 +14,10 @@ namespace GVFS.Common
 
         public class VersionRange
         {
+            [JsonConverter(typeof(VersionConverter))]
             public Version Min { get; set; }
+
+            [JsonConverter(typeof(VersionConverter))]
             public Version Max { get; set; }
         }
     }

--- a/GVFS/GVFS.Common/Tracing/EventMetadataConverter.cs
+++ b/GVFS/GVFS.Common/Tracing/EventMetadataConverter.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GVFS.Common.Tracing
+{
+    /// <summary>
+    /// Custom JSON converter for EventMetadata (Dictionary&lt;string, object&gt;).
+    /// Handles the known value types stored in EventMetadata without relying on
+    /// System.Text.Json's polymorphic object serialization, which can produce
+    /// unexpected results for boxed enums, HttpStatusCode, etc.
+    /// </summary>
+    public class EventMetadataConverter : JsonConverter<EventMetadata>
+    {
+        public override EventMetadata Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject");
+            }
+
+            EventMetadata metadata = new EventMetadata();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return metadata;
+                }
+
+                string key = reader.GetString();
+                reader.Read();
+
+                object value = reader.TokenType switch
+                {
+                    JsonTokenType.String => reader.GetString(),
+                    JsonTokenType.Number when reader.TryGetInt32(out int i) => i,
+                    JsonTokenType.Number when reader.TryGetInt64(out long l) => l,
+                    JsonTokenType.Number when reader.TryGetDouble(out double d) => d,
+                    JsonTokenType.True => true,
+                    JsonTokenType.False => false,
+                    JsonTokenType.Null => null,
+                    _ => reader.GetString()
+                };
+
+                metadata[key] = value;
+            }
+
+            throw new JsonException("Unexpected end of JSON");
+        }
+
+        public override void Write(Utf8JsonWriter writer, EventMetadata value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            foreach (KeyValuePair<string, object> kvp in value)
+            {
+                writer.WritePropertyName(kvp.Key);
+                WriteValue(writer, kvp.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Serialize EventMetadata directly using Utf8JsonWriter, bypassing
+        /// JsonSerializer entirely. Safe for all known EventMetadata value types.
+        /// </summary>
+        public static string SerializeToString(EventMetadata metadata)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (Utf8JsonWriter writer = new Utf8JsonWriter(stream))
+                {
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<string, object> kvp in metadata)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        WriteValue(writer, kvp.Value);
+                    }
+
+                    writer.WriteEndObject();
+                }
+
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+
+        private static void WriteValue(Utf8JsonWriter writer, object value)
+        {
+            switch (value)
+            {
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                case string s:
+                    writer.WriteStringValue(s);
+                    break;
+                case int i:
+                    writer.WriteNumberValue(i);
+                    break;
+                case long l:
+                    writer.WriteNumberValue(l);
+                    break;
+                case double d:
+                    writer.WriteNumberValue(d);
+                    break;
+                case bool b:
+                    writer.WriteBooleanValue(b);
+                    break;
+                case float f:
+                    writer.WriteNumberValue(f);
+                    break;
+                case HttpStatusCode status:
+                    writer.WriteNumberValue((int)status);
+                    break;
+                case Enum e:
+                    writer.WriteStringValue(e.ToString());
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/Tracing/JsonTracer.cs
+++ b/GVFS/GVFS.Common/Tracing/JsonTracer.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -346,7 +345,7 @@ namespace GVFS.Common.Tracing
                 Level = EventLevel.Informational,
                 Keywords = Keywords.Any,
                 Opcode = EventOpcode.Info,
-                Payload = JsonConvert.SerializeObject(new Dictionary<string, string>
+                Payload = GVFSJsonOptions.Serialize(new Dictionary<string, string>
                 {
                     ["EventListener"] = recoveredListener.GetType().Name
                 })
@@ -361,7 +360,7 @@ namespace GVFS.Common.Tracing
                 Level = EventLevel.Error,
                 Keywords = Keywords.Any,
                 Opcode = EventOpcode.Info,
-                Payload = JsonConvert.SerializeObject(new Dictionary<string, string>
+                Payload = GVFSJsonOptions.Serialize(new Dictionary<string, string>
                 {
                     ["EventListener"] = failedListener.GetType().Name,
                     ["ErrorMessage"] = errorMessage,
@@ -371,7 +370,7 @@ namespace GVFS.Common.Tracing
 
         private void WriteEvent(string eventName, EventLevel level, Keywords keywords, EventMetadata metadata, EventOpcode opcode)
         {
-            string jsonPayload = metadata != null ? JsonConvert.SerializeObject(metadata) : null;
+            string jsonPayload = metadata != null ? EventMetadataConverter.SerializeToString(metadata) : null;
 
             if (this.isDisposed)
             {

--- a/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+using System;
 
 namespace GVFS.Common.Tracing
 {
@@ -24,7 +23,7 @@ namespace GVFS.Common.Tracing
                 return;
             }
 
-            ConsoleOutputPayload payload = JsonConvert.DeserializeObject<ConsoleOutputPayload>(message.Payload);
+            ConsoleOutputPayload payload = GVFSJsonOptions.Deserialize<ConsoleOutputPayload>(message.Payload);
             if (string.IsNullOrEmpty(payload.ErrorMessage))
             {
                 return;

--- a/GVFS/GVFS.Common/Tracing/TelemetryDaemonEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/TelemetryDaemonEventListener.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO.Pipes;
 using GVFS.Common.Git;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace GVFS.Common.Tracing
 {
@@ -129,38 +130,38 @@ namespace GVFS.Common.Tracing
 
         public class PipeMessage
         {
-            [JsonProperty("version")]
+            [JsonPropertyName("version")]
             public string Version { get; set; }
-            [JsonProperty("providerName")]
+            [JsonPropertyName("providerName")]
             public string ProviderName { get; set; }
-            [JsonProperty("eventName")]
+            [JsonPropertyName("eventName")]
             public string EventName { get; set; }
-            [JsonProperty("eventLevel")]
+            [JsonPropertyName("eventLevel")]
             public EventLevel EventLevel { get; set; }
-            [JsonProperty("eventOpcode")]
+            [JsonPropertyName("eventOpcode")]
             public EventOpcode EventOpcode { get; set; }
-            [JsonProperty("payload")]
+            [JsonPropertyName("payload")]
             public PipeMessagePayload Payload { get; set; }
 
             public static PipeMessage FromJson(string json)
             {
-                return JsonConvert.DeserializeObject<PipeMessage>(json);
+                return GVFSJsonOptions.Deserialize<PipeMessage>(json);
             }
 
             public string ToJson()
             {
-                return JsonConvert.SerializeObject(this);
+                return GVFSJsonOptions.Serialize(this);
             }
 
             public class PipeMessagePayload
             {
-                [JsonProperty("enlistmentId")]
+                [JsonPropertyName("enlistmentId")]
                 public string EnlistmentId { get; set; }
-                [JsonProperty("mountId")]
+                [JsonPropertyName("mountId")]
                 public string MountId { get; set; }
-                [JsonProperty("gitCommandSessionId")]
+                [JsonPropertyName("gitCommandSessionId")]
                 public string GitCommandSessionId { get; set; }
-                [JsonProperty("json")]
+                [JsonPropertyName("json")]
                 public string Json { get; set; }
             }
         }

--- a/GVFS/GVFS.Common/VersionConverter.cs
+++ b/GVFS/GVFS.Common/VersionConverter.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Custom JsonConverter for System.Version that handles both string format ("1.0.0.0")
+    /// and object format ({"Major":1,"Minor":0,"Build":0,"Revision":0}).
+    ///
+    /// Newtonsoft.Json could deserialize System.Version from either format automatically.
+    /// System.Text.Json has no built-in converter for System.Version, so this is required.
+    /// </summary>
+    public class VersionConverter : JsonConverter<Version>
+    {
+        public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return new Version(reader.GetString());
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                int major = 0, minor = 0, build = -1, revision = -1;
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        break;
+                    }
+
+                    if (reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        string propertyName = reader.GetString();
+                        reader.Read();
+
+                        switch (propertyName)
+                        {
+                            case "Major":
+                                major = reader.GetInt32();
+                                break;
+                            case "Minor":
+                                minor = reader.GetInt32();
+                                break;
+                            case "Build":
+                                build = reader.GetInt32();
+                                break;
+                            case "Revision":
+                                revision = reader.GetInt32();
+                                break;
+                            default:
+                                reader.Skip();
+                                break;
+                        }
+                    }
+                }
+
+                if (build < 0)
+                {
+                    return new Version(major, minor);
+                }
+
+                if (revision < 0)
+                {
+                    return new Version(major, minor, build);
+                }
+
+                return new Version(major, minor, build, revision);
+            }
+
+            throw new JsonException($"Unexpected token type '{reader.TokenType}' when deserializing System.Version.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Version value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value.ToString());
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.Common/VersionResponse.cs
+++ b/GVFS/GVFS.Common/VersionResponse.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 
 namespace GVFS.Common
 {
@@ -8,7 +7,7 @@ namespace GVFS.Common
 
         public static VersionResponse FromJsonString(string jsonString)
         {
-            return JsonConvert.DeserializeObject<VersionResponse>(jsonString);
+            return GVFSJsonOptions.Deserialize<VersionResponse>(jsonString);
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
+++ b/GVFS/GVFS.FunctionalTests/GVFS.FunctionalTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="NUnitLite" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSFunctionalTestEnlistment.cs
@@ -2,12 +2,12 @@
 using GVFS.FunctionalTests.Should;
 using GVFS.FunctionalTests.Tests;
 using GVFS.Tests.Should;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading;
 
 namespace GVFS.FunctionalTests.Tools
@@ -152,12 +152,14 @@ namespace GVFS.FunctionalTests.Tools
                                                             .ToArray();
             objectRootEntries.Length.ShouldEqual(1, $"Should be only one entry for repo url: {this.RepoUrl} mapping file content: {mappingFileContents}");
             objectRootEntries[0].Substring(0, 2).ShouldEqual("A ", $"Invalid mapping entry for repo: {objectRootEntries[0]}");
-            JObject rootEntryJson = JObject.Parse(objectRootEntries[0].Substring(2));
-            string objectRootFolder = rootEntryJson.GetValue("Value").ToString();
-            objectRootFolder.ShouldNotBeNull();
-            objectRootFolder.Length.ShouldBeAtLeast(1, $"Invalid object root folder: {objectRootFolder} for {this.RepoUrl} mapping file content: {mappingFileContents}");
+            using (JsonDocument rootEntryJson = JsonDocument.Parse(objectRootEntries[0].Substring(2)))
+            {
+                string objectRootFolder = rootEntryJson.RootElement.GetProperty("Value").GetString();
+                objectRootFolder.ShouldNotBeNull();
+                objectRootFolder.Length.ShouldBeAtLeast(1, $"Invalid object root folder: {objectRootFolder} for {this.RepoUrl} mapping file content: {mappingFileContents}");
 
-            return Path.Combine(this.LocalCacheRoot, objectRootFolder, "gitObjects");
+                return Path.Combine(this.LocalCacheRoot, objectRootFolder, "gitObjects");
+            }
         }
 
         public string GetPackRoot(FileSystemRunner fileSystem)

--- a/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GVFSHelpers.cs
@@ -1,8 +1,8 @@
-﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.Common;
+using GVFS.FunctionalTests.FileSystemRunners;
 using GVFS.FunctionalTests.Should;
 using GVFS.Tests.Should;
 using Microsoft.Data.Sqlite;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -289,7 +289,7 @@ namespace GVFS.FunctionalTests.Tools
                     json = reader.ReadLine();
                     json.Substring(0, 2).ShouldEqual("A ");
 
-                    KeyValuePair<string, string> kvp = JsonConvert.DeserializeObject<KeyValuePair<string, string>>(json.Substring(2));
+                    KeyValuePair<string, string> kvp = GVFSJsonOptions.Deserialize<KeyValuePair<string, string>>(json.Substring(2));
                     if (kvp.Key == key)
                     {
                         return kvp.Value;
@@ -314,7 +314,7 @@ namespace GVFS.FunctionalTests.Tools
                     json = reader.ReadLine();
                     json.Substring(0, 2).ShouldEqual("A ");
 
-                    KeyValuePair<string, string> kvp = JsonConvert.DeserializeObject<KeyValuePair<string, string>>(json.Substring(2));
+                    KeyValuePair<string, string> kvp = GVFSJsonOptions.Deserialize<KeyValuePair<string, string>>(json.Substring(2));
                     repoMetadata.Add(kvp.Key, kvp.Value);
                 }
             }
@@ -325,7 +325,7 @@ namespace GVFS.FunctionalTests.Tools
 
             foreach (KeyValuePair<string, string> kvp in repoMetadata)
             {
-                newRepoMetadataContents += "A " + JsonConvert.SerializeObject(kvp).Trim() + "\r\n";
+                newRepoMetadataContents += "A " + GVFSJsonOptions.Serialize(kvp).Trim() + "\r\n";
             }
 
             File.WriteAllText(metadataPath, newRepoMetadataContents);

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Common.Database;
 using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
@@ -9,7 +9,6 @@ using GVFS.Common.Tracing;
 using GVFS.PlatformLoader;
 using GVFS.Virtualization;
 using GVFS.Virtualization.FileSystem;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -971,7 +970,7 @@ namespace GVFS.Mount
             NamedPipeMessages.RunPostFetchJob.Response response;
             if (this.currentState == MountState.Ready)
             {
-                List<string> packIndexes = JsonConvert.DeserializeObject<List<string>>(message.Body);
+                List<string> packIndexes = GVFSJsonOptions.Deserialize<List<string>>(message.Body);
                 this.maintenanceScheduler.EnqueueOneTimeStep(new PostFetchStep(this.context, packIndexes));
 
                 response = new NamedPipeMessages.RunPostFetchJob.Response(NamedPipeMessages.RunPostFetchJob.QueuedResult);

--- a/GVFS/GVFS.Service/GVFS.Service.csproj
+++ b/GVFS/GVFS.Service/GVFS.Service.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 

--- a/GVFS/GVFS.Service/RepoRegistration.cs
+++ b/GVFS/GVFS.Service/RepoRegistration.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using GVFS.Common;
 
 namespace GVFS.Service
 {
@@ -21,12 +21,7 @@ namespace GVFS.Service
 
         public static RepoRegistration FromJson(string json)
         {
-            return JsonConvert.DeserializeObject<RepoRegistration>(
-                json,
-                new JsonSerializerSettings
-                {
-                    MissingMemberHandling = MissingMemberHandling.Ignore
-                });
+            return GVFSJsonOptions.Deserialize<RepoRegistration>(json);
         }
 
         public override string ToString()
@@ -41,7 +36,7 @@ namespace GVFS.Service
 
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this);
+            return GVFSJsonOptions.Serialize(this);
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/CacheServerResolverTests.cs
@@ -1,10 +1,9 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace GVFS.UnitTests.Common
@@ -217,7 +216,7 @@ namespace GVFS.UnitTests.Common
 
         private ServerGVFSConfig CreateDefaultDeserializedGVFSConfig()
         {
-            return JsonConvert.DeserializeObject<ServerGVFSConfig>("{}");
+            return GVFSJsonOptions.Deserialize<ServerGVFSConfig>("{}");
         }
 
         private CacheServerResolver CreateResolver(MockGVFSEnlistment enlistment = null)

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -1,5 +1,5 @@
+using GVFS.Common;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -54,7 +54,7 @@ namespace GVFS.UnitTests.Mock.Common
         public void RelatedInfo(EventMetadata metadata, string message)
         {
             metadata[TracingConstants.MessageKey.InfoMessage] = message;
-            this.RelatedInfoEvents.Add(JsonConvert.SerializeObject(metadata));
+            this.RelatedInfoEvents.Add(GVFSJsonOptions.Serialize(metadata));
         }
 
         public void RelatedInfo(string format, params object[] args)
@@ -67,7 +67,7 @@ namespace GVFS.UnitTests.Mock.Common
             if (metadata != null)
             {
                 metadata[TracingConstants.MessageKey.WarningMessage] = message;
-                this.RelatedWarningEvents.Add(JsonConvert.SerializeObject(metadata));
+                this.RelatedWarningEvents.Add(GVFSJsonOptions.Serialize(metadata));
             }
             else if (message != null)
             {
@@ -93,7 +93,7 @@ namespace GVFS.UnitTests.Mock.Common
         public void RelatedError(EventMetadata metadata, string message)
         {
             metadata[TracingConstants.MessageKey.ErrorMessage] = message;
-            this.RelatedErrorEvents.Add(JsonConvert.SerializeObject(metadata));
+            this.RelatedErrorEvents.Add(GVFSJsonOptions.Serialize(metadata));
         }
 
         public void RelatedError(EventMetadata metadata, string message, Keywords keyword)

--- a/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
+++ b/GVFS/GVFS.UnitTests/Tracing/TelemetryDaemonEventListenerTests.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace GVFS.UnitTests.Tracing
@@ -22,22 +23,6 @@ namespace GVFS.UnitTests.Tracing
             const string gitCommandSessionId = "test_sessionId";
             const string payload = "test-payload";
 
-            Dictionary<string, object> expectedDict = new Dictionary<string, object>
-            {
-                ["version"] = vfsVersion,
-                ["providerName"] = providerName,
-                ["eventName"] = eventName,
-                ["eventLevel"] = (int)level,
-                ["eventOpcode"] = (int)opcode,
-                ["payload"] = new Dictionary<string, string>
-                {
-                    ["enlistmentId"] = enlistmentId,
-                    ["mountId"] = mountId,
-                    ["gitCommandSessionId"] = gitCommandSessionId,
-                    ["json"] = payload,
-                },
-            };
-
             TelemetryDaemonEventListener.PipeMessage message = new TelemetryDaemonEventListener.PipeMessage
             {
                 Version = vfsVersion,
@@ -56,22 +41,23 @@ namespace GVFS.UnitTests.Tracing
 
             string messageJson = message.ToJson();
 
-            Dictionary<string, object> actualDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(messageJson);
+            using (JsonDocument doc = JsonDocument.Parse(messageJson))
+            {
+                JsonElement root = doc.RootElement;
+                root.EnumerateObject().Count().ShouldEqual(6);
+                root.GetProperty("version").GetString().ShouldEqual(vfsVersion);
+                root.GetProperty("providerName").GetString().ShouldEqual(providerName);
+                root.GetProperty("eventName").GetString().ShouldEqual(eventName);
+                root.GetProperty("eventLevel").GetInt32().ShouldEqual((int)level);
+                root.GetProperty("eventOpcode").GetInt32().ShouldEqual((int)opcode);
 
-            actualDict.Count.ShouldEqual(expectedDict.Count);
-            actualDict["version"].ShouldEqual(expectedDict["version"]);
-            actualDict["providerName"].ShouldEqual(expectedDict["providerName"]);
-            actualDict["eventName"].ShouldEqual(expectedDict["eventName"]);
-            actualDict["eventLevel"].ShouldEqual(expectedDict["eventLevel"]);
-            actualDict["eventOpcode"].ShouldEqual(expectedDict["eventOpcode"]);
-
-            Dictionary<string, string> expectedPayloadDict = (Dictionary<string, string>)expectedDict["payload"];
-            Dictionary<string, string> actualPayloadDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(actualDict["payload"].ToString());
-            actualPayloadDict.Count.ShouldEqual(expectedPayloadDict.Count);
-            actualPayloadDict["enlistmentId"].ShouldEqual(expectedPayloadDict["enlistmentId"]);
-            actualPayloadDict["mountId"].ShouldEqual(expectedPayloadDict["mountId"]);
-            actualPayloadDict["gitCommandSessionId"].ShouldEqual(expectedPayloadDict["gitCommandSessionId"]);
-            actualPayloadDict["json"].ShouldEqual(expectedPayloadDict["json"]);
+                JsonElement payloadElement = root.GetProperty("payload");
+                payloadElement.EnumerateObject().Count().ShouldEqual(4);
+                payloadElement.GetProperty("enlistmentId").GetString().ShouldEqual(enlistmentId);
+                payloadElement.GetProperty("mountId").GetString().ShouldEqual(mountId);
+                payloadElement.GetProperty("gitCommandSessionId").GetString().ShouldEqual(gitCommandSessionId);
+                payloadElement.GetProperty("json").GetString().ShouldEqual(payload);
+            }
         }
     }
 }

--- a/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/FileSystemCallbacksTests.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Common.Database;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
@@ -13,7 +13,6 @@ using GVFS.UnitTests.Virtual;
 using GVFS.Virtualization;
 using GVFS.Virtualization.Background;
 using Moq;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -163,8 +162,8 @@ namespace GVFS.UnitTests.Virtualization
                 metadata.Count.ShouldEqual(8);
                 metadata.ContainsKey("FilePlaceholderCreation").ShouldBeTrue();
                 metadata.TryGetValue("FilePlaceholderCreation", out object fileNestedMetadata);
-                JsonConvert.SerializeObject(fileNestedMetadata).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe\"");
-                JsonConvert.SerializeObject(fileNestedMetadata).ShouldContain("\"ProcessCount1\":1");
+                GVFSJsonOptions.Serialize(fileNestedMetadata).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe\"");
+                GVFSJsonOptions.Serialize(fileNestedMetadata).ShouldContain("\"ProcessCount1\":1");
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("FilePlaceholderCount", 1);
                 metadata.ShouldContain("FolderPlaceholderCount", 0);
@@ -188,16 +187,16 @@ namespace GVFS.UnitTests.Virtualization
                 // Only processes that have created placeholders since the last heartbeat should be named
                 metadata.ContainsKey("FilePlaceholderCreation").ShouldBeTrue();
                 metadata.TryGetValue("FilePlaceholderCreation", out object fileNestedMetadata2);
-                JsonConvert.SerializeObject(fileNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
-                JsonConvert.SerializeObject(fileNestedMetadata2).ShouldContain("\"ProcessCount1\":2");
+                GVFSJsonOptions.Serialize(fileNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
+                GVFSJsonOptions.Serialize(fileNestedMetadata2).ShouldContain("\"ProcessCount1\":2");
                 metadata.ContainsKey("FolderPlaceholderCreation").ShouldBeTrue();
                 metadata.TryGetValue("FolderPlaceholderCreation", out object folderNestedMetadata2);
-                JsonConvert.SerializeObject(folderNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
-                JsonConvert.SerializeObject(folderNestedMetadata2).ShouldContain("\"ProcessCount1\":1");
+                GVFSJsonOptions.Serialize(folderNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
+                GVFSJsonOptions.Serialize(folderNestedMetadata2).ShouldContain("\"ProcessCount1\":1");
                 metadata.ContainsKey("FilePlaceholdersHydrated").ShouldBeTrue();
                 metadata.TryGetValue("FilePlaceholdersHydrated", out object hydrationNestedMetadata2);
-                JsonConvert.SerializeObject(hydrationNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
-                JsonConvert.SerializeObject(hydrationNestedMetadata2).ShouldContain("\"ProcessCount1\":1");
+                GVFSJsonOptions.Serialize(hydrationNestedMetadata2).ShouldContain("\"ProcessName1\":\"GVFS.UnitTests.exe2\"");
+                GVFSJsonOptions.Serialize(hydrationNestedMetadata2).ShouldContain("\"ProcessCount1\":1");
                 metadata.ShouldContain("ModifiedPathsCount", 1);
                 metadata.ShouldContain("FilePlaceholderCount", 3);
                 metadata.ShouldContain("FolderPlaceholderCount", 1);

--- a/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
+++ b/GVFS/GVFS.Virtualization/Background/FileSystemTask.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using GVFS.Common;
 
 namespace GVFS.Virtualization.Background
 {
@@ -133,7 +133,7 @@ namespace GVFS.Virtualization.Background
 
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this);
+            return GVFSJsonOptions.Serialize(this);
         }
     }
 }

--- a/GVFS/GVFS.Virtualization/GVFS.Virtualization.csproj
+++ b/GVFS/GVFS.Virtualization/GVFS.Virtualization.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -4,11 +4,11 @@ using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Security;
 using System.Text;
 
@@ -63,7 +63,7 @@ namespace GVFS.CommandLine
 
                         this.StartedByService = mountInternal.StartedByService;
                     }
-                    catch (JsonReaderException e)
+                    catch (JsonException e)
                     {
                         this.ReportErrorAndExit("Failed to parse InternalParameters: {0}.\n {1}", value, e);
                     }


### PR DESCRIPTION
# Migrate from Newtonsoft.Json to System.Text.Json

## Summary

Replace Newtonsoft.Json 13.0.1 with System.Text.Json 8.0.5 across the entire codebase. This eliminates the reflection-heavy Newtonsoft dependency, a prerequisite for NativeAOT compilation.

## What changed

- **New: `GVFSJsonOptions.cs`** — shared `JsonSerializerOptions` with `PropertyNameCaseInsensitive = true`, centralized `Serialize<T>`/`Serialize(obj, Type)`/`Deserialize<T>` helpers, and registered custom converters
- **New: `EventMetadataConverter.cs`** — custom `JsonConverter<EventMetadata>` for AOT-safe `Dictionary<string, object>` serialization (handles boxed enums, HttpStatusCode, int/long/double/bool/float)
- **New: `VersionConverter.cs`** — custom `JsonConverter<Version>` for `System.Version` (STJ has no built-in support, unlike Newtonsoft)
- **23 source files** — replaced `JsonConvert.SerializeObject/DeserializeObject` with `GVFSJsonOptions.Serialize/Deserialize` helpers
- **10 attribute changes** — `[JsonProperty("name")]` → `[JsonPropertyName("name")]` in `TelemetryDaemonEventListener`
- **`ServerGVFSConfig.VersionRange`** — added `[JsonConverter(typeof(VersionConverter))]` on `Min`/`Max` properties
- **`BaseResponse<T>.ToMessage()`** — uses `GVFSJsonOptions.Serialize(this, this.GetType())` for runtime type dispatch (prevents polymorphic serialization from dropping derived-class properties)
- **`GitObjectSize`** — changed readonly fields to properties (STJ ignores fields by default)
- **`DehydrateFolders.Request/Response`** — added parameterless constructors and public setters for STJ deserialization
- **`JObject.Parse`** → `JsonDocument.Parse` in functional tests (read-only, IDisposable)
- **`JsonReaderException`** → `JsonException`
- **`Directory.Build.props`** — set `LangVersion=latest`
- **5 csproj files** — swapped `Newtonsoft.Json` → `System.Text.Json`
- **`Directory.Packages.props`** — removed Newtonsoft.Json

## Review guide

- **`GVFSJsonOptions.cs`** — two `Serialize` overloads: generic (compile-time type) and `(object, Type)` (runtime type). The runtime-type overload is critical for `BaseResponse<T>` polymorphic serialization
- **`NamedPipeMessages.cs`** — highest-risk file (IPC contract); `BaseResponse<T>.ToMessage()` must use runtime type dispatch
- **`EventMetadataConverter.cs`** — handles all value types stored in `EventMetadata` without reflection
- **`VersionConverter.cs`** — required because STJ has no built-in `System.Version` support; handles both string and object JSON formats

## Verification

- ✅ All C# projects build
- ✅ 800/800 unit tests pass
- ✅ 20+ functional tests pass locally (clone, mount, file operations)
- ✅ Compared against miniksa's NativeAOT branch for completeness

## Context

Phase 2A of .NET 10 NativeAOT migration.
