### PR TITLE
Re-enable functional tests disabled for ProjFS buffer regression (#1696)

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/CheckoutTests.cs
@@ -112,7 +112,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Ignore("This doesn't work right now. Tracking if this is a ProjFS problem. See #1696 for tracking.")]
         public void CheckoutNewBranchFromStartingPointTest()
         {
             this.ControlGitRepo.Fetch(BranchWithFiles);
@@ -132,7 +131,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Ignore("This doesn't work right now. Tracking if this is a ProjFS problem. See #1696 for tracking.")]
         public void CheckoutOrhpanBranchFromStartingPointTest()
         {
             this.ControlGitRepo.Fetch(BranchWithoutFiles);

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/DeleteEmptyFolderTests.cs
@@ -14,7 +14,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Ignore("This doesn't work right now. Tracking if this is a ProjFS problem. See #1696 for tracking.")]
         public void VerifyResetHardDeletesEmptyFolders()
         {
             this.SetupFolderDeleteTest();

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/ResetHardTests.cs
@@ -16,7 +16,6 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        [Ignore("This doesn't work right now. Tracking if this is a ProjFS problem. See #1696 for tracking.")]
         public void VerifyResetHardDeletesEmptyFolders()
         {
             this.ControlGitRepo.Fetch("FunctionalTests/20201014_RenameTestMergeTarget");


### PR DESCRIPTION
Remove [Ignore] attributes from 4 functional tests disabled in #1697 due to a ProjFS buffer resizing regression tracked in #1696.

The ProjFS fix has likely shipped since Oct 2020 — re-enabling to verify these tests pass on current build agents.

**Tests re-enabled:**
- \DeleteEmptyFolderTests.VerifyResetHardDeletesEmptyFolders\
- \CheckoutTests.CheckoutNewBranchFromStartingPointTest\
- \CheckoutTests.CheckoutOrhpanBranchFromStartingPointTest\
- \ResetHardTests.VerifyResetHardDeletesEmptyFolders\

Resolves #1696