### PR TITLE
Non-disruptive upgrade: staged install with in-process file copy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -247,10 +247,17 @@ jobs:
     with:
       skip: ${{ needs.validate.outputs.skip }}
 
+  upgrade_tests:
+    name: Upgrade Tests
+    needs: [validate, build]
+    uses: ./.github/workflows/upgrade-tests.yaml
+    with:
+      skip: ${{ needs.validate.outputs.skip }}
+
   result:
     runs-on: ubuntu-latest
     name: Build, Unit and Functional Tests Successful
-    needs: [functional_tests]
+    needs: [functional_tests, upgrade_tests]
 
     steps:
       - name: Success! # for easier identification of successful runs in the Checks Required for Pull Requests

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -1,0 +1,290 @@
+name: Upgrade Tests
+
+on:
+  workflow_call:
+    inputs:
+      skip:
+        description: 'URL of a previous successful run; if non-empty, all steps are skipped'
+        required: false
+        type: string
+        default: ''
+      lkg_release_tag:
+        description: 'Tag of the last known good release to upgrade from (default: latest release)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  upgrade_test:
+    runs-on: windows-2025
+    name: Upgrade
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        configuration: [ Debug ]
+        scenario:
+          - staging-upgrade
+          - clean-upgrade
+          - double-staging
+          - staging-then-clean
+          - mount-safety-deferral
+      fail-fast: false
+
+    steps:
+    - name: Skip this job if there is a previous successful run
+      if: inputs.skip != ''
+      id: skip
+      uses: actions/github-script@v9
+      with:
+        script: |
+          core.info(`Skipping: There already is a successful run: ${{ inputs.skip }}`)
+          return true
+
+    # -- Artifacts --
+
+    - name: Download LKG release installer
+      if: steps.skip.outputs.result != 'true'
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        $tag = "${{ inputs.lkg_release_tag }}"
+        if (-not $tag) {
+          $tag = gh api repos/microsoft/VFSForGit/releases/latest --jq '.tag_name'
+          Write-Host "Auto-detected latest release: $tag"
+        }
+        New-Item -ItemType Directory -Path gvfs-lkg -Force | Out-Null
+        gh release download $tag --repo microsoft/VFSForGit --pattern "SetupGVFS*.exe" --dir gvfs-lkg
+
+    - name: Download Git installer
+      if: steps.skip.outputs.result != 'true'
+      uses: actions/download-artifact@v8
+      with:
+        name: MicrosoftGit
+        path: git
+
+    - name: Download current GVFS installer
+      if: steps.skip.outputs.result != 'true'
+      uses: actions/download-artifact@v8
+      with:
+        name: GVFS_${{ matrix.configuration }}
+        path: gvfs-new
+
+    # -- Setup --
+
+    - name: Install Git
+      if: steps.skip.outputs.result != 'true'
+      shell: cmd
+      run: git\install.bat
+
+    - name: Enable ProjFS
+      if: steps.skip.outputs.result != 'true'
+      shell: pwsh
+      run: |
+        $feature = Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS
+        if ($feature.State -ne 'Enabled') {
+          Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
+        }
+
+    # -- Test Execution --
+
+    - name: Run upgrade test - ${{ matrix.scenario }}
+      if: steps.skip.outputs.result != 'true'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $lkgInstaller = (Get-ChildItem gvfs-lkg\SetupGVFS*.exe).FullName
+        $newInstaller = (Get-ChildItem gvfs-new\SetupGVFS*.exe).FullName
+        $installDir = "C:\Program Files\VFS for Git"
+        $testRepo = "https://dev.azure.com/gvfs/ci/_git/ForTests"
+        $enlistment = "C:\gvfs-upgrade-test"
+
+        function Install-GVFS($installer, [string[]]$extraArgs = @()) {
+          $logDir = "C:\temp\gvfs-install-logs"
+          New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+          $logFile = Join-Path $logDir "gvfs-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+          $allArgs = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/LOG=$logFile") + $extraArgs
+          Write-Host "Installing: $installer $($allArgs -join ' ')"
+          # Start without -Wait: Inno Setup launches child processes
+          # (e.g. GVFS.Service.UI) that stay running, causing -Wait to
+          # hang. Instead, wait only for the installer process itself.
+          $proc = Start-Process -FilePath $installer -ArgumentList $allArgs -PassThru
+          $proc.WaitForExit()
+          if ($proc.ExitCode -ne 0) {
+            Get-Content $logFile -Tail 30 -ErrorAction SilentlyContinue
+            throw "Installer failed with exit code $($proc.ExitCode)"
+          }
+          Write-Host "Installed successfully"
+        }
+
+        function Assert-ServiceRunning {
+          $svc = sc.exe query GVFS.Service 2>&1 | Select-String "STATE"
+          if ($svc -notmatch "RUNNING") { throw "GVFS.Service is not running: $svc" }
+        }
+
+        function Mount-TestRepo {
+          if (Test-Path $enlistment) {
+            & "$installDir\gvfs.exe" mount $enlistment 2>&1 | Write-Host
+          } else {
+            & "$installDir\gvfs.exe" clone $testRepo $enlistment 2>&1 | Write-Host
+          }
+          if ($LASTEXITCODE -ne 0) { throw "Mount/clone failed" }
+          $mountProc = Get-Process -Name "GVFS.Mount" -ErrorAction SilentlyContinue
+          if (-not $mountProc) { throw "No GVFS.Mount process after mount" }
+          return $mountProc.Id
+        }
+
+        function Assert-MountAlive($expectedPid) {
+          $proc = Get-Process -Id $expectedPid -ErrorAction SilentlyContinue
+          if (-not $proc -or $proc.ProcessName -ne "GVFS.Mount") {
+            throw "Mount process $expectedPid is no longer running"
+          }
+          # Verify the mount is functional by accessing a file
+          $readmePath = Join-Path $enlistment "src\Readme.md"
+          if (-not (Test-Path $readmePath)) {
+            throw "Mount is running but cannot access $readmePath"
+          }
+        }
+
+        function Unmount-TestRepo {
+          & "$installDir\gvfs.exe" unmount $enlistment 2>&1
+          Start-Sleep -Seconds 3
+        }
+
+        function Restart-Service {
+          sc.exe stop GVFS.Service | Out-Null
+          Start-Sleep -Seconds 10
+          sc.exe start GVFS.Service | Out-Null
+          Start-Sleep -Seconds 10
+          Assert-ServiceRunning
+        }
+
+        function Assert-PendingUpgrade($expected) {
+          $exists = Test-Path "$installDir\PendingUpgrade"
+          if ($exists -ne $expected) {
+            throw "PendingUpgrade directory: expected=$expected, actual=$exists"
+          }
+        }
+
+        # =============================================
+        # Test scenarios
+        # =============================================
+
+        switch ("${{ matrix.scenario }}") {
+
+          "staging-upgrade" {
+            Write-Host "=== Scenario: Staging upgrade e2e ==="
+            # Install LKG, mount, staging upgrade, unmount, verify completion
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            Unmount-TestRepo
+            Restart-Service
+            Assert-PendingUpgrade $false
+            Write-Host "PASS: Staging upgrade completed"
+          }
+
+          "clean-upgrade" {
+            Write-Host "=== Scenario: Clean upgrade (traditional) ==="
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            Mount-TestRepo | Write-Host
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=false")
+            Assert-PendingUpgrade $false
+            Assert-ServiceRunning
+            Write-Host "PASS: Clean upgrade completed"
+          }
+
+          "double-staging" {
+            Write-Host "=== Scenario: Double staging install ==="
+            # Install LKG, mount, staging install twice, verify second overwrites
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            # Second staging install should overwrite PendingUpgrade
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            Unmount-TestRepo
+            Restart-Service
+            Assert-PendingUpgrade $false
+            Write-Host "PASS: Double staging handled correctly"
+          }
+
+          "staging-then-clean" {
+            Write-Host "=== Scenario: Staging then clean install ==="
+            # Install LKG, mount, staging install, unmount, clean install
+            # Verify PendingUpgrade is cleaned up by clean install
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            Unmount-TestRepo
+            # Now clean install — should remove PendingUpgrade
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=false")
+            Assert-PendingUpgrade $false
+            Assert-ServiceRunning
+            Write-Host "PASS: Staging then clean install handled correctly"
+          }
+
+          "mount-safety-deferral" {
+            Write-Host "=== Scenario: Mount safety deferral ==="
+            # Install LKG, mount, staging install, restart service WITH mount
+            # running — upgrade should be deferred
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            # Restart service WITHOUT unmounting — upgrade should defer
+            Restart-Service
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+            Write-Host "Upgrade correctly deferred while mount running"
+
+            # Now unmount and restart — should complete
+            Unmount-TestRepo
+            Restart-Service
+            Assert-PendingUpgrade $false
+            Write-Host "PASS: Mount safety deferral works correctly"
+          }
+
+          default {
+            throw "Unknown scenario: ${{ matrix.scenario }}"
+          }
+        }
+
+    - name: Upload service logs
+      if: always() && steps.skip.outputs.result != 'true'
+      uses: actions/upload-artifact@v7
+      continue-on-error: true
+      with:
+        name: UpgradeTest_Logs_${{ matrix.scenario }}
+        path: |
+          C:\ProgramData\GVFS\GVFS.Service\Logs\
+          C:\temp\gvfs-install-logs\

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -42,7 +42,7 @@ ArchitecturesInstallIn64BitMode=x64compatible
 ArchitecturesAllowed=x64compatible
 WizardImageStretch=no
 WindowResizable=no
-CloseApplications=yes
+CloseApplications=no
 ChangesEnvironment=yes
 RestartIfNeededByRun=yes
 
@@ -59,8 +59,14 @@ Name: "full"; Description: "Full installation"; Flags: iscustom;
 Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
-DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService
+; Normal install: all files go to {app}, service gets AfterInstall callback
+DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsNormalInstall
+DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: IsNormalInstall
+; Staging install: most files go to {app}\PendingUpgrade, but GVFS.Service.exe
+; goes directly to {app} so the restarted service has PendingUpgradeHandler code.
+; The service is briefly stopped/restarted (mounts are independent processes).
+DestDir: "{app}\PendingUpgrade"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsStagingInstall
+DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: StagingUpdateService; Check: IsStagingInstall
 
 [Dirs]
 Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
@@ -84,6 +90,17 @@ Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
 [Code]
 var
   ExitCode: Integer;
+  KeepMountsRunning: Boolean;
+
+function IsNormalInstall(): Boolean;
+begin
+  Result := not KeepMountsRunning;
+end;
+
+function IsStagingInstall(): Boolean;
+begin
+  Result := KeepMountsRunning;
+end;
 
 function NeedsAddPath(Param: string): boolean;
 var
@@ -156,6 +173,55 @@ begin
     end;
 end;
 
+procedure WaitForServiceProcessToExit(ServiceName: string);
+var
+  ResultCode: integer;
+  Attempts: integer;
+  TempFile: string;
+  QueryOutput: ansiString;
+begin
+  // sc stop/delete returns before the service process actually exits.
+  // Poll sc query until the service is fully gone (1060) or stopped.
+  Attempts := 0;
+  TempFile := ExpandConstant('{tmp}\~scquery.txt');
+  while Attempts < 30 do
+    begin
+      if Exec(ExpandConstant('{cmd}'), '/C "' + ExpandConstant('{sys}\SC.EXE') + '" query ' + ServiceName + ' > "' + TempFile + '" 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+        begin
+          // 1060 = service does not exist (fully deleted and process exited)
+          if ResultCode = 1060 then
+            begin
+              Log('WaitForServiceProcessToExit: Service no longer exists');
+              break;
+            end;
+          if LoadStringFromFile(TempFile, QueryOutput) then
+            begin
+              if Pos('STOPPED', QueryOutput) > 0 then
+                begin
+                  Log('WaitForServiceProcessToExit: Service is stopped');
+                  break;
+                end;
+            end;
+        end
+      else
+        begin
+          Log('WaitForServiceProcessToExit: sc query failed, assuming service is gone');
+          break;
+        end;
+      Attempts := Attempts + 1;
+      Log('WaitForServiceProcessToExit: Waiting for service to stop (attempt ' + IntToStr(Attempts) + ')');
+      Sleep(1000);
+    end;
+  if Attempts >= 30 then
+    begin
+      if LoadStringFromFile(TempFile, QueryOutput) then
+        Log('WaitForServiceProcessToExit: Timed out. Last sc query output: ' + QueryOutput)
+      else
+        Log('WaitForServiceProcessToExit: Timed out waiting for service to stop');
+    end;
+  DeleteFile(TempFile);
+end;
+
 procedure UninstallService(ServiceName: string; ShowProgress: boolean);
 var
   ResultCode: integer;
@@ -177,6 +243,8 @@ begin
             Log('UninstallService: Could not uninstall service: ' + ServiceName);
             RaiseException('Fatal: Could not uninstall service: ' + ServiceName);
           end;
+
+        WaitForServiceProcessToExit(ServiceName);
 
         if (ShowProgress) then
           begin
@@ -243,6 +311,33 @@ begin
     begin
       RaiseException('Fatal: An error occured while installing GVFS.Service.');
     end;
+end;
+
+procedure StagingUpdateService();
+var
+  ResultCode: integer;
+  StatusText: string;
+begin
+  // In staging mode: the service was stopped in PrepareToInstall so its exe
+  // could be replaced. Now start it with the new binary. The new service has
+  // PendingUpgradeHandler which will complete the upgrade on next restart
+  // when no mounts are running.
+  StatusText := WizardForm.StatusLabel.Caption;
+  WizardForm.StatusLabel.Caption := 'Starting GVFS.Service.';
+  WizardForm.ProgressGauge.Style := npbstMarquee;
+
+  try
+    Log('StagingUpdateService: Starting service with new binary');
+    if not Exec(ExpandConstant('{sys}\SC.EXE'), 'start GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+      begin
+        Log('StagingUpdateService: Warning - could not start service: ' + SysErrorMessage(ResultCode));
+      end;
+
+    WriteOnDiskVersion16CapableFile();
+  finally
+    WizardForm.StatusLabel.Caption := StatusText;
+    WizardForm.ProgressGauge.Style := npbstNormal;
+  end;
 end;
 
 function DeleteFileIfItExists(FilePath: string) : Boolean;
@@ -485,39 +580,6 @@ begin
   MigrateFile(CommonAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}', SecureAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}');
 end;
 
-function ConfirmUnmountAll(): Boolean;
-var
-  MsgBoxResult: integer;
-  Repos: ansiString;
-  ResultCode: integer;
-  MsgBoxText: string;
-begin
-  Result := False;
-  if ExecWithResult('gvfs.exe', 'service --list-mounted', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, Repos) then
-    begin
-      if Repos = '' then
-        begin
-          Result := False;
-        end
-      else
-        begin
-          if ResultCode = 0 then
-            begin
-              MsgBoxText := 'The following repos are currently mounted:' + #13#10 + Repos + #13#10 + 'Setup needs to unmount all repos before it can proceed, and those repos will be unavailable while setup is running. Do you want to continue?';
-              MsgBoxResult := SuppressibleMsgBox(MsgBoxText, mbConfirmation, MB_OKCANCEL, IDOK);
-              if (MsgBoxResult = IDOK) then
-                begin
-                  Result := True;
-                end
-              else
-                begin
-                  Abort();
-                end;
-            end;
-        end;
-    end;
-end;
-
 function EnsureGvfsNotRunning(): Boolean;
 var
   MsgBoxResult: integer;
@@ -647,12 +709,21 @@ begin
   case CurStep of
     ssInstall:
       begin
-        UninstallService('GVFS.Service', True);
+        if not KeepMountsRunning then
+          UninstallService('GVFS.Service', True);
       end;
     ssPostInstall:
       begin
+        if KeepMountsRunning then
+          begin
+            // All staged files have been written to PendingUpgrade.
+            // Write .ready marker so the service knows the staging is
+            // complete and safe to apply.
+            SaveStringToFile(ExpandConstant('{app}\PendingUpgrade\.ready'), '', False);
+            Log('CurStepChanged: Wrote PendingUpgrade .ready marker');
+          end;
         MigrateConfigAndStatusCacheFiles();
-        if ExpandConstant('{param:REMOUNTREPOS|true}') = 'true' then
+        if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
           begin
             MountRepos();
           end
@@ -677,22 +748,125 @@ begin
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  MsgBoxResult: integer;
+  Repos: ansiString;
+  ResultCode: integer;
+  HasMounts: Boolean;
 begin
   NeedsRestart := False;
+  KeepMountsRunning := False;
   Result := '';
   SetNuGetFeedIfNecessary();
-  if ConfirmUnmountAll() then
+
+  // Check for mounted repos by querying the service, and also check for
+  // running GVFS processes (a mount can be running without being registered
+  // in the service's repo-registry, e.g., after a reinstall).
+  HasMounts := False;
+  if ExecWithResult('gvfs.exe', 'service --list-mounted', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, Repos) then
     begin
-      if ExpandConstant('{param:REMOUNTREPOS|true}') = 'true' then
+      if (ResultCode = 0) and (Repos <> '') then
+        HasMounts := True;
+    end;
+  if (not HasMounts) and IsGVFSRunning() then
+    begin
+      HasMounts := True;
+      Repos := '(GVFS processes detected)';
+      Log('PrepareToInstall: No registered mounts but GVFS processes are running');
+    end;
+
+  if HasMounts then
+    begin
+      if WizardSilent() then
+        begin
+          // Silent mode: STAGEIFMOUNTED=true stages files instead of unmounting.
+          // Default: false (clean upgrade, matching pre-existing behavior).
+          KeepMountsRunning := ExpandConstant('{param:STAGEIFMOUNTED|false}') = 'true';
+          if KeepMountsRunning then
+            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=True')
+          else
+            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=False');
+        end
+      else
+        begin
+          // Interactive mode: let user choose
+          MsgBoxResult := SuppressibleMsgBox(
+            'The following repos are currently mounted:' + #13#10 + Repos + #13#10#13#10 +
+            'Click Yes to keep repos mounted during the upgrade.' + #13#10 +
+            'The upgrade will complete automatically when all repos are unmounted.' + #13#10#13#10 +
+            'Click No to unmount all repos now and upgrade without restart.' + #13#10 +
+            'Repos will be temporarily unavailable during the upgrade.',
+            mbConfirmation, MB_YESNOCANCEL, IDYES);
+          if MsgBoxResult = IDYES then
+            KeepMountsRunning := True
+          else if MsgBoxResult = IDNO then
+            KeepMountsRunning := False
+          else
+            begin
+              Result := 'Installation cancelled.';
+              exit;
+            end;
+        end;
+    end;
+
+  if KeepMountsRunning then
+    begin
+      // Staging mode: most files go to {app}\PendingUpgrade\ via [Files] entries
+      // with Check: IsStagingInstall. GVFS.Service.exe goes directly to {app}.
+      // Clean up any leftover staging dirs from a prior attempt first,
+      // so we don't mix files from different upgrade versions.
+      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
+        begin
+          Log('PrepareToInstall: Removing stale PendingUpgrade from prior staging attempt');
+          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
+        end;
+      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
+        begin
+          Log('PrepareToInstall: Removing stale PreviousVersion from prior staging attempt');
+          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
+        end;
+      // Stop the service now so its exe is unlocked for replacement.
+      // Mounts are independent processes and unaffected.
+      Log('PrepareToInstall: Staging mode. Stopping service for exe replacement.');
+      StopService('GVFS.Service');
+      WaitForServiceProcessToExit('GVFS.Service');
+    end
+  else
+    begin
+      // Clean upgrade: unmount, stop everything, replace files directly.
+      // Remove any leftover PendingUpgrade or PreviousVersion from a
+      // previous staging install so stale files don't interfere with
+      // the fresh install.
+      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
+        begin
+          Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
+          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
+        end;
+      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
+        begin
+          Log('PrepareToInstall: Removing leftover PreviousVersion directory');
+          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
+        end;
+      if HasMounts then
         begin
           UnmountRepos();
-        end
+        end;
+      // With CloseApplications=no, Restart Manager won't kill GVFS
+      // processes. If unmount-all didn't clean up everything (e.g.
+      // registry was empty), force-kill remaining processes since
+      // the user already consented to a full upgrade.
+      if IsGVFSRunning() then
+        begin
+          Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
+          Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+          Sleep(2000);
+        end;
+      if not EnsureGvfsNotRunning() then
+        begin
+          Abort();
+        end;
+      StopService('GVFS.Service');
+      UninstallGvFlt();
+      UninstallProjFSIfNecessary();
     end;
-  if not EnsureGvfsNotRunning() then
-    begin
-      Abort();
-    end;
-  StopService('GVFS.Service');
-  UninstallGvFlt();
-  UninstallProjFSIfNecessary();
 end;

--- a/GVFS/GVFS.Service/GVFSService.Windows.cs
+++ b/GVFS/GVFS.Service/GVFSService.Windows.cs
@@ -43,6 +43,12 @@ namespace GVFS.Service
                 metadata.Add("Version", ProcessHelper.GetCurrentProcessVersion());
                 this.tracer.RelatedEvent(EventLevel.Informational, $"{nameof(GVFSService)}_{nameof(this.Run)}", metadata);
 
+                // Check for a staged upgrade before doing anything else.
+                // If no GVFS.Mount processes are running (typical at boot or after
+                // unmount-all), copy staged files in-place and proceed normally.
+                // If mounts ARE running, the upgrade is deferred to next restart.
+                PendingUpgradeHandler.TryApplyPendingUpgrade(this.tracer);
+
                 this.repoRegistry = new RepoRegistry(
                     this.tracer,
                     new PhysicalFileSystem(),

--- a/GVFS/GVFS.Service/Handlers/RequestHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/RequestHandler.cs
@@ -1,6 +1,7 @@
 ﻿using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace GVFS.Service.Handlers
 {
@@ -14,6 +15,8 @@ namespace GVFS.Service.Handlers
     /// </summary>
     public class RequestHandler
     {
+        private const int PendingUpgradeDelayMs = 5000;
+
         protected const string EnableProjFSRequestDescription = "attach volume";
         protected string requestDescription;
 
@@ -25,6 +28,7 @@ namespace GVFS.Service.Handlers
         private string etwArea;
         private ITracer tracer;
         private IRepoRegistry repoRegistry;
+        private Timer pendingUpgradeTimer;
 
         public RequestHandler(ITracer tracer, string etwArea, IRepoRegistry repoRegistry)
         {
@@ -80,6 +84,14 @@ namespace GVFS.Service.Handlers
                     UnregisterRepoHandler unmountHandler = new UnregisterRepoHandler(tracer, this.repoRegistry, connection, unmountRequest);
                     unmountHandler.Run();
 
+                    // After unmount, check for pending staged upgrade on a
+                    // background thread. The deferred check gives the calling
+                    // GVFS.Mount process time to exit so its executable is no
+                    // longer locked when the upgrade runs.
+                    // Use the long-lived service tracer, not the scoped activity
+                    // tracer which will be disposed when this handler returns.
+                    this.TryDeferredPendingUpgradeCheck(this.tracer);
+
                     break;
 
                 case NamedPipeMessages.GetActiveRepoListRequest.Header:
@@ -119,6 +131,36 @@ namespace GVFS.Service.Handlers
             if (!connection.TrySendResponse(message))
             {
                 tracer.RelatedError($"{nameof(this.TrySendResponse)}: Could not send response to client. Reply Info: {message}");
+            }
+        }
+
+        private void TryDeferredPendingUpgradeCheck(ITracer tracer)
+        {
+            string installDir = Service.Configuration.AssemblyPath;
+            string pendingUpgradeDir = System.IO.Path.Combine(installDir, PendingUpgradeHandler.PendingUpgradeDirectoryName);
+            if (!System.IO.Directory.Exists(pendingUpgradeDir))
+            {
+                return;
+            }
+
+            // Debounce: reset the timer on each unmount so the check fires
+            // once after the last unmount settles. If multiple repos unmount
+            // in quick succession, only one upgrade attempt runs.
+            if (this.pendingUpgradeTimer == null)
+            {
+                this.pendingUpgradeTimer = new Timer(
+                    _ =>
+                    {
+                        tracer.RelatedInfo("TryDeferredPendingUpgradeCheck: Checking pending upgrade after unmount");
+                        PendingUpgradeHandler.TryApplyPendingUpgrade(tracer);
+                    },
+                    null,
+                    PendingUpgradeDelayMs,
+                    Timeout.Infinite);
+            }
+            else
+            {
+                this.pendingUpgradeTimer.Change(PendingUpgradeDelayMs, Timeout.Infinite);
             }
         }
     }

--- a/GVFS/GVFS.Service/PendingUpgradeHandler.cs
+++ b/GVFS/GVFS.Service/PendingUpgradeHandler.cs
@@ -1,0 +1,443 @@
+using GVFS.Common;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace GVFS.Service
+{
+    /// <summary>
+    /// Detects and applies staged upgrades from the PendingUpgrade directory.
+    ///
+    /// When the installer runs with mounts active, it stages new files to
+    /// {installDir}\PendingUpgrade\ instead of replacing files in-place.
+    /// This class applies the upgrade when no GVFS.Mount processes are
+    /// running — either on service start (before automount) or after a
+    /// repo unmount (via deferred check from RequestHandler).
+    ///
+    ///   1. Move old files from install dir → PreviousVersion\
+    ///   2. Move new files from PendingUpgrade\ → install dir
+    ///   3. Delete PreviousVersion\ and PendingUpgrade\
+    ///
+    /// File.Move on the same volume is an atomic rename at the filesystem
+    /// level, so a crash mid-upgrade leaves files intact (either at the old
+    /// or new location). On retry, the handler resumes from where it left off.
+    ///
+    /// With native AOT, each exe is self-contained — the only locked file
+    /// is GVFS.Service.exe itself, which the installer already replaced.
+    /// </summary>
+    public static class PendingUpgradeHandler
+    {
+        public const string PendingUpgradeDirectoryName = "PendingUpgrade";
+        private const string PreviousVersionDirectoryName = "PreviousVersion";
+        private const string ReadyMarkerFileName = ".ready";
+        private const string Phase1CompleteMarkerFileName = ".phase1-complete";
+        private const string ServiceExeName = "GVFS.Service.exe";
+        private const string MountProcessName = "GVFS.Mount";
+
+        // Executables that users or the service can launch to start new
+        // mount/hook processes. During upgrade these are moved out first
+        // (Phase 1) and moved in last (Phase 2) so that no new GVFS
+        // processes can start while the upgrade is in progress.
+        // Ordered most-likely-to-be-called first for Phase 1 removal.
+        private static readonly StringComparer PathComparer = StringComparer.OrdinalIgnoreCase;
+        private static readonly string[] PriorityExes = new[]
+        {
+            "GVFS.Hooks.exe",
+            "GVFS.exe",
+            "GVFS.Mount.exe",
+        };
+
+        /// <summary>
+        /// Checks for and applies a pending staged upgrade.
+        /// </summary>
+        public static void TryApplyPendingUpgrade(ITracer tracer)
+        {
+            string installDir = Configuration.AssemblyPath;
+            string pendingUpgradeDir = Path.Combine(installDir, PendingUpgradeDirectoryName);
+            string previousVersionDir = Path.Combine(installDir, PreviousVersionDirectoryName);
+
+            if (!Directory.Exists(pendingUpgradeDir))
+            {
+                // No pending upgrade. Clean up PreviousVersion if it exists
+                // (leftover from a completed upgrade where cleanup was interrupted).
+                TryDeleteDirectory(tracer, previousVersionDir, "leftover PreviousVersion");
+                return;
+            }
+
+            // Installer writes .ready marker as its last step. If missing,
+            // the installer was interrupted mid-write — don't apply partial files.
+            string readyMarker = Path.Combine(pendingUpgradeDir, ReadyMarkerFileName);
+            if (!File.Exists(readyMarker))
+            {
+                EventMetadata readyMetadata = new EventMetadata();
+                readyMetadata.Add("PendingUpgradeDir", pendingUpgradeDir);
+                tracer.RelatedWarning(
+                    readyMetadata,
+                    $"{nameof(PendingUpgradeHandler)}: PendingUpgrade directory exists but {ReadyMarkerFileName} marker " +
+                    "is missing — installer was likely interrupted. Skipping until next install completes.",
+                    Keywords.Telemetry);
+                return;
+            }
+
+            tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Pending upgrade detected at {pendingUpgradeDir}");
+
+            // Don't apply if GVFS.Mount processes are still running — their
+            // executables are locked and moves would fail. Upgrade will be
+            // retried on next service start when no mounts are active.
+            Process[] mountProcesses = Array.Empty<Process>();
+            try
+            {
+                mountProcesses = Process.GetProcessesByName(MountProcessName);
+                if (mountProcesses.Length > 0)
+                {
+                    EventMetadata deferMetadata = new EventMetadata();
+                    deferMetadata.Add("MountProcessCount", mountProcesses.Length);
+                    tracer.RelatedEvent(
+                        EventLevel.Informational,
+                        $"{nameof(PendingUpgradeHandler)}_Deferred",
+                        deferMetadata,
+                        Keywords.Telemetry);
+                    return;
+                }
+            }
+            finally
+            {
+                foreach (Process p in mountProcesses)
+                {
+                    p.Dispose();
+                }
+            }
+
+            try
+            {
+                // Phase 1: Move old files to PreviousVersion (backup for rollback).
+                // priority exes (GVFS.exe, GVFS.Hooks.exe, GVFS.Mount.exe) are
+                // moved FIRST so no new GVFS processes can start during the upgrade.
+                // Use a marker file to track completion — directory existence alone
+                // is insufficient because a crash mid-phase leaves the directory
+                // with only some files backed up.
+                string[] stagedFiles = Directory.GetFiles(pendingUpgradeDir, "*", SearchOption.AllDirectories);
+                string phase1Marker = Path.Combine(previousVersionDir, Phase1CompleteMarkerFileName);
+                if (!File.Exists(phase1Marker))
+                {
+                    // Clean up any partial Phase 1 from a prior crash — re-run
+                    // from scratch to ensure all files are backed up.
+                    if (Directory.Exists(previousVersionDir))
+                    {
+                        tracer.RelatedWarning(
+                            $"{nameof(PendingUpgradeHandler)}: Phase 1 incomplete from prior attempt, restarting backup",
+                            Keywords.Telemetry);
+                        TryRestoreFromPreviousVersion(tracer, previousVersionDir, installDir);
+                        TryDeleteDirectory(tracer, previousVersionDir, "incomplete PreviousVersion");
+                    }
+
+                    tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Phase 1 - backing up {stagedFiles.Length} file(s) to PreviousVersion");
+
+                    int backedUp = 0;
+                    foreach (string relativePath in OrderForRemoval(stagedFiles, pendingUpgradeDir))
+                    {
+                        string installedFile = Path.Combine(installDir, relativePath);
+                        if (File.Exists(installedFile))
+                        {
+                            string backupFile = Path.Combine(previousVersionDir, relativePath);
+                            string backupDir = Path.GetDirectoryName(backupFile);
+                            if (!Directory.Exists(backupDir))
+                            {
+                                Directory.CreateDirectory(backupDir);
+                            }
+
+                            MoveFileWithRetry(tracer, installedFile, backupFile);
+                            backedUp++;
+                        }
+                    }
+
+                    File.WriteAllText(phase1Marker, string.Empty);
+                    tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Phase 1 complete. Backed up {backedUp} file(s)");
+                }
+                else
+                {
+                    tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Phase 1 already done ({Phase1CompleteMarkerFileName} exists). Resuming phase 2.");
+                }
+
+                // Phase 2: Move new files from PendingUpgrade to install dir.
+                // priority exes are moved LAST so all supporting files (DLLs,
+                // hooks, etc.) are in place before any GVFS process can start.
+                tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Phase 2 - applying {stagedFiles.Length} staged file(s)");
+
+                int applied = 0;
+                foreach (string relativePath in OrderForInstall(stagedFiles, pendingUpgradeDir))
+                {
+                    string sourceFile = Path.Combine(pendingUpgradeDir, relativePath);
+                    string destFile = Path.Combine(installDir, relativePath);
+                    string destDir = Path.GetDirectoryName(destFile);
+                    if (!Directory.Exists(destDir))
+                    {
+                        Directory.CreateDirectory(destDir);
+                    }
+
+                    // If dest already exists (phase 2 partially completed on a prior
+                    // run), delete it first so File.Move can succeed.
+                    if (File.Exists(destFile))
+                    {
+                        File.Delete(destFile);
+                    }
+
+                    MoveFileWithRetry(tracer, sourceFile, destFile);
+                    applied++;
+                }
+
+                tracer.RelatedInfo(
+                    $"{nameof(PendingUpgradeHandler)}: Phase 2 complete. Applied={applied}");
+
+                // Phase 3: Clean up
+                // Capture old version before deleting PreviousVersion.
+                string oldVersion = TryGetOldVersion(previousVersionDir);
+
+                // Delete the skipped GVFS.Service.exe from PendingUpgrade first,
+                // otherwise Directory.Delete will fail on the non-empty directory.
+                string skippedServiceExe = Path.Combine(pendingUpgradeDir, ServiceExeName);
+                if (File.Exists(skippedServiceExe))
+                {
+                    File.Delete(skippedServiceExe);
+                }
+
+                TryDeleteDirectory(tracer, pendingUpgradeDir, "PendingUpgrade");
+                TryDeleteDirectory(tracer, previousVersionDir, "PreviousVersion");
+
+                string newVersion = ProcessHelper.GetCurrentProcessVersion();
+                EventMetadata successMetadata = new EventMetadata();
+                successMetadata.Add("NewVersion", newVersion);
+                successMetadata.Add("OldVersion", oldVersion ?? "unknown");
+                successMetadata.Add("FilesApplied", applied);
+                tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    $"{nameof(PendingUpgradeHandler)}_Complete",
+                    successMetadata,
+                    Keywords.Telemetry);
+                return;
+            }
+            catch (Exception ex)
+            {
+                EventMetadata errorMetadata = new EventMetadata();
+                errorMetadata.Add("Exception", ex.ToString());
+                tracer.RelatedError(
+                    errorMetadata,
+                    $"{nameof(PendingUpgradeHandler)}: Upgrade failed: {ex.Message}. " +
+                    "PendingUpgrade retained for retry on next service start. " +
+                    "If PreviousVersion exists, old files are preserved for manual recovery.",
+                    Keywords.Telemetry);
+                return;
+            }
+        }
+
+        private static bool IsSkippedFile(string relativePath)
+        {
+            return IsMarkerFile(relativePath) ||
+                   string.Equals(relativePath, ServiceExeName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsPriorityExe(string relativePath)
+        {
+            foreach (string exe in PriorityExes)
+            {
+                if (PathComparer.Equals(relativePath, exe))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsMarkerFile(string relativePath)
+        {
+            return string.Equals(relativePath, ReadyMarkerFileName, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(relativePath, Phase1CompleteMarkerFileName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Moves a file, retrying once after killing any process that has the
+        /// source file locked (e.g. a GVFS process that started mid-upgrade).
+        /// </summary>
+        private static void MoveFileWithRetry(ITracer tracer, string source, string dest)
+        {
+            try
+            {
+                File.Move(source, dest);
+            }
+            catch (IOException)
+            {
+                if (TryKillProcessByPath(tracer, source))
+                {
+                    Thread.Sleep(1000);
+                    File.Move(source, dest);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns relative paths ordered for removal: priority exes first
+        /// (so no new GVFS processes can start), then everything else.
+        /// Skips marker files and GVFS.Service.exe.
+        /// </summary>
+        private static List<string> OrderForRemoval(string[] absolutePaths, string baseDir)
+        {
+            List<string> rest = new List<string>();
+            HashSet<string> present = new HashSet<string>(PathComparer);
+
+            foreach (string fullPath in absolutePaths)
+            {
+                string relativePath = fullPath.Substring(baseDir.Length).TrimStart(Path.DirectorySeparatorChar);
+                if (IsSkippedFile(relativePath))
+                {
+                    continue;
+                }
+
+                if (IsPriorityExe(relativePath))
+                {
+                    present.Add(relativePath);
+                }
+                else
+                {
+                    rest.Add(relativePath);
+                }
+            }
+
+            List<string> ordered = new List<string>();
+            foreach (string exe in PriorityExes)
+            {
+                if (present.Contains(exe))
+                {
+                    ordered.Add(exe);
+                }
+            }
+
+            ordered.AddRange(rest);
+            return ordered;
+        }
+
+        /// <summary>
+        /// Returns relative paths ordered for install: reverse of removal order
+        /// so priority exes are replaced last (all supporting files in place
+        /// before any GVFS process can start).
+        /// </summary>
+        private static List<string> OrderForInstall(string[] absolutePaths, string baseDir)
+        {
+            List<string> ordered = OrderForRemoval(absolutePaths, baseDir);
+            ordered.Reverse();
+            return ordered;
+        }
+
+        /// <summary>
+        /// Finds and kills any process whose main module matches the given
+        /// file path. Returns true if a process was found and killed.
+        /// </summary>
+        private static bool TryKillProcessByPath(ITracer tracer, string filePath)
+        {
+            bool killed = false;
+            try
+            {
+                foreach (Process process in Process.GetProcesses())
+                {
+                    try
+                    {
+                        if (PathComparer.Equals(process.MainModule?.FileName, filePath))
+                        {
+                            tracer.RelatedWarning(
+                                $"{nameof(PendingUpgradeHandler)}: Killing process {process.ProcessName} " +
+                                $"(PID {process.Id}) that is locking {filePath}");
+                            process.Kill();
+                            process.WaitForExit(5000);
+                            killed = true;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Access denied or process already exited — skip
+                    }
+                    finally
+                    {
+                        process.Dispose();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                tracer.RelatedWarning($"{nameof(PendingUpgradeHandler)}: Error enumerating processes: {ex.Message}");
+            }
+
+            return killed;
+        }
+
+        private static string TryGetOldVersion(string previousVersionDir)
+        {
+            try
+            {
+                string oldGvfsExe = Path.Combine(previousVersionDir, "GVFS.exe");
+                if (File.Exists(oldGvfsExe))
+                {
+                    return FileVersionInfo.GetVersionInfo(oldGvfsExe).ProductVersion;
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static void TryRestoreFromPreviousVersion(ITracer tracer, string previousVersionDir, string installDir)
+        {
+            // Move any backed-up files back to the install directory so we
+            // can retry Phase 1 cleanly.
+            try
+            {
+                foreach (string backupFile in Directory.GetFiles(previousVersionDir, "*", SearchOption.AllDirectories))
+                {
+                    string relativePath = backupFile.Substring(previousVersionDir.Length).TrimStart(Path.DirectorySeparatorChar);
+                    if (IsMarkerFile(relativePath))
+                    {
+                        continue;
+                    }
+
+                    string installedFile = Path.Combine(installDir, relativePath);
+                    if (!File.Exists(installedFile))
+                    {
+                        File.Move(backupFile, installedFile);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                tracer.RelatedWarning(
+                    $"{nameof(PendingUpgradeHandler)}: Failed to restore from PreviousVersion: {ex.Message}",
+                    Keywords.Telemetry);
+            }
+        }
+
+        private static void TryDeleteDirectory(ITracer tracer, string path, string description)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                tracer.RelatedInfo($"{nameof(PendingUpgradeHandler)}: Removed {description} directory");
+            }
+            catch (Exception ex)
+            {
+                tracer.RelatedWarning($"{nameof(PendingUpgradeHandler)}: Failed to remove {description} directory: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

To roll out upgrades automatically (e.g. via fleet management or scheduled tasks), the installer needs to work without disrupting active GVFS mounts. Today, upgrading requires unmounting all repos — interrupting builds, IDE indexing, and any in-progress work. This PR adds a staged upgrade mode so users can be moved to newer versions transparently.

## Changes

### Installer (Setup.iss)

New `/STAGEIFMOUNTED=true` flag for silent installs (default: false — existing behavior preserved). Interactive installs show a dialog when mounts are detected. When staging:

1. Files are written to `{app}\PendingUpgrade\` instead of replacing in-place
2. `GVFS.Service.exe` is replaced directly (brief stop/start — mounts unaffected)
3. A `.ready` marker is written after all files are staged (guards against partial writes from interrupted installs)

`CloseApplications=no` prevents Restart Manager from killing GVFS processes. The clean upgrade path now force-kills processes if `unmount-all` fails to clean up.

### Service (PendingUpgradeHandler.cs, RequestHandler.cs)

Completes the staged upgrade when no mounts are running:

- **On service start:** checks before automount
- **After unmount:** timer-based debounce (5s) fires once after the last repo unmounts

The upgrade uses atomic `File.Move` in two phases:
1. Back up old files to `PreviousVersion\` (with `.phase1-complete` marker for crash recovery)
2. Move staged files to install dir

Safety: defers if GVFS.Mount processes are still running. Rejects PendingUpgrade without `.ready` marker. Crash mid-Phase-1 restores backed-up files and retries.

### CI (upgrade-tests.yaml)

Five test scenarios: staging upgrade, clean upgrade, double staging, staging-then-clean, and mount safety deferral.