### PR TITLE
Fix flaky WriteWithoutClose/CreateFileWithoutClose functional tests

### DIFF
--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -304,12 +304,12 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             return long.Parse(this.RunProcess(statCommand));
         }
 
-        public override void CreateFileWithoutClose(string path)
+        public override IDisposable CreateFileWithoutClose(string path)
         {
             throw new NotImplementedException();
         }
 
-        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        public override IDisposable OpenFileAndWriteWithoutClose(string path, string data)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -238,12 +238,12 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             throw new NotSupportedException();
         }
 
-        public override void CreateFileWithoutClose(string path)
+        public override IDisposable CreateFileWithoutClose(string path)
         {
             throw new NotImplementedException();
         }
 
-        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        public override IDisposable OpenFileAndWriteWithoutClose(string path, string data)
         {
             throw new NotImplementedException();
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -76,8 +76,8 @@ namespace GVFS.FunctionalTests.FileSystemRunners
         /// <param name="path">Path to file</param>
         /// <param name="contents">File contents</param>
         public abstract void WriteAllText(string path, string contents);
-        public abstract void CreateFileWithoutClose(string path);
-        public abstract void OpenFileAndWriteWithoutClose(string path, string data);
+        public abstract IDisposable CreateFileWithoutClose(string path);
+        public abstract IDisposable OpenFileAndWriteWithoutClose(string path, string data);
 
         /// <summary>
         /// Append the specified contents to the specified file.  By calling this method the caller is

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -1,4 +1,5 @@
 ﻿using GVFS.Tests.Should;
+using System;
 using System.IO;
 
 namespace GVFS.FunctionalTests.FileSystemRunners
@@ -217,12 +218,12 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             throw new System.NotSupportedException();
         }
 
-        public override void CreateFileWithoutClose(string path)
+        public override IDisposable CreateFileWithoutClose(string path)
         {
             throw new System.NotSupportedException();
         }
 
-        public override void OpenFileAndWriteWithoutClose(string path, string data)
+        public override IDisposable OpenFileAndWriteWithoutClose(string path, string data)
         {
             throw new System.NotSupportedException();
         }

--- a/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/GVFS/GVFS.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -22,15 +22,17 @@ namespace GVFS.FunctionalTests.FileSystemRunners
             return string.Empty;
         }
 
-        public override void CreateFileWithoutClose(string path)
+        public override IDisposable CreateFileWithoutClose(string path)
         {
-            File.Create(path);
+            return File.Create(path);
         }
 
-        public override void OpenFileAndWriteWithoutClose(string path, string content)
+        public override IDisposable OpenFileAndWriteWithoutClose(string path, string content)
         {
             StreamWriter file = new StreamWriter(path);
             file.Write(content);
+            file.Flush();
+            return file;
         }
 
         public override void MoveFileShouldFail(string sourcePath, string targetPath)

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -326,22 +326,24 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileSystem.WriteAllText(controlFile, content);
         }
 
-        protected void CreateFileWithoutClose(string path)
+        protected IDisposable CreateFileWithoutClose(string path)
         {
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
-            this.FileSystem.CreateFileWithoutClose(virtualFile);
-            this.FileSystem.CreateFileWithoutClose(controlFile);
+            IDisposable virtualHandle = this.FileSystem.CreateFileWithoutClose(virtualFile);
+            IDisposable controlHandle = this.FileSystem.CreateFileWithoutClose(controlFile);
+            return new CompositeDisposable(virtualHandle, controlHandle);
         }
 
-        protected void ReadFileAndWriteWithoutClose(string path, string contents)
+        protected IDisposable ReadFileAndWriteWithoutClose(string path, string contents)
         {
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
             string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
             this.FileSystem.ReadAllText(virtualFile);
             this.FileSystem.ReadAllText(controlFile);
-            this.FileSystem.OpenFileAndWriteWithoutClose(virtualFile, contents);
-            this.FileSystem.OpenFileAndWriteWithoutClose(controlFile, contents);
+            IDisposable virtualHandle = this.FileSystem.OpenFileAndWriteWithoutClose(virtualFile, contents);
+            IDisposable controlHandle = this.FileSystem.OpenFileAndWriteWithoutClose(controlFile, contents);
+            return new CompositeDisposable(virtualHandle, controlHandle);
         }
 
         protected void CreateFolder(string folderPath)
@@ -666,6 +668,28 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
             this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "ConflictingChange.txt");
             this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SameChange.txt");
             this.FileContentsShouldMatch("Test_ConflictTests", "ModifiedFiles", "SuccessfulMerge.txt");
+        }
+
+        /// <summary>
+        /// Disposes multiple <see cref="IDisposable"/> objects as a single unit.
+        /// Used to hold file handles open for the duration of a test scope.
+        /// </summary>
+        protected sealed class CompositeDisposable : IDisposable
+        {
+            private readonly IDisposable[] disposables;
+
+            public CompositeDisposable(params IDisposable[] disposables)
+            {
+                this.disposables = disposables;
+            }
+
+            public void Dispose()
+            {
+                foreach (IDisposable disposable in this.disposables)
+                {
+                    disposable?.Dispose();
+                }
+            }
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -46,16 +46,20 @@ namespace GVFS.FunctionalTests.Tests.GitCommands
         public void CreateFileWithoutClose()
         {
             string srcPath = @"CreateFileWithoutClose.md";
-            this.CreateFileWithoutClose(srcPath);
-            this.ValidGitStatusWithRetry(srcPath);
+            using (IDisposable handles = this.CreateFileWithoutClose(srcPath))
+            {
+                this.ValidGitStatusWithRetry(srcPath);
+            }
         }
 
         [TestCase]
         public void WriteWithoutClose()
         {
             string srcPath = @"Readme.md";
-            this.ReadFileAndWriteWithoutClose(srcPath, "More Stuff");
-            this.ValidGitStatusWithRetry(srcPath);
+            using (IDisposable handles = this.ReadFileAndWriteWithoutClose(srcPath, "More Stuff"))
+            {
+                this.ValidGitStatusWithRetry(srcPath);
+            }
         }
 
          [TestCase]


### PR DESCRIPTION
## Summary

Fix GC-dependent race condition causing flaky failures in `StatusTests.WriteWithoutClose()` and `StatusTests.CreateFileWithoutClose()`.

## Problem

These tests intentionally open file handles without closing them to validate that `git status` works with locked files. The handles were created as local variables inside `OpenFileAndWriteWithoutClose`/`CreateFileWithoutClose` with no reference kept — making them eligible for GC immediately. If the GC finalized the handles before TearDown ran `git reset --hard`, the reset would succeed (no lock errors) while the control repo might still have errors, causing a flaky error mismatch in TearDown.

## Fix

- Change `FileSystemRunner.CreateFileWithoutClose` and `OpenFileAndWriteWithoutClose` to return `IDisposable` instead of `void`
- `SystemIORunner` returns the actual `FileStream`/`StreamWriter` handle, with an explicit `Flush()` to ensure data is on disk
- `GitRepoTests` helpers return a `CompositeDisposable` wrapping handles for both GVFS and control repos
- `StatusTests` uses `using` blocks — handles stay alive during the assertion scope and are deterministically disposed before TearDown runs

This eliminates the GC race: both repos have unlocked files when `reset --hard` runs in TearDown, so errors match (both 0).

## Testing

- Built GVFS.FunctionalTests project successfully (C# compilation clean)
- The fix is structural — deterministic disposal replaces non-deterministic GC finalization
