### PR TITLE
Update GVFS version to 2.0 in release pipeline

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 
 variables:
-  GVFSMajorAndMinorVersion: 1.0
+  GVFSMajorAndMinorVersion: 2.0
   GVFSRevision: $(Build.BuildNumber)
   BuildConfiguration: Release
   TeamName: GVFS


### PR DESCRIPTION
Upgrade to .NET 10 is a major change, and excluding bundled ProjFS driver for older systems is potentially breaking.