### PR TITLE
Statically link libgit2 into NativeAOT executables via vcpkg

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -204,6 +204,13 @@ jobs:
       if: steps.skip.outputs.result != 'true'
       uses: microsoft/setup-msbuild@v3.0.0
 
+    - name: Install vcpkg native dependencies
+      if: steps.skip.outputs.result != 'true'
+      shell: cmd
+      run: |
+        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-static-aot --overlay-triplets=src\triplets --overlay-ports=src\overlays --x-install-root=src\vcpkg_installed\static --x-manifest-root=src || exit /b 1
+        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-dynamic --overlay-triplets=src\triplets --overlay-ports=src\overlays --x-install-root=src\vcpkg_installed\dynamic --x-manifest-root=src || exit /b 1
+
     - name: Build VFS for Git
       if: steps.skip.outputs.result != 'true'
       shell: cmd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,8 +208,8 @@ jobs:
       if: steps.skip.outputs.result != 'true'
       shell: cmd
       run: |
-        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-static-aot --overlay-triplets=src\triplets --overlay-ports=src\overlays --x-install-root=src\vcpkg_installed\static --x-manifest-root=src || exit /b 1
-        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-dynamic --overlay-triplets=src\triplets --overlay-ports=src\overlays --x-install-root=src\vcpkg_installed\dynamic --x-manifest-root=src || exit /b 1
+        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-static-aot --x-install-root=out\vcpkg_installed\static --x-manifest-root=src || exit /b 1
+        "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" install --triplet x64-windows-dynamic --x-install-root=out\vcpkg_installed\dynamic --x-manifest-root=src || exit /b 1
 
     - name: Build VFS for Git
       if: steps.skip.outputs.result != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -229,5 +229,4 @@ ModelManifest.xml
 
 # ProjFS Kext Unit Test coverage results
 ProjFS.Mac/CoverageResult.txt
-# vcpkg build output (rebuilt locally via vcpkg install)
-vcpkg_installed/
+

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ ModelManifest.xml
 
 # ProjFS Kext Unit Test coverage results
 ProjFS.Mac/CoverageResult.txt
+# vcpkg build output (rebuilt locally via vcpkg install)
+vcpkg_installed/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -55,7 +55,7 @@
     See THIRD-PARTY-NOTICES.md for license details on these native libraries.
   -->
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
-    <VcpkgInstalledDir>$(RepoSrcPath)vcpkg_installed\static\x64-windows-static-aot\</VcpkgInstalledDir>
+    <VcpkgInstalledDir>$(RepoOutPath)vcpkg_installed\static\x64-windows-static-aot\</VcpkgInstalledDir>
   </PropertyGroup>
 
   <!-- Set libgit2 library name unconditionally — all builds use vcpkg-sourced libgit2 -->
@@ -83,18 +83,18 @@
     Non-AOT projects (tests) need git2.dll for runtime P/Invoke.
     Copy from the vcpkg dynamic build output.
   -->
-  <ItemGroup Condition="'$(PublishAot)' != 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
-    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll">
+  <ItemGroup Condition="'$(PublishAot)' != 'true' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IncludeBuildOutput)' != 'false'">
+    <Content Include="$(RepoOutPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <Link>git2.dll</Link>
     </Content>
-    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\pcre.dll">
+    <Content Include="$(RepoOutPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\pcre.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <Link>pcre.dll</Link>
     </Content>
-    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\z.dll">
+    <Content Include="$(RepoOutPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\z.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <Link>z.dll</Link>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,74 @@
     <BaseIntermediateOutputPath>$(ProjectOutPath)obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
+  <!--
+    Static native linking: embed libgit2 directly into AOT-compiled executables.
+
+    vcpkg builds a static git2.lib (via the x64-windows-static-aot triplet) which
+    the NativeAOT linker links into the final executable. This eliminates the
+    "DLL missing" crash vector for libgit2.
+
+    How it works:
+      1. vcpkg install produces git2.lib + transitive deps (pcre, zlib, etc.)
+      2. <NativeLibrary> items tell the NativeAOT linker where to find the .lib files
+      3. <DirectPInvoke> tells the linker to resolve P/Invoke calls at link time
+      4. libgit2_filename is overridden from "git2-XXXXXXX" (NuGet) to "git2" (vcpkg)
+
+    A side benefit of this approach: we can apply patches to libgit2 that haven't
+    been included in an official release yet, via the overlay port in overlays/.
+
+    To rebuild vcpkg libs after overlay changes:
+      vcpkg install [triplet x64-windows-static-aot] [overlay-triplets=triplets] [overlay-ports=overlays]
+
+    See THIRD-PARTY-NOTICES.md for license details on these native libraries.
+  -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <VcpkgInstalledDir>$(RepoSrcPath)vcpkg_installed\static\x64-windows-static-aot\</VcpkgInstalledDir>
+  </PropertyGroup>
+
+  <!-- Set libgit2 library name unconditionally — all builds use vcpkg-sourced libgit2 -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <libgit2_filename>git2</libgit2_filename>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <DirectPInvoke Include="git2" />
+
+    <!-- libgit2 static library and its transitive dependencies -->
+    <NativeLibrary Include="$(VcpkgInstalledDir)lib\git2.lib" />
+    <NativeLibrary Include="$(VcpkgInstalledDir)lib\pcre.lib" />
+    <NativeLibrary Include="$(VcpkgInstalledDir)lib\http_parser.lib" />
+    <NativeLibrary Include="$(VcpkgInstalledDir)lib\zs.lib" />
+
+    <!-- Windows system libraries required by libgit2 (WinHTTP TLS backend) -->
+    <NativeLibrary Include="winhttp.lib" />
+    <NativeLibrary Include="crypt32.lib" />
+    <NativeLibrary Include="rpcrt4.lib" />
+    <NativeLibrary Include="secur32.lib" />
+  </ItemGroup>
+
+  <!--
+    Non-AOT projects (tests) need git2.dll for runtime P/Invoke.
+    Copy from the vcpkg dynamic build output.
+  -->
+  <ItemGroup Condition="'$(PublishAot)' != 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
+    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <Link>git2.dll</Link>
+    </Content>
+    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\pcre.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <Link>pcre.dll</Link>
+    </Content>
+    <Content Include="$(RepoSrcPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\z.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <Link>z.dll</Link>
+    </Content>
+  </ItemGroup>
+
   <!-- Native project properties -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
     <Platform>x64</Platform>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,6 +13,75 @@
   <Import Project="$(MSBuildThisFileDirectory)GVFS\GVFS.MSBuild\GVFS.targets" />
 
   <!--
+    Auto-restore vcpkg native dependencies when missing.
+    Modeled after vcpkg's official VcpkgInstallManifestDependencies target
+    (scripts/buildsystems/msbuild/vcpkg.targets), adapted for .csproj projects
+    and dual-triplet installs (static-aot + dynamic).
+
+    Key differences from official vcpkg.targets:
+      - Hooks PrepareForBuild instead of ClCompile (which doesn't exist in csproj)
+      - Installs two triplets (static for AOT linking, dynamic for runtime P/Invoke)
+      - Outputs to out/vcpkg_installed/ instead of src/vcpkg_installed/
+      - Discovers vcpkg via VCPKG_INSTALLATION_ROOT, VS-bundled path, or PATH
+
+    Stamp file pattern: the target uses Inputs/Outputs so MSBuild skips it entirely
+    when the manifests haven't changed and the stamp file is up-to-date.
+    Build.bat also runs vcpkg install upfront, making this a no-op for CLI builds.
+  -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <_VcpkgManifestFile>$(RepoSrcPath)vcpkg.json</_VcpkgManifestFile>
+    <_VcpkgConfigFile>$(RepoSrcPath)vcpkg-configuration.json</_VcpkgConfigFile>
+    <_VcpkgStampFile>$(RepoOutPath)vcpkg_installed\.msbuildstamp</_VcpkgStampFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <_VcpkgManifestInputs Include="$(_VcpkgManifestFile)" />
+    <_VcpkgManifestInputs Include="$(_VcpkgConfigFile)" Condition="Exists('$(_VcpkgConfigFile)')" />
+  </ItemGroup>
+
+  <Target Name="_RestoreVcpkgDependencies"
+          BeforeTargets="PrepareForBuild;ComputeFilesToPublish"
+          Condition="'$(MSBuildProjectName)' == 'GVFS.Common'"
+          Inputs="@(_VcpkgManifestInputs)"
+          Outputs="$(_VcpkgStampFile)">
+
+    <!-- Locate vcpkg: VCPKG_INSTALLATION_ROOT > VS-bundled > PATH -->
+    <PropertyGroup>
+      <_VcpkgExe Condition="Exists('$(VCPKG_INSTALLATION_ROOT)\vcpkg.exe')">$(VCPKG_INSTALLATION_ROOT)\vcpkg.exe</_VcpkgExe>
+      <_VcpkgExe Condition="'$(_VcpkgExe)' == '' and Exists('$(VsInstallRoot)\VC\vcpkg\vcpkg.exe')">$(VsInstallRoot)\VC\vcpkg\vcpkg.exe</_VcpkgExe>
+      <_VcpkgManifestArg>--x-manifest-root="$(RepoSrcPath.TrimEnd('\'))"</_VcpkgManifestArg>
+    </PropertyGroup>
+
+    <!-- For dotnet build (no VsInstallRoot): find VS-bundled vcpkg via vswhere -->
+    <Exec Command="&quot;$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe&quot; -latest -products * -property installationPath"
+          ConsoleToMSBuild="true" IgnoreExitCode="true" StandardOutputImportance="low"
+          Condition="'$(_VcpkgExe)' == ''">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_VsInstallPath" />
+    </Exec>
+    <PropertyGroup Condition="'$(_VcpkgExe)' == '' and '$(_VsInstallPath)' != '' and Exists('$(_VsInstallPath)\VC\vcpkg\vcpkg.exe')">
+      <_VcpkgExe>$(_VsInstallPath)\VC\vcpkg\vcpkg.exe</_VcpkgExe>
+    </PropertyGroup>
+
+    <!-- Final fallback: bare vcpkg on PATH -->
+    <PropertyGroup Condition="'$(_VcpkgExe)' == ''">
+      <_VcpkgExe>vcpkg</_VcpkgExe>
+    </PropertyGroup>
+
+    <Message Importance="high" Text="[vcpkg] Installing native dependencies to $(RepoOutPath)vcpkg_installed\" />
+
+    <MakeDir Directories="$(RepoOutPath)vcpkg_installed\" />
+    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-static-aot --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\static&quot; $(_VcpkgManifestArg)"
+          StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-dynamic --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\dynamic&quot; $(_VcpkgManifestArg)"
+          StandardOutputImportance="High" StandardErrorImportance="High" />
+
+    <Error Condition="!Exists('$(RepoOutPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll')"
+           Text="vcpkg install completed but expected output files are missing. Check vcpkg output above for errors." />
+
+    <Touch Files="$(_VcpkgStampFile)" AlwaysCreate="true" />
+  </Target>
+
+  <!--
     Copy native C++ hook executables and managed peer executables to GVFS.exe
     output directory. In a production install all binaries are co-located in one
     directory. During dev builds each project has its own output; this target

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
 
     <!-- Git -->
-    <PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" />
+    <!-- libgit2 native library is now provided by vcpkg (see overlays/libgit2) -->
 
     <!-- ProjFS -->
     <PackageVersion Include="Microsoft.Windows.ProjFS" Version="2.1.0" />

--- a/GVFS/GVFS.Common/GVFS.Common.csproj
+++ b/GVFS/GVFS.Common/GVFS.Common.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="SharpZipLib" />
   </ItemGroup>

--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -483,7 +483,7 @@ namespace GVFS.Common.Git
                 return Marshal.PtrToStructure<GitError>(ptr).Message;
             }
 
-            [DllImport(Git2NativeLibName, EntryPoint = "giterr_last")]
+            [DllImport(Git2NativeLibName, EntryPoint = "git_error_last")]
             private static extern IntPtr GetLastGitError();
 
             [StructLayout(LayoutKind.Sequential)]

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!--
     Files from GVFS.Common included as links here to prevent adding
     project reference. The project reference leads to performance degradation

--- a/Readme.md
+++ b/Readme.md
@@ -89,3 +89,7 @@ See [License.md](License.md).
 
 VFS for Git relies on the PrjFlt filter driver, formerly known as the GvFlt
 filter driver, available as a prerelease NuGet package.
+
+VFS for Git also includes or links to third-party native libraries at build
+time. See [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for details on
+these dependencies and their licenses.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,69 @@
+# Third-Party Notices
+
+VFS for Git incorporates third-party native libraries that are statically
+linked into the final executable when building with NativeAOT. This file
+documents those dependencies and their licenses.
+
+## libgit2
+
+**Source:** https://github.com/libgit2/libgit2
+**Version:** 1.9.3 (via vcpkg overlay port in overlays/libgit2/)
+**License:** GPLv2 with Linking Exception
+
+libgit2 is used for local Git object lookups (commit parsing, tree walking,
+blob size queries, config reading). VFS for Git calls libgit2 via P/Invoke
+and, when building with NativeAOT, statically links the compiled library into
+the executable.
+
+The libgit2 COPYING file (https://github.com/libgit2/libgit2/blob/main/COPYING)
+includes the following linking exception:
+
+> In addition to the permissions in the GNU General Public License,
+> the authors give you unlimited permission to link the compiled
+> version of this library into combinations with other programs,
+> and to distribute those combinations without any restriction
+> coming from the use of this file. (The General Public License
+> restrictions do apply in other respects; for example, they cover
+> modification of the file, and distribution when not linked into
+> a combined executable.)
+
+This exception explicitly permits both dynamic and static linking of the
+compiled libgit2 library into VFS for Git without imposing GPL obligations
+on VFS for Git's own MIT-licensed source code. Modifications to libgit2
+itself remain subject to the GPLv2.
+
+The full GPLv2 license text is available at:
+https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
+## SQLite
+
+**Source:** https://www.sqlite.org/
+**Version:** Bundled via SQLitePCLRaw.lib.e_sqlite3 NuGet package
+**License:** Public Domain
+
+SQLite is used for persistent storage of placeholder lists and blob size
+caches. The SQLite C library is in the public domain and imposes no
+restrictions on linking or distribution.
+
+> The author disclaims copyright to this source code. In place of a
+> legal notice, here is a blessing:
+>
+> May you do good and not evil.
+> May you find forgiveness for yourself and forgive others.
+> May you share freely, never taking more than you give.
+
+https://www.sqlite.org/copyright.html
+
+## SQLitePCLRaw / Microsoft.Data.Sqlite
+
+**Source:** https://github.com/ericsink/SQLitePCL.raw (SQLitePCLRaw),
+https://github.com/dotnet/efcore (Microsoft.Data.Sqlite)
+**License:** Apache License 2.0
+
+These managed libraries provide the .NET API surface for SQLite access.
+SQLitePCLRaw handles the P/Invoke layer to the native SQLite library, and
+Microsoft.Data.Sqlite provides the ADO.NET provider. Both are licensed under
+the Apache License 2.0, which permits static linking without restriction.
+
+The full Apache License 2.0 text is available at:
+https://www.apache.org/licenses/LICENSE-2.0

--- a/overlays/libgit2/README.md
+++ b/overlays/libgit2/README.md
@@ -1,0 +1,46 @@
+# libgit2 vcpkg Overlay Port
+
+This overlay replaces the default vcpkg `libgit2` port to pin a specific
+version and optionally carry patches ahead of upstream releases.
+
+## Current version
+
+**libgit2 v1.9.3** — includes C4703 warning fixes (libgit2/libgit2#7154)
+that were missing from v1.9.1.
+
+## Patches
+
+- `dependencies.diff` — adjusts CMake dependency resolution for vcpkg
+  (copied from official vcpkg port, required for PCRE discovery)
+
+Additional patches can be added to the `PATCHES` list in `portfile.cmake`
+to apply fixes that haven't shipped in an official libgit2 release yet.
+
+## File provenance
+
+All files were copied from the
+[official vcpkg libgit2 port](https://github.com/microsoft/vcpkg/tree/master/ports/libgit2)
+and then modified as noted below.
+
+| File | Source | Changes |
+|------|--------|---------|
+| `vcpkg.json` | Official vcpkg port | Unchanged |
+| `dependencies.diff` | Official vcpkg port | Unchanged |
+| `portfile.cmake` | Official vcpkg port | Removed patches not needed for MSVC x64: `c-standard.diff` (C99 inline keyword — MSVC handles natively), `cli-include-dirs.diff` (CLI tool build — we set `BUILD_CLI=OFF`), `mingw-winhttp.diff` (MinGW only) |
+| `README.md` | New | VFSForGit-specific documentation |
+
+When updating to a new libgit2 version, compare these files against the
+official vcpkg port to pick up any new patches or portfile changes.
+
+## How overlays work
+
+A vcpkg overlay port **completely replaces** the official port — it doesn't
+layer on top. When `--overlay-ports=overlays` is specified, vcpkg uses this
+directory's `portfile.cmake` and `vcpkg.json` instead of the registry's.
+
+## Usage
+
+```
+vcpkg install --triplet x64-windows-static-aot ^
+  --overlay-triplets=triplets --overlay-ports=overlays
+```

--- a/overlays/libgit2/dependencies.diff
+++ b/overlays/libgit2/dependencies.diff
@@ -1,0 +1,13 @@
+diff --git a/cmake/SelectRegex.cmake b/cmake/SelectRegex.cmake
+index 2a3a91b..523fa72 100644
+--- a/cmake/SelectRegex.cmake
++++ b/cmake/SelectRegex.cmake
+@@ -1,5 +1,7 @@
+ # Specify regular expression implementation
+-find_package(PCRE)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(PCRE REQUIRED libpcre)
++set(PCRE_LIBRARIES "${PCRE_LINK_LIBRARIES}")
+ 
+ if(REGEX_BACKEND STREQUAL "")
+ 	check_symbol_exists(regcomp_l "regex.h;xlocale.h" HAVE_REGCOMP_L)

--- a/overlays/libgit2/portfile.cmake
+++ b/overlays/libgit2/portfile.cmake
@@ -1,0 +1,107 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libgit2/libgit2
+    REF "v${VERSION}"
+    SHA512 5359d07b85b691b92784d5ef52825be2c1f1616bab8e969e51177bf8f5e767edbaf267943296407f62df1f3d7fa08e48c802374289046b71da2cc1ac7d43a15f
+    HEAD_REF main
+    PATCHES
+        dependencies.diff
+)
+
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/cmake/FindPCRE.cmake"
+    "${SOURCE_PATH}/cmake/FindPCRE2.cmake"
+    "${SOURCE_PATH}/deps/chromium-zlib"
+    "${SOURCE_PATH}/deps/http-parser"
+    "${SOURCE_PATH}/deps/pcre"
+    "${SOURCE_PATH}/deps/winhttp"
+    "${SOURCE_PATH}/deps/zlib"
+)
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)
+
+set(REGEX_BACKEND OFF)
+set(USE_HTTPS OFF)
+set(USE_SSH OFF)
+
+function(set_regex_backend VALUE)
+    if(REGEX_BACKEND)
+        message(FATAL_ERROR "Only one regex backend (pcre,pcre2) is allowed")
+    endif()
+    set(REGEX_BACKEND ${VALUE} PARENT_SCOPE)
+endfunction()
+
+function(set_tls_backend VALUE)
+    if(USE_HTTPS)
+        message(FATAL_ERROR "Only one TLS backend (openssl,winhttp,sectransp,mbedtls) is allowed")
+    endif()
+    set(USE_HTTPS ${VALUE} PARENT_SCOPE)
+endfunction()
+
+foreach(GIT2_FEATURE ${FEATURES})
+    if(GIT2_FEATURE STREQUAL "pcre")
+        set_regex_backend("pcre")
+    elseif(GIT2_FEATURE STREQUAL "pcre2")
+        set_regex_backend("pcre2")
+    elseif(GIT2_FEATURE STREQUAL "openssl")
+        set_tls_backend("OpenSSL")
+    elseif(GIT2_FEATURE STREQUAL "winhttp")
+        set_tls_backend("WinHTTP")
+    elseif(GIT2_FEATURE STREQUAL "sectransp")
+        set_tls_backend("SecureTransport")
+    elseif(GIT2_FEATURE STREQUAL "mbedtls")
+        set_tls_backend("mbedTLS")
+    elseif(GIT2_FEATURE STREQUAL "ssh")
+        set(USE_SSH ON)
+    endif()
+endforeach()
+
+if(NOT REGEX_BACKEND)
+    message(FATAL_ERROR "Must choose pcre or pcre2 regex backend")
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS GIT2_FEATURES
+    FEATURES
+        tools   BUILD_CLI
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DUSE_HTTP_PARSER=system
+        -DUSE_HTTPS=${USE_HTTPS}
+        -DREGEX_BACKEND=${REGEX_BACKEND}
+        -DUSE_SSH=${USE_SSH}
+        -DSTATIC_CRT=${STATIC_CRT}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        -DCMAKE_DISABLE_FIND_PACKAGE_GSSAPI:BOOL=ON
+        ${GIT2_FEATURES}
+    OPTIONS_DEBUG
+        -DBUILD_CLI=OFF
+    MAYBE_UNUSED_VARIABLES
+        STATIC_CRT
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES git2 AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+set(file_list "${SOURCE_PATH}/COPYING")
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    file(WRITE "${CURRENT_BUILDTREES_DIR}/Notice for ntlmclient" [[
+Copyright (c) Edward Thomson.  All rights reserved.
+These source files are part of ntlmclient, distributed under the MIT license.
+]])
+    list(APPEND file_list "${CURRENT_BUILDTREES_DIR}/Notice for ntlmclient")
+endif()
+vcpkg_install_copyright(FILE_LIST ${file_list})

--- a/overlays/libgit2/vcpkg.json
+++ b/overlays/libgit2/vcpkg.json
@@ -1,0 +1,97 @@
+{
+  "name": "libgit2",
+  "version-semver": "1.9.3",
+  "description": "A C library implementing the Git core methods with a solid API",
+  "homepage": "https://github.com/libgit2/libgit2",
+  "license": null,
+  "supports": "!uwp",
+  "dependencies": [
+    "http-parser",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "pcre",
+    "ssl"
+  ],
+  "features": {
+    "mbedtls": {
+      "description": "SSL support (mbedTLS)",
+      "supports": "!windows",
+      "dependencies": [
+        "mbedtls"
+      ]
+    },
+    "openssl": {
+      "description": "SSL support (OpenSSL)",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "pcre": {
+      "description": "Build against external libpcre",
+      "dependencies": [
+        "pcre"
+      ]
+    },
+    "pcre2": {
+      "description": "Build against external libpcre2",
+      "dependencies": [
+        "pcre2"
+      ]
+    },
+    "sectransp": {
+      "description": "SSL support (sectransp)",
+      "supports": "osx"
+    },
+    "ssh": {
+      "description": "SSH support via libssh2",
+      "dependencies": [
+        "libssh2"
+      ]
+    },
+    "ssl": {
+      "description": "Default SSL backend",
+      "dependencies": [
+        {
+          "name": "libgit2",
+          "default-features": false,
+          "features": [
+            "sectransp"
+          ],
+          "platform": "osx"
+        },
+        {
+          "name": "libgit2",
+          "default-features": false,
+          "features": [
+            "winhttp"
+          ],
+          "platform": "windows"
+        },
+        {
+          "name": "libgit2",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ],
+          "platform": "!windows & !osx"
+        }
+      ]
+    },
+    "tools": {
+      "description": "Build CLI tools"
+    },
+    "winhttp": {
+      "description": "SSL support (WinHTTP)",
+      "supports": "windows & !uwp"
+    }
+  }
+}

--- a/scripts/Build.bat
+++ b/scripts/Build.bat
@@ -32,6 +32,44 @@ dotnet restore "%VFS_SRCDIR%\GVFS.sln" ^
         /v:%VERBOSITY% ^
         /p:Configuration=%CONFIGURATION% || GOTO ERROR
 
+ECHO ^*************************************
+ECHO ^* Installing vcpkg native libraries *
+ECHO ^*************************************
+IF EXIST "%VFS_OUTDIR%\vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll" (
+    ECHO INFO: vcpkg native libraries already present, skipping install.
+    GOTO :VCPKG_DONE
+)
+SET VCPKG_EXEC=
+IF DEFINED VCPKG_INSTALLATION_ROOT (
+    IF EXIST "%VCPKG_INSTALLATION_ROOT%\vcpkg.exe" (
+        SET "VCPKG_EXEC=%VCPKG_INSTALLATION_ROOT%\vcpkg.exe"
+        GOTO :FOUND_VCPKG
+    )
+)
+FOR /F "tokens=* USEBACKQ" %%F IN (`where vcpkg.exe 2^>nul`) DO (
+    SET "VCPKG_EXEC=%%F"
+    GOTO :FOUND_VCPKG
+)
+REM Try VS-bundled vcpkg via vswhere
+SET VSWHERE_VCPKG="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+IF EXIST %VSWHERE_VCPKG% (
+    FOR /F "tokens=* USEBACKQ" %%F IN (`%VSWHERE_VCPKG% -latest -products * -property installationPath`) DO (
+        IF EXIST "%%F\VC\vcpkg\vcpkg.exe" (
+            SET "VCPKG_EXEC=%%F\VC\vcpkg\vcpkg.exe"
+            GOTO :FOUND_VCPKG
+        )
+    )
+)
+ECHO ERROR: vcpkg.exe not found. Install vcpkg or set VCPKG_INSTALLATION_ROOT.
+ECHO        See https://learn.microsoft.com/en-us/vcpkg/get-started/get-started
+EXIT /B 1
+
+:FOUND_VCPKG
+ECHO INFO: Using vcpkg at '%VCPKG_EXEC%'
+"%VCPKG_EXEC%" install --triplet x64-windows-static-aot --x-install-root="%VFS_OUTDIR%\vcpkg_installed\static" --x-manifest-root="%VFS_SRCDIR%" || GOTO ERROR
+"%VCPKG_EXEC%" install --triplet x64-windows-dynamic --x-install-root="%VFS_OUTDIR%\vcpkg_installed\dynamic" --x-manifest-root="%VFS_SRCDIR%" || GOTO ERROR
+:VCPKG_DONE
+
 ECHO ^**************************
 ECHO ^* Building C++ Projects  *
 ECHO ^**************************

--- a/triplets/x64-windows-dynamic.cmake
+++ b/triplets/x64-windows-dynamic.cmake
@@ -1,0 +1,5 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+# Dynamic linkage: produces git2.dll for non-AOT projects (tests) that use
+# runtime P/Invoke. AOT projects use the static triplet instead.
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)

--- a/triplets/x64-windows-static-aot.cmake
+++ b/triplets/x64-windows-static-aot.cmake
@@ -1,0 +1,12 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+# Static linkage: libgit2 and its dependencies (pcre, zlib) are compiled into
+# the consuming binary. This eliminates "DLL missing" crashes for the native
+# git2 library.
+#
+# Licensing notes:
+#   libgit2 — GPLv2 with linking exception (see COPYING in libgit2 repo), which
+#             explicitly permits static linking without imposing GPL on the consumer.
+#   pcre    — BSD license (permissive, no static-linking restrictions).
+#   zlib    — zlib license (permissive, no static-linking restrictions).
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Pin the vcpkg default registry to a known baseline for reproducible builds.",
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "940f58770cee8e2011bfb4847fb2bd70057301a8"
+  }
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,5 +1,7 @@
 {
   "$comment": "Pin the vcpkg default registry to a known baseline for reproducible builds.",
+  "overlay-ports": ["./overlays"],
+  "overlay-triplets": ["./triplets"],
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "vcpkg manifest for native dependencies built as static libraries for NativeAOT linking.",
+  "dependencies": [
+    "libgit2"
+  ]
+}


### PR DESCRIPTION
## Summary

Replace the `LibGit2Sharp.NativeBinaries` NuGet package (dynamic `git2-*.dll`) with a vcpkg-built **static** `git2.lib` that the NativeAOT linker embeds directly into the executable. This eliminates the libgit2 DLL-missing crashes we see in telemetry.

## Motivation

Telemetry shows occasional `DllNotFoundException` / process crashes when `git2-a418d9d.dll` is missing or fails to load at runtime. With static linking, the native code is part of the executable itself — there is no separate DLL to lose.

## How it works

| Component | Purpose |
|-----------|---------|
| `vcpkg.json` | Declares libgit2 as a vcpkg dependency |
| `vcpkg-configuration.json` | Pins the vcpkg registry baseline + declares overlay ports/triplets |
| `triplets/x64-windows-static-aot.cmake` | Static CRT + library linkage → produces `git2.lib` for AOT executables |
| `triplets/x64-windows-dynamic.cmake` | Dynamic linkage → produces `git2.dll` for non-AOT test projects |
| `overlays/libgit2/` | Port overlay pinning v1.9.3, can carry patches ahead of upstream releases |
| `Directory.Build.props` | AOT: `<DirectPInvoke>` + `<NativeLibrary>` for static link; non-AOT: `<Content>` items copy `git2.dll` + deps |
| `Directory.Build.targets` | `_RestoreVcpkgDependencies` target — auto-runs vcpkg on first build (modeled after official `VcpkgInstallManifestDependencies`) |
| `scripts/Build.bat` | Discovers and runs vcpkg before building (vswhere-based discovery) |
| `.github/workflows/build.yaml` | Runs `vcpkg install` (both triplets) in CI using preinstalled `%VCPKG_INSTALLATION_ROOT%` |

### vcpkg auto-restore

vcpkg native libraries are automatically installed on first build via three complementary paths:

| Build path | How vcpkg runs |
|------------|----------------|
| **Visual Studio** | MSBuild `_RestoreVcpkgDependencies` target in GVFS.Common auto-discovers vcpkg and installs both triplets. Uses stamp file + `Inputs`/`Outputs` for incrementality. |
| **Build.bat** | Explicit vcpkg step with discovery via `VCPKG_INSTALLATION_ROOT` → PATH → vswhere. Skips if outputs already cached. |
| **CI** | Explicit step using preinstalled `%VCPKG_INSTALLATION_ROOT%` before Build.bat. |

vcpkg outputs go to `out/vcpkg_installed/` (alongside other build artifacts), not inside the git working tree.

### Side benefits

**Patchable libgit2:** The vcpkg overlay port lets us apply patches to libgit2 that haven't shipped in an official release yet. For example, the non-elevated admin ownership fix ([libgit2/libgit2#7200](https://github.com/libgit2/libgit2/pull/7200)) can be added as a `.patch` file in `overlays/libgit2/` in a follow-up PR.

**libgit2 version upgrade:** The `LibGit2Sharp.NativeBinaries` NuGet package (v2.0.322) bundled libgit2 **v1.7.2** from January 2024. The "2.0" was the wrapper's own version, not libgit2's. This PR upgrades to libgit2 **v1.9.3** (May 2026), picking up over two years of upstream bug fixes, performance improvements, and security patches.

**ABI verified:** All 21 P/Invoke entry points in `LibGit2Repo.cs` are ABI-stable between the old libgit2 and v1.9.3. The deprecated `giterr_last` has been updated to `git_error_last`.

**SHA512 verified:** The source archive hash in `portfile.cmake` has been independently verified against the official GitHub release tarball.

## Developer workflow

**No manual steps required.** Open the solution in Visual Studio and build — vcpkg dependencies are installed automatically on first build. Subsequent builds skip vcpkg entirely (stamp file).

For CLI builds, `scripts\Build.bat` handles everything including vcpkg discovery and installation.

## CI changes

The build workflow (`.github/workflows/build.yaml`) runs `vcpkg install` using the pre-installed vcpkg on GitHub Actions `windows-2025` runners via `%VCPKG_INSTALLATION_ROOT%`, then calls Build.bat (which skips vcpkg since outputs already exist).

## Licensing

libgit2's `COPYING` file includes an explicit **linking exception** (both dynamic and static):

> *the authors give you unlimited permission to link the compiled version of this library into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file.*

Full details in `THIRD-PARTY-NOTICES.md`.

## Testing

- [x] Clean build (no stale NuGet DLLs in output)
- [x] AOT executables: no `git2*.dll` — libgit2 fully embedded
- [x] Non-AOT test projects: `git2.dll` + deps copied to output and publish dirs
- [x] Unit tests: 803 pass, 0 fail (from publish directory)
- [x] Functional tests (clone + mount + ProjFS hydration): pass
- [x] CI: build + unit tests pass for both Debug and Release
- [x] VS clean build: auto-restore works, single vcpkg invocation via GVFS.Common
- [x] Build.bat clean build: vcpkg discovered via vswhere, full build succeeds
- [x] dotnet build: MSBuild target auto-discovers vcpkg and restores
- [x] SHA512 independently verified against official GitHub release
- [x] ABI compatibility verified for all P/Invoke entry points

## Future work (separate PRs)

- Static link SQLite (`e_sqlite3`) — needs SQLitePCLRaw 2.2.0+ or amalgamation build
- Add admin linked token patch ([libgit2/libgit2#7200](https://github.com/libgit2/libgit2/pull/7200)) via overlay