### PR TITLE
azure-pipelines: move to new MicroBuild pool

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -25,7 +25,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
 
     featureFlags:
       incrementalSDLBinaryAnalysis: false


### PR DESCRIPTION
Move from the `VSEngSS-MicroBuild2022-1ES` pool to the new `VSEng-MicroBuildVSStable` pool, which has Windows Server 2025 + Visual Studio 2026 images instead.

This is targeting the `releases/shipped` branch. Once merged will port back to `master.`