### PR TITLE
Fix FastFetch MicroBuild signing for NativeAOT publish

### DIFF
--- a/GVFS/FastFetch/FastFetch.csproj
+++ b/GVFS/FastFetch/FastFetch.csproj
@@ -16,11 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FilesToSign Include="
-      $(OutputPath)\FastFetch.exe;
-      $(OutputPath)\GVFS.Common.dll;
-      $(OutputPath)\GVFS.Platform.Windows.dll;
-      $(OutputPath)\GVFS.Virtualization.dll;">
+    <FilesToSign Include="$(PublishDir)\FastFetch.exe">
       <Authenticode>Microsoft400</Authenticode>
       <InProject>false</InProject>
     </FilesToSign>


### PR DESCRIPTION
With `PublishAot=true`, `dotnet publish` produces the native executable in `$(PublishDir)` rather than `$(OutputPath)`. The `FilesToSign` items in `FastFetch.csproj` were still referencing `$(OutputPath)\FastFetch.exe`, causing the ESRP signing task to fail because the file doesn't exist at that path.

**Changes:**
- Use `$(PublishDir)` instead of `$(OutputPath)` for the signing path
- Remove managed DLL entries (`GVFS.Common.dll`, `GVFS.Platform.Windows.dll`, `GVFS.Virtualization.dll`) which are statically linked into the NativeAOT binary and no longer exist as separate files

This is consistent with how `GVFS.Payload` handles it — its `layout.bat` already copies from the `publish\` subdirectory and cleans up orphaned managed artifacts.