### PR TITLE
global.json: enable roll forward in .NET SDK (port to master)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.203",
-    "rollForward": "disable"
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.0",


### PR DESCRIPTION
Our release agent pools use 10.0.300. Our GitHub Agents use 10.0.203. Let's just be less picky about the exact version of "10.x".

Cherry-picking commit 954f8fba that is already in `releases/shipped` from #1970