### PR TITLE
Fix: --unmount-all now triggers pending staged upgrade

### DIFF
--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -33,6 +33,7 @@ jobs:
           - double-staging
           - staging-then-clean
           - mount-safety-deferral
+          - unmount-all-triggers-upgrade
       fail-fast: false
 
     steps:
@@ -272,6 +273,35 @@ jobs:
             Restart-Service
             Assert-PendingUpgrade $false
             Write-Host "PASS: Mount safety deferral works correctly"
+          }
+
+          "unmount-all-triggers-upgrade" {
+            Write-Host "=== Scenario: unmount-all triggers staged upgrade ==="
+            # Install LKG, mount, staging upgrade, then unmount via
+            # 'gvfs service --unmount-all' instead of 'gvfs unmount'.
+            # --unmount-all skips the unregister message, so without the
+            # PendingUpgradeCheckRequest fix the upgrade would never apply.
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            Assert-MountAlive $mountPid
+            Assert-PendingUpgrade $true
+
+            # Unmount via --unmount-all (not per-repo unmount)
+            & "$installDir\gvfs.exe" service --unmount-all 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) { throw "unmount-all failed" }
+
+            # The deferred upgrade timer fires after ~5 seconds.
+            # Wait for it to complete.
+            $deadline = (Get-Date).AddSeconds(30)
+            while ((Test-Path "$installDir\PendingUpgrade") -and (Get-Date) -lt $deadline) {
+              Start-Sleep -Seconds 2
+            }
+
+            Assert-PendingUpgrade $false
+            Write-Host "PASS: unmount-all triggers staged upgrade"
           }
 
           default {

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -427,6 +427,29 @@ namespace GVFS.Common.NamedPipes
             }
         }
 
+        public class PendingUpgradeCheckRequest
+        {
+            public const string Header = nameof(PendingUpgradeCheckRequest);
+
+            public static PendingUpgradeCheckRequest FromMessage(Message message)
+            {
+                return GVFSJsonOptions.Deserialize<PendingUpgradeCheckRequest>(message.Body);
+            }
+
+            public Message ToMessage()
+            {
+                return new Message(Header, GVFSJsonOptions.Serialize(this));
+            }
+
+            public class Response : BaseResponse<PendingUpgradeCheckRequest>
+            {
+                public static Response FromMessage(Message message)
+                {
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
+                }
+            }
+        }
+
         public class GetActiveRepoListRequest
         {
             public const string Header = nameof(GetActiveRepoListRequest);

--- a/GVFS/GVFS.Service/Handlers/RequestHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/RequestHandler.cs
@@ -95,6 +95,18 @@ namespace GVFS.Service.Handlers
 
                     break;
 
+                case NamedPipeMessages.PendingUpgradeCheckRequest.Header:
+                    this.requestDescription = "pending upgrade check";
+
+                    this.TryDeferredPendingUpgradeCheck(this.tracer);
+
+                    NamedPipeMessages.PendingUpgradeCheckRequest.Response upgradeCheckResponse =
+                        new NamedPipeMessages.PendingUpgradeCheckRequest.Response();
+                    upgradeCheckResponse.State = NamedPipeMessages.CompletionState.Success;
+                    this.TrySendResponse(tracer, upgradeCheckResponse.ToMessage().ToString(), connection);
+
+                    break;
+
                 case NamedPipeMessages.GetActiveRepoListRequest.Header:
                     this.requestDescription = RepoListRequestDescription;
                     NamedPipeMessages.GetActiveRepoListRequest repoListRequest = NamedPipeMessages.GetActiveRepoListRequest.FromMessage(message);

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -136,6 +136,12 @@ namespace GVFS.CommandLine
                     }
                 }
 
+                // Notify the service so it can check for a pending staged
+                // upgrade. Individual unmounts skip unregister (to preserve
+                // automount registration), so the service's normal unmount
+                // trigger never fires during --unmount-all.
+                this.TryNotifyPendingUpgradeCheck();
+
                 if (failedRepoRoots.Count() > 0)
                 {
                     string errorString = $"The following repos failed to unmount:{Environment.NewLine}{string.Join(Environment.NewLine, failedRepoRoots.ToArray())}";
@@ -216,6 +222,47 @@ namespace GVFS.CommandLine
             }
 
             return false;
+        }
+
+        private void TryNotifyPendingUpgradeCheck()
+        {
+            NamedPipeMessages.PendingUpgradeCheckRequest request = new NamedPipeMessages.PendingUpgradeCheckRequest();
+
+            try
+            {
+                using (NamedPipeClient client = new NamedPipeClient(this.ServicePipeName))
+                {
+                    if (!client.Connect())
+                    {
+                        this.Output.WriteLine("    WARNING: Could not notify GVFS.Service to check for pending upgrade (service not responding).");
+                        return;
+                    }
+
+                    client.SendRequest(request.ToMessage());
+                    NamedPipeMessages.Message response = client.ReadResponse();
+                    if (response.Header == NamedPipeMessages.PendingUpgradeCheckRequest.Response.Header)
+                    {
+                        NamedPipeMessages.PendingUpgradeCheckRequest.Response typedResponse =
+                            NamedPipeMessages.PendingUpgradeCheckRequest.Response.FromMessage(response);
+                        if (typedResponse.State != NamedPipeMessages.CompletionState.Success)
+                        {
+                            this.Output.WriteLine("    WARNING: Pending upgrade check failed: " + typedResponse.ErrorMessage);
+                        }
+                    }
+                    else
+                    {
+                        this.Output.WriteLine("    WARNING: GVFS.Service responded with unexpected message: " + response.Header);
+                    }
+                }
+            }
+            catch (BrokenPipeException)
+            {
+                this.Output.WriteLine("    WARNING: Could not notify GVFS.Service to check for pending upgrade.");
+            }
+            catch (Exception ex)
+            {
+                this.Output.WriteLine("    WARNING: Error notifying GVFS.Service to check for pending upgrade: " + ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

When an installer runs while mounts are active, it stages new files to
`PendingUpgrade\` instead of replacing files in-place. The service is
supposed to apply the upgrade when all mounts are unmounted.

This works correctly for `gvfs unmount` because each unmount sends an
`UnregisterRepoRequest` to the service, which triggers
`TryDeferredPendingUpgradeCheck` in `RequestHandler`.

However, `gvfs service --unmount-all` sets `SkipUnregister = true` on
each unmount (to preserve automount registration), so **no message reaches
the service** and the staged upgrade is never applied — it sits in
`PendingUpgrade\` indefinitely until the next service restart.

## Fix

**New `PendingUpgradeCheckRequest` named pipe message** (3 files, ~65 lines):

1. **`NamedPipeMessages.cs`** — Added `PendingUpgradeCheckRequest` with
   header, `FromMessage`/`ToMessage`, and `Response` (follows existing
   `EnableAndAttachProjFSRequest` pattern).

2. **`RequestHandler.cs`** — Handle the new message by calling the existing
   `TryDeferredPendingUpgradeCheck` (same debounced timer that individual
   unmounts use) and returning a success response.

3. **`ServiceVerb.cs`** — After the `--unmount-all` loop completes, send
   `PendingUpgradeCheckRequest` to the service pipe. Placed **before** the
   failure exit path so partial unmount failures still trigger the check.
   Notification failure is treated as a warning (unmounts themselves succeeded).

The service-side `PendingUpgradeHandler.TryApplyPendingUpgrade` already
checks for running `GVFS.Mount` processes and defers if any are present,
so sending the notification even after partial unmount failures is safe.

## Test

Added `unmount-all-triggers-upgrade` scenario to the CI upgrade test matrix
(`upgrade-tests.yaml`). It follows the same pattern as `staging-upgrade`
but uses `gvfs service --unmount-all` instead of per-repo unmount, then
polls for `PendingUpgrade\` directory removal to confirm the upgrade
applied without needing a service restart.