### PR TITLE
Replace object locks with System.Threading.Lock

### DIFF
--- a/GVFS/GVFS.Common/Database/PlaceholderTable.cs
+++ b/GVFS/GVFS.Common/Database/PlaceholderTable.cs
@@ -2,16 +2,17 @@
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Threading;
 
 namespace GVFS.Common.Database
 {
     /// <summary>
-    /// This class is for interacting with the Placeholder table in the SQLite database
+    /// This class is for interacting with the Placeholder tablein the SQLite database
     /// </summary>
     public class PlaceholderTable : IPlaceholderCollection
     {
         private IGVFSConnectionPool connectionPool;
-        private object writerLock = new object();
+        private Lock writerLock = new Lock();
 
         public PlaceholderTable(IGVFSConnectionPool connectionPool)
         {

--- a/GVFS/GVFS.Common/Database/SparseTable.cs
+++ b/GVFS/GVFS.Common/Database/SparseTable.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Threading;
 
 namespace GVFS.Common.Database
 {
     public class SparseTable : ISparseCollection
     {
         private IGVFSConnectionPool connectionPool;
-        private object writerLock = new object();
+        private Lock writerLock = new Lock();
 
         public SparseTable(IGVFSConnectionPool connectionPool)
         {

--- a/GVFS/GVFS.Common/FileBasedCollection.cs
+++ b/GVFS/GVFS.Common/FileBasedCollection.cs
@@ -27,7 +27,7 @@ namespace GVFS.Common
         /// </summary>
         private readonly bool collectionAppendsDirectlyToFile;
 
-        private readonly object fileLock = new object();
+        private readonly Lock fileLock = new Lock();
 
         private readonly PhysicalFileSystem fileSystem;
         private readonly string dataDirectoryPath;

--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common
 {
     public partial class GVFSLock
     {
-        private readonly object acquisitionLock = new object();
+        private readonly Lock acquisitionLock = new Lock();
         private readonly ITracer tracer;
         private readonly LockHolder currentLockHolder = new LockHolder();
 

--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 
 namespace GVFS.Common.Git
 {
@@ -13,7 +14,7 @@ namespace GVFS.Common.Git
     {
         private const double MaxBackoffSeconds = 30;
 
-        private readonly object gitAuthLock = new object();
+        private readonly Lock gitAuthLock = new Lock();
         private readonly ICredentialStore credentialStore;
         private readonly string repoUrl;
 

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace GVFS.Common.Git
 {
@@ -21,14 +22,14 @@ namespace GVFS.Common.Git
         /// <summary>
         /// Lock taken for duration of running executingProcess.
         /// </summary>
-        private object executionLock = new object();
+        private Lock executionLock = new Lock();
 
         /// <summary>
         /// Lock taken when changing the running state of executingProcess.
         ///
         /// Can be taken within executionLock.
         /// </summary>
-        private object processLock = new object();
+        private Lock processLock = new Lock();
 
         private string gitBinPath;
         private string workingDirectoryRoot;

--- a/GVFS/GVFS.Common/Git/LibGit2RepoInvoker.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2RepoInvoker.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.Git
     {
         private readonly Func<LibGit2Repo> createRepo;
         private readonly ITracer tracer;
-        private readonly object sharedRepoLock = new object();
+        private readonly Lock sharedRepoLock = new Lock();
         private volatile bool disposing;
         private volatile int activeCallers;
         private LibGit2Repo sharedRepo;

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -56,7 +56,7 @@ namespace GVFS.Common
 
         private volatile CacheState cacheState = CacheState.Dirty;
 
-        private object cacheFileLock = new object();
+        private Lock cacheFileLock = new Lock();
 
         internal static bool? TEST_EnableHydrationSummaryOverride = null;
 
@@ -597,7 +597,7 @@ namespace GVFS.Common
 
         private bool TryDeleteStatusCacheFile()
         {
-            Debug.Assert(Monitor.IsEntered(this.cacheFileLock), "Attempting to delete the git status cache file without the cacheFileLock");
+            Debug.Assert(this.cacheFileLock.IsHeldByCurrentThread, "Attempting to delete the git status cache file without the cacheFileLock");
 
             try
             {
@@ -635,7 +635,7 @@ namespace GVFS.Common
         /// <returns>True on success, False on failure</returns>
         private bool MoveCacheFileToFinalLocation(string tmpStatusFilePath)
         {
-            Debug.Assert(Monitor.IsEntered(this.cacheFileLock), "Attempting to update the git status cache file without the cacheFileLock");
+            Debug.Assert(this.cacheFileLock.IsHeldByCurrentThread, "Attempting to update the git status cache file without the cacheFileLock");
 
             try
             {

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceQueue.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceQueue.cs
@@ -8,7 +8,7 @@ namespace GVFS.Common.Maintenance
 {
     public class GitMaintenanceQueue
     {
-        private readonly object queueLock = new object();
+        private readonly Lock queueLock = new Lock();
         private GVFSContext context;
         private BlockingCollection<GitMaintenanceStep> queue = new BlockingCollection<GitMaintenanceStep>();
         private GitMaintenanceStep currentStep;

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -4,13 +4,14 @@ using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace GVFS.Common.Maintenance
 {
     public abstract class GitMaintenanceStep
     {
         public const string ObjectCacheLock = "git-maintenance-step.lock";
-        private readonly object gitProcessLock = new object();
+        private readonly Lock gitProcessLock = new Lock();
 
         public GitMaintenanceStep(GVFSContext context, bool requireObjectCacheLock, GitProcessChecker gitProcessChecker = null)
         {

--- a/GVFS/GVFS.Common/MissingTreeTracker.cs
+++ b/GVFS/GVFS.Common/MissingTreeTracker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using GVFS.Common.Tracing;
 
 namespace GVFS.Common
@@ -16,7 +17,7 @@ namespace GVFS.Common
 
         private readonly int treeCapacity;
         private readonly ITracer tracer;
-        private readonly object syncLock = new object();
+        private readonly Lock syncLock = new Lock();
 
         // Primary storage: commit -> set of missing trees
         private readonly Dictionary<string, HashSet<string>> missingTreesByCommit;

--- a/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
+++ b/GVFS/GVFS.Common/Tracing/PrettyConsoleEventListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace GVFS.Common.Tracing
 {
@@ -9,7 +10,7 @@ namespace GVFS.Common.Tracing
     /// </summary>
     public class PrettyConsoleEventListener : EventListener
     {
-        private static object consoleLock = new object();
+        private static Lock consoleLock = new Lock();
 
         public PrettyConsoleEventListener(EventLevel maxVerbosity, Keywords keywordFilter, IEventListenerEventSink eventSink)
             : base(maxVerbosity, keywordFilter, eventSink)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileBasedLock.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileBasedLock.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Text;
+using System.Threading;
 
 namespace GVFS.Platform.Windows
 {
@@ -16,7 +17,7 @@ namespace GVFS.Platform.Windows
         private const string EtwArea = nameof(WindowsFileBasedLock);
         private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false, true); // Default encoding used by StreamWriter
 
-        private readonly object deleteOnCloseStreamLock = new object();
+        private readonly Lock deleteOnCloseStreamLock = new Lock();
         private Stream deleteOnCloseStream;
 
         /// <summary>

--- a/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/EnableAndAttachProjFSHandler.cs
@@ -3,6 +3,7 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.Platform.Windows;
+using System.Threading;
 
 namespace GVFS.Service.Handlers
 {
@@ -10,7 +11,7 @@ namespace GVFS.Service.Handlers
     {
         private const string EtwArea = nameof(EnableAndAttachProjFSHandler);
 
-        private static object enablePrjFltLock = new object();
+        private static Lock enablePrjFltLock = new Lock();
 
         private NamedPipeServer.Connection connection;
         private NamedPipeMessages.EnableAndAttachProjFSRequest request;

--- a/GVFS/GVFS.Service/Handlers/RequestHandler.cs
+++ b/GVFS/GVFS.Service/Handlers/RequestHandler.cs
@@ -29,7 +29,7 @@ namespace GVFS.Service.Handlers
         private ITracer tracer;
         private IRepoRegistry repoRegistry;
         private Timer pendingUpgradeTimer;
-        private readonly object pendingUpgradeTimerLock = new object();
+        private readonly Lock pendingUpgradeTimerLock = new Lock();
 
         public RequestHandler(ITracer tracer, string etwArea, IRepoRegistry repoRegistry)
         {

--- a/GVFS/GVFS.Service/PendingUpgradeHandler.cs
+++ b/GVFS/GVFS.Service/PendingUpgradeHandler.cs
@@ -39,7 +39,7 @@ namespace GVFS.Service
         private const string MountProcessName = "GVFS.Mount";
         private const string MountExeName = "GVFS.Mount.exe";
 
-        private static readonly object ApplyLock = new object();
+        private static readonly Lock ApplyLock = new Lock();
 
         // Executables that users or the service can launch to start new
         // mount/hook processes. During upgrade these are moved out first

--- a/GVFS/GVFS.Service/PendingUpgradeMonitor.cs
+++ b/GVFS/GVFS.Service/PendingUpgradeMonitor.cs
@@ -27,7 +27,7 @@ namespace GVFS.Service
         private const int DebouncePeriodMs = 1000;
 
         private readonly ITracer tracer;
-        private readonly object syncLock = new object();
+        private readonly Lock syncLock = new Lock();
         private List<Process> trackedProcesses = new List<Process>();
         private Timer debounceTimer;
         private bool disposed;

--- a/GVFS/GVFS.Service/RepoRegistry.cs
+++ b/GVFS/GVFS.Service/RepoRegistry.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace GVFS.Service
 {
@@ -20,7 +21,7 @@ namespace GVFS.Service
         private string registryParentFolderPath;
         private ITracer tracer;
         private PhysicalFileSystem fileSystem;
-        private object repoLock = new object();
+        private Lock repoLock = new Lock();
         private IRepoMounter repoMounter;
         private INotificationHandler notificationHandler;
 

--- a/GVFS/GVFS.UnitTests/Tracing/QueuedPipeStringWriterTests.cs
+++ b/GVFS/GVFS.UnitTests/Tracing/QueuedPipeStringWriterTests.cs
@@ -124,7 +124,7 @@ namespace GVFS.UnitTests.Tracing
 
             private int bufferLength = 0;
             private byte[] buffer = new byte[16*1024];
-            private object bufferLock = new object();
+            private Lock bufferLock = new Lock();
             private Thread thread;
             private bool isRunning;
             private bool isDisposed;


### PR DESCRIPTION
## Summary

Migrate all private lock fields from `object` + `new object()` to `System.Threading.Lock` + `new Lock()`, the dedicated lightweight synchronization primitive introduced in .NET 9.

## Changes

- **20 lock fields** across **19 files** updated: `private [static] [readonly] object fooLock = new object()` → `Lock fooLock = new Lock()`
- **2 Monitor.IsEntered() assertions** in `GitStatusCache.cs` replaced with `Lock.IsHeldByCurrentThread` (Monitor APIs are incompatible with the Lock type)
- Added `using System.Threading;` to 10 files that were missing it

## Why

`System.Threading.Lock` is purpose-built for `lock()` usage — it avoids the overhead of locking on a general-purpose `object` and makes the intent explicit. Since VFSForGit now targets .NET 10, all lock fields can benefit from this.

No instances of `Monitor.Wait`/`Pulse`/`Enter`/`Exit` were found, so every lock object in the codebase was a straightforward migration candidate.

## Validation

- Build: ✅ succeeded
- Unit tests: ✅ 803/803 passed