### PR TITLE
Fix handle leak in GetFinalPathName

### DIFF
--- a/GVFS/GVFS.NativeHooks.Common/common.windows.cpp
+++ b/GVFS/GVFS.NativeHooks.Common/common.windows.cpp
@@ -28,6 +28,7 @@ PATH_STRING GetFinalPathName(const PATH_STRING& path)
 
     wchar_t finalPathByHandle[MAX_PATH] = { 0 };
     DWORD finalPathSize = GetFinalPathNameByHandleW(fileHandle, finalPathByHandle, MAX_PATH, FILE_NAME_NORMALIZED);
+    CloseHandle(fileHandle);
     if (finalPathSize == 0)
     {
         die(ReturnCode::PathNameError, "Could not get final path name by handle for %ls, Error: %d\n", path.c_str(), GetLastError());


### PR DESCRIPTION
The fileHandle obtained from CreateFileW in GetFinalPathName (common.windows.cpp) was never closed after calling GetFinalPathNameByHandleW, leaking a kernel handle on every invocation.

This adds CloseHandle(fileHandle) immediately after GetFinalPathNameByHandleW returns, before the error check — the handle is no longer needed once the API call completes.