### PR TITLE
Eliminate conhost.exe from git.exe and hooks process launches

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -815,16 +815,24 @@ namespace GVFS.Common.Git
             return this.InvokeGitAgainstDotGitFolder($"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize} --no-progress");
         }
 
-        public Process GetGitProcess(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, bool redirectStandardError, string gitObjectsDirectory, bool usePreCommandHook)
+        public Process GetGitProcess(string command, string workingDirectory, string dotGitDirectory, bool useReadObjectHook, string gitObjectsDirectory, bool usePreCommandHook)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(this.gitBinPath);
             processInfo.WorkingDirectory = workingDirectory;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardInput = true;
             processInfo.RedirectStandardOutput = true;
-            processInfo.RedirectStandardError = redirectStandardError;
+            processInfo.RedirectStandardError = true;
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            processInfo.CreateNoWindow = true;
+
+            // CreateNoWindow=false avoids allocating a hidden conhost.exe per child
+            // process. This is safe because both stdout and stderr are redirected via
+            // pipes, so the child never needs a console for I/O. If a future change
+            // stops redirecting either stream (to forward output to the parent console
+            // instead), CreateNoWindow must be set to true for that case — otherwise
+            // the non-redirected stream inherits the parent's console handle, which
+            // may be absent when running as a service, causing lost output.
+            processInfo.CreateNoWindow = false;
 
             processInfo.StandardOutputEncoding = UTF8NoBOM;
             processInfo.StandardErrorEncoding = UTF8NoBOM;
@@ -903,7 +911,7 @@ namespace GVFS.Common.Git
                 // From https://msdn.microsoft.com/en-us/library/system.diagnostics.process.standardoutput.aspx
                 // To avoid deadlocks, use asynchronous read operations on at least one of the streams.
                 // Do not perform a synchronous read to the end of both redirected streams.
-                using (this.executingProcess = this.GetGitProcess(command, workingDirectory, dotGitDirectory, useReadObjectHook, redirectStandardError: true, gitObjectsDirectory: gitObjectsDirectory, usePreCommandHook: usePreCommandHook))
+                using (this.executingProcess = this.GetGitProcess(command, workingDirectory, dotGitDirectory, useReadObjectHook, gitObjectsDirectory: gitObjectsDirectory, usePreCommandHook: usePreCommandHook))
                 {
                     StringBuilder output = new StringBuilder();
                     StringBuilder errors = new StringBuilder();

--- a/GVFS/GVFS.Common/ProcessHelper.cs
+++ b/GVFS/GVFS.Common/ProcessHelper.cs
@@ -18,7 +18,16 @@ namespace GVFS.Common
             processInfo.RedirectStandardOutput = redirectOutput;
             processInfo.RedirectStandardError = redirectOutput;
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            processInfo.CreateNoWindow = redirectOutput;
+
+            // CreateNoWindow=false avoids allocating a hidden conhost.exe per child
+            // process. When redirectOutput is true, I/O goes through pipes so no
+            // console is needed. When redirectOutput is false, the child inherits the
+            // parent's console handles — this works when the parent has a console
+            // (e.g., GVFS.Hooks invoked from a terminal), but output is silently lost
+            // when the parent has no console (e.g., service context). This is
+            // acceptable because CreateNoWindow=true would only send that output to
+            // an invisible hidden console instead.
+            processInfo.CreateNoWindow = false;
             processInfo.Arguments = args;
 
             return Run(processInfo);

--- a/GVFS/GitHooksLoader/GitHooksLoader.cpp
+++ b/GVFS/GitHooksLoader/GitHooksLoader.cpp
@@ -129,7 +129,7 @@ int ExecuteHook(const std::wstring &applicationName, wchar_t *hookName, int argc
         /* Git disallows stdin from hooks */
         si.dwFlags = STARTF_USESTDHANDLES;
 
-        creationFlags |= CREATE_NO_WINDOW;
+        creationFlags |= DETACHED_PROCESS;
     }
 
     ZeroMemory(&pi, sizeof(pi));


### PR DESCRIPTION
## Summary

GVFS launches git.exe processes with `CreateNoWindow=true` (or `CREATE_NO_WINDOW` in native code). Despite the name, this flag tells Windows to create a **new hidden console** for each child process, which allocates a `conhost.exe` instance. For frequent, small git operations (e.g., during prefetch), the per-process conhost creation/teardown overhead is disproportionately large.

## Changes

| File | Change | Why |
|------|--------|-----|
| `GitProcess.cs:827` | `CreateNoWindow = true` to `false` | Central git.exe wrapper (all prefetch calls route here) |
| `ProcessHelper.cs:21` | `CreateNoWindow = redirectOutput` to `false` | Generic process helper |
| `GitHooksLoader.cpp:132` | `CREATE_NO_WINDOW` to `DETACHED_PROCESS` | Native hooks loader — truly detaches from console |

## How it works

- **`CreateNoWindow = false`** with `UseShellExecute = false`: child inherits parent console state. Since GVFS runs as a service with no console, child gets no console and no conhost.
- **`DETACHED_PROCESS`** (native): explicitly detaches from any console without allocating a new one.

## Verification

### Conhost elimination confirmed

| Setting | conhost.exe per git.exe |
|---------|------------------------|
| `CreateNoWindow=true` (old) | **1** conhost.exe spawned |
| `CreateNoWindow=false` (new) | **0** — eliminated |

### Benchmark (3 runs x 50 git.exe invocations)

| Metric | Old | New | Improvement |
|--------|-----|-----|-------------|
| Total (50 processes) | 3905ms | 2949ms | **956ms saved (24.5%)** |
| Per-process | 78.1ms | 59.0ms | **19.1ms saved** |

For a prefetch spawning 20-50 git.exe processes, this eliminates ~380-960ms of pure conhost overhead per cycle.

## Reference

- Same pattern as ToolLocationTransformer PR 15071136 (merged)
- ADO 62385282
