### PR TITLE
Add non-elevated admin owner patch to libgit2 overlay

### DIFF
--- a/overlays/libgit2/README.md
+++ b/overlays/libgit2/README.md
@@ -12,6 +12,11 @@ that were missing from v1.9.1.
 
 - `dependencies.diff` — adjusts CMake dependency resolution for vcpkg
   (copied from official vcpkg port, required for PCRE discovery)
+- `non-elevated-admin-owner.diff` — support non-elevated admin user
+  ownership check on Windows ([libgit2/libgit2#7200](https://github.com/libgit2/libgit2/pull/7200)).
+  Allows non-elevated processes run by Administrators group members to be
+  considered the owner of repos owned by that group. Related to
+  [libgit2/libgit2#6279](https://github.com/libgit2/libgit2/issues/6279).
 
 Additional patches can be added to the `PATCHES` list in `portfile.cmake`
 to apply fixes that haven't shipped in an official libgit2 release yet.
@@ -27,6 +32,7 @@ and then modified as noted below.
 | `vcpkg.json` | Official vcpkg port | Unchanged |
 | `dependencies.diff` | Official vcpkg port | Unchanged |
 | `portfile.cmake` | Official vcpkg port | Removed patches not needed for MSVC x64: `c-standard.diff` (C99 inline keyword — MSVC handles natively), `cli-include-dirs.diff` (CLI tool build — we set `BUILD_CLI=OFF`), `mingw-winhttp.diff` (MinGW only) |
+| `non-elevated-admin-owner.diff` | [libgit2/libgit2#7200](https://github.com/libgit2/libgit2/pull/7200) | PR diff, verbatim |
 | `README.md` | New | VFSForGit-specific documentation |
 
 When updating to a new libgit2 version, compare these files against the

--- a/overlays/libgit2/non-elevated-admin-owner.diff
+++ b/overlays/libgit2/non-elevated-admin-owner.diff
@@ -1,0 +1,70 @@
+diff --git a/src/util/fs_path.c b/src/util/fs_path.c
+index ff0836ff874..5be2da35b34 100644
+--- a/src/util/fs_path.c
++++ b/src/util/fs_path.c
+@@ -1853,12 +1853,16 @@ static PSID *sid_dup(PSID sid)
+ 	return dup;
+ }
+ 
+-static int current_user_sid(PSID *out)
++static int current_user_sid(PSID *sid, HANDLE *linked_token)
+ {
+ 	TOKEN_USER *info = NULL;
+ 	HANDLE token = NULL;
+ 	DWORD len = 0;
+ 	int error = -1;
++	TOKEN_ELEVATION_TYPE elevation_type;
++	DWORD size;
++
++	*linked_token = NULL;
+ 
+ 	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+ 		git_error_set(GIT_ERROR_OS, "could not lookup process information");
+@@ -1879,9 +1883,19 @@ static int current_user_sid(PSID *out)
+ 		goto done;
+ 	}
+ 
+-	if ((*out = sid_dup(info->User.Sid)))
++	if ((*sid = sid_dup(info->User.Sid)))
+ 		error = 0;
+ 
++	if (GetTokenInformation(token, TokenElevationType, &elevation_type, sizeof(elevation_type), &size) &&
++	    elevation_type == TokenElevationTypeLimited) {
++		/*
++		 * The current process is run by a member of the Administrators group
++		 * but is not running elevated.
++		 */
++			if (!GetTokenInformation(token, TokenLinkedToken, linked_token, sizeof(HANDLE), &size)) {
++			linked_token = NULL;
++		}
++	}
+ done:
+ 	if (token)
+ 		CloseHandle(token);
+@@ -1926,6 +1940,7 @@ int git_fs_path_owner_is(
+ 	git_fs_path_owner_t owner_type)
+ {
+ 	PSID owner_sid = NULL, user_sid = NULL;
++	static HANDLE linked_token;
+ 	BOOL is_admin, admin_owned;
+ 	int error;
+ 
+@@ -1938,7 +1953,7 @@ int git_fs_path_owner_is(
+ 		goto done;
+ 
+ 	if ((owner_type & GIT_FS_PATH_OWNER_CURRENT_USER) != 0) {
+-		if ((error = current_user_sid(&user_sid)) < 0)
++		if ((error = current_user_sid(&user_sid, &linked_token)) < 0)
+ 			goto done;
+ 
+ 		if (EqualSid(owner_sid, user_sid)) {
+@@ -1959,7 +1974,8 @@ int git_fs_path_owner_is(
+ 
+ 	if (admin_owned &&
+ 	    (owner_type & GIT_FS_PATH_USER_IS_ADMINISTRATOR) != 0 &&
+-	    CheckTokenMembership(NULL, owner_sid, &is_admin) &&
++	    (CheckTokenMembership(NULL, owner_sid, &is_admin) &&
++	        CheckTokenMembership(linked_token, owner_sid, &is_admin)) &&
+ 	    is_admin) {
+ 		*out = true;
+ 		goto done;

--- a/overlays/libgit2/portfile.cmake
+++ b/overlays/libgit2/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         dependencies.diff
+        non-elevated-admin-owner.diff
 )
 
 file(REMOVE_RECURSE


### PR DESCRIPTION
Add patch from [libgit2/libgit2#7200](https://github.com/libgit2/libgit2/pull/7200) to the vcpkg libgit2 overlay port.

## Problem

When a repository is owned by the Administrators group, libgit2 only considers the current user to be the owner if the process is running elevated. This causes safe-directory ownership checks to fail for non-elevated admin users.

## Solution

Carry the patch from libgit2/libgit2#7200 in our vcpkg overlay until it ships in an official libgit2 release. The patch modifies \src/util/fs_path.c\ to check the linked token for Administrators group membership when the process is running non-elevated, matching the corresponding [change in git](https://github.com/git/git/commit/6b11e3d52e).

Related: [libgit2/libgit2#6279](https://github.com/libgit2/libgit2/issues/6279)

## Changes

- \overlays/libgit2/non-elevated-admin-owner.diff\ — patch from PR #7200
- \overlays/libgit2/portfile.cmake\ — added patch to PATCHES list
- \overlays/libgit2/README.md\ — documented new patch