### PR TITLE
ci: add retry for artifact download steps

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -77,7 +77,19 @@ jobs:
           return true
 
     - name: Download Git installer
+      id: download-git
       if: steps.skip.outputs.result != 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.git_artifact_name }}
+        path: git
+        repository: ${{ inputs.git_repository || github.repository }}
+        run-id: ${{ inputs.git_run_id || github.run_id }}
+        github-token: ${{ secrets.git_token || github.token }}
+
+    - name: Download Git installer (retry)
+      if: steps.skip.outputs.result != 'true' && steps.download-git.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.git_artifact_name }}
@@ -87,7 +99,19 @@ jobs:
         github-token: ${{ secrets.git_token || github.token }}
 
     - name: Download GVFS installer
+      id: download-gvfs
       if: steps.skip.outputs.result != 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: GVFS_${{ matrix.configuration }}
+        path: gvfs
+        repository: ${{ inputs.vfs_repository || github.repository }}
+        run-id: ${{ inputs.vfs_run_id || github.run_id }}
+        github-token: ${{ secrets.vfs_token || github.token }}
+
+    - name: Download GVFS installer (retry)
+      if: steps.skip.outputs.result != 'true' && steps.download-gvfs.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: GVFS_${{ matrix.configuration }}
@@ -97,7 +121,19 @@ jobs:
         github-token: ${{ secrets.vfs_token || github.token }}
 
     - name: Download functional tests drop
+      id: download-ft
       if: steps.skip.outputs.result != 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: FunctionalTests_${{ matrix.configuration }}
+        path: ft
+        repository: ${{ inputs.vfs_repository || github.repository }}
+        run-id: ${{ inputs.vfs_run_id || github.run_id }}
+        github-token: ${{ secrets.vfs_token || github.token }}
+
+    - name: Download functional tests drop (retry)
+      if: steps.skip.outputs.result != 'true' && steps.download-ft.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: FunctionalTests_${{ matrix.configuration }}

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -63,14 +63,32 @@ jobs:
         gh release download $tag --repo microsoft/VFSForGit --pattern "SetupGVFS*.exe" --dir gvfs-lkg
 
     - name: Download Git installer
+      id: download-git
       if: steps.skip.outputs.result != 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: MicrosoftGit
+        path: git
+
+    - name: Download Git installer (retry)
+      if: steps.skip.outputs.result != 'true' && steps.download-git.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: MicrosoftGit
         path: git
 
     - name: Download current GVFS installer
+      id: download-gvfs
       if: steps.skip.outputs.result != 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        name: GVFS_${{ matrix.configuration }}
+        path: gvfs-new
+
+    - name: Download current GVFS installer (retry)
+      if: steps.skip.outputs.result != 'true' && steps.download-gvfs.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: GVFS_${{ matrix.configuration }}


### PR DESCRIPTION
Transient failures in `actions/download-artifact` are a frequent source of flaky CI runs — I see these several times a week, always succeeding on manual re-run.

This adds a single automatic retry for each `download-artifact` step using the `continue-on-error` + `outcome == 'failure'` pattern:

- **functional-tests.yaml**: retry for Git installer, GVFS installer, and functional tests drop (3 download steps)
- **upgrade-tests.yaml**: retry for Git installer and GVFS installer (2 download steps)

**How it works:** Each download step gets `id` + `continue-on-error: true`. A duplicate step follows that only runs when the first attempt failed (`steps.<id>.outcome == 'failure'`). No new dependencies, no third-party actions.

Example of a recent failure this would fix: https://github.com/microsoft/VFSForGit/actions/runs/26310137269/job/77463758324?pr=1981