### PR TITLE
Add unique exit code for mount authentication failures

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -4,6 +4,7 @@ using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 
@@ -51,7 +52,7 @@ namespace GVFS.Common
         /// This method should only be called by processes whose code we own as the background process must
         /// do some extra work after it starts.
         /// </remarks>
-        public abstract void StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args);
+        public abstract Process StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args);
 
         /// <summary>
         /// Adjusts the current process for running in the background.

--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -200,7 +200,8 @@ namespace GVFS.Common.Git
                 enlistment,
                 new RetryConfig(),
                 out _,
-                out errorMessage);
+                out errorMessage,
+                out _);
         }
 
         /// <summary>
@@ -217,7 +218,8 @@ namespace GVFS.Common.Git
             Enlistment enlistment,
             RetryConfig retryConfig,
             out ServerGVFSConfig serverGVFSConfig,
-            out string errorMessage)
+            out string errorMessage,
+            out bool isAuthFailure)
         {
             if (this.isInitialized)
             {
@@ -226,6 +228,7 @@ namespace GVFS.Common.Git
 
             serverGVFSConfig = null;
             errorMessage = null;
+            isAuthFailure = false;
 
             using (ConfigHttpRequestor configRequestor = new ConfigHttpRequestor(tracer, enlistment, retryConfig))
             {
@@ -253,6 +256,7 @@ namespace GVFS.Common.Git
 
                 if (!this.TryCallGitCredential(tracer, out errorMessage))
                 {
+                    isAuthFailure = true;
                     tracer.RelatedWarning("{0}: Credential fetch failed: {1}", nameof(this.TryInitializeAndQueryGVFSConfig), errorMessage);
                     return false;
                 }
@@ -260,10 +264,16 @@ namespace GVFS.Common.Git
                 this.isInitialized = true;
 
                 // Retry with credentials using the same ConfigHttpRequestor (reuses HttpClient/connection)
-                if (configRequestor.TryQueryGVFSConfig(true, out serverGVFSConfig, out _, out errorMessage))
+                HttpStatusCode? retryHttpStatus;
+                if (configRequestor.TryQueryGVFSConfig(true, out serverGVFSConfig, out retryHttpStatus, out errorMessage))
                 {
                     tracer.RelatedInfo("{0}: Config obtained with credentials", nameof(this.TryInitializeAndQueryGVFSConfig));
                     return true;
+                }
+
+                if (retryHttpStatus == HttpStatusCode.Unauthorized || retryHttpStatus == HttpStatusCode.Forbidden)
+                {
+                    isAuthFailure = true;
                 }
 
                 tracer.RelatedWarning("{0}: Config query failed with credentials: {1}", nameof(this.TryInitializeAndQueryGVFSConfig), errorMessage);

--- a/GVFS/GVFS.Common/ReturnCode.cs
+++ b/GVFS/GVFS.Common/ReturnCode.cs
@@ -11,5 +11,6 @@
         UnableToRegisterForOfflineIO = 6,
         DehydrateFolderFailures = 7,
         MountAlreadyRunning = 8,
+        AuthenticationError = 9,
     }
 }

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -133,10 +133,11 @@ namespace GVFS.Mount
                 Stopwatch sw = Stopwatch.StartNew();
                 ServerGVFSConfig config;
                 string authConfigError;
+                bool isAuthFailure;
 
                 if (!this.enlistment.Authentication.TryInitializeAndQueryGVFSConfig(
                     this.tracer, this.enlistment, this.retryConfig,
-                    out config, out authConfigError))
+                    out config, out authConfigError, out isAuthFailure))
                 {
                     if (this.cacheServer != null && !string.IsNullOrWhiteSpace(this.cacheServer.Url))
                     {
@@ -145,7 +146,9 @@ namespace GVFS.Mount
                     }
                     else
                     {
-                        this.FailMountAndExit("Unable to query /gvfs/config" + Environment.NewLine + authConfigError);
+                        this.FailMountAndExit(
+                            isAuthFailure ? ReturnCode.AuthenticationError : ReturnCode.GenericError,
+                            "Unable to query /gvfs/config" + Environment.NewLine + authConfigError);
                     }
                 }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -137,7 +137,7 @@ namespace GVFS.Platform.Windows
             return WindowsPlatform.GetLogsDirectoryForGVFSComponentImplementation(componentName);
         }
 
-        public override void StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args)
+        public override Process StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args)
         {
             string programArguments = string.Empty;
             try
@@ -156,6 +156,7 @@ namespace GVFS.Platform.Windows
                 Process executingProcess = new Process();
                 executingProcess.StartInfo = processInfo;
                 executingProcess.Start();
+                return executingProcess;
             }
             catch (Exception ex)
             {

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -6,6 +6,7 @@ using GVFS.UnitTests.Mock.FileSystem;
 using GVFS.UnitTests.Mock.Git;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
@@ -152,7 +153,7 @@ namespace GVFS.UnitTests.Mock.Common
             throw new NotImplementedException();
         }
 
-        public override void StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args)
+        public override Process StartBackgroundVFS4GProcess(ITracer tracer, string programName, string[] args)
         {
             throw new NotSupportedException();
         }

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -243,7 +243,8 @@ namespace GVFS.CommandLine
                     enlistment,
                     retryConfig ?? new RetryConfig(),
                     out config,
-                    out error),
+                    out error,
+                    out _),
                 "Authenticating",
                 enlistment.EnlistmentRoot);
 

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -4,6 +4,7 @@ using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using GVFS.DiskLayoutUpgrades;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -12,6 +13,7 @@ namespace GVFS.CommandLine
     public class MountVerb : GVFSVerb.ForExistingEnlistment
     {
         private const string MountVerbName = "mount";
+        private Process mountProcess;
 
         public string Verbosity { get; set; }
 
@@ -197,8 +199,36 @@ namespace GVFS.CommandLine
                     () => { return this.TryMount(tracer, enlistment, mountExecutableLocation, out errorMessage); },
                     "Mounting"))
                 {
-                    this.ReportErrorAndExit(tracer, errorMessage);
+                    ReturnCode mountExitCode = ReturnCode.GenericError;
+                    if (this.mountProcess != null)
+                    {
+                        try
+                        {
+                            if (!this.mountProcess.HasExited)
+                            {
+                                this.mountProcess.WaitForExit(1000);
+                            }
+
+                            if (this.mountProcess.HasExited)
+                            {
+                                mountExitCode = (ReturnCode)this.mountProcess.ExitCode;
+                            }
+                        }
+                        catch (InvalidOperationException)
+                        {
+                        }
+                        finally
+                        {
+                            this.mountProcess.Dispose();
+                            this.mountProcess = null;
+                        }
+                    }
+
+                    this.ReportErrorAndExit(tracer, mountExitCode, errorMessage);
                 }
+
+                this.mountProcess?.Dispose();
+                this.mountProcess = null;
 
                 if (!this.Unattended)
                 {
@@ -229,7 +259,7 @@ namespace GVFS.CommandLine
 
             tracer.RelatedInfo($"{nameof(this.TryMount)}: Launching background process('{mountExecutableLocation}') for {mountPath}");
 
-            GVFSPlatform.Instance.StartBackgroundVFS4GProcess(
+            this.mountProcess = GVFSPlatform.Instance.StartBackgroundVFS4GProcess(
                 tracer,
                 mountExecutableLocation,
                 new[]


### PR DESCRIPTION
## Summary

When `gvfs mount` fails due to authentication, both `GVFS.Mount.exe` and `gvfs.exe` now exit with `ReturnCode.AuthenticationError` (9) instead of `GenericError` (3), enabling callers to distinguish auth failures from other errors.

## Changes

- **`ReturnCode.AuthenticationError = 9`** — new enum value
- **`GitAuthentication.TryInitializeAndQueryGVFSConfig`** — added `out bool isAuthFailure` parameter that explicitly classifies auth failures:
  - Credential fetch failure → auth failure
  - 401/403 on credentialed retry → auth failure
  - Other failures (500, timeout, network) → not auth failure
- **`InProcessMount`** — uses `isAuthFailure` to select `ReturnCode.AuthenticationError` when calling `FailMountAndExit`
- **`GVFSPlatform.StartBackgroundVFS4GProcess`** — returns `Process` (was `void`) so `MountVerb` can read the mount process exit code
- **`MountVerb`** — captures the mount process handle, waits up to 1s for exit on failure, and propagates the exit code to the caller

## Testing

- All 811 unit tests pass
- Auth failure classification tested against four scenarios:
  1. Non-401 on anonymous probe → NOT auth (correct)
  2. 401 + credential fetch fails → IS auth (correct)
  3. 401 + creds obtained + retry returns 401/403 → IS auth (correct)
  4. 401 + creds obtained + retry returns 500/timeout → NOT auth (correct)
- Verified that Azure DevOps returns proper 401 (not 302/203 redirect) for the anonymous config probe because `HttpRequestor` sends the `X-TFS-FedAuthRedirect: Suppress` header on all requests

## Future Work

**Concurrent mount exit code propagation:** When two `gvfs mount` commands run simultaneously, the second mount process (`GVFS.Mount.exe`) fails to acquire the mount lock and exits with `MountAlreadyRunning` (8). If the first mount also fails (e.g., due to auth), `MountVerb` for the second invocation currently reports `MountAlreadyRunning` rather than the first mount's actual failure reason. A follow-up PR will address this by having the mount process persist its exit status so that concurrent mount attempts can propagate the correct error.

**Early exit detection:** Currently, if `GVFS.Mount.exe` exits before starting its named pipe server (as happens with auth failures), `MountVerb` still waits for the full named pipe connection timeout (60s, or 300s unattended) before checking the process exit code. A follow-up PR will add early exit detection so `MountVerb` can fail fast when the mount process has already terminated.
