### PR TITLE
Fix flaky CreatePlaceholderTests stderr comparison

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
+++ b/GVFS/GVFS.FunctionalTests/Tools/GitProcess.cs
@@ -35,6 +35,9 @@ namespace GVFS.FunctionalTests.Tools
             }
 
             processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+            // Suppress progress output (e.g. "Updating files: 100%") which is timing-dependent
+            // and causes flaky stderr comparisons between control and GVFS repos.
+            processInfo.EnvironmentVariables["GIT_PROGRESS_DELAY"] = "3600";
 
             if (environmentVariables != null)
             {


### PR DESCRIPTION
The `AllowsPlaceholderCreationWhileGitCommandIsRunning` test fails intermittently because `git reset --hard` produces non-deterministic `Updating files` progress output on stderr. When one repo emits progress and the other does not, `ErrorsShouldMatch` fails.

Set `GIT_PROGRESS_DELAY=3600` on all test git invocations (in `GitProcess.InvokeProcess`) so progress output is never emitted for commands completing under an hour. This eliminates the flake at the source without skipping error validation.