### PR TITLE
Release pipeline: route vcpkg through Terrapin asset cache

### DIFF
--- a/.azure-pipelines/official-release-nuget.config
+++ b/.azure-pipelines/official-release-nuget.config
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Official-release NuGet configuration. Pipeline-only.
+
+  Used by the official release pipeline ONLY, supplied at build time via
+  -ConfigFile to a one-off `nuget install Microsoft.Build.Vcpkg` command
+  that fetches the Terrapin retrieval tool. The root nuget.config (the
+  one external contributors and the public GitHub Actions workflow use)
+  does NOT reference this internal feed, so building VFS for Git from a
+  fresh clone requires no internal authentication.
+
+  Why this file exists:
+    Microsoft.Build.Vcpkg is an internal-only NuGet package that ships
+    the proprietary TerrapinRetrievalTool.exe. The release pipeline
+    downloads the package out-of-band (i.e. not via msbuild SDK
+    resolution, which would force the internal feed into the root
+    nuget.config and expose it to every consumer) and passes the path to
+    the extracted retrieval tool via -p:TerrapinRetrievalToolPath. vcpkg
+    then routes its asset downloads through the Terrapin cache, because
+    the release pipeline's build agents have x-block-origin enforced at
+    the network layer and cannot fetch from public origins
+    (sourceforge.net, github.com release artifacts, etc.).
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="GitClient" value="https://pkgs.dev.azure.com/mseng/1ES/_packaging/GitClient/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -111,6 +111,9 @@ extends:
                 inputs:
                   versionSpec: '6.x'
 
+              - task: NuGetAuthenticate@1
+                displayName: 'Authenticate to internal NuGet feed (for Microsoft.Build.Vcpkg)'
+
               - task: PowerShell@2
                 displayName: 'Install VS C++ workload (NativeAOT prerequisite)'
                 inputs:
@@ -120,6 +123,37 @@ extends:
                 displayName: 'Enable Projected File System (ProjFS)'
                 inputs:
                   filePath: $(Build.SourcesDirectory)\.azure-pipelines\scripts\enable-projfs.ps1
+
+              # Download the Microsoft.Build.Vcpkg NuGet package out-of-band so we
+              # can hand the build a path to TerrapinRetrievalTool.exe via
+              # -p:TerrapinRetrievalToolPath. The package is pulled from an
+              # internal NuGet feed (see .azure-pipelines/official-release-nuget.config).
+              # Downloading it this way -- rather than as an msbuild Sdk import --
+              # keeps the internal feed out of the root nuget.config that
+              # external contributors and the public GitHub Actions workflow see.
+              - task: NuGetCommand@2
+                displayName: 'Download Microsoft.Build.Vcpkg package (Terrapin retrieval tool)'
+                inputs:
+                  command: custom
+                  arguments: 'install Microsoft.Build.Vcpkg -Version 2026.5.25.434-aa40adda53 -ConfigFile $(Build.SourcesDirectory)\.azure-pipelines\official-release-nuget.config -OutputDirectory $(Agent.TempDirectory)\nuget-internal -ExcludeVersion -DirectDownload -NonInteractive'
+
+              # Restore vcpkg native dependencies through the Terrapin asset
+              # cache (the release pipeline's build agents have x-block-origin
+              # enforced and cannot download from the public internet). Runs the
+              # _RestoreVcpkgDependencies MSBuild target with
+              # UseTerrapinAssetCache=true and TerrapinRetrievalToolPath pointing
+              # at the binary extracted by the previous step. vcpkg downloads
+              # then route through https://vcpkg.storage.devpackages.microsoft.io.
+              # Build.bat's own vcpkg install step then skips because the libs
+              # are already present.
+              - script: |
+                  dotnet build "$(Build.SourcesDirectory)\GVFS\GVFS.Common\GVFS.Common.csproj" ^
+                    /t:_RestoreVcpkgDependencies ^
+                    -c $(BuildConfiguration) ^
+                    -p:UseTerrapinAssetCache=true ^
+                    -p:TerrapinRetrievalToolPath=$(Agent.TempDirectory)\nuget-internal\Microsoft.Build.Vcpkg\trt\TerrapinRetrievalTool.exe ^
+                    -v:detailed
+                displayName: 'Restore vcpkg native libraries (Terrapin cache)'
 
               - script: |
                   $(Build.SourcesDirectory)\scripts\Build.bat ^

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,25 @@
       but our .NET projects do.
       -->
     <RestorePackagesConfig>true</RestorePackagesConfig>
+
+    <!--
+      Set to true when building locally to allow Terrapin to upload missing
+      vcpkg assets to the shared cache. CI agents must keep this false so
+      vcpkg uses x-block-origin (fail fast instead of attempting direct
+      downloads from the public internet, which is blocked at the agent
+      network layer).
+    -->
+    <IsLocalBuild Condition="'$(IsLocalBuild)' == ''">false</IsLocalBuild>
+
+    <!--
+      Set to true on the official release pipeline to route vcpkg asset
+      downloads through the internal Terrapin cache via the
+      Microsoft.Build.Vcpkg SDK (an internal-only package). Defaults to
+      false so external contributors and the public GitHub Actions
+      PR-validation workflow continue to use the standard vcpkg flow
+      with direct downloads from the public internet.
+    -->
+    <UseTerrapinAssetCache Condition="'$(UseTerrapinAssetCache)' == ''">false</UseTerrapinAssetCache>
   </PropertyGroup>
 
   <!-- Managed project properties -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,6 +32,22 @@
     <_VcpkgManifestFile>$(RepoSrcPath)vcpkg.json</_VcpkgManifestFile>
     <_VcpkgConfigFile>$(RepoSrcPath)vcpkg-configuration.json</_VcpkgConfigFile>
     <_VcpkgStampFile>$(RepoOutPath)vcpkg_installed\.msbuildstamp</_VcpkgStampFile>
+
+    <!--
+      Terrapin asset caching for vcpkg downloads (only when explicitly
+      enabled by the release pipeline). -a $(IsLocalBuild) controls whether
+      the retrieval script may upload missing assets back to the Terrapin
+      cache: true on dev boxes (write permission available), false on CI
+      agents (read-only; x-block-origin causes immediate failure rather
+      than attempting public-internet downloads).
+
+      $(TerrapinRetrievalToolPath) is supplied by the release pipeline
+      after it downloads the internal Microsoft.Build.Vcpkg NuGet package
+      that ships the retrieval tool. The repo intentionally does not
+      reference that internal package directly; the pipeline is the only
+      bridge between this repo and the internal feed.
+    -->
+    <_VcpkgAssetSources Condition="'$(UseTerrapinAssetCache)' == 'true'">"--x-asset-sources=x-script,$(TerrapinRetrievalToolPath) -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a $(IsLocalBuild) -p {url} -s {sha512} -d {dst};x-block-origin"</_VcpkgAssetSources>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
@@ -70,13 +86,25 @@
     <Message Importance="high" Text="[vcpkg] Installing native dependencies to $(RepoOutPath)vcpkg_installed\" />
 
     <MakeDir Directories="$(RepoOutPath)vcpkg_installed\" />
-    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-static-aot --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\static&quot; $(_VcpkgManifestArg)"
+
+    <!--
+      Guard: if asset caching was requested but the tool path was not
+      supplied, the asset-source string would be malformed and vcpkg
+      would fail with a confusing error. Surface the misconfiguration up
+      front.
+    -->
+    <Error Condition="'$(UseTerrapinAssetCache)' == 'true' and ('$(TerrapinRetrievalToolPath)' == '' or !Exists('$(TerrapinRetrievalToolPath)'))"
+           Text="UseTerrapinAssetCache=true but TerrapinRetrievalToolPath is empty or does not exist. The release pipeline must pre-download the Microsoft.Build.Vcpkg NuGet package and pass -p:TerrapinRetrievalToolPath=&lt;path-to-TerrapinRetrievalTool.exe&gt;." />
+
+    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-static-aot --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\static&quot; $(_VcpkgManifestArg) $(_VcpkgAssetSources)"
           StandardOutputImportance="High" StandardErrorImportance="High" />
-    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-dynamic --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\dynamic&quot; $(_VcpkgManifestArg)"
+    <Exec Command="&quot;$(_VcpkgExe)&quot; install --x-wait-for-lock --triplet x64-windows-dynamic --x-install-root=&quot;$(RepoOutPath)vcpkg_installed\dynamic&quot; $(_VcpkgManifestArg) $(_VcpkgAssetSources)"
           StandardOutputImportance="High" StandardErrorImportance="High" />
 
     <Error Condition="!Exists('$(RepoOutPath)vcpkg_installed\dynamic\x64-windows-dynamic\bin\git2.dll')"
-           Text="vcpkg install completed but expected output files are missing. Check vcpkg output above for errors." />
+           Text="vcpkg install completed but git2.dll (dynamic) is missing. Check vcpkg output above for errors." />
+    <Error Condition="!Exists('$(RepoOutPath)vcpkg_installed\static\x64-windows-static-aot\lib\git2.lib')"
+           Text="vcpkg install completed but git2.lib (static) is missing. Check vcpkg output above for errors." />
 
     <Touch Files="$(_VcpkgStampFile)" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
## Problem

The official release pipeline has been failing since libgit2 was
statically linked via vcpkg, because the pool's build agents do not have
direct public-internet access. vcpkg was reaching out to sourceforge.net
for libgit2 transitive dependencies (pcre, zlib, http_parser, ...) which
the network layer blocked, causing WinHttpSendRequest 12029 errors.

## Solution

Route vcpkg asset downloads through the internal Terrapin cache (the
canonical CI asset-caching service). This is **opt-in** — external
contributors and the public GitHub Actions PR-validation workflow
(`.github/workflows/build.yaml`) continue to use the standard vcpkg flow
with direct downloads from public origins. No internal feed
authentication is required to build VFS for Git from a fresh clone, and
the repo source code intentionally contains no msbuild SDK references
that would pull internal packages into a default restore.

## Changes

- **`Directory.Build.props`**: add `IsLocalBuild` and
  `UseTerrapinAssetCache` properties, both defaulted to false.
  `IsLocalBuild` controls Terrapin upload-on-fetch (allowed on dev boxes
  only); `UseTerrapinAssetCache` opts the build into the Terrapin
  asset-cache machinery (release pipeline only).

- **`Directory.Build.targets`**: build a `--x-asset-sources` string that
  combines the Terrapin retrieval script with `x-block-origin`, gated on
  `UseTerrapinAssetCache=true`, and append it to both vcpkg install
  invocations. Add a guard `<Error>` that requires the pipeline to
  supply `TerrapinRetrievalToolPath` up front when asset caching is
  enabled. Also validate static `git2.lib` (was only checking dynamic
  `git2.dll`).

- **`.azure-pipelines/official-release-nuget.config`** (new):
  pipeline-only NuGet config that points at an internal feed. Used
  solely by a one-off `nuget install` of `Microsoft.Build.Vcpkg`, not by
  any csproj restore. Not consulted by external contributors or by
  GitHub Actions.

- **`.azure-pipelines/release.yml`**:
  - Add `NuGetAuthenticate@1` task.
  - Add a `NuGetCommand@2` task that out-of-band installs the internal
    `Microsoft.Build.Vcpkg` package (which ships
    `TerrapinRetrievalTool.exe`) into `$(Agent.TempDirectory)`.
  - Add an explicit *Restore vcpkg native libraries (Terrapin cache)*
    step that invokes `_RestoreVcpkgDependencies` on
    `GVFS.Common.csproj` with `-p:UseTerrapinAssetCache=true` and
    `TerrapinRetrievalToolPath` pointing at the extracted tool. The
    existing `Build.bat` invocation downstream then skips the vcpkg
    install because the libs are already present.

## Verification

Verified with a successful run of the build stage in the official
release pipeline. End-to-end green: Restore vcpkg native libraries,
Build (Release), unit tests, installer build, and all 4 pipeline
artifacts (Installer, FastFetch, Symbols, FunctionalTests). The
Terrapin cache had every libgit2 transitive dep already seeded, so no
follow-up cache-seeding request is needed.
