### PR TITLE
Service: add versioned install layout support

### DIFF
--- a/GVFS/GVFS.Service/Configuration.cs
+++ b/GVFS/GVFS.Service/Configuration.cs
@@ -1,16 +1,25 @@
 ﻿using GVFS.Common;
+using System;
 using System.IO;
 
 namespace GVFS.Service
 {
     public class Configuration
     {
+        /// <summary>
+        /// Subdirectory name for the junction that points to the active version.
+        /// When a versioned install layout is present, <c>{app}\Current</c> is a
+        /// junction pointing to <c>{app}\Versions\{version}</c>.
+        /// </summary>
+        public const string CurrentVersionDirName = "Current";
+
+        private static readonly Lazy<string> assemblyPath =
+            new Lazy<string>(ProcessHelper.GetCurrentProcessLocation);
+
         private static Configuration instance = new Configuration();
-        private static string assemblyPath = null;
 
         private Configuration()
         {
-            this.GVFSLocation = Path.Combine(AssemblyPath, GVFSPlatform.Instance.Constants.GVFSExecutableName);
         }
 
         public static Configuration Instance
@@ -21,19 +30,39 @@ namespace GVFS.Service
             }
         }
 
-        public static string AssemblyPath
+        /// <summary>
+        /// The directory containing <c>GVFS.Service.exe</c> (the install root).
+        /// </summary>
+        public static string AssemblyPath => assemblyPath.Value;
+
+        /// <summary>
+        /// The directory containing the current version's binaries.
+        /// With versioned layout this resolves through the <c>Current</c> junction
+        /// (e.g. <c>{app}\Current</c> → <c>{app}\Versions\1.0.X</c>).
+        /// Falls back to <see cref="AssemblyPath"/> when no <c>Current</c>
+        /// junction exists (flat/legacy layout).
+        /// Evaluated on each access so that junction re-targeting is picked up
+        /// without restarting the service.
+        /// </summary>
+        public static string CurrentVersionPath
         {
             get
             {
-                if (assemblyPath == null)
+                string currentDir = Path.Combine(AssemblyPath, CurrentVersionDirName);
+                if (Directory.Exists(currentDir))
                 {
-                    assemblyPath = ProcessHelper.GetCurrentProcessLocation();
+                    return currentDir;
                 }
 
-                return assemblyPath;
+                // Legacy flat layout — binaries are siblings of the service.
+                return AssemblyPath;
             }
         }
 
-        public string GVFSLocation { get; private set; }
+        /// <summary>
+        /// Full path to the current version's <c>GVFS.exe</c>. Resolved
+        /// dynamically so that junction re-targeting takes effect immediately.
+        /// </summary>
+        public string GVFSLocation => Path.Combine(CurrentVersionPath, GVFSPlatform.Instance.Constants.GVFSExecutableName);
     }
 }

--- a/GVFS/GVFS.Service/PendingUpgradeHandler.cs
+++ b/GVFS/GVFS.Service/PendingUpgradeHandler.cs
@@ -82,16 +82,15 @@ namespace GVFS.Service
 
         /// <summary>
         /// Returns GVFS.Mount processes whose executable is in the install
-        /// directory. Processes from dev builds or other installs are excluded
-        /// so they don't block upgrades of the system install. If a process's
-        /// path cannot be read (access denied, 32/64-bit mismatch), it is
-        /// included conservatively.
+        /// directory (or any versioned subdirectory). Processes from dev builds
+        /// or other installs are excluded so they don't block upgrades of the
+        /// system install. If a process's path cannot be read (access denied,
+        /// 32/64-bit mismatch), it is included conservatively.
         /// Caller must dispose the returned Process objects.
         /// </summary>
         public static List<Process> GetInstalledMountProcesses(ITracer tracer)
         {
             string installDir = Configuration.AssemblyPath;
-            string expectedPath = Path.Combine(installDir, MountExeName);
             Process[] allMountProcesses = Process.GetProcessesByName(MountProcessName);
             List<Process> installed = new List<Process>();
 
@@ -101,8 +100,7 @@ namespace GVFS.Service
                 try
                 {
                     string processPath = process.MainModule?.FileName;
-                    if (processPath != null &&
-                        !PathComparer.Equals(processPath, expectedPath))
+                    if (processPath != null && !IsInstalledMountPath(installDir, processPath))
                     {
                         include = false;
                         tracer.RelatedInfo(
@@ -324,6 +322,26 @@ namespace GVFS.Service
         {
             return string.Equals(relativePath, ReadyMarkerFileName, StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(relativePath, Phase1CompleteMarkerFileName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns true if the given GVFS.Mount.exe path is under the install
+        /// directory — either in the flat layout (<c>{app}\GVFS.Mount.exe</c>)
+        /// or in a versioned subdirectory (<c>{app}\Versions\*\GVFS.Mount.exe</c>
+        /// or <c>{app}\Current\GVFS.Mount.exe</c>).
+        /// </summary>
+        private static bool IsInstalledMountPath(string installDir, string processPath)
+        {
+            // Verify filename is actually GVFS.Mount.exe (not some other exe
+            // under the install dir).
+            if (!PathComparer.Equals(Path.GetFileName(processPath), MountExeName))
+            {
+                return false;
+            }
+
+            // Verify the exe lives under the install directory.
+            string normalizedInstallDir = installDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            return processPath.StartsWith(normalizedInstallDir, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds versioned install layout awareness to `GVFS.Service` — groundwork for non-disruptive upgrades.

### Changes

**Configuration.cs:**
- New `CurrentVersionPath` property resolves `{app}\Current` junction when present, falls back to flat layout
- `GVFSLocation` is now a computed property (not cached in constructor) so junction re-targeting takes effect without service restart
- `AssemblyPath` uses `Lazy<string>` for thread-safe initialization

**PendingUpgradeHandler.cs:**
- `GetInstalledMountProcesses` now recognizes mount processes from any `Versions\` subdirectory (not just flat `{app}\GVFS.Mount.exe`)
- New `IsInstalledMountPath` helper validates both filename and install-root prefix

### Backward Compatibility

Fully backward-compatible. On existing flat installs:
- `CurrentVersionPath` → no `Current` dir → falls back to `AssemblyPath` → identical behavior
- `GVFSLocation` → same path as before
- Mount process detection → same match as before

**818 unit tests pass.**

### Context

This is the first step toward a Chrome-like versioned install layout:
```
C:\Program Files\VFS for Git\
  GVFS.Service.exe            ← stays at root (SCM needs stable path)
  gvfs.exe                    ← shim (future PR)
  Versions\
    1.0.X\  ...               ← old version (running)
    1.0.Y\  ...               ← new version (installed)
  Current -> Versions\1.0.Y   ← junction
```
