### PR TITLE
Download commit pack even when commit exists as loose object

### DIFF
--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -101,6 +101,35 @@ namespace GVFS.Common.Git
             return output;
         }
 
+        /// <summary>
+        /// Check whether a given object SHA exists as a loose object file
+        /// in the shared cache or local object store.
+        /// </summary>
+        public virtual bool LooseObjectExists(string sha)
+        {
+            if (GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem)
+            {
+                sha = sha.ToLower();
+            }
+
+            string looseObjectPath = Path.Combine(
+                this.enlistment.GitObjectsRoot,
+                sha.Substring(0, 2),
+                sha.Substring(2));
+
+            if (this.fileSystem.FileExists(looseObjectPath))
+            {
+                return true;
+            }
+
+            looseObjectPath = Path.Combine(
+                this.enlistment.LocalObjectsRoot,
+                sha.Substring(0, 2),
+                sha.Substring(2));
+
+            return this.fileSystem.FileExists(looseObjectPath);
+        }
+
         public virtual bool ObjectExists(string blobSha)
         {
             bool output = false;

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -487,13 +487,31 @@ You can specify a URL, a name of a configured cache server, or the special names
             out string error,
             bool checkLocalObjectCache = true)
         {
-            if (!checkLocalObjectCache || !repo.CommitAndRootTreeExists(commitId, out _))
+            if (checkLocalObjectCache && repo.CommitAndRootTreeExists(commitId, out _))
             {
-                if (!gitObjects.TryDownloadCommit(commitId))
+                if (repo.LooseObjectExists(commitId))
                 {
-                    error = "Could not download commit " + commitId + " from: " + Uri.EscapeDataString(objectRequestor.CacheServer.ObjectsEndpointUrl);
-                    return false;
+                    // The commit exists as a loose object (e.g., from a prior 'git show'
+                    // or 'git log' in a mounted enlistment). Loose commits do not include
+                    // their reachable trees — those would need to be fetched individually.
+                    // Download the commit pack which includes all reachable trees so that
+                    // operations like 'git checkout -f' can succeed without the read-object
+                    // hook.
                 }
+                else
+                {
+                    // The commit exists in a pack file (prefetch pack or a previous commit
+                    // pack download). Packs from the GVFS protocol include all reachable
+                    // trees, so we can safely skip re-downloading.
+                    error = null;
+                    return true;
+                }
+            }
+
+            if (!gitObjects.TryDownloadCommit(commitId))
+            {
+                error = "Could not download commit " + commitId + " from: " + Uri.EscapeDataString(objectRequestor.CacheServer.ObjectsEndpointUrl);
+                return false;
             }
 
             error = null;


### PR DESCRIPTION
## Summary

Fixes the worst-case clone performance when a commit exists as a loose object in the shared cache (e.g., from a prior `git show` or `git log` in a mounted enlistment).

**Before:** `TryDownloadCommit` checks `CommitAndRootTreeExists` - if the commit and root tree exist (even as loose objects), the commit+trees pack download is skipped. `git checkout -f` then fails with `unable to read tree` because subtrees are missing, triggering an expensive fallback: re-download the pack + retry checkout. On a large repo this wastes ~60 seconds.

**After:** `TryDownloadCommit` additionally checks whether the commit is a loose object via the new `GitRepo.LooseObjectExists()` method. If the commit is loose, the pack is downloaded proactively. If the commit is in a pack file, trees are included by the GVFS protocol, so the download is safely skipped.

## Changes

- **GVFSVerb.cs**: When `CommitAndRootTreeExists` returns true, check `LooseObjectExists` before skipping download
- **GitRepo.cs**: New `LooseObjectExists` method - fast filesystem check for loose object files

## Performance Impact (large repo)

| Scenario | Before | After |
|---|---|---|
| Commit in pack | Skip download (22s saved) | Same |
| Commit is loose object | Skip -> checkout fails -> fallback (~60s wasted) | Download proactively (~60s saved) |
| Commit not in cache | Download pack | Same |