### PR TITLE
Add diagnostic logging to GetFileStreamException catch block

### DIFF
--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -981,6 +981,9 @@ namespace GVFS.Platform.Windows
             }
             catch (GetFileStreamException e)
             {
+                requestMetadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.GetFileStreamHandlerAsyncHandler)}: GetFileStreamException HResult 0x{e.HResult:X8}");
+                this.Context.Tracer.RelatedWarning(requestMetadata, nameof(this.GetFileStreamHandlerAsyncHandler) + "_GetFileStreamException");
+
                 this.TryCompleteCommand(commandId, (HResult)e.HResult);
                 return;
             }


### PR DESCRIPTION
The `GetFileStreamException` catch in `GetFileStreamHandlerAsyncHandler` silently completed the ProjFS command without logging `requestMetadata` (SHA, virtual path). The other catch blocks in the same handler (`OperationCanceledException`, generic `Exception`) all log this metadata.

This adds a `RelatedWarning` log call with the HResult value before `TryCompleteCommand`, providing diagnostic visibility while keeping the severity appropriate for expected/benign `HResult.Handle` results.