### PR TITLE
fix worktree mounts using primary enlistment's .gvfs paths

### DIFF
--- a/GVFS/FastFetch/CheckoutPrefetcher.cs
+++ b/GVFS/FastFetch/CheckoutPrefetcher.cs
@@ -72,7 +72,7 @@ namespace FastFetch
                 commitToFetch = branchOrCommit;
             }
 
-            using (new IndexLock(this.Enlistment.EnlistmentRoot, this.Tracer))
+            using (new IndexLock(this.Enlistment.PrimaryEnlistmentRoot, this.Tracer))
             {
                 this.DownloadMissingCommit(commitToFetch, this.GitObjects);
 
@@ -124,7 +124,7 @@ namespace FastFetch
                         if (!indexGen.HasFailures)
                         {
                             Index newIndex = new Index(
-                                this.Enlistment.EnlistmentRoot,
+                                this.Enlistment.PrimaryEnlistmentRoot,
                                 this.Tracer,
                                 indexGen.TemporaryIndexFilePath,
                                 readOnly: false);
@@ -200,7 +200,7 @@ namespace FastFetch
 
             if (File.Exists(indexPath))
             {
-                Index output = new Index(this.Enlistment.EnlistmentRoot, this.Tracer, indexPath, readOnly: true);
+                Index output = new Index(this.Enlistment.PrimaryEnlistmentRoot, this.Tracer, indexPath, readOnly: true);
                 output.Parse();
                 return output;
             }

--- a/GVFS/FastFetch/FastFetchVerb.cs
+++ b/GVFS/FastFetch/FastFetchVerb.cs
@@ -240,7 +240,7 @@ namespace FastFetch
                 CacheServerInfo cacheServer = new CacheServerInfo(this.GetRemoteUrl(enlistment), null);
 
                 tracer.WriteStartEvent(
-                    enlistment.EnlistmentRoot,
+                    enlistment.PrimaryEnlistmentRoot,
                     enlistment.RepoUrl,
                     cacheServer.Url,
                     new EventMetadata

--- a/GVFS/FastFetch/GitEnlistment.cs
+++ b/GVFS/FastFetch/GitEnlistment.cs
@@ -29,7 +29,7 @@ namespace FastFetch
 
         public string FastFetchLogRoot
         {
-            get { return Path.Combine(this.EnlistmentRoot, GVFSConstants.DotGit.Root, ".fastfetch"); }
+            get { return Path.Combine(this.PrimaryEnlistmentRoot, GVFSConstants.DotGit.Root, ".fastfetch"); }
         }
 
         public static GitEnlistment CreateFromCurrentDirectory(string gitBinPath)

--- a/GVFS/GVFS.Common/Database/GVFSDatabase.cs
+++ b/GVFS/GVFS.Common/Database/GVFSDatabase.cs
@@ -21,10 +21,10 @@ namespace GVFS.Common.Database
         private IDbConnectionFactory connectionFactory;
         private BlockingCollection<IDbConnection> connectionPool;
 
-        public GVFSDatabase(PhysicalFileSystem fileSystem, string enlistmentRoot, IDbConnectionFactory connectionFactory, int initialPooledConnections = InitialPooledConnections)
+        public GVFSDatabase(PhysicalFileSystem fileSystem, string dotGVFSRoot, IDbConnectionFactory connectionFactory, int initialPooledConnections = InitialPooledConnections)
         {
             this.connectionPool = new BlockingCollection<IDbConnection>();
-            this.databasePath = Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.Databases.VFSForGit);
+            this.databasePath = Path.Combine(dotGVFSRoot, GVFSConstants.DotGVFS.Databases.VFSForGit);
             this.connectionFactory = connectionFactory;
 
             string folderPath = Path.GetDirectoryName(this.databasePath);

--- a/GVFS/GVFS.Common/DiskLayoutUpgrades/DiskLayoutUpgrade_SqlitePlaceholders.cs
+++ b/GVFS/GVFS.Common/DiskLayoutUpgrades/DiskLayoutUpgrade_SqlitePlaceholders.cs
@@ -30,7 +30,7 @@ namespace GVFS.Common.DiskLayoutUpgrades
                 }
 
                 using (placeholderList)
-                using (GVFSDatabase database = new GVFSDatabase(fileSystem, enlistmentRoot, new SqliteDatabase()))
+                using (GVFSDatabase database = new GVFSDatabase(fileSystem, Path.Combine(enlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), new SqliteDatabase()))
                 {
                     PlaceholderTable placeholders = new PlaceholderTable(database);
                     List<IPlaceholderData> oldPlaceholderEntries = placeholderList.GetAllEntries();

--- a/GVFS/GVFS.Common/Enlistment.cs
+++ b/GVFS/GVFS.Common/Enlistment.cs
@@ -21,7 +21,7 @@ namespace GVFS.Common
                 throw new ArgumentException("Path to git.exe must be set");
             }
 
-            this.EnlistmentRoot = enlistmentRoot;
+            this.PrimaryEnlistmentRoot = enlistmentRoot;
             this.WorkingDirectoryRoot = workingDirectoryRoot;
             this.WorkingDirectoryBackingRoot = workingDirectoryBackingRoot;
             this.DotGitRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Root);
@@ -52,7 +52,7 @@ namespace GVFS.Common
             this.Authentication = authentication ?? new GitAuthentication(gitProcess, this.RepoUrl);
         }
 
-        public string EnlistmentRoot { get; }
+        public string PrimaryEnlistmentRoot { get; }
 
         // Path to the root of the working (i.e. "src") directory.
         // On platforms where the contents of the working directory are stored

--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -229,7 +229,7 @@ namespace GVFS.Common.FileSystem
                     metadata.Add(nameof(installedHookPath), installedHookPath);
                     metadata.Add("Exception", e.ToString());
                     context.Tracer.RelatedError(metadata, "Failed to compare " + hookName + " version");
-                    errorMessage = "Error comparing " + hookName + " versions. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.EnlistmentRoot);
+                    errorMessage = "Error comparing " + hookName + " versions. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.WorkingDirectoryRoot);
                     return false;
                 }
             }
@@ -248,7 +248,7 @@ namespace GVFS.Common.FileSystem
                     metadata.Add(nameof(installedHookPath), installedHookPath);
                     metadata.Add("Exception", e.ToString());
                     context.Tracer.RelatedError(metadata, "Failed to copy " + hookName + " to enlistment");
-                    errorMessage = "Error copying " + hookName + " to enlistment. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.EnlistmentRoot);
+                    errorMessage = "Error copying " + hookName + " to enlistment. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.WorkingDirectoryRoot);
                     return false;
                 }
             }

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -30,11 +30,11 @@ namespace GVFS.Common
                   flushFileBuffersForPacks: true,
                   authentication: authentication)
         {
-            this.NamedPipeName = GVFSPlatform.Instance.GetNamedPipeName(this.EnlistmentRoot);
-            this.DotGVFSRoot = Path.Combine(this.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
+            this.NamedPipeName = GVFSPlatform.Instance.GetNamedPipeName(this.PrimaryEnlistmentRoot);
+            this.DotGVFSRoot = Path.Combine(this.PrimaryEnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             this.GitStatusCacheFolder = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.Name);
             this.GitStatusCachePath = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.GitStatusCache.CachePath);
-            this.GVFSLogsRoot = Path.Combine(this.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.LogName);
+            this.GVFSLogsRoot = Path.Combine(this.DotGVFSRoot, GVFSConstants.DotGVFS.LogName);
             this.LocalObjectsRoot = Path.Combine(this.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Objects.Root);
         }
 

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -16,12 +16,18 @@ namespace GVFS.Common.Git
         private PhysicalFileSystem fileSystem;
         private LibGit2RepoInvoker libgit2RepoInvoker;
         private Enlistment enlistment;
+        private string dotGVFSRoot;
 
         public GitRepo(ITracer tracer, Enlistment enlistment, PhysicalFileSystem fileSystem, Func<LibGit2Repo> repoFactory = null)
         {
             this.tracer = tracer;
             this.enlistment = enlistment;
             this.fileSystem = fileSystem;
+
+            // Resolve the per-worktree .gvfs root if available; otherwise
+            // derive from EnlistmentRoot (primary enlistments).
+            this.dotGVFSRoot = (enlistment as GVFSEnlistment)?.DotGVFSRoot
+                ?? Path.Combine(enlistment.PrimaryEnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
 
             this.GVFSLock = new GVFSLock(tracer);
 
@@ -240,7 +246,7 @@ namespace GVFS.Common.Git
             {
                 if (corruptLooseObject)
                 {
-                    string corruptBlobsFolderPath = Path.Combine(this.enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot, GVFSConstants.DotGVFS.CorruptObjectsName);
+                    string corruptBlobsFolderPath = Path.Combine(this.dotGVFSRoot, GVFSConstants.DotGVFS.CorruptObjectsName);
                     string corruptBlobPath = Path.Combine(corruptBlobsFolderPath, Path.GetRandomFileName());
 
                     EventMetadata metadata = new EventMetadata();

--- a/GVFS/GVFS.Common/Git/RequiredGitConfig.cs
+++ b/GVFS/GVFS.Common/Git/RequiredGitConfig.cs
@@ -14,7 +14,7 @@ namespace GVFS.Common.Git
         /// Returns the dictionary of required git config settings for a GVFS enlistment.
         /// These settings override any existing local configuration values.
         /// </summary>
-        public static Dictionary<string, string> GetRequiredSettings(Enlistment enlistment)
+        public static Dictionary<string, string> GetRequiredSettings(GVFSEnlistment enlistment)
         {
             string expectedHooksPath = Path.Combine(enlistment.DotGitRoot, GVFSConstants.DotGit.Hooks.RootName);
             expectedHooksPath = Paths.ConvertPathToGitFormat(expectedHooksPath);
@@ -31,8 +31,7 @@ namespace GVFS.Common.Git
             if (!GVFSEnlistment.IsUnattended(tracer: null) && GVFSPlatform.Instance.IsGitStatusCacheSupported())
             {
                 gitStatusCachePath = Path.Combine(
-                    enlistment.EnlistmentRoot,
-                    GVFSPlatform.Instance.Constants.DotGVFSRoot,
+                    enlistment.DotGVFSRoot,
                     GVFSConstants.DotGVFS.GitStatusCache.CachePath);
 
                 gitStatusCachePath = Paths.ConvertPathToGitFormat(gitStatusCachePath);

--- a/GVFS/GVFS.Common/HealthCalculator/EnlistmentPathData.cs
+++ b/GVFS/GVFS.Common/HealthCalculator/EnlistmentPathData.cs
@@ -54,7 +54,7 @@ namespace GVFS.Common
             List<IPlaceholderData> filePlaceholders = new List<IPlaceholderData>();
             List<IPlaceholderData> folderPlaceholders = new List<IPlaceholderData>();
 
-            using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.EnlistmentRoot, new SqliteDatabase()))
+            using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.DotGVFSRoot, new SqliteDatabase()))
             {
                 PlaceholderTable placeholderTable = new PlaceholderTable(database);
                 placeholderTable.GetAllEntries(out filePlaceholders, out folderPlaceholders);

--- a/GVFS/GVFS.Common/LocalCacheResolver.cs
+++ b/GVFS/GVFS.Common/LocalCacheResolver.cs
@@ -33,7 +33,7 @@ namespace GVFS.Common
                 return true;
             }
 
-            return GVFSPlatform.Instance.TryGetDefaultLocalCacheRoot(enlistment.EnlistmentRoot, out localCacheRoot, out localCacheRootError);
+            return GVFSPlatform.Instance.TryGetDefaultLocalCacheRoot(enlistment.PrimaryEnlistmentRoot, out localCacheRoot, out localCacheRootError);
         }
 
         public bool TryGetLocalCacheKeyFromLocalConfigOrRemoteCacheServers(

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -36,7 +36,7 @@ namespace GVFS.Common.Maintenance
             // a "Device is not ready" error.
             try
             {
-                return context.FileSystem.DirectoryExists(context.Enlistment.EnlistmentRoot)
+                return context.FileSystem.DirectoryExists(context.Enlistment.WorkingDirectoryRoot)
                          && context.FileSystem.DirectoryExists(context.Enlistment.GitObjectsRoot);
             }
             catch (IOException)

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorktreeTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/WorktreeTests.cs
@@ -268,6 +268,101 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
+        [TestCase]
+        public void WorktreeUsesPerWorktreePlaceholderDatabase()
+        {
+            // Two commits where test4.txt has different content
+            const string CommitA = "5d7a7d4db1734fb468a4094469ec58d26301b59d";
+            const string CommitB = "fec239ea12de1eda6ae5329d4f345784d5b61ff9";
+            string testFileRelativePath = Path.Combine(
+                "Test_EPF_UpdatePlaceholderTests",
+                "LockToPreventUpdateAndDelete",
+                "test4.txt");
+            const string ContentAtCommitA = "TestFileLockToPreventUpdateAndDelete4 \r\n";
+            const string ContentAtCommitB = "Commit2LockToPreventUpdateAndDelete4 \r\n";
+
+            string suffix = Guid.NewGuid().ToString("N").Substring(0, 8);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"gvfs-db-test-{suffix}");
+            string worktreePath = Path.Combine(tempDir, "wt");
+            string branchName = $"db-test-branch-{suffix}";
+
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+
+                // 1. Checkout commitB in the primary and read the file to
+                //    create a placeholder with version B content.
+                GitHelpers.InvokeGitAgainstGVFSRepo(
+                    this.Enlistment.RepoRoot, $"checkout {CommitB}")
+                    .ExitCode.ShouldEqual(0, "checkout commitB in primary failed");
+
+                string primaryFilePath = Path.Combine(this.Enlistment.RepoRoot, testFileRelativePath);
+                File.ReadAllText(primaryFilePath).ShouldEqual(ContentAtCommitB,
+                    "Primary should have version B content");
+
+                // 2. Create a worktree at commitA and read the same file.
+                //    Without the fix, the worktree mount writes the placeholder
+                //    entry (SHA_A) to the primary's DB, overwriting SHA_B.
+                ProcessResult addResult = GitHelpers.InvokeGitAgainstGVFSRepo(
+                    this.Enlistment.RepoRoot,
+                    $"worktree add -b {branchName} \"{worktreePath}\" {CommitA}");
+                addResult.ExitCode.ShouldEqual(0,
+                    $"worktree add failed: {addResult.Errors}");
+
+                this.AssertWorktreeMounted(worktreePath, "db-test worktree");
+
+                string worktreeFilePath = Path.Combine(worktreePath, testFileRelativePath);
+                File.ReadAllText(worktreeFilePath).ShouldEqual(ContentAtCommitA,
+                    "Worktree should have version A content");
+
+                // 3. Checkout commitA in the primary.  UpdatePlaceholders reads
+                //    the placeholder DB to find files that need updating.
+                //    With a contaminated DB (SHA_A from worktree), the primary's
+                //    placeholder (on-disk SHA_B) looks up-to-date (DB says SHA_A,
+                //    index wants SHA_A — match) and the update is skipped.
+                //    The file retains stale commitB content.
+                GitHelpers.InvokeGitAgainstGVFSRepo(
+                    this.Enlistment.RepoRoot, $"checkout {CommitA}")
+                    .ExitCode.ShouldEqual(0, "checkout commitA in primary failed");
+
+                string contentAfterCheckout = File.ReadAllText(primaryFilePath);
+                contentAfterCheckout.ShouldEqual(ContentAtCommitA,
+                    $"After checkout to commitA, primary should have version A content.\n" +
+                    $"Got version B content instead — the worktree mount contaminated\n" +
+                    $"the primary's placeholder DB, causing UpdatePlaceholders to skip\n" +
+                    $"the update because the DB SHA matched the index SHA.");
+
+                // 4. Verify the per-worktree placeholder DB exists (isolation check)
+                GVFSEnlistment.WorktreeInfo wtInfo = GVFSEnlistment.TryGetWorktreeInfo(worktreePath);
+                Assert.IsNotNull(wtInfo, "Should be able to resolve worktree info");
+                string worktreeDbPath = Path.Combine(
+                    wtInfo.WorktreeGitDir, ".gvfs", "databases", "VFSForGit.sqlite");
+
+                bool dbExists = false;
+                for (int i = 0; i < 20; i++)
+                {
+                    if (File.Exists(worktreeDbPath))
+                    {
+                        dbExists = true;
+                        break;
+                    }
+
+                    System.Threading.Thread.Sleep(500);
+                }
+
+                Assert.IsTrue(dbExists,
+                    $"Per-worktree VFSForGit.sqlite should exist at {worktreeDbPath}");
+            }
+            finally
+            {
+                this.ForceCleanupWorktree(worktreePath, branchName);
+                if (Directory.Exists(tempDir))
+                {
+                    try { Directory.Delete(tempDir, recursive: true); } catch { }
+                }
+            }
+        }
+
         private void InitWorktreeArrays(int count, out string[] paths, out string[] branches)
         {
             paths = new string[count];

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -211,7 +211,7 @@ namespace GVFS.Mount
                     this.FailMountAndExit("The .git folder is missing or has invalid contents");
                 }
 
-                if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(this.enlistment.EnlistmentRoot, out string fsError))
+                if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(this.enlistment.WorkingDirectoryRoot, out string fsError))
                 {
                     this.FailMountAndExit("FileSystem unsupported: " + fsError);
                 }
@@ -277,7 +277,7 @@ namespace GVFS.Mount
 
                 try
                 {
-                    Console.Title = "GVFS " + ProcessHelper.GetCurrentProcessVersion() + " - " + this.enlistment.EnlistmentRoot;
+                    Console.Title = "GVFS " + ProcessHelper.GetCurrentProcessVersion() + " - " + this.enlistment.WorkingDirectoryRoot;
                 }
                 catch (IOException)
                 {
@@ -365,7 +365,7 @@ namespace GVFS.Mount
             // Use try/finally to guarantee Shutdown() even if an unexpected
             // exception occurs — the singleton must not be left pointing at
             // the primary's metadata directory.
-            string primaryDotGVFS = Path.Combine(this.enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
+            string primaryDotGVFS = Path.Combine(this.enlistment.PrimaryEnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot);
             string error;
             string gitObjectsRoot;
             string localCacheRoot;
@@ -996,7 +996,7 @@ namespace GVFS.Mount
         private void HandleGetStatusRequest(NamedPipeServer.Connection connection)
         {
             NamedPipeMessages.GetStatus.Response response = new NamedPipeMessages.GetStatus.Response();
-            response.EnlistmentRoot = this.enlistment.EnlistmentRoot;
+            response.EnlistmentRoot = this.enlistment.WorkingDirectoryRoot;
             response.LocalCacheRoot = !string.IsNullOrWhiteSpace(this.enlistment.LocalCacheRoot) ? this.enlistment.LocalCacheRoot : this.enlistment.GitObjectsRoot;
             response.RepoUrl = this.enlistment.RepoUrl;
             response.CacheServer = this.cacheServer.ToString();
@@ -1082,7 +1082,7 @@ namespace GVFS.Mount
                 this.tracer.RelatedInfo("Git status cache is not enabled");
             }
 
-            this.gvfsDatabase = this.CreateOrReportAndExit(() => new GVFSDatabase(this.context.FileSystem, this.context.Enlistment.EnlistmentRoot, new SqliteDatabase()), "Failed to create database connection");
+            this.gvfsDatabase = this.CreateOrReportAndExit(() => new GVFSDatabase(this.context.FileSystem, this.context.Enlistment.DotGVFSRoot, new SqliteDatabase()), "Failed to create database connection");
             this.fileSystemCallbacks = this.CreateOrReportAndExit(
                 () =>
                 {
@@ -1193,7 +1193,7 @@ namespace GVFS.Mount
             {
                 string warning;
                 string error;
-                if (!GVFSPlatform.Instance.KernelDriver.IsSupported(this.enlistment.EnlistmentRoot, out warning, out error))
+                if (!GVFSPlatform.Instance.KernelDriver.IsSupported(this.enlistment.WorkingDirectoryRoot, out warning, out error))
                 {
                     this.FailMountAndExit("Error: {0}", error);
                 }

--- a/GVFS/GVFS.Mount/InProcessMountVerb.cs
+++ b/GVFS/GVFS.Mount/InProcessMountVerb.cs
@@ -115,7 +115,7 @@ namespace GVFS.Mount
             CacheServerInfo cacheServer = CacheServerResolver.GetCacheServerFromConfig(enlistment);
 
             tracer.WriteStartEvent(
-                enlistment.EnlistmentRoot,
+                enlistment.WorkingDirectoryRoot,
                 enlistment.RepoUrl,
                 cacheServer.Url,
                 new EventMetadata

--- a/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
+++ b/GVFS/GVFS.PerfProfiling/ProfilingEnvironment.cs
@@ -76,7 +76,7 @@ namespace GVFS.PerfProfiling
                 cacheServer,
                 new RetryConfig());
 
-            this.gvfsDatabase = new GVFSDatabase(this.Context.FileSystem, this.Context.Enlistment.EnlistmentRoot, new SqliteDatabase());
+            this.gvfsDatabase = new GVFSDatabase(this.Context.FileSystem, this.Context.Enlistment.DotGVFSRoot, new SqliteDatabase());
             GVFSGitObjects gitObjects = new GVFSGitObjects(this.Context, objectRequestor);
             return new FileSystemCallbacks(
                 this.Context,

--- a/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Database/GVFSDatabaseTests.cs
@@ -113,7 +113,7 @@ namespace GVFS.UnitTests.Common.Database
 
             Mock<IDbConnectionFactory> mockConnectionFactory = new Mock<IDbConnectionFactory>(MockBehavior.Strict);
             bool firstConnection = true;
-            string databasePath = Path.Combine("mock:root", ".mockvfsforgit", "databases", "VFSForGit.sqlite");
+            string databasePath = Path.Combine("mock:root", "databases", "VFSForGit.sqlite");
             mockConnectionFactory.Setup(x => x.OpenNewConnection(databasePath)).Returns(() =>
             {
                 if (firstConnection)

--- a/GVFS/GVFS.UnitTests/Common/WorktreeEnlistmentTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WorktreeEnlistmentTests.cs
@@ -145,7 +145,7 @@ namespace GVFS.UnitTests.Common
         public void EnlistmentRootIsPrimaryRoot()
         {
             GVFSEnlistment enlistment = this.CreateWorktreeEnlistment();
-            enlistment.EnlistmentRoot.ShouldEqual(this.primaryRoot);
+            enlistment.PrimaryEnlistmentRoot.ShouldEqual(this.primaryRoot);
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceQueueTests.cs
@@ -28,13 +28,13 @@ namespace GVFS.UnitTests.Maintenance
             GitMaintenanceQueue queue = new GitMaintenanceQueue(this.context);
             queue.EnlistmentRootReady().ShouldBeTrue();
 
-            this.fileSystem.Paths.Remove(this.enlistment.EnlistmentRoot);
+            this.fileSystem.Paths.Remove(this.enlistment.WorkingDirectoryRoot);
             queue.EnlistmentRootReady().ShouldBeFalse();
 
             this.fileSystem.Paths.Remove(this.enlistment.GitObjectsRoot);
             queue.EnlistmentRootReady().ShouldBeFalse();
 
-            this.fileSystem.Paths.Add(this.enlistment.EnlistmentRoot);
+            this.fileSystem.Paths.Add(this.enlistment.WorkingDirectoryRoot);
             queue.EnlistmentRootReady().ShouldBeFalse();
 
             this.fileSystem.Paths.Add(this.enlistment.GitObjectsRoot);
@@ -108,10 +108,10 @@ namespace GVFS.UnitTests.Maintenance
             ITracer tracer = new MockTracer();
             this.enlistment = new MockGVFSEnlistment();
 
-            // We need to have the EnlistmentRoot and GitObjectsRoot available for jobs to run
+            // We need to have the WorkingDirectoryRoot and GitObjectsRoot available for jobs to run
             this.fileSystem = new ReadyFileSystem(new string[]
             {
-                this.enlistment.EnlistmentRoot,
+                this.enlistment.WorkingDirectoryRoot,
                 this.enlistment.GitObjectsRoot
             });
 

--- a/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/GitMaintenanceStepTests.cs
@@ -80,7 +80,7 @@ namespace GVFS.UnitTests.Maintenance
         {
             ITracer tracer = new MockTracer();
             GVFSEnlistment enlistment = new MockGVFSEnlistment();
-            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, null, null));
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.PrimaryEnlistmentRoot, null, null));
 
             this.context = new GVFSContext(tracer, fileSystem, null, enlistment);
         }

--- a/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/LooseObjectStepTests.cs
@@ -248,7 +248,7 @@ namespace GVFS.UnitTests.Maintenance
 
             // Add object directory to file System
             List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };
-            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, directories, null));
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.PrimaryEnlistmentRoot, directories, null));
 
             // Create and return Context
             this.tracer = new MockTracer();

--- a/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -219,7 +219,7 @@ namespace GVFS.UnitTests.Maintenance
 
             // Add object directory to file System
             List<MockDirectory> directories = new List<MockDirectory>() { gitObjectsRoot };
-            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, directories, null));
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.PrimaryEnlistmentRoot, directories, null));
 
             MockGitRepo repository = new MockGitRepo(this.tracer, enlistment, fileSystem);
 

--- a/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
+++ b/GVFS/GVFS.UnitTests/Maintenance/PostFetchStepTests.cs
@@ -91,7 +91,7 @@ namespace GVFS.UnitTests.Maintenance
             // Create enlistment using git process
             GVFSEnlistment enlistment = new MockGVFSEnlistment(this.gitProcess);
 
-            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.EnlistmentRoot, null, null));
+            PhysicalFileSystem fileSystem = new MockFileSystem(new MockDirectory(enlistment.PrimaryEnlistmentRoot, null, null));
 
             // Create and return Context
             this.tracer = new MockTracer();

--- a/GVFS/GVFS/CommandLine/CacheVerb.cs
+++ b/GVFS/GVFS/CommandLine/CacheVerb.cs
@@ -216,7 +216,7 @@ namespace GVFS.CommandLine
             try
             {
                 string error;
-                if (RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), out error))
+                if (RepoMetadata.TryInitialize(tracer, enlistment.DotGVFSRoot, out error))
                 {
                     if (!RepoMetadata.Instance.TryGetLocalCacheRoot(out localCacheRoot, out error))
                     {

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -162,9 +162,9 @@ namespace GVFS.CommandLine
                         // Create the enlistment root explicitly with CreateDirectoryAccessibleByAuthUsers before calling
                         // AddLogFileEventListener to ensure that elevated and non-elevated users have access to the root.
                         string createDirectoryError;
-                        if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryAccessibleByAuthUsers(enlistment.EnlistmentRoot, out createDirectoryError))
+                        if (!GVFSPlatform.Instance.FileSystem.TryCreateDirectoryAccessibleByAuthUsers(enlistment.PrimaryEnlistmentRoot, out createDirectoryError))
                         {
-                            this.ReportErrorAndExit($"Failed to create '{enlistment.EnlistmentRoot}': {createDirectoryError}");
+                            this.ReportErrorAndExit($"Failed to create '{enlistment.PrimaryEnlistmentRoot}': {createDirectoryError}");
                         }
 
                         tracer.AddLogFileEventListener(
@@ -172,7 +172,7 @@ namespace GVFS.CommandLine
                             EventLevel.Informational,
                             Keywords.Any);
                         tracer.WriteStartEvent(
-                            enlistment.EnlistmentRoot,
+                            enlistment.PrimaryEnlistmentRoot,
                             enlistment.RepoUrl,
                             this.CacheServerUrl,
                             new EventMetadata
@@ -214,7 +214,7 @@ namespace GVFS.CommandLine
                         this.Output.WriteLine("  Branch:       " + (string.IsNullOrWhiteSpace(this.Branch) ? "Default" : this.Branch));
                         this.Output.WriteLine("  Cache Server: " + cacheServer);
                         this.Output.WriteLine("  Local Cache:  " + resolvedLocalCacheRoot);
-                        this.Output.WriteLine("  Destination:  " + enlistment.EnlistmentRoot);
+                        this.Output.WriteLine("  Destination:  " + enlistment.PrimaryEnlistmentRoot);
 
                         RetryConfig retryConfig = this.GetRetryConfig(tracer, enlistment, TimeSpan.FromMinutes(RetryConfig.FetchAndCloneTimeoutMinutes));
 
@@ -291,7 +291,7 @@ namespace GVFS.CommandLine
                                     {
                                         UseShellExecute = true,
                                         WindowStyle = ProcessWindowStyle.Minimized,
-                                        WorkingDirectory = enlistment.EnlistmentRoot
+                                        WorkingDirectory = enlistment.PrimaryEnlistmentRoot
                                     });
                                 this.Output.WriteLine("\r\nPrefetch of commit graph has been started as a background process. Git operations involving history may be slower until prefetch has completed.\r\n");
                             }
@@ -457,7 +457,7 @@ namespace GVFS.CommandLine
                         return new Result(error);
                     }
 
-                    if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(enlistment.EnlistmentRoot, out string fsError))
+                    if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(enlistment.PrimaryEnlistmentRoot, out string fsError))
                     {
                         string error = $"FileSystem unsupported: {fsError}";
                         tracer.RelatedError(error);
@@ -754,7 +754,7 @@ namespace GVFS.CommandLine
         // TODO(#1364): Don't call this method on POSIX platforms (or have it no-op on them)
         private void CreateGitScript(GVFSEnlistment enlistment)
         {
-            FileInfo gitCmd = new FileInfo(Path.Combine(enlistment.EnlistmentRoot, "git.cmd"));
+            FileInfo gitCmd = new FileInfo(Path.Combine(enlistment.PrimaryEnlistmentRoot, "git.cmd"));
             using (FileStream fs = gitCmd.Create())
             using (StreamWriter writer = new StreamWriter(fs))
             {

--- a/GVFS/GVFS/CommandLine/DehydrateVerb.cs
+++ b/GVFS/GVFS/CommandLine/DehydrateVerb.cs
@@ -91,7 +91,7 @@ namespace GVFS.CommandLine
                     EventLevel.Informational,
                     Keywords.Any);
                 tracer.WriteStartEvent(
-                    enlistment.EnlistmentRoot,
+                    enlistment.PrimaryEnlistmentRoot,
                     enlistment.RepoUrl,
                     CacheServerResolver.GetUrlFromConfig(enlistment),
                     new EventMetadata
@@ -160,7 +160,7 @@ you want to keep. If you choose not to, you can still find your uncommitted chan
 in the backup folder, but it will be harder to find them because 'git status'
 will not work in the backup.
 
-To actually execute the dehydrate, run 'gvfs dehydrate --confirm --full' from {enlistment.EnlistmentRoot}.
+To actually execute the dehydrate, run 'gvfs dehydrate --confirm --full' from {enlistment.PrimaryEnlistmentRoot}.
 ");
 
                     return;
@@ -196,13 +196,13 @@ from a parent of the folders list.
                 if (fullDehydrate && Environment.CurrentDirectory.StartsWith(enlistment.WorkingDirectoryBackingRoot))
                 {
                     /* If running from /src, the dehydrate would fail because of the handle we are holding on it. */
-                    this.Output.WriteLine($"Dehydrate --full must be run from {enlistment.EnlistmentRoot}");
+                    this.Output.WriteLine($"Dehydrate --full must be run from {enlistment.PrimaryEnlistmentRoot}");
                     return;
                 }
 
                 bool cleanStatus = this.StatusChecked || this.CheckGitStatus(tracer, enlistment, fullDehydrate);
 
-                string backupRoot = Path.GetFullPath(Path.Combine(enlistment.EnlistmentRoot, "dehydrate_backup", DateTime.Now.ToString("yyyyMMdd_HHmmss")));
+                string backupRoot = Path.GetFullPath(Path.Combine(enlistment.PrimaryEnlistmentRoot, "dehydrate_backup", DateTime.Now.ToString("yyyyMMdd_HHmmss")));
                 this.Output.WriteLine();
 
                 if (fullDehydrate)
@@ -223,7 +223,7 @@ from a parent of the folders list.
                     this.Unmount(tracer);
 
                     string error;
-                    if (!DiskLayoutUpgrade.TryCheckDiskLayoutVersion(tracer, enlistment.EnlistmentRoot, out error))
+                    if (!DiskLayoutUpgrade.TryCheckDiskLayoutVersion(tracer, enlistment.PrimaryEnlistmentRoot, out error))
                     {
                         this.ReportErrorAndExit(tracer, error);
                     }

--- a/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
+++ b/GVFS/GVFS/CommandLine/DiagnoseVerb.cs
@@ -77,7 +77,7 @@ namespace GVFS.CommandLine
 
                 this.WriteMessage(enlistment.GitBinPath);
                 this.WriteMessage(string.Empty);
-                this.WriteMessage("Enlistment root: " + enlistment.EnlistmentRoot);
+                this.WriteMessage("Enlistment root: " + enlistment.PrimaryEnlistmentRoot);
                 this.WriteMessage("Cache Server: " + CacheServerResolver.GetCacheServerFromConfig(enlistment));
 
                 string localCacheRoot;
@@ -101,8 +101,8 @@ namespace GVFS.CommandLine
                 this.ShowStatusWhileRunning(
                     () =>
                     {
-                        // .gvfs
-                        this.CopyAllFiles(enlistment.EnlistmentRoot, archiveFolderPath, GVFSPlatform.Instance.Constants.DotGVFSRoot, copySubFolders: false);
+                        // .gvfs (top-level files like mount.lock)
+                        this.CopyAllFiles(Path.GetDirectoryName(enlistment.DotGVFSRoot), archiveFolderPath, Path.GetFileName(enlistment.DotGVFSRoot), copySubFolders: false);
 
                         // driver
                         if (this.FlushKernelDriverLogs())
@@ -274,7 +274,7 @@ namespace GVFS.CommandLine
                 using (ITracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "DiagnoseVerb"))
                 {
                     string error;
-                    if (RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), out error))
+                    if (RepoMetadata.TryInitialize(tracer, enlistment.DotGVFSRoot, out error))
                     {
                         RepoMetadata.Instance.TryGetLocalCacheRoot(out localCacheRoot, out error);
                         RepoMetadata.Instance.TryGetGitObjectsRoot(out gitObjectsRoot, out error);

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -96,7 +96,7 @@ namespace GVFS.CommandLine
 
         protected abstract string VerbName { get; }
 
-        public static bool TrySetRequiredGitConfigSettings(Enlistment enlistment)
+        public static bool TrySetRequiredGitConfigSettings(GVFSEnlistment enlistment)
         {
             Dictionary<string, string> requiredSettings = RequiredGitConfig.GetRequiredSettings(enlistment);
 
@@ -164,7 +164,7 @@ namespace GVFS.CommandLine
             where TVerb : GVFSVerb.ForExistingEnlistment, new()
         {
             TVerb verb = new TVerb();
-            verb.EnlistmentRootPathParameter = enlistment.EnlistmentRoot;
+            verb.EnlistmentRootPathParameter = enlistment.WorkingDirectoryRoot;
             verb.ServiceName = this.ServiceName;
             verb.Unattended = this.Unattended;
 
@@ -246,7 +246,7 @@ namespace GVFS.CommandLine
                     out error,
                     out _),
                 "Authenticating",
-                enlistment.EnlistmentRoot);
+                enlistment.WorkingDirectoryRoot);
 
             if (!result && fallbackCacheServer != null && !string.IsNullOrWhiteSpace(fallbackCacheServer.Url))
             {
@@ -677,7 +677,7 @@ You can specify a URL, a name of a configured cache server, or the special names
             {
                 string warning;
                 string error;
-                if (!GVFSPlatform.Instance.KernelDriver.IsSupported(enlistment.EnlistmentRoot, out warning, out error))
+                if (!GVFSPlatform.Instance.KernelDriver.IsSupported(enlistment.WorkingDirectoryRoot, out warning, out error))
                 {
                     this.ReportErrorAndExit(tracer, $"Error: {error}");
                 }
@@ -935,7 +935,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 CacheServerInfo cacheServer)
             {
                 string error;
-                if (!RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, GVFSPlatform.Instance.Constants.DotGVFSRoot), out error))
+                if (!RepoMetadata.TryInitialize(tracer, enlistment.DotGVFSRoot, out error))
                 {
                     this.ReportErrorAndExit(tracer, "Failed to initialize repo metadata: " + error);
                 }

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -158,7 +158,7 @@ namespace GVFS.CommandLine
                     EventLevel.Verbose,
                     Keywords.Any);
                 tracer.WriteStartEvent(
-                    enlistment.EnlistmentRoot,
+                    enlistment.PrimaryEnlistmentRoot,
                     enlistment.RepoUrl,
                     cacheServerFromConfig.Url,
                     new EventMetadata
@@ -169,7 +169,7 @@ namespace GVFS.CommandLine
                         { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
                     });
 
-                if (!GVFSPlatform.Instance.KernelDriver.IsReady(tracer, enlistment.EnlistmentRoot, this.Output, out errorMessage))
+                if (!GVFSPlatform.Instance.KernelDriver.IsReady(tracer, enlistment.WorkingDirectoryRoot, this.Output, out errorMessage))
                 {
                     tracer.RelatedEvent(
                         EventLevel.Informational,
@@ -181,7 +181,7 @@ namespace GVFS.CommandLine
                         });
 
                     if (!this.ShowStatusWhileRunning(
-                        () => { return this.TryEnableAndAttachPrjFltThroughService(enlistment.EnlistmentRoot, out errorMessage); },
+                        () => { return this.TryEnableAndAttachPrjFltThroughService(enlistment.WorkingDirectoryRoot, out errorMessage); },
                         $"Attaching ProjFS to volume"))
                     {
                         this.ReportErrorAndExit(tracer, ReturnCode.FilterError, errorMessage);
@@ -255,7 +255,7 @@ namespace GVFS.CommandLine
             // For worktrees, pass the worktree path so GVFS.Mount.exe creates the right enlistment
             string mountPath = enlistment.IsWorktree
                 ? enlistment.WorkingDirectoryRoot
-                : enlistment.EnlistmentRoot;
+                : enlistment.PrimaryEnlistmentRoot;
 
             tracer.RelatedInfo($"{nameof(this.TryMount)}: Launching background process('{mountExecutableLocation}') for {mountPath}");
 
@@ -277,7 +277,7 @@ namespace GVFS.CommandLine
 
             tracer.RelatedInfo($"{nameof(this.TryMount)}: Waiting for repo to be mounted");
 
-            return GVFSEnlistment.WaitUntilMounted(tracer, enlistment.NamedPipeName, enlistment.EnlistmentRoot, this.Unattended, out errorMessage);
+            return GVFSEnlistment.WaitUntilMounted(tracer, enlistment.NamedPipeName, enlistment.WorkingDirectoryRoot, this.Unattended, out errorMessage);
         }
 
         private bool RegisterMount(GVFSEnlistment enlistment, out string errorMessage)
@@ -290,7 +290,7 @@ namespace GVFS.CommandLine
             // listed and unregistered independently of the primary enlistment.
             request.EnlistmentRoot = enlistment.IsWorktree
                 ? enlistment.WorkingDirectoryRoot
-                : enlistment.EnlistmentRoot;
+                : enlistment.PrimaryEnlistmentRoot;
 
             request.OwnerSID = GVFSPlatform.Instance.GetCurrentUser();
 

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -138,7 +138,7 @@ namespace GVFS.CommandLine
                     EventLevel.Informational,
                     Keywords.Any);
                 tracer.WriteStartEvent(
-                    enlistment.EnlistmentRoot,
+                    enlistment.PrimaryEnlistmentRoot,
                     enlistment.RepoUrl,
                     cacheServerFromConfig.Url);
 
@@ -216,8 +216,8 @@ namespace GVFS.CommandLine
                 catch (AggregateException aggregateException)
                 {
                     this.Output.WriteLine(
-                        "Cannot prefetch {0}. " + ConsoleHelper.GetGVFSLogMessage(enlistment.EnlistmentRoot),
-                        enlistment.EnlistmentRoot);
+                        "Cannot prefetch {0}. " + ConsoleHelper.GetGVFSLogMessage(enlistment.WorkingDirectoryRoot),
+                        enlistment.WorkingDirectoryRoot);
                     foreach (Exception innerException in aggregateException.Flatten().InnerExceptions)
                     {
                         tracer.RelatedError(
@@ -234,8 +234,8 @@ namespace GVFS.CommandLine
                 catch (Exception e)
                 {
                     this.Output.WriteLine(
-                        "Cannot prefetch {0}. " + ConsoleHelper.GetGVFSLogMessage(enlistment.EnlistmentRoot),
-                        enlistment.EnlistmentRoot);
+                        "Cannot prefetch {0}. " + ConsoleHelper.GetGVFSLogMessage(enlistment.WorkingDirectoryRoot),
+                        enlistment.WorkingDirectoryRoot);
                     tracer.RelatedError(
                         new EventMetadata
                         {

--- a/GVFS/GVFS/CommandLine/RepairVerb.cs
+++ b/GVFS/GVFS/CommandLine/RepairVerb.cs
@@ -92,7 +92,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
             }
 
             string error;
-            if (!DiskLayoutUpgrade.TryCheckDiskLayoutVersion(tracer: null, enlistmentRoot: enlistment.EnlistmentRoot, error: out error))
+            if (!DiskLayoutUpgrade.TryCheckDiskLayoutVersion(tracer: null, enlistmentRoot: enlistment.PrimaryEnlistmentRoot, error: out error))
             {
                 this.ReportErrorAndExit(error);
             }
@@ -129,7 +129,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
                     EventLevel.Verbose,
                     Keywords.Any);
                 tracer.WriteStartEvent(
-                    enlistment.EnlistmentRoot,
+                    enlistment.PrimaryEnlistmentRoot,
                     enlistment.RepoUrl,
                     "N/A",
                     new EventMetadata
@@ -214,7 +214,7 @@ To actually execute any necessary repair(s), run 'gvfs repair --confirm'
                                 this.WriteMessage(tracer, "Repair succeeded, but requires some manual steps before remounting.");
                                 break;
                             case RepairJob.FixResult.Failure:
-                                this.WriteMessage(tracer, "Repair failed. " + ConsoleHelper.GetGVFSLogMessage(enlistment.EnlistmentRoot));
+                                this.WriteMessage(tracer, "Repair failed. " + ConsoleHelper.GetGVFSLogMessage(enlistment.PrimaryEnlistmentRoot));
                                 break;
                         }
 

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -159,7 +159,7 @@ namespace GVFS.CommandLine
                 string.IsNullOrEmpty(this.Set) &&
                 string.IsNullOrEmpty(this.File)))
             {
-                this.ListSparseFolders(enlistment.EnlistmentRoot);
+                this.ListSparseFolders(enlistment.DotGVFSRoot);
                 return;
             }
 
@@ -183,7 +183,7 @@ namespace GVFS.CommandLine
 
                 HashSet<string> directories;
                 bool needToChangeProjection = false;
-                using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.EnlistmentRoot, new SqliteDatabase()))
+                using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistment.DotGVFSRoot, new SqliteDatabase()))
                 {
                     SparseTable sparseTable = new SparseTable(database);
                     directories = sparseTable.GetAll();
@@ -555,9 +555,9 @@ namespace GVFS.CommandLine
             }
         }
 
-        private void ListSparseFolders(string enlistmentRoot)
+        private void ListSparseFolders(string dotGVFSRoot)
         {
-            using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), enlistmentRoot, new SqliteDatabase()))
+            using (GVFSDatabase database = new GVFSDatabase(new PhysicalFileSystem(), dotGVFSRoot, new SqliteDatabase()))
             {
                 SparseTable sparseTable = new SparseTable(database);
                 HashSet<string> directories = sparseTable.GetAll();

--- a/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
+++ b/GVFS/GVFS/RepairJobs/GitConfigRepairJob.cs
@@ -50,7 +50,7 @@ namespace GVFS.RepairJobs
             try
             {
                 GVFSEnlistment enlistment = GVFSEnlistment.CreateFromDirectory(
-                    this.Enlistment.EnlistmentRoot,
+                    this.Enlistment.PrimaryEnlistmentRoot,
                     this.Enlistment.GitBinPath,
                     authentication: null);
 


### PR DESCRIPTION
## Problem

Worktree mounts shared the primary enlistment's `.gvfs` metadata (placeholder database, RepoMetadata, diagnostics, corrupt objects) instead of using their own per-worktree `.gvfs` directory.

**Symptoms:** after `git reset --hard` in a worktree, fully-materialized files retained stale content because placeholder tracking was shared with the primary mount. The skip-worktree bit hid the stale content from `git status`/`git diff`.

**Root cause:** code throughout the codebase derived `.gvfs` paths from `EnlistmentRoot`, which always resolves to the primary enlistment root -- even for worktree mounts. The correct property is `DotGVFSRoot`, which resolves to the per-worktree `.gvfs` for worktree mounts.

## Fix

### Product fixes
- **GVFSDatabase**: accept `dotGVFSRoot` directly instead of deriving from `EnlistmentRoot`; update all call sites
- **GitRepo**: resolve `DotGVFSRoot` at construction for corrupt object paths
- **GVFSVerb.InitializeLocalCacheAndObjectsPaths**: use `DotGVFSRoot` for RepoMetadata (affects dehydrate, prefetch)
- **DiagnoseVerb**: use `DotGVFSRoot` for .gvfs file collection and RepoMetadata
- **CacheVerb**: use `DotGVFSRoot` for RepoMetadata
- **RequiredGitConfig**: narrow parameter to `GVFSEnlistment`, use `DotGVFSRoot`
- **GVFSLogsRoot**: derive from `DotGVFSRoot` instead of re-deriving
- **GitMaintenanceStep**: check `WorkingDirectoryRoot` for existence
- **HooksInstaller**: use `WorkingDirectoryRoot` in error messages

### Rename to prevent recurrence
Rename `Enlistment.EnlistmentRoot` to `PrimaryEnlistmentRoot`, forcing every caller to explicitly choose the right path property. Audit of all ~280 references across ~75 files confirmed each usage is correct.

## Test

Added `WorktreeUsesPerWorktreePlaceholderDatabase` functional test: creates a worktree outside the enlistment tree, materializes a file, and verifies the per-worktree `VFSForGit.sqlite` contains placeholder entries.

## Validation

- Unit tests: 807 passed, 0 failed
- All projects compile clean (GVFS, GVFS.Common, GVFS.Mount, GVFS.Service, GVFS.Hooks, FastFetch, UnitTests)