### PR TITLE
Use Console.IsOutputRedirected instead of P/Invoke for redirect detection

### DIFF
--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -103,8 +103,6 @@ namespace GVFS.Common
 
         public abstract Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly);
 
-        public abstract bool IsConsoleOutputRedirectedToFile();
-
         public abstract bool TryKillProcessTree(int processId, out int exitCode, out string error);
 
         public abstract bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage);

--- a/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.cs
+++ b/GVFS/GVFS.Hooks/HooksPlatform/GVFSHooksPlatform.cs
@@ -22,11 +22,6 @@ namespace GVFS.Hooks.HooksPlatform
             return WindowsPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
         }
 
-        public static bool IsConsoleOutputRedirectedToFile()
-        {
-            return WindowsPlatform.IsConsoleOutputRedirectedToFileImplementation();
-        }
-
         public static bool TryGetGVFSEnlistmentRoot(string directory, out string enlistmentRoot, out string errorMessage)
         {
             return WindowsPlatform.TryGetGVFSEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);

--- a/GVFS/GVFS.Hooks/Program.cs
+++ b/GVFS/GVFS.Hooks/Program.cs
@@ -317,7 +317,7 @@ namespace GVFS.Hooks
                     fullCommand,
                     pid,
                     GVFSHooksPlatform.IsElevated(),
-                    isConsoleOutputRedirectedToFile: GVFSHooksPlatform.IsConsoleOutputRedirectedToFile(),
+                    isConsoleOutputRedirectedToFile: Console.IsOutputRedirected,
                     checkAvailabilityOnly: checkGvfsLockAvailabilityOnly,
                     gvfsEnlistmentRoot: null,
                     gitCommandSessionId: gitCommandSessionId,
@@ -337,7 +337,7 @@ namespace GVFS.Hooks
                 fullCommand,
                 pid,
                 GVFSHooksPlatform.IsElevated(),
-                GVFSHooksPlatform.IsConsoleOutputRedirectedToFile(),
+                Console.IsOutputRedirected,
                 response =>
                 {
                     if (response == null || response.ResponseData == null)

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -3,7 +3,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Security.Principal;
 
 namespace GVFS.Platform.Windows
@@ -14,22 +13,6 @@ namespace GVFS.Platform.Windows
         public const string UpgradeConfirmMessage = "`gvfs upgrade --confirm`";
 
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
-
-        private enum StdHandle
-        {
-            Stdin = -10,
-            Stdout = -11,
-            Stderr = -12
-        }
-
-        private enum FileType : uint
-        {
-            Unknown = 0x0000,
-            Disk = 0x0001,
-            Char = 0x0002,
-            Pipe = 0x0003,
-            Remote = 0x8000,
-        }
 
         public static bool IsElevatedImplementation()
         {
@@ -153,11 +136,6 @@ namespace GVFS.Platform.Windows
             return Path.Combine(GetSecureDataRootForGVFSImplementation(), componentName);
         }
 
-        public static bool IsConsoleOutputRedirectedToFileImplementation()
-        {
-            return FileType.Disk == GetFileType(GetStdHandle(StdHandle.Stdout));
-        }
-
         public static bool TryGetGVFSEnlistmentRootImplementation(string directory, out string enlistmentRoot, out string errorMessage)
         {
             enlistmentRoot = null;
@@ -177,11 +155,5 @@ namespace GVFS.Platform.Windows
 
             return true;
         }
-
-        [DllImport("kernel32.dll")]
-        private static extern IntPtr GetStdHandle(StdHandle std);
-
-        [DllImport("kernel32.dll")]
-        private static extern FileType GetFileType(IntPtr hdl);
     }
 }

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -331,11 +331,6 @@ namespace GVFS.Platform.Windows
 
         public override Dictionary<string, string> GetPhysicalDiskInfo(string path, bool sizeStatsOnly) => WindowsPhysicalDiskInfo.GetPhysicalDiskInfo(path, sizeStatsOnly);
 
-        public override bool IsConsoleOutputRedirectedToFile()
-        {
-            return WindowsPlatform.IsConsoleOutputRedirectedToFileImplementation();
-        }
-
         public override bool IsGitStatusCacheSupported()
         {
             return File.Exists(Path.Combine(GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(GVFSConstants.Service.ServiceName), GVFSConstants.GitStatusCache.EnableGitStatusCacheTokenFile));

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -131,11 +131,6 @@ namespace GVFS.UnitTests.Mock.Common
             return "MockPath";
         }
 
-        public override bool IsConsoleOutputRedirectedToFile()
-        {
-            throw new NotSupportedException();
-        }
-
         public override bool IsElevated()
         {
             throw new NotSupportedException();

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -193,7 +193,7 @@ namespace GVFS.CommandLine
                 action,
                 message,
                 this.Output,
-                showSpinner: !this.Unattended && this.Output == Console.Out && !GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
+                showSpinner: !this.Unattended && this.Output == Console.Out && !Console.IsOutputRedirected,
                 gvfsLogEnlistmentRoot: gvfsLogEnlistmentRoot,
                 initialDelayMs: 0);
         }

--- a/GVFS/GVFS/CommandLine/UnmountVerb.cs
+++ b/GVFS/GVFS/CommandLine/UnmountVerb.cs
@@ -261,7 +261,7 @@ namespace GVFS.CommandLine
                             "gvfs unmount",
                             currentProcess.Id,
                             GVFSPlatform.Instance.IsElevated(),
-                            isConsoleOutputRedirectedToFile: GVFSPlatform.Instance.IsConsoleOutputRedirectedToFile(),
+                            isConsoleOutputRedirectedToFile: Console.IsOutputRedirected,
                             checkAvailabilityOnly: false,
                             gvfsEnlistmentRoot: enlistmentRoot,
                             gitCommandSessionId: string.Empty,


### PR DESCRIPTION
The previous `IsConsoleOutputRedirectedToFile()` used Win32 `GetFileType` to check if stdout was redirected to a disk file. This missed the pipe case (`GetFileType` returns `Pipe`, not `Disk`), so the console spinner would still run when stdout was captured via `Process.Start` with `RedirectStandardOutput` (e.g. in functional tests and CI), polluting captured output with `\r` and spinner characters.

Replace with .NET's `Console.IsOutputRedirected` which returns true for any non-console handle (files, pipes, NUL). Remove the now-unused P/Invoke declarations (`GetStdHandle`, `GetFileType`) and the platform abstraction (`IsConsoleOutputRedirectedToFile`) from `GVFSPlatform`, `WindowsPlatform`, `GVFSHooksPlatform`, and `MockPlatform`.