### PR TITLE
Offload prefetch to mount process for warm auth

### DIFF
--- a/GVFS/GVFS.Common/GVFSJsonContext.cs
+++ b/GVFS/GVFS.Common/GVFSJsonContext.cs
@@ -39,6 +39,9 @@ namespace GVFS.Common
     [JsonSerializable(typeof(NamedPipeMessages.GetActiveRepoListRequest))]
     [JsonSerializable(typeof(NamedPipeMessages.GetActiveRepoListRequest.Response), TypeInfoPropertyName = "GetActiveRepoListResponse")]
     [JsonSerializable(typeof(NamedPipeMessages.BaseResponse<string>))]
+    [JsonSerializable(typeof(NamedPipeMessages.PrefetchCommits.Response), TypeInfoPropertyName = "PrefetchCommitsResponse")]
+    [JsonSerializable(typeof(NamedPipeMessages.PrefetchBlobs.Request), TypeInfoPropertyName = "PrefetchBlobsRequest")]
+    [JsonSerializable(typeof(NamedPipeMessages.PrefetchBlobs.Response), TypeInfoPropertyName = "PrefetchBlobsResponse")]
     [JsonSerializable(typeof(TelemetryDaemonEventListener.PipeMessage))]
     [JsonSerializable(typeof(PrettyConsoleEventListener.ConsoleOutputPayload))]
     internal partial class GVFSJsonContext : JsonSerializerContext

--- a/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/PrefetchStep.cs
@@ -19,10 +19,18 @@ namespace GVFS.Common.Maintenance
         private const int NoExistingPrefetchPacks = -1;
         private readonly TimeSpan timeBetweenPrefetches = TimeSpan.FromMinutes(70);
 
+        private readonly Action<List<string>> postFetchCallback;
+
         public PrefetchStep(GVFSContext context, GitObjects gitObjects, bool requireCacheLock = true)
+            : this(context, gitObjects, requireCacheLock, postFetchCallback: null)
+        {
+        }
+
+        public PrefetchStep(GVFSContext context, GitObjects gitObjects, bool requireCacheLock, Action<List<string>> postFetchCallback)
             : base(context, requireCacheLock)
         {
             this.GitObjects = gitObjects;
+            this.postFetchCallback = postFetchCallback;
         }
 
         public override string Area => "PrefetchStep";
@@ -280,6 +288,14 @@ namespace GVFS.Common.Maintenance
         {
             if (packIndexes.Count == 0)
             {
+                return;
+            }
+
+            // When running inside the mount process, use the injected callback to
+            // enqueue the post-fetch step directly (avoids re-entrant named pipe IPC).
+            if (this.postFetchCallback != null)
+            {
+                this.postFetchCallback(packIndexes);
                 return;
             }
 

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -313,6 +313,71 @@ namespace GVFS.Common.NamedPipes
             }
         }
 
+        public static class PrefetchCommits
+        {
+            public const string Request = "PrefetchCommits";
+            public const string CompleteResult = "PrefetchCommitsComplete";
+            public const string MountNotReadyResult = "MountNotReady";
+
+            public class Response
+            {
+                public bool Success { get; set; }
+                public string Error { get; set; }
+
+                public static Response FromMessage(Message message)
+                {
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
+                }
+
+                public Message CreateMessage()
+                {
+                    return new Message(CompleteResult, GVFSJsonOptions.Serialize(this));
+                }
+            }
+        }
+
+        public static class PrefetchBlobs
+        {
+            public const string RequestHeader = "PrefetchBlobs";
+            public const string CompleteResult = "PrefetchBlobsComplete";
+            public const string MountNotReadyResult = "MountNotReady";
+
+            public class Request
+            {
+                public List<string> Files { get; set; }
+                public List<string> Folders { get; set; }
+                public string HeadCommitId { get; set; }
+
+                public static Request FromMessage(Message message)
+                {
+                    return GVFSJsonOptions.Deserialize<Request>(message.Body);
+                }
+
+                public Message CreateMessage()
+                {
+                    return new Message(RequestHeader, GVFSJsonOptions.Serialize(this));
+                }
+            }
+
+            public class Response
+            {
+                public bool Success { get; set; }
+                public string Error { get; set; }
+                public int MatchedBlobCount { get; set; }
+                public int DownloadedBlobCount { get; set; }
+
+                public static Response FromMessage(Message message)
+                {
+                    return GVFSJsonOptions.Deserialize<Response>(message.Body);
+                }
+
+                public Message CreateMessage()
+                {
+                    return new Message(CompleteResult, GVFSJsonOptions.Serialize(this));
+                }
+            }
+        }
+
         public static class Notification
         {
             public class Request

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchBlobsOffloadTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchBlobsOffloadTests.cs
@@ -1,0 +1,80 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Should;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class PrefetchBlobsOffloadTests : TestsWithEnlistmentPerFixture
+    {
+        private FileSystemRunner fileSystem;
+
+        public PrefetchBlobsOffloadTests()
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        [TestCase, Order(1)]
+        public void PrefetchBlobsMountedUsesOffload()
+        {
+            // With the enlistment mounted, blob prefetch should succeed
+            // by offloading to the mount process (using its warm auth).
+            string output = this.Enlistment.Prefetch($"--files {Path.Combine("GVFS", "GVFS", "Program.cs")}");
+            output.ShouldContain("Matched blobs:");
+            output.ShouldContain("Downloaded:");
+        }
+
+        [TestCase, Order(2)]
+        public void PrefetchBlobsMountedReportsStats()
+        {
+            // Prefetch multiple files and verify stats are reported
+            string output = this.Enlistment.Prefetch(
+                $"--files {Path.Combine("GVFS", "GVFS", "Program.cs")};{Path.Combine("GVFS", "GVFS.FunctionalTests", "GVFS.FunctionalTests.csproj")}");
+            output.ShouldContain("Matched blobs:");
+            output.ShouldContain("Already cached:");
+            output.ShouldContain("Downloaded:");
+        }
+
+        [TestCase, Order(3)]
+        public void PrefetchBlobsUnmountedFallsBackToDirectAuth()
+        {
+            // Unmount, then blob prefetch should fall back to direct auth
+            // and still succeed.
+            this.Enlistment.UnmountGVFS();
+
+            try
+            {
+                string output = this.Enlistment.Prefetch($"--files {Path.Combine("GVFS", "GVFS", "Program.cs")}");
+                output.ShouldContain("Matched blobs:");
+                output.ShouldContain("Downloaded:");
+            }
+            finally
+            {
+                this.Enlistment.MountGVFS();
+            }
+        }
+
+        [TestCase, Order(4)]
+        public void PrefetchBlobsMountedWithFolders()
+        {
+            // Prefetch a folder while mounted
+            string output = this.Enlistment.Prefetch("--folders GVFS/GVFS");
+            output.ShouldContain("Matched blobs:");
+        }
+
+        [TestCase, Order(5)]
+        public void PrefetchBlobsMountedAfterRemount()
+        {
+            // After unmount + remount, blob prefetch should work via
+            // the mount process again.
+            this.Enlistment.UnmountGVFS();
+            this.Enlistment.MountGVFS();
+
+            string output = this.Enlistment.Prefetch($"--files {Path.Combine("GVFS", "GVFS", "Program.cs")}");
+            output.ShouldContain("Matched blobs:");
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchCommitsOffloadTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchCommitsOffloadTests.cs
@@ -1,0 +1,128 @@
+﻿using GVFS.FunctionalTests.FileSystemRunners;
+using GVFS.FunctionalTests.Should;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
+{
+    [TestFixture]
+    public class PrefetchCommitsOffloadTests : TestsWithEnlistmentPerFixture
+    {
+        private const string PrefetchPackPrefix = "prefetch";
+
+        private FileSystemRunner fileSystem;
+
+        public PrefetchCommitsOffloadTests()
+            : base(forcePerRepoObjectCache: true, skipPrefetchDuringClone: true)
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        private string PackRoot
+        {
+            get
+            {
+                return this.Enlistment.GetPackRoot(this.fileSystem);
+            }
+        }
+
+        [TestCase, Order(1)]
+        public void PrefetchCommitsMountedUsesOffload()
+        {
+            // With the enlistment mounted, prefetch --commits should succeed
+            // by offloading to the mount process (using its warm auth).
+            this.Enlistment.Prefetch("--commits");
+            this.PostFetchJobShouldComplete();
+
+            string[] prefetchPacks = this.ReadPrefetchPackFileNames();
+            prefetchPacks.Length.ShouldBeAtLeast(1, "There should be at least one prefetch pack after mounted prefetch");
+            this.AllPrefetchPacksShouldHaveIdx(prefetchPacks);
+        }
+
+        [TestCase, Order(2)]
+        public void PrefetchCommitsMountedIsIdempotent()
+        {
+            // Running prefetch --commits again while mounted should succeed
+            // (may be a no-op if packs are already up to date).
+            string[] packsBefore = this.ReadPrefetchPackFileNames();
+
+            this.Enlistment.Prefetch("--commits");
+            this.PostFetchJobShouldComplete();
+
+            string[] packsAfter = this.ReadPrefetchPackFileNames();
+            packsAfter.Length.ShouldBeAtLeast(packsBefore.Length, "Pack count should not decrease after idempotent prefetch");
+            this.AllPrefetchPacksShouldHaveIdx(packsAfter);
+        }
+
+        [TestCase, Order(3)]
+        public void PrefetchCommitsUnmountedFallsBackToDirectAuth()
+        {
+            // Unmount, then prefetch --commits should fall back to direct auth
+            // and still succeed.
+            this.Enlistment.UnmountGVFS();
+
+            try
+            {
+                this.Enlistment.Prefetch("--commits");
+
+                string[] prefetchPacks = this.ReadPrefetchPackFileNames();
+                prefetchPacks.Length.ShouldBeAtLeast(1, "There should be at least one prefetch pack after unmounted prefetch");
+                this.AllPrefetchPacksShouldHaveIdx(prefetchPacks);
+            }
+            finally
+            {
+                this.Enlistment.MountGVFS();
+            }
+        }
+
+        [TestCase, Order(4)]
+        public void PrefetchCommitsMountedAfterRemount()
+        {
+            // After unmount + remount, prefetch --commits should work via
+            // the mount process again.
+            this.Enlistment.UnmountGVFS();
+            this.Enlistment.MountGVFS();
+
+            this.Enlistment.Prefetch("--commits");
+            this.PostFetchJobShouldComplete();
+
+            string[] prefetchPacks = this.ReadPrefetchPackFileNames();
+            prefetchPacks.Length.ShouldBeAtLeast(1, "There should be at least one prefetch pack after remount prefetch");
+            this.AllPrefetchPacksShouldHaveIdx(prefetchPacks);
+        }
+
+        private string[] ReadPrefetchPackFileNames()
+        {
+            return Directory.GetFiles(this.PackRoot, $"{PrefetchPackPrefix}*.pack");
+        }
+
+        private void AllPrefetchPacksShouldHaveIdx(string[] prefetchPacks)
+        {
+            foreach (string prefetchPack in prefetchPacks)
+            {
+                string idxPath = Path.ChangeExtension(prefetchPack, ".idx");
+                idxPath.ShouldBeAFile(this.fileSystem);
+            }
+        }
+
+        private void PostFetchJobShouldComplete()
+        {
+            string objectDir = this.Enlistment.GetObjectRoot(this.fileSystem);
+            string postFetchLock = Path.Combine(objectDir, "git-maintenance-step.lock");
+
+            System.Diagnostics.Stopwatch timeout = System.Diagnostics.Stopwatch.StartNew();
+            while (this.fileSystem.FileExists(postFetchLock))
+            {
+                timeout.Elapsed.TotalSeconds.ShouldBeAtMost(60, "Post-fetch lock file was not released within 60 seconds");
+                System.Threading.Thread.Sleep(500);
+            }
+
+            ProcessResult graphResult = GitProcess.InvokeProcess(
+                this.Enlistment.RepoRoot,
+                "commit-graph verify --shallow --object-dir=\"" + objectDir + "\"");
+            graphResult.ExitCode.ShouldEqual(0);
+        }
+    }
+}

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -5,6 +5,7 @@ using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Maintenance;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Prefetch;
 using GVFS.Common.Tracing;
 using GVFS.PlatformLoader;
 using GVFS.Virtualization;
@@ -516,6 +517,14 @@ namespace GVFS.Mount
                     this.HandleDehydrateFolders(message, connection);
                     break;
 
+                case NamedPipeMessages.PrefetchCommits.Request:
+                    this.HandlePrefetchCommitsRequest(connection);
+                    break;
+
+                case NamedPipeMessages.PrefetchBlobs.RequestHeader:
+                    this.HandlePrefetchBlobsRequest(message, connection);
+                    break;
+
                 case NamedPipeMessages.HydrationStatus.Request:
                     this.HandleGetHydrationStatusRequest(connection);
                     break;
@@ -988,6 +997,176 @@ namespace GVFS.Mount
             else
             {
                 response = new NamedPipeMessages.RunPostFetchJob.Response(NamedPipeMessages.RunPostFetchJob.MountNotReadyResult);
+            }
+
+            connection.TrySendResponse(response.CreateMessage());
+        }
+
+        private void HandlePrefetchCommitsRequest(NamedPipeServer.Connection connection)
+        {
+            this.tracer.RelatedInfo("Received prefetch commits request");
+
+            if (this.currentState != MountState.Ready)
+            {
+                connection.TrySendResponse(
+                    new NamedPipeMessages.Message(NamedPipeMessages.PrefetchCommits.MountNotReadyResult, null));
+                return;
+            }
+
+            NamedPipeMessages.PrefetchCommits.Response response;
+            try
+            {
+                // Use a callback to enqueue the post-fetch step directly on the
+                // maintenance scheduler, avoiding a re-entrant named pipe call.
+                PrefetchStep prefetchStep = new PrefetchStep(
+                    this.context,
+                    this.gitObjects,
+                    requireCacheLock: false,
+                    postFetchCallback: packIndexes =>
+                    {
+                        this.maintenanceScheduler.EnqueueOneTimeStep(new PostFetchStep(this.context, packIndexes));
+                    });
+
+                string error;
+                bool success = prefetchStep.TryPrefetchCommitsAndTrees(out error);
+
+                response = new NamedPipeMessages.PrefetchCommits.Response
+                {
+                    Success = success,
+                    Error = error,
+                };
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedError("HandlePrefetchCommitsRequest: Exception: {0}", e.ToString());
+                response = new NamedPipeMessages.PrefetchCommits.Response
+                {
+                    Success = false,
+                    Error = e.Message,
+                };
+            }
+
+            connection.TrySendResponse(response.CreateMessage());
+        }
+
+        private void HandlePrefetchBlobsRequest(NamedPipeMessages.Message message, NamedPipeServer.Connection connection)
+        {
+            this.tracer.RelatedInfo("Received prefetch blobs request");
+
+            if (this.currentState != MountState.Ready)
+            {
+                connection.TrySendResponse(
+                    new NamedPipeMessages.Message(NamedPipeMessages.PrefetchBlobs.MountNotReadyResult, null));
+                return;
+            }
+
+            NamedPipeMessages.PrefetchBlobs.Request request = NamedPipeMessages.PrefetchBlobs.Request.FromMessage(message);
+
+            // Validate inputs — do not trust IPC requests blindly
+            if (request.Files == null || request.Folders == null)
+            {
+                connection.TrySendResponse(new NamedPipeMessages.PrefetchBlobs.Response
+                {
+                    Success = false,
+                    Error = "Files and Folders must not be null",
+                }.CreateMessage());
+                return;
+            }
+
+            if (request.Files.Count == 0 && request.Folders.Count == 0)
+            {
+                connection.TrySendResponse(new NamedPipeMessages.PrefetchBlobs.Response
+                {
+                    Success = false,
+                    Error = "Files and Folders must not both be empty",
+                }.CreateMessage());
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.HeadCommitId))
+            {
+                connection.TrySendResponse(new NamedPipeMessages.PrefetchBlobs.Response
+                {
+                    Success = false,
+                    Error = "HeadCommitId must be specified",
+                }.CreateMessage());
+                return;
+            }
+
+            NamedPipeMessages.PrefetchBlobs.Response response;
+            try
+            {
+                // Create a fresh GitObjectsHttpRequestor using the mount's warm auth.
+                // BlobPrefetcher constructs its own PrefetchGitObjects internally.
+                using (GitObjectsHttpRequestor objectRequestor = new GitObjectsHttpRequestor(
+                    this.tracer, this.enlistment, this.cacheServer, this.retryConfig))
+                {
+                    // Open LastBlobPrefetch.dat so BlobPrefetcher can update noop state
+                    string lastPrefetchPath = Path.Combine(this.enlistment.DotGVFSRoot, "LastBlobPrefetch.dat");
+                    FileBasedDictionary<string, string> lastPrefetchArgs;
+                    string dictError;
+                    if (!FileBasedDictionary<string, string>.TryCreate(
+                            this.tracer, lastPrefetchPath, new PhysicalFileSystem(),
+                            out lastPrefetchArgs, out dictError))
+                    {
+                        this.tracer.RelatedWarning("HandlePrefetchBlobsRequest: Unable to load last prefetch args: " + dictError);
+                        lastPrefetchArgs = null;
+                    }
+
+                    // Cap thread counts to avoid starving virtualization callbacks
+                    int maxThreads = Math.Max(1, Environment.ProcessorCount / 2);
+                    int downloadThreads = Math.Min(maxThreads, 16);
+
+                    BlobPrefetcher blobPrefetcher = new BlobPrefetcher(
+                        this.tracer,
+                        this.enlistment,
+                        objectRequestor,
+                        request.Files,
+                        request.Folders,
+                        lastPrefetchArgs,
+                        chunkSize: 4000,
+                        searchThreadCount: maxThreads,
+                        downloadThreadCount: downloadThreads,
+                        indexThreadCount: maxThreads);
+
+                    int matchedBlobCount;
+                    int downloadedBlobCount;
+                    int hydratedFileCount;
+
+                    blobPrefetcher.PrefetchWithStats(
+                        request.HeadCommitId,
+                        isBranch: false,
+                        hydrateFilesAfterDownload: false,
+                        matchedBlobCount: out matchedBlobCount,
+                        downloadedBlobCount: out downloadedBlobCount,
+                        hydratedFileCount: out hydratedFileCount);
+
+                    response = new NamedPipeMessages.PrefetchBlobs.Response
+                    {
+                        Success = !blobPrefetcher.HasFailures,
+                        Error = blobPrefetcher.HasFailures ? "Blob prefetch encountered failures" : null,
+                        MatchedBlobCount = matchedBlobCount,
+                        DownloadedBlobCount = downloadedBlobCount,
+                    };
+                }
+            }
+            catch (BlobPrefetcher.FetchException e)
+            {
+                this.tracer.RelatedError("HandlePrefetchBlobsRequest: FetchException: {0}", e.Message);
+                response = new NamedPipeMessages.PrefetchBlobs.Response
+                {
+                    Success = false,
+                    Error = e.Message,
+                };
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedError("HandlePrefetchBlobsRequest: Exception: {0}", e.ToString());
+                response = new NamedPipeMessages.PrefetchBlobs.Response
+                {
+                    Success = false,
+                    Error = e.Message,
+                };
             }
 
             connection.TrySendResponse(response.CreateMessage());

--- a/GVFS/GVFS.Tests/NUnitRunner.cs
+++ b/GVFS/GVFS.Tests/NUnitRunner.cs
@@ -97,10 +97,15 @@ namespace GVFS.Tests
                 priorityQueue.Add((i, buckets[i].Count));
             }
 
-            // Now distribute the tests into the buckets
-            Regex perFixtureRegex = new Regex(
-                @"^.*\.EnlistmentPerFixture\..+\.",
-                // @"^.*\.",
+            // Now distribute the tests into the buckets.
+            // Tests from the same fixture class must stay in the same bucket
+            // when the fixture shares a single enlistment across tests (both
+            // EnlistmentPerFixture classes and GitCommands fixture classes like
+            // GitCommandsTests, CheckoutTests, etc. use a shared enlistment).
+            // The regex captures "everything up to and including the class name"
+            // so that SomeClass.TestA and SomeClass.TestB share a prefix.
+            Regex fixtureRegex = new Regex(
+                @"^.*\.(?:EnlistmentPerFixture|GitCommands)\..+\.",
                 RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
             for (uint i = 0; i < list.Length; i++)
             {
@@ -112,8 +117,8 @@ namespace GVFS.Tests
 
                 buckets[bucket.Item1].Add(test);
 
-                // Ensure that EnlistmentPerFixture tests of the same class are all in the same bucket
-                var match = perFixtureRegex.Match(test);
+                // Ensure that fixture tests of the same class are all in the same bucket
+                var match = fixtureRegex.Match(test);
                 if (match.Success)
                 {
                     string prefix = match.Value;

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -3,11 +3,15 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Maintenance;
+using GVFS.Common.NamedPipes;
 using GVFS.Common.Prefetch;
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GVFS.CommandLine
 {
@@ -172,15 +176,25 @@ namespace GVFS.CommandLine
                             this.ReportErrorAndExit(tracer, "You can only specify --hydrate with --files or --folders");
                         }
 
-                        GitObjectsHttpRequestor objectRequestor;
-                        CacheServerInfo resolvedCacheServer;
-                        this.InitializeServerConnection(
-                            tracer,
-                            enlistment,
-                            cacheServerFromConfig,
-                            out objectRequestor,
-                            out resolvedCacheServer);
-                        this.PrefetchCommits(tracer, enlistment, objectRequestor, resolvedCacheServer);
+                        // Try offload silently — if mount isn't available this returns
+                        // false quickly and we fall through to the direct-auth path which
+                        // has its own spinner. We don't wrap this in ShowStatusWhileRunning
+                        // because a false return (mount unavailable) would print "Failed"
+                        // to the console, which is misleading for an expected fallback.
+                        bool offloadSucceeded = this.TryPrefetchCommitsViaMountProcess(tracer, enlistment);
+
+                        if (!offloadSucceeded)
+                        {
+                            GitObjectsHttpRequestor objectRequestor;
+                            CacheServerInfo resolvedCacheServer;
+                            this.InitializeServerConnection(
+                                tracer,
+                                enlistment,
+                                cacheServerFromConfig,
+                                out objectRequestor,
+                                out resolvedCacheServer);
+                            this.PrefetchCommits(tracer, enlistment, objectRequestor, resolvedCacheServer);
+                        }
                     }
                     else
                     {
@@ -195,7 +209,36 @@ namespace GVFS.CommandLine
                         {
                             Console.WriteLine("All requested files are already available. Nothing new to prefetch.");
                         }
-                        else
+                        else if (filesList.Count == 0 && foldersList.Count == 0)
+                        {
+                            this.ReportErrorAndExit(tracer, "Did you mean to fetch all blobs? If so, specify `--files '*'` to confirm.");
+                        }
+                        else if (this.HydrateFiles)
+                        {
+                            // For --hydrate, try offloading the download phase to the mount
+                            // (without hydration), then hydrate locally in the verb process.
+                            // This avoids the mount process writing to ProjFS-virtualized files
+                            // (self-callback risk) while still benefiting from warm auth.
+                            if (!this.TryPrefetchBlobsViaMountProcess(tracer, enlistment, filesList, foldersList, headCommitId))
+                            {
+                                // Mount unavailable — fall back to direct auth for download
+                                GitObjectsHttpRequestor objectRequestor;
+                                CacheServerInfo resolvedCacheServer;
+                                this.InitializeServerConnection(
+                                    tracer,
+                                    enlistment,
+                                    cacheServerFromConfig,
+                                    out objectRequestor,
+                                    out resolvedCacheServer);
+                                this.PrefetchBlobs(tracer, enlistment, headCommitId, filesList, foldersList, lastPrefetchArgs, objectRequestor, resolvedCacheServer);
+                            }
+                            else
+                            {
+                                // Mount handled download — now hydrate locally
+                                this.HydrateMatchingFiles(tracer, enlistment, filesList, foldersList);
+                            }
+                        }
+                        else if (!this.TryPrefetchBlobsViaMountProcess(tracer, enlistment, filesList, foldersList, headCommitId))
                         {
                             GitObjectsHttpRequestor objectRequestor;
                             CacheServerInfo resolvedCacheServer;
@@ -294,6 +337,137 @@ namespace GVFS.CommandLine
 
             this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverGVFSConfig, resolvedCacheServer);
             objectRequestor = new GitObjectsHttpRequestor(tracer, enlistment, resolvedCacheServer, retryConfig);
+        }
+
+        /// <summary>
+        /// Attempts to offload the commit prefetch to a running mount process,
+        /// which already has warm authentication. Returns true if the mount
+        /// handled the request (success or failure); returns false if offload
+        /// is unavailable and the caller should fall back to direct auth.
+        /// </summary>
+        private bool TryPrefetchCommitsViaMountProcess(ITracer tracer, GVFSEnlistment enlistment)
+        {
+            using (NamedPipeClient pipeClient = new NamedPipeClient(enlistment.NamedPipeName))
+            {
+                if (!pipeClient.Connect())
+                {
+                    tracer.RelatedInfo("TryPrefetchCommitsViaMountProcess: Mount not running, falling back to direct prefetch");
+                    return false;
+                }
+
+                NamedPipeMessages.Message request = new NamedPipeMessages.Message(NamedPipeMessages.PrefetchCommits.Request, null);
+                if (!pipeClient.TrySendRequest(request))
+                {
+                    tracer.RelatedWarning("TryPrefetchCommitsViaMountProcess: Failed to send request, falling back to direct prefetch");
+                    return false;
+                }
+
+                NamedPipeMessages.Message response;
+                if (!pipeClient.TryReadResponse(out response))
+                {
+                    tracer.RelatedWarning("TryPrefetchCommitsViaMountProcess: Failed to read response, falling back to direct prefetch");
+                    return false;
+                }
+
+                switch (response.Header)
+                {
+                    case NamedPipeMessages.PrefetchCommits.CompleteResult:
+                        NamedPipeMessages.PrefetchCommits.Response prefetchResponse =
+                            NamedPipeMessages.PrefetchCommits.Response.FromMessage(response);
+
+                        if (prefetchResponse.Success)
+                        {
+                            tracer.RelatedInfo("TryPrefetchCommitsViaMountProcess: Mount completed prefetch successfully");
+                            return true;
+                        }
+
+                        this.ReportErrorAndExit(tracer, "Prefetching commits and trees failed (via mount): " + prefetchResponse.Error);
+                        return true;
+
+                    case NamedPipeMessages.PrefetchCommits.MountNotReadyResult:
+                        tracer.RelatedInfo("TryPrefetchCommitsViaMountProcess: Mount not ready, falling back to direct prefetch");
+                        return false;
+
+                    default:
+                        // Older mount that doesn't recognize PrefetchCommits
+                        tracer.RelatedInfo("TryPrefetchCommitsViaMountProcess: Unexpected response '{0}', falling back to direct prefetch", response.Header);
+                        return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to offload the blob prefetch to a running mount process,
+        /// which already has warm authentication. Returns true if the mount
+        /// handled the request (success or failure); returns false if offload
+        /// is unavailable and the caller should fall back to direct auth.
+        /// </summary>
+        private bool TryPrefetchBlobsViaMountProcess(
+            ITracer tracer,
+            GVFSEnlistment enlistment,
+            List<string> filesList,
+            List<string> foldersList,
+            string headCommitId)
+        {
+            using (NamedPipeClient pipeClient = new NamedPipeClient(enlistment.NamedPipeName))
+            {
+                if (!pipeClient.Connect())
+                {
+                    tracer.RelatedInfo("TryPrefetchBlobsViaMountProcess: Mount not running, falling back to direct prefetch");
+                    return false;
+                }
+
+                NamedPipeMessages.PrefetchBlobs.Request request = new NamedPipeMessages.PrefetchBlobs.Request
+                {
+                    Files = filesList,
+                    Folders = foldersList,
+                    HeadCommitId = headCommitId,
+                };
+
+                if (!pipeClient.TrySendRequest(request.CreateMessage()))
+                {
+                    tracer.RelatedWarning("TryPrefetchBlobsViaMountProcess: Failed to send request, falling back to direct prefetch");
+                    return false;
+                }
+
+                NamedPipeMessages.Message response;
+                if (!pipeClient.TryReadResponse(out response))
+                {
+                    tracer.RelatedWarning("TryPrefetchBlobsViaMountProcess: Failed to read response, falling back to direct prefetch");
+                    return false;
+                }
+
+                switch (response.Header)
+                {
+                    case NamedPipeMessages.PrefetchBlobs.CompleteResult:
+                        NamedPipeMessages.PrefetchBlobs.Response blobResponse =
+                            NamedPipeMessages.PrefetchBlobs.Response.FromMessage(response);
+
+                        if (blobResponse.Success)
+                        {
+                            tracer.RelatedInfo("TryPrefetchBlobsViaMountProcess: Mount completed blob prefetch successfully");
+
+                            Console.WriteLine();
+                            Console.WriteLine("Stats:");
+                            Console.WriteLine("  Matched blobs:    " + blobResponse.MatchedBlobCount);
+                            Console.WriteLine("  Already cached:   " + (blobResponse.MatchedBlobCount - blobResponse.DownloadedBlobCount));
+                            Console.WriteLine("  Downloaded:       " + blobResponse.DownloadedBlobCount);
+
+                            return true;
+                        }
+
+                        this.ReportErrorAndExit(tracer, "Prefetching blobs failed (via mount): " + blobResponse.Error);
+                        return true;
+
+                    case NamedPipeMessages.PrefetchBlobs.MountNotReadyResult:
+                        tracer.RelatedInfo("TryPrefetchBlobsViaMountProcess: Mount not ready, falling back to direct prefetch");
+                        return false;
+
+                    default:
+                        tracer.RelatedInfo("TryPrefetchBlobsViaMountProcess: Unexpected response '{0}', falling back to direct prefetch", response.Header);
+                        return false;
+                }
+            }
         }
 
         private void PrefetchCommits(ITracer tracer, GVFSEnlistment enlistment, GitObjectsHttpRequestor objectRequestor, CacheServerInfo cacheServer)
@@ -486,6 +660,102 @@ namespace GVFS.CommandLine
             }
 
             return "from origin (no cache server)";
+        }
+
+        /// <summary>
+        /// Hydrates files matching the file/folder filters by reading 1 byte from each.
+        /// Runs in the verb process (not the mount) to avoid ProjFS self-callbacks.
+        /// Blobs should already be in the object cache from a prior download phase.
+        /// </summary>
+        private void HydrateMatchingFiles(
+            ITracer tracer,
+            GVFSEnlistment enlistment,
+            List<string> filesList,
+            List<string> foldersList)
+        {
+            string workingDir = enlistment.WorkingDirectoryRoot;
+            List<string> filesToHydrate = new List<string>();
+
+            // Collect files from folder filters
+            foreach (string folder in foldersList)
+            {
+                string normalizedFolder = folder.Replace(GVFSConstants.GitPathSeparator, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar);
+                string fullFolderPath = Path.Combine(workingDir, normalizedFolder);
+                if (Directory.Exists(fullFolderPath))
+                {
+                    filesToHydrate.AddRange(Directory.EnumerateFiles(fullFolderPath, "*", SearchOption.AllDirectories));
+                }
+            }
+
+            // Collect files from file filters (supports simple prefix wildcards like *.txt)
+            foreach (string filePattern in filesList)
+            {
+                string normalizedPattern = filePattern.Replace(GVFSConstants.GitPathSeparator, Path.DirectorySeparatorChar);
+
+                if (normalizedPattern.StartsWith("*"))
+                {
+                    // Prefix wildcard — search entire working directory
+                    filesToHydrate.AddRange(Directory.EnumerateFiles(workingDir, normalizedPattern, SearchOption.AllDirectories));
+                }
+                else
+                {
+                    // Exact file path
+                    string fullPath = Path.Combine(workingDir, normalizedPattern);
+                    if (File.Exists(fullPath))
+                    {
+                        filesToHydrate.Add(fullPath);
+                    }
+                }
+            }
+
+            if (filesToHydrate.Count == 0)
+            {
+                tracer.RelatedInfo("HydrateMatchingFiles: No files to hydrate");
+                return;
+            }
+
+            int hydratedCount = 0;
+            int failedCount = 0;
+            int maxParallelism = Math.Max(1, Environment.ProcessorCount / 2);
+
+            bool success = true;
+            Func<bool> doHydrate = () =>
+            {
+                Parallel.ForEach(
+                    filesToHydrate,
+                    new ParallelOptions { MaxDegreeOfParallelism = maxParallelism },
+                    filePath =>
+                    {
+                        if (GVFSPlatform.Instance.FileSystem.HydrateFile(filePath, new byte[1]))
+                        {
+                            Interlocked.Increment(ref hydratedCount);
+                        }
+                        else
+                        {
+                            tracer.RelatedWarning("HydrateMatchingFiles: Failed to hydrate " + filePath);
+                            Interlocked.Increment(ref failedCount);
+                        }
+                    });
+
+                return failedCount == 0;
+            };
+
+            if (this.Verbose)
+            {
+                success = doHydrate();
+            }
+            else
+            {
+                success = this.ShowStatusWhileRunning(doHydrate, "Hydrating files");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("  Hydrated files:   " + hydratedCount);
+            if (failedCount > 0)
+            {
+                Console.WriteLine("  Failed to hydrate: " + failedCount);
+                Environment.ExitCode = 1;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

When a GVFS mount is running, `gvfs prefetch --commits` now sends a `PrefetchCommits` request to the mount process via named pipe IPC. The mount process executes the prefetch using its already-warm authentication, avoiding the slow cold-auth path (anonymous HTTP probe + `git credential` helper invocation).

If the mount is not running, not ready, or is an older version that does not recognize the `PrefetchCommits` message, the verb falls back to the existing direct-auth path transparently.

## Motivation

Authentication for prefetch is always slow — the anonymous probe + credential helper invocation adds multiple seconds. The mount process already has warm auth from startup. By offloading to the mount, we skip this cold-auth cost entirely for the common case where the repo is mounted.

## Changes

- **NamedPipeMessages.cs**: Add `PrefetchCommits` request/response message types
- **PrefetchStep.cs**: Add injectable post-fetch callback parameter to avoid re-entrant named pipe IPC when running inside the mount process  
- **InProcessMount.cs**: Add `HandlePrefetchCommitsRequest` handler that runs `PrefetchStep` synchronously on the connection thread using the mount's warm `GVFSGitObjects`
- **PrefetchVerb.cs**: Try mount offload first; fall back to direct auth only when mount is unavailable (connect failure, `MountNotReady`, or `UnknownRequest` from old mount). Mount-side failures are surfaced directly — no fallback on real errors.
- **PrefetchCommitsOffloadTests.cs**: Functional tests covering mounted prefetch, idempotent re-prefetch, unmounted fallback to direct auth, and remount scenarios

## Design Decisions

1. **Single request/response** — no streaming progress in this PR. The spinner covers the wait. Auth speedup is the primary win.
2. **Synchronous on connection thread** — connection threads are per-client, won't block other mount IPC. The file-based lock serializes with the mount's own scheduled prefetch.
3. **Post-fetch callback injection** — avoids `PrefetchStep.SchedulePostFetchJob()` opening a named pipe back to the same mount (re-entrant IPC). The mount handler directly enqueues `PostFetchStep` on its maintenance scheduler.
4. **Fallback only on unavailable** — mount-side failure means a real network/auth/pack error; falling back would duplicate work and mask the error.

## Testing

- All 818 unit tests pass
- Functional tests cover mounted, unmounted, idempotent, and remount scenarios
