### PR TITLE
Expand blob prefetch noop cache to N entries

### DIFF
--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -9,6 +9,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 
 namespace GVFS.Common.Prefetch
@@ -32,7 +34,13 @@ namespace GVFS.Common.Prefetch
         private const string AreaPath = nameof(BlobPrefetcher);
         private static string pathSeparatorString = Path.DirectorySeparatorChar.ToString();
 
-        private FileBasedDictionary<string, string> lastPrefetchArgs;
+        public const string BlobPrefetchCacheFile = "BlobPrefetchCache.dat";
+        public const string PrefetchCacheSizeConfigKey = GVFSConstants.GitConfig.GVFSPrefix + "prefetch-cache-size";
+        public const int DefaultPrefetchCacheSize = 100;
+        public const int MaxPrefetchCacheSize = 1000;
+
+        private FileBasedDictionary<string, string> prefetchCache;
+        private int maxCacheSize;
 
         public BlobPrefetcher(
             ITracer tracer,
@@ -42,7 +50,7 @@ namespace GVFS.Common.Prefetch
             int searchThreadCount,
             int downloadThreadCount,
             int indexThreadCount)
-            : this(tracer, enlistment, objectRequestor, null, null, null, chunkSize, searchThreadCount, downloadThreadCount, indexThreadCount)
+            : this(tracer, enlistment, objectRequestor, null, null, null, DefaultPrefetchCacheSize, chunkSize, searchThreadCount, downloadThreadCount, indexThreadCount)
         {
         }
 
@@ -52,7 +60,8 @@ namespace GVFS.Common.Prefetch
             GitObjectsHttpRequestor objectRequestor,
             List<string> fileList,
             List<string> folderList,
-            FileBasedDictionary<string, string> lastPrefetchArgs,
+            FileBasedDictionary<string, string> prefetchCache,
+            int maxCacheSize,
             int chunkSize,
             int searchThreadCount,
             int downloadThreadCount,
@@ -70,7 +79,8 @@ namespace GVFS.Common.Prefetch
             this.FileList = fileList ?? new List<string>();
             this.FolderList = folderList ?? new List<string>();
 
-            this.lastPrefetchArgs = lastPrefetchArgs;
+            this.prefetchCache = prefetchCache;
+            this.maxCacheSize = maxCacheSize;
 
             // We never want to update config settings for a GVFSEnlistment
             this.SkipConfigUpdate = enlistment is GVFSEnlistment;
@@ -127,39 +137,26 @@ namespace GVFS.Common.Prefetch
 
         public static bool IsNoopPrefetch(
             ITracer tracer,
-            FileBasedDictionary<string, string> lastPrefetchArgs,
+            FileBasedDictionary<string, string> prefetchCache,
             string commitId,
             List<string> files,
             List<string> folders,
             bool hydrateFilesAfterDownload)
         {
-            if (lastPrefetchArgs != null &&
-                lastPrefetchArgs.TryGetValue(PrefetchArgs.CommitId, out string lastCommitId) &&
-                lastPrefetchArgs.TryGetValue(PrefetchArgs.Files, out string lastFilesString) &&
-                lastPrefetchArgs.TryGetValue(PrefetchArgs.Folders, out string lastFoldersString) &&
-                lastPrefetchArgs.TryGetValue(PrefetchArgs.Hydrate, out string lastHydrateString))
+            if (prefetchCache != null)
             {
-                string newFilesString = GVFSJsonOptions.Serialize(files);
-                string newFoldersString = GVFSJsonOptions.Serialize(folders);
-                bool isNoop =
-                    commitId == lastCommitId &&
-                    hydrateFilesAfterDownload.ToString() == lastHydrateString &&
-                    newFilesString == lastFilesString &&
-                    newFoldersString == lastFoldersString;
+                string cacheKey = ComputeCacheKey(files, folders, hydrateFilesAfterDownload);
+                bool hasEntry = prefetchCache.TryGetValue(cacheKey, out string cachedCommitId);
+                bool isNoop = hasEntry && commitId == cachedCommitId;
 
                 tracer.RelatedEvent(
                     EventLevel.Informational,
                     "BlobPrefetcher.IsNoopPrefetch",
                     new EventMetadata
                     {
-                        { "Last" + PrefetchArgs.CommitId, lastCommitId },
-                        { "Last" + PrefetchArgs.Files, lastFilesString },
-                        { "Last" + PrefetchArgs.Folders, lastFoldersString },
-                        { "Last" + PrefetchArgs.Hydrate, lastHydrateString },
-                        { "New" + PrefetchArgs.CommitId, commitId },
-                        { "New" + PrefetchArgs.Files, newFilesString },
-                        { "New" + PrefetchArgs.Folders, newFoldersString },
-                        { "New" + PrefetchArgs.Hydrate, hydrateFilesAfterDownload.ToString() },
+                        { "CacheKey", cacheKey },
+                        { "CachedCommitId", cachedCommitId ?? "(none)" },
+                        { "NewCommitId", commitId },
                         { "Result", isNoop },
                     });
 
@@ -580,17 +577,42 @@ namespace GVFS.Common.Prefetch
 
         private void SavePrefetchArgs(string targetCommit, bool hydrate)
         {
-            if (this.lastPrefetchArgs != null)
+            if (this.prefetchCache != null && this.maxCacheSize > 0)
             {
-                this.lastPrefetchArgs.SetValuesAndFlush(
-                    new[]
+                string cacheKey = ComputeCacheKey(this.FileList, this.FolderList, hydrate);
+
+                Dictionary<string, string> allEntries = this.prefetchCache.GetAllKeysAndValues();
+                if (allEntries.Count >= this.maxCacheSize && !allEntries.ContainsKey(cacheKey))
+                {
+                    // Evict one arbitrary entry to make room
+                    using (Dictionary<string, string>.Enumerator enumerator = allEntries.GetEnumerator())
                     {
-                        new KeyValuePair<string, string>(PrefetchArgs.CommitId, targetCommit),
-                        new KeyValuePair<string, string>(PrefetchArgs.Files, GVFSJsonOptions.Serialize(this.FileList)),
-                        new KeyValuePair<string, string>(PrefetchArgs.Folders, GVFSJsonOptions.Serialize(this.FolderList)),
-                        new KeyValuePair<string, string>(PrefetchArgs.Hydrate, hydrate.ToString()),
-                    });
+                        if (enumerator.MoveNext())
+                        {
+                            this.prefetchCache.RemoveAndFlush(enumerator.Current.Key);
+                        }
+                    }
+                }
+
+                this.prefetchCache.SetValueAndFlush(cacheKey, targetCommit);
             }
+        }
+
+        internal static string ComputeCacheKey(List<string> files, List<string> folders, bool hydrate)
+        {
+            List<string> sortedFiles = new List<string>(files);
+            sortedFiles.Sort(StringComparer.Ordinal);
+
+            List<string> sortedFolders = new List<string>(folders);
+            sortedFolders.Sort(StringComparer.Ordinal);
+
+            string compositeInput = string.Join("\n",
+                GVFSJsonOptions.Serialize(sortedFiles),
+                GVFSJsonOptions.Serialize(sortedFolders),
+                hydrate.ToString());
+
+            byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(compositeInput));
+            return Convert.ToHexString(hashBytes);
         }
 
         public class FetchException : Exception
@@ -599,14 +621,6 @@ namespace GVFS.Common.Prefetch
                 : base(string.Format(format, args))
             {
             }
-        }
-
-        private static class PrefetchArgs
-        {
-            public const string CommitId = "CommitId";
-            public const string Files = "Files";
-            public const string Folders = "Folders";
-            public const string Hydrate = "Hydrate";
         }
     }
 }

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/PrefetchVerbTests.cs
@@ -37,6 +37,16 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem = new SystemIORunner();
         }
 
+        [SetUp]
+        public void DeletePrefetchCache()
+        {
+            string cachePath = Path.Combine(this.Enlistment.DotGVFSRoot, "BlobPrefetchCache.dat");
+            if (File.Exists(cachePath))
+            {
+                File.Delete(cachePath);
+            }
+        }
+
         [TestCase, Order(1)]
         public void PrefetchAllMustBeExplicit()
         {

--- a/GVFS/GVFS.UnitTests/Prefetch/BlobPrefetcherTests.cs
+++ b/GVFS/GVFS.UnitTests/Prefetch/BlobPrefetcherTests.cs
@@ -1,7 +1,11 @@
-﻿using GVFS.Common.Prefetch;
+﻿using GVFS.Common;
+using GVFS.Common.Prefetch;
 using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock;
+using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.FileSystem;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 
 namespace GVFS.UnitTests.Prefetch
@@ -9,6 +13,8 @@ namespace GVFS.UnitTests.Prefetch
     [TestFixture]
     public class BlobPrefetcherTests
     {
+        private const string MockCacheFileName = "mock:\\prefetch-cache.dat";
+
         [TestCase]
         public void AppendToNewlineSeparatedFileTests()
         {
@@ -28,6 +34,208 @@ namespace GVFS.UnitTests.Prefetch
             fileSystem.WriteAllText(testFileName, "existing content\n");
             BlobPrefetcher.AppendToNewlineSeparatedFile(fileSystem, testFileName, "expected line 2");
             fileSystem.ReadAllText(testFileName).ShouldEqual("existing content\nexpected line 2\n");
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyIsDeterministic()
+        {
+            List<string> files = new List<string> { "src/a.cs", "src/b.cs" };
+            List<string> folders = new List<string> { "src/dir1", "src/dir2" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: false);
+
+            key1.ShouldEqual(key2);
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyDiffersForDifferentFiles()
+        {
+            List<string> files1 = new List<string> { "src/a.cs" };
+            List<string> files2 = new List<string> { "src/b.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(files1, folders, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(files2, folders, hydrate: false);
+
+            key1.ShouldNotEqual(key2);
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyDiffersForDifferentFolders()
+        {
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders1 = new List<string> { "src/dir1" };
+            List<string> folders2 = new List<string> { "src/dir2" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(files, folders1, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(files, folders2, hydrate: false);
+
+            key1.ShouldNotEqual(key2);
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyDiffersForHydrateFlag()
+        {
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: true);
+
+            key1.ShouldNotEqual(key2);
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyIsOrderIndependent()
+        {
+            List<string> filesA = new List<string> { "src/b.cs", "src/a.cs" };
+            List<string> filesB = new List<string> { "src/a.cs", "src/b.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(filesA, folders, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(filesB, folders, hydrate: false);
+
+            key1.ShouldEqual(key2);
+        }
+
+        [TestCase]
+        public void ComputeCacheKeyFolderOrderIndependent()
+        {
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> foldersA = new List<string> { "src/dir2", "src/dir1" };
+            List<string> foldersB = new List<string> { "src/dir1", "src/dir2" };
+
+            string key1 = BlobPrefetcher.ComputeCacheKey(files, foldersA, hydrate: false);
+            string key2 = BlobPrefetcher.ComputeCacheKey(files, foldersB, hydrate: false);
+
+            key1.ShouldEqual(key2);
+        }
+
+        [TestCase]
+        public void IsNoopPrefetchReturnsFalseWhenCacheIsNull()
+        {
+            MockTracer tracer = new MockTracer();
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+
+            BlobPrefetcher.IsNoopPrefetch(tracer, null, "abc123", files, folders, false).ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void IsNoopPrefetchReturnsFalseWhenCacheIsEmpty()
+        {
+            MockTracer tracer = new MockTracer();
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+            FileBasedDictionary<string, string> cache = CreateEmptyCache();
+
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, "abc123", files, folders, false).ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void IsNoopPrefetchReturnsTrueOnCacheHit()
+        {
+            MockTracer tracer = new MockTracer();
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+            string commitId = "abc123";
+
+            FileBasedDictionary<string, string> cache = CreateEmptyCache();
+            string cacheKey = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: false);
+            cache.SetValueAndFlush(cacheKey, commitId);
+
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, commitId, files, folders, false).ShouldEqual(true);
+        }
+
+        [TestCase]
+        public void IsNoopPrefetchReturnsFalseWhenCommitIdChanged()
+        {
+            MockTracer tracer = new MockTracer();
+            List<string> files = new List<string> { "src/a.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+
+            FileBasedDictionary<string, string> cache = CreateEmptyCache();
+            string cacheKey = BlobPrefetcher.ComputeCacheKey(files, folders, hydrate: false);
+            cache.SetValueAndFlush(cacheKey, "oldcommit");
+
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, "newcommit", files, folders, false).ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void IsNoopPrefetchSupportsMultipleEntries()
+        {
+            MockTracer tracer = new MockTracer();
+            List<string> filesA = new List<string> { "src/a.cs" };
+            List<string> filesB = new List<string> { "src/b.cs" };
+            List<string> folders = new List<string> { "src/dir1" };
+            string commitId = "abc123";
+
+            FileBasedDictionary<string, string> cache = CreateEmptyCache();
+
+            string keyA = BlobPrefetcher.ComputeCacheKey(filesA, folders, hydrate: false);
+            cache.SetValueAndFlush(keyA, commitId);
+
+            string keyB = BlobPrefetcher.ComputeCacheKey(filesB, folders, hydrate: false);
+            cache.SetValueAndFlush(keyB, commitId);
+
+            // Both should hit
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, commitId, filesA, folders, false).ShouldEqual(true);
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, commitId, filesB, folders, false).ShouldEqual(true);
+
+            // A third pattern should miss
+            List<string> filesC = new List<string> { "src/c.cs" };
+            BlobPrefetcher.IsNoopPrefetch(tracer, cache, commitId, filesC, folders, false).ShouldEqual(false);
+        }
+
+        private static FileBasedDictionary<string, string> CreateEmptyCache()
+        {
+            CacheFileSystem fs = new CacheFileSystem();
+            fs.ExpectedFiles.Add(MockCacheFileName, new ReusableMemoryStream(string.Empty));
+            fs.ExpectedOpenFileStreams.Add(MockCacheFileName + ".tmp", new ReusableMemoryStream(string.Empty));
+            fs.ExpectedOpenFileStreams.Add(MockCacheFileName, fs.ExpectedFiles[MockCacheFileName]);
+
+            FileBasedDictionary<string, string>.TryCreate(
+                null,
+                MockCacheFileName,
+                fs,
+                out FileBasedDictionary<string, string> cache,
+                out string error).ShouldEqual(true, error);
+
+            fs.ExpectedOpenFileStreams.Remove(MockCacheFileName);
+            return cache;
+        }
+
+        private class CacheFileSystem : ConfigurableFileSystem
+        {
+            public CacheFileSystem()
+            {
+                this.ExpectedOpenFileStreams = new Dictionary<string, ReusableMemoryStream>();
+            }
+
+            public Dictionary<string, ReusableMemoryStream> ExpectedOpenFileStreams { get; }
+
+            public override Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare shareMode, FileOptions options, bool flushesToDisk)
+            {
+                this.ExpectedOpenFileStreams.TryGetValue(path, out ReusableMemoryStream stream);
+
+                if (fileMode == FileMode.Create)
+                {
+                    this.ExpectedFiles[path] = new ReusableMemoryStream(string.Empty);
+                }
+
+                this.ExpectedFiles.TryGetValue(path, out stream).ShouldEqual(true, "Unexpected access of file: " + path);
+                return stream;
+            }
+
+            public override void MoveAndOverwriteFile(string sourceFileName, string destinationFilename)
+            {
+                this.ExpectedFiles.TryGetValue(sourceFileName, out ReusableMemoryStream source).ShouldEqual(true, "Source file does not exist: " + sourceFileName);
+                this.ExpectedFiles.ContainsKey(destinationFilename).ShouldEqual(true, "MoveAndOverwriteFile expects the destination file to exist: " + destinationFilename);
+
+                this.ExpectedFiles.Remove(sourceFileName);
+                this.ExpectedFiles[destinationFilename] = source;
+            }
         }
     }
 }

--- a/GVFS/GVFS/CommandLine/PrefetchVerb.cs
+++ b/GVFS/GVFS/CommandLine/PrefetchVerb.cs
@@ -187,11 +187,12 @@ namespace GVFS.CommandLine
                         string headCommitId;
                         List<string> filesList;
                         List<string> foldersList;
-                        FileBasedDictionary<string, string> lastPrefetchArgs;
+                        FileBasedDictionary<string, string> prefetchCache;
+                        int prefetchCacheSize;
 
-                        this.LoadBlobPrefetchArgs(tracer, enlistment, out headCommitId, out filesList, out foldersList, out lastPrefetchArgs);
+                        this.LoadBlobPrefetchArgs(tracer, enlistment, out headCommitId, out filesList, out foldersList, out prefetchCache, out prefetchCacheSize);
 
-                        if (BlobPrefetcher.IsNoopPrefetch(tracer, lastPrefetchArgs, headCommitId, filesList, foldersList, this.HydrateFiles))
+                        if (BlobPrefetcher.IsNoopPrefetch(tracer, prefetchCache, headCommitId, filesList, foldersList, this.HydrateFiles))
                         {
                             Console.WriteLine("All requested files are already available. Nothing new to prefetch.");
                         }
@@ -205,7 +206,7 @@ namespace GVFS.CommandLine
                                 cacheServerFromConfig,
                                 out objectRequestor,
                                 out resolvedCacheServer);
-                            this.PrefetchBlobs(tracer, enlistment, headCommitId, filesList, foldersList, lastPrefetchArgs, objectRequestor, resolvedCacheServer);
+                            this.PrefetchBlobs(tracer, enlistment, headCommitId, filesList, foldersList, prefetchCache, prefetchCacheSize, objectRequestor, resolvedCacheServer);
                         }
                     }
                 }
@@ -328,18 +329,38 @@ namespace GVFS.CommandLine
             out string headCommitId,
             out List<string> filesList,
             out List<string> foldersList,
-            out FileBasedDictionary<string, string> lastPrefetchArgs)
+            out FileBasedDictionary<string, string> prefetchCache,
+            out int prefetchCacheSize)
         {
             string error;
 
-            if (!FileBasedDictionary<string, string>.TryCreate(
-                    tracer,
-                    Path.Combine(enlistment.DotGVFSRoot, "LastBlobPrefetch.dat"),
-                    new PhysicalFileSystem(),
-                    out lastPrefetchArgs,
-                    out error))
+            // Read cache size from git config
+            prefetchCacheSize = BlobPrefetcher.DefaultPrefetchCacheSize;
+            GitProcess gitProcess = new GitProcess(enlistment);
+            if (gitProcess.TryGetFromConfig(BlobPrefetcher.PrefetchCacheSizeConfigKey, forceOutsideEnlistment: false, out string cacheSizeValue))
             {
-                tracer.RelatedWarning("Unable to load last prefetch args: " + error);
+                if (int.TryParse(cacheSizeValue, out int parsedSize))
+                {
+                    prefetchCacheSize = Math.Clamp(parsedSize, 0, BlobPrefetcher.MaxPrefetchCacheSize);
+                }
+                else
+                {
+                    tracer.RelatedWarning($"Invalid value '{cacheSizeValue}' for {BlobPrefetcher.PrefetchCacheSizeConfigKey}, using default {BlobPrefetcher.DefaultPrefetchCacheSize}");
+                }
+            }
+
+            prefetchCache = null;
+            if (prefetchCacheSize > 0)
+            {
+                if (!FileBasedDictionary<string, string>.TryCreate(
+                        tracer,
+                        Path.Combine(enlistment.DotGVFSRoot, BlobPrefetcher.BlobPrefetchCacheFile),
+                        new PhysicalFileSystem(),
+                        out prefetchCache,
+                        out error))
+                {
+                    tracer.RelatedWarning("Unable to load prefetch cache: " + error);
+                }
             }
 
             filesList = new List<string>();
@@ -355,7 +376,6 @@ namespace GVFS.CommandLine
                 this.ReportErrorAndExit(tracer, error);
             }
 
-            GitProcess gitProcess = new GitProcess(enlistment);
             GitProcess.Result result = gitProcess.RevParse(GVFSConstants.DotGit.HeadName);
             if (result.ExitCodeIsFailure)
             {
@@ -371,7 +391,8 @@ namespace GVFS.CommandLine
             string headCommitId,
             List<string> filesList,
             List<string> foldersList,
-            FileBasedDictionary<string, string> lastPrefetchArgs,
+            FileBasedDictionary<string, string> prefetchCache,
+            int prefetchCacheSize,
             GitObjectsHttpRequestor objectRequestor,
             CacheServerInfo cacheServer)
         {
@@ -381,7 +402,8 @@ namespace GVFS.CommandLine
                 objectRequestor,
                 filesList,
                 foldersList,
-                lastPrefetchArgs,
+                prefetchCache,
+                prefetchCacheSize,
                 ChunkSize,
                 SearchThreadCount,
                 DownloadThreadCount,


### PR DESCRIPTION
## Summary

Replace the single-entry `LastBlobPrefetch.dat` cache with a multi-entry `BlobPrefetchCache.dat` that stores up to N entries (default 100), keyed by SHA256 hash of (files, folders, hydrate) and storing the commit ID.

## Problem

The most common blob prefetch use case cycles through ~3 different prefetch calls with different file/folder patterns. Since only 1 entry was cached, 2 of the 3 always missed and re-ran the full pipeline (diff + existence checks + downloads) even when nothing changed.

## Changes

- **`BlobPrefetcher.cs`**: Replace flat 4-key dictionary with hash-keyed multi-entry cache. Add `ComputeCacheKey` (canonical, order-independent SHA256 hashing) and single-entry eviction when at capacity.
- **`PrefetchVerb.cs`**: Read `gvfs.prefetch-cache-size` config (default 100, 0 disables, max 1000). Use `BlobPrefetchCache.dat` instead of `LastBlobPrefetch.dat`.
- **`BlobPrefetcherTests.cs`**: 12 unit tests covering key determinism, order independence, cache hit/miss, multi-entry support, and null/empty edge cases.

## Configuration

```
git config gvfs.prefetch-cache-size 100   # default
git config gvfs.prefetch-cache-size 0     # disable caching
```

## Backward Compatibility

`LastBlobPrefetch.dat` is simply ignored — the first prefetch after upgrade is a cache miss (acceptable).