### PR TITLE
Use git_odb_exists instead of git_revparse_single for ObjectExists

### DIFF
--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -115,6 +115,18 @@ namespace GVFS.Common.Git
         }
 
         /// <summary>
+        /// Checks whether the object can be fully parsed by libgit2 (not just that it exists).
+        /// Use this to detect corrupt objects. For simple existence checks,
+        /// prefer <see cref="ObjectExists"/> which is faster.
+        /// </summary>
+        public virtual bool ObjectCanBeParsed(string sha)
+        {
+            bool output = false;
+            this.libgit2RepoInvoker.TryInvoke(repo => repo.ObjectCanBeParsed(sha), out output);
+            return output;
+        }
+
+        /// <summary>
         /// Try to find the size of a given blob by SHA1 hash.
         ///
         /// Returns true iff the blob exists as a loose object.

--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -3,12 +3,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace GVFS.Common.Git
 {
     public class LibGit2Repo : IDisposable
     {
         private bool disposedValue = false;
+        private IntPtr odbHandle = IntPtr.Zero;
 
         public delegate void MultiVarConfigCallback(string value);
 
@@ -104,6 +106,55 @@ namespace GVFS.Common.Git
         }
 
         public virtual bool ObjectExists(string sha)
+        {
+            IntPtr odb = this.odbHandle;
+            if (odb == IntPtr.Zero)
+            {
+                if (Native.Odb.GetOdb(out IntPtr newOdb, this.RepoHandle) != Native.ResultCode.Success)
+                {
+                    return this.ObjectExistsFallback(sha);
+                }
+
+                IntPtr existing = Interlocked.CompareExchange(ref this.odbHandle, newOdb, IntPtr.Zero);
+                if (existing != IntPtr.Zero)
+                {
+                    // Another thread won the race — free our duplicate and use theirs
+                    Native.Odb.Free(newOdb);
+                    odb = existing;
+                }
+                else
+                {
+                    odb = newOdb;
+                }
+            }
+
+            GitOid oid;
+            if (Native.Odb.OidFromStr(out oid, sha) != Native.ResultCode.Success)
+            {
+                return false;
+            }
+
+            return Native.Odb.Exists(odb, ref oid) == 1;
+        }
+
+        private bool ObjectExistsFallback(string sha)
+        {
+            IntPtr objHandle;
+            if (Native.RevParseSingle(out objHandle, this.RepoHandle, sha) != Native.ResultCode.Success)
+            {
+                return false;
+            }
+
+            Native.Object.Free(objHandle);
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the object can be fully parsed by libgit2 (not just that it exists).
+        /// Use this when you need to detect corrupt objects. For simple existence checks,
+        /// prefer <see cref="ObjectExists"/> which is faster.
+        /// </summary>
+        public virtual bool ObjectCanBeParsed(string sha)
         {
             IntPtr objHandle;
             if (Native.RevParseSingle(out objHandle, this.RepoHandle, sha) != Native.ResultCode.Success)
@@ -360,6 +411,12 @@ namespace GVFS.Common.Git
         {
             if (!this.disposedValue)
             {
+                if (this.odbHandle != IntPtr.Zero)
+                {
+                    Native.Odb.Free(this.odbHandle);
+                    this.odbHandle = IntPtr.Zero;
+                }
+
                 Native.Repo.Free(this.RepoHandle);
                 Native.Shutdown();
                 this.disposedValue = true;
@@ -502,6 +559,22 @@ namespace GVFS.Common.Git
 
                 [DllImport(Git2NativeLibName, EntryPoint = "git_repository_free")]
                 public static extern void Free(IntPtr repoHandle);
+            }
+
+            public static class Odb
+            {
+                [DllImport(Git2NativeLibName, EntryPoint = "git_repository_odb")]
+                public static extern ResultCode GetOdb(out IntPtr odbHandle, IntPtr repoHandle);
+
+                /// <returns>1 if the object exists, 0 otherwise</returns>
+                [DllImport(Git2NativeLibName, EntryPoint = "git_odb_exists")]
+                public static extern int Exists(IntPtr odbHandle, ref GitOid id);
+
+                [DllImport(Git2NativeLibName, EntryPoint = "git_odb_free")]
+                public static extern void Free(IntPtr odbHandle);
+
+                [DllImport(Git2NativeLibName, EntryPoint = "git_oid_fromstr")]
+                public static extern ResultCode OidFromStr(out GitOid oid, string str);
             }
 
             public static class Config

--- a/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/LooseObjectsStep.cs
@@ -172,7 +172,7 @@ namespace GVFS.Common.Maintenance
             // may be more bad objects in the next batch after deleting the corrupt objects.
             foreach (string objectId in this.GetBatchOfLooseObjects(2 * this.MaxLooseObjectsInPack))
             {
-                if (!this.Context.Repository.ObjectExists(objectId))
+                if (!this.Context.Repository.ObjectCanBeParsed(objectId))
                 {
                     string objectFile = this.GetLooseObjectFileName(objectId);
 

--- a/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
+++ b/GVFS/GVFS.Common/Prefetch/BlobPrefetcher.cs
@@ -476,7 +476,10 @@ namespace GVFS.Common.Prefetch
             {
                 using (LibGit2Repo repo = new LibGit2Repo(this.Tracer, this.Enlistment.WorkingDirectoryBackingRoot))
                 {
-                    if (!repo.ObjectExists(commitSha))
+                    // Use ObjectCanBeParsed (revparse) rather than ObjectExists (odb_exists)
+                    // because commitSha may be a ref name or abbreviated SHA from CLI input
+                    // (e.g. FastFetch --commit), not necessarily a full 40-char hex SHA.
+                    if (!repo.ObjectCanBeParsed(commitSha))
                     {
                         if (!gitObjects.TryDownloadCommit(commitSha))
                         {


### PR DESCRIPTION
## Summary

Replaces the heavyweight `git_revparse_single` call in `LibGit2Repo.ObjectExists` with `git_odb_exists`, a purpose-built existence check that skips revparse expression parsing and `git_object` handle allocation.

### Benchmark (os.2020 enlistment, 59.7M objects, 14 packs)

| Scenario | Before (revparse) | After (odb_exists) | Speedup |
|----------|-------------------|-------------------|---------|
| Existing objects | ~800 ns/op | ~800 ns/op | ~1x |
| Missing objects | 2,800,000 ns/op | 1,320,000 ns/op | **2.1x** |

### Implementation

- Add P/Invoke bindings for `git_repository_odb`, `git_odb_exists`, `git_odb_free`, `git_oid_fromstr`
- ODB handle lazily acquired on first `ObjectExists` call, freed in `Dispose`
- Thread-safe lazy init via `Interlocked.CompareExchange` -- if two threads race on the first call, the loser frees its duplicate handle
- Falls back to `git_revparse_single` if ODB handle acquisition fails

### Full-SHA requirement and caller audit

`git_odb_exists` + `git_oid_fromstr` requires a full 40-character hex SHA (unlike `git_revparse_single` which also resolves refs and abbreviated SHAs). All callers were audited:

| Caller | Input source | Full SHA? | Action |
|--------|-------------|-----------|--------|
| `FindBlobsStage` | Blob SHAs from diff output | Yes | Uses `ObjectExists` |
| `EnumerateMissingTreeEntries` | `GitOid.ToString()` | Yes | Uses `ObjectExists` |
| `CommitAndRootTreeExists` | Tree SHA from `GitOid.ToString()` (commitish resolved via `GetTreeSha` which still uses revparse) | Yes | Uses `ObjectExists` |
| `GVFSVerb` (gitattributes) | `DiffTreeResult.TargetSha` from ls-tree | Yes | Uses `ObjectExists` |
| `GVFSVerb.TryDownloadCommit` | `refs.GetTipCommitId()` (CloneVerb), `git rev-parse HEAD` output (DehydrateVerb) | Yes | Uses `CommitAndRootTreeExists` |
| `InProcessMount` | Object SHA from download pipe | Yes | Uses `CommitAndRootTreeExists` |
| `LibGit2RepoInvoker.InitializeSharedRepo` | Hardcoded 40-char SHA | Yes | Uses `ObjectExists` |
| **`BlobPrefetcher.DownloadMissingCommit`** | **Raw `--commit` CLI arg from FastFetch (may be ref or abbreviated SHA)** | **No** | **Switched to `ObjectCanBeParsed`** |
| `LooseObjectsStep.ClearCorruptLooseObjects` | Loose object file names | Yes (but needs parse validation) | Switched to `ObjectCanBeParsed` |

### Semantic split: ObjectExists vs ObjectCanBeParsed

`git_odb_exists` only checks whether an OID is present in the object store -- it does not decompress or validate the object, and it requires a full 40-char hex SHA. Two callers need the old `git_revparse_single` behavior:

1. **`LooseObjectsStep.ClearCorruptLooseObjects`** -- needs corruption detection (revparse fails on corrupt objects, `odb_exists` does not)
2. **`BlobPrefetcher.DownloadMissingCommit`** -- receives raw CLI input that may be a ref name or abbreviated SHA

For these callers, `ObjectCanBeParsed(sha)` retains the old revparse path.

| Method | Implementation | Use case |
|--------|---------------|----------|
| `ObjectExists` | `git_odb_exists` (fast) | Existence checks with full 40-char SHAs |
| `ObjectCanBeParsed` | `git_revparse_single` (slow but resolves refs and validates) | Corruption detection, non-SHA input |

### Files changed

- `LibGit2Repo.cs` -- new P/Invokes, `ObjectExists` uses `git_odb_exists`, new `ObjectCanBeParsed`, thread-safe lazy ODB init
- `GitRepo.cs` -- expose `ObjectCanBeParsed` through the invoker
- `LooseObjectsStep.cs` -- call `ObjectCanBeParsed` instead of `ObjectExists`
- `BlobPrefetcher.cs` -- `DownloadMissingCommit` calls `ObjectCanBeParsed` instead of `ObjectExists`
