### PR TITLE
Fix repair of corrupt BlobSizes.sql and mount tolerance

### DIFF
--- a/GVFS/GVFS.Common/Database/SqliteDatabase.cs
+++ b/GVFS/GVFS.Common/Database/SqliteDatabase.cs
@@ -21,7 +21,7 @@ namespace GVFS.Common.Database
 
                 try
                 {
-                    string sqliteConnectionString = CreateConnectionString(databasePath);
+                    string sqliteConnectionString = $"data source={databasePath};Pooling=False";
                     using (SqliteConnection integrityConnection = new SqliteConnection(sqliteConnectionString))
                     {
                         integrityConnection.Open();

--- a/GVFS/GVFS.Common/Database/SqliteErrorCodes.cs
+++ b/GVFS/GVFS.Common/Database/SqliteErrorCodes.cs
@@ -1,0 +1,15 @@
+namespace GVFS.Common.Database
+{
+    /// <summary>
+    /// SQLite result codes used for error classification.
+    /// See https://www.sqlite.org/rescode.html
+    /// </summary>
+    public static class SqliteErrorCodes
+    {
+        /// <summary>SQLITE_CORRUPT (11) — database disk image is malformed</summary>
+        public const int Corrupt = 11;
+
+        /// <summary>SQLITE_NOTADB (26) — file is not a database</summary>
+        public const int NotADatabase = 26;
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -60,7 +60,6 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         [TestCase]
-        [SkipInCI("Product bug: repair does not fully restore corrupt BlobSizes.sql — mount crashes after repair")]
         public void RepairFixesCorruptBlobSizesDatabase()
         {
             GVFSFunctionalTestEnlistment enlistment = this.CloneAndMountEnlistment();
@@ -74,9 +73,12 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
             blobSizesDbPath.ShouldBeAFile(this.fileSystem);
             this.fileSystem.WriteAllText(blobSizesDbPath, "0000");
 
-            // GVFS now tolerates corrupt blob sizes DB on mount (recreates
-            // in-memory), but repair should still fix the underlying file.
+            // Repair should detect and fix the corrupt database
             enlistment.Repair(confirm: true);
+
+            // Verify repair actually cleaned up the corrupt file
+            blobSizesRoot.ShouldNotExistOnDisk(this.fileSystem);
+
             enlistment.MountGVFS();
         }
 

--- a/GVFS/GVFS.Virtualization/BlobSize/BlobSizes.cs
+++ b/GVFS/GVFS.Virtualization/BlobSize/BlobSizes.cs
@@ -54,6 +54,54 @@ namespace GVFS.Virtualization.BlobSize
             string folderPath = Path.GetDirectoryName(this.databasePath);
             this.fileSystem.CreateDirectory(folderPath);
 
+            try
+            {
+                this.InitializeDatabase();
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == SqliteErrorCodes.Corrupt || ex.SqliteErrorCode == SqliteErrorCodes.NotADatabase)
+            {
+                EventMetadata metadata = this.CreateEventMetadata(ex);
+                metadata.Add("SqliteErrorCode", ex.SqliteErrorCode);
+                this.tracer.RelatedWarning(metadata, $"{nameof(BlobSizes)}.{nameof(this.Initialize)}: database corrupt, deleting and recreating");
+
+                SqliteConnection.ClearAllPools();
+                this.DeleteDatabaseFiles();
+                this.InitializeDatabase();
+            }
+
+            this.flushDataThread = new Thread(this.FlushDbThreadMain);
+            this.flushDataThread.IsBackground = true;
+            this.flushDataThread.Start();
+        }
+
+        public virtual void Shutdown()
+        {
+            this.isStopping = true;
+            this.wakeUpFlushThread.Set();
+            this.flushDataThread.Join();
+        }
+
+        public virtual void AddSize(Sha1Id sha, long size)
+        {
+            this.queuedSizes.Enqueue(new BlobSize(sha, size));
+        }
+
+        public virtual void Flush()
+        {
+            this.wakeUpFlushThread.Set();
+        }
+
+        public void Dispose()
+        {
+            if (this.wakeUpFlushThread != null)
+            {
+                this.wakeUpFlushThread.Dispose();
+                this.wakeUpFlushThread = null;
+            }
+        }
+
+        private void InitializeDatabase()
+        {
             using (SqliteConnection connection = new SqliteConnection(this.sqliteConnectionString))
             {
                 connection.Open();
@@ -125,36 +173,13 @@ namespace GVFS.Virtualization.BlobSize
                     createTableCommand.ExecuteNonQuery();
                 }
             }
-
-            this.flushDataThread = new Thread(this.FlushDbThreadMain);
-            this.flushDataThread.IsBackground = true;
-            this.flushDataThread.Start();
         }
 
-        public virtual void Shutdown()
+        private void DeleteDatabaseFiles()
         {
-            this.isStopping = true;
-            this.wakeUpFlushThread.Set();
-            this.flushDataThread.Join();
-        }
-
-        public virtual void AddSize(Sha1Id sha, long size)
-        {
-            this.queuedSizes.Enqueue(new BlobSize(sha, size));
-        }
-
-        public virtual void Flush()
-        {
-            this.wakeUpFlushThread.Set();
-        }
-
-        public void Dispose()
-        {
-            if (this.wakeUpFlushThread != null)
-            {
-                this.wakeUpFlushThread.Dispose();
-                this.wakeUpFlushThread = null;
-            }
+            this.fileSystem.TryDeleteFile(this.databasePath);
+            this.fileSystem.TryDeleteFile(this.databasePath + "-wal");
+            this.fileSystem.TryDeleteFile(this.databasePath + "-shm");
         }
 
         private void FlushDbThreadMain()


### PR DESCRIPTION
## Summary

Fix `gvfs repair --confirm` failing to delete corrupt BlobSizes.sql on Windows, and add defense-in-depth so mount tolerates corruption.

**Stacked on #1997**

## Root Cause

`SqliteDatabase.HasIssue()` opened a pooled SQLite connection for the integrity check. On Windows, disposing the connection returned the handle to the pool but kept the file locked. When repair tried to delete the corrupt folder, `TryDeleteFolder` failed silently (repair still exited 0). The corrupt file remained, causing mount to crash with a broken pipe.

## Changes

1. **`SqliteDatabase.HasIssue`** — Use `Pooling=False` for integrity-check connections so handles are released on dispose.
2. **`BlobSizes.Initialize`** — Catch `SQLITE_CORRUPT`/`SQLITE_NOTADB`, call `ClearAllPools()`, delete corrupt DB + WAL/SHM sidecars, recreate fresh. BlobSizes is a cache, so recreation is safe.
3. **`SqliteErrorCodes.cs`** — New constants for SQLite result codes.
4. **Test** — Remove `[SkipInCI]` from `RepairFixesCorruptBlobSizesDatabase`, add assertion that repair deletes the blob sizes folder.