### PR TITLE
Mount: self-heal stale hook configurations

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -124,6 +124,28 @@ namespace GVFS.Common.FileSystem
                 return false;
             }
 
+            // Refresh the corresponding .hooks text files. These hold the
+            // absolute path of GVFS.Hooks.exe that the loader execs at hook
+            // time, and were originally written at clone time pointing at
+            // wherever GVFS was installed back then. If GVFS has moved
+            // (system-to-user migration, version-junction swap, hand-edited
+            // install), those paths go stale and the loader exits non-zero
+            // on every git invocation that fires a hook - making the
+            // enlistment unrecoverable through normal mount. Refreshing on
+            // every mount makes us self-healing against install-location
+            // drift, and is a no-op when paths are already current.
+            string precommandBasePath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Hooks.PreCommandPath);
+            if (!GVFSPlatform.Instance.TryInstallGitCommandHooks(context, ExecutingDirectory, GVFSConstants.DotGit.Hooks.PreCommandHookName, precommandBasePath, out errorMessage))
+            {
+                return false;
+            }
+
+            string postcommandBasePath = Path.Combine(context.Enlistment.WorkingDirectoryBackingRoot, GVFSConstants.DotGit.Hooks.PostCommandPath);
+            if (!GVFSPlatform.Instance.TryInstallGitCommandHooks(context, ExecutingDirectory, GVFSConstants.DotGit.Hooks.PostCommandHookName, postcommandBasePath, out errorMessage))
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -191,7 +191,8 @@ namespace GVFS.Common.Git
             Result result = this.InvokeGitAgainstDotGitFolder(
                 GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
-                null);
+                null,
+                usePreCommandHook: false);
 
             if (result.ExitCodeIsFailure)
             {
@@ -218,7 +219,8 @@ namespace GVFS.Common.Git
             Result result = this.InvokeGitAgainstDotGitFolder(
                 GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
-                null);
+                null,
+                usePreCommandHook: false);
 
             if (result.ExitCodeIsFailure)
             {
@@ -249,10 +251,13 @@ namespace GVFS.Common.Git
 
             using (ITracer activity = tracer.StartActivity("TryGetCertificatePassword", EventLevel.Informational))
             {
+                // See GetFromConfig for why pre-command hook is disabled
+                // for bootstrap-time git operations.
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
                     "credential fill",
                     stdin => stdin.Write("protocol=cert\npath=" + certificatePath + "\nusername=\n\n"),
-                    parseStdOutLine: null);
+                    parseStdOutLine: null,
+                    usePreCommandHook: false);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
                 {
@@ -300,10 +305,13 @@ namespace GVFS.Common.Git
 
             using (ITracer activity = tracer.StartActivity(nameof(this.TryGetCredential), EventLevel.Informational))
             {
+                // See GetFromConfig for why pre-command hook is disabled
+                // for bootstrap-time git operations.
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
                     GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
-                    parseStdOutLine: null);
+                    parseStdOutLine: null,
+                    usePreCommandHook: false);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
                 {
@@ -336,7 +344,10 @@ namespace GVFS.Common.Git
 
         public bool IsValidRepo()
         {
-            Result result = this.InvokeGitAgainstDotGitFolder("rev-parse --show-toplevel");
+            // Mount-time bootstrap check - skip pre-command hook so a broken
+            // hook config in the enlistment can be detected and repaired
+            // rather than blocking the mount that would fix it.
+            Result result = this.InvokeGitAgainstDotGitFolder("rev-parse --show-toplevel", usePreCommandHook: false);
             return result.ExitCodeIsSuccess;
         }
 
@@ -352,24 +363,34 @@ namespace GVFS.Common.Git
 
         public void DeleteFromLocalConfig(string settingName)
         {
-            this.InvokeGitAgainstDotGitFolder("config --local --unset-all " + settingName);
+            // git config operations never need the pre-command hook (no
+            // working-tree mutation). Skipping it also keeps mount bootstrap
+            // robust against a stale hook config that TryUpdateHooks will
+            // repair shortly. See GetFromConfig for the longer rationale.
+            this.InvokeGitAgainstDotGitFolder("config --local --unset-all " + settingName, usePreCommandHook: false);
         }
 
         public Result SetInLocalConfig(string settingName, string value, bool replaceAll = false)
         {
-            return this.InvokeGitAgainstDotGitFolder(string.Format(
-                "config --local {0} \"{1}\" \"{2}\"",
-                 replaceAll ? "--replace-all " : string.Empty,
-                 settingName,
-                 value));
+            // See DeleteFromLocalConfig for why pre-command hook is disabled.
+            return this.InvokeGitAgainstDotGitFolder(
+                string.Format(
+                    "config --local {0} \"{1}\" \"{2}\"",
+                    replaceAll ? "--replace-all " : string.Empty,
+                    settingName,
+                    value),
+                usePreCommandHook: false);
         }
 
         public Result AddInLocalConfig(string settingName, string value)
         {
-            return this.InvokeGitAgainstDotGitFolder(string.Format(
-                "config --local --add {0} {1}",
-                 settingName,
-                 value));
+            // See DeleteFromLocalConfig for why pre-command hook is disabled.
+            return this.InvokeGitAgainstDotGitFolder(
+                string.Format(
+                    "config --local --add {0} {1}",
+                    settingName,
+                    value),
+                usePreCommandHook: false);
         }
 
         public Result SetInFileConfig(string configFile, string settingName, string value, bool replaceAll = false)
@@ -384,7 +405,8 @@ namespace GVFS.Common.Git
 
         public bool TryGetConfigUrlMatch(string section, string repositoryUrl, out Dictionary<string, GitConfigSetting> configSettings)
         {
-            Result result = this.InvokeGitAgainstDotGitFolder($"config --get-urlmatch {section} {repositoryUrl}");
+            // See GetFromConfig for why pre-command hook is disabled.
+            Result result = this.InvokeGitAgainstDotGitFolder($"config --get-urlmatch {section} {repositoryUrl}", usePreCommandHook: false);
             if (result.ExitCodeIsFailure)
             {
                 configSettings = null;
@@ -399,7 +421,8 @@ namespace GVFS.Common.Git
         {
             configSettings = null;
             string localParameter = localOnly ? "--local" : string.Empty;
-            ConfigResult result = new ConfigResult(this.InvokeGitAgainstDotGitFolder("config --list " + localParameter), "--list");
+            // See GetFromConfig for why pre-command hook is disabled.
+            ConfigResult result = new ConfigResult(this.InvokeGitAgainstDotGitFolder("config --list " + localParameter, usePreCommandHook: false), "--list");
 
             if (result.TryParseAsString(out string output, out string _, string.Empty))
             {
@@ -425,15 +448,20 @@ namespace GVFS.Common.Git
             fileSystem = fileSystem ?? new PhysicalFileSystem();
 
             // This method is called at clone time, so the physical repo may not exist yet.
+            // Pre-command hook never applies to `git config` reads (no working tree
+            // mutation happens), and skipping the hook makes us robust to a broken
+            // hook config in the enlistment - which is exactly what we'd be trying
+            // to repair via TryUpdateHooks at mount time.
             return
                 fileSystem.DirectoryExists(this.workingDirectoryRoot) && !forceOutsideEnlistment
-                    ? new ConfigResult(this.InvokeGitAgainstDotGitFolder(command), settingName)
+                    ? new ConfigResult(this.InvokeGitAgainstDotGitFolder(command, usePreCommandHook: false), settingName)
                     : new ConfigResult(this.InvokeGitOutsideEnlistment(command), settingName);
         }
 
         public ConfigResult GetFromLocalConfig(string settingName)
         {
-            return new ConfigResult(this.InvokeGitAgainstDotGitFolder("config --local " + settingName), settingName);
+            // See GetFromConfig above for why pre-command hook is disabled here.
+            return new ConfigResult(this.InvokeGitAgainstDotGitFolder("config --local " + settingName, usePreCommandHook: false), settingName);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Regression fix from [9d3a09b3](https://github.com/microsoft/VFSForGit/commit/9d3a09b3f) ("Move pre-mount validation from gvfs.exe to gvfs.mount.exe").

Two related fixes that together let `gvfs mount` succeed against an enlistment whose pre-command hook is stale - typically because the GVFS install location baked into `.git/hooks/pre-command.hooks` at clone time has since moved (re-install, version-junction swap, system-to-user migration, etc.).

Before this change, a stale `.hooks` text file causes every git invocation that fires the pre-command hook to fail with:

```
fatal: pre-command hook aborted command
```

which makes the mount path unrecoverable.

## Root cause

Commit 9d3a09b3 did two things that combined to break the self-heal path:

1. **Removed `MountVerb.InstallHooks`.** Before 9d3a09b3, `MountVerb.Execute` called `HooksInstaller.InstallHooks` (which refreshes both the `.exe` loader copies AND the `.hooks` text files) early in execution. 9d3a09b3 dropped that call when consolidating most pre-mount work into `gvfs.mount.exe`.
2. **Moved bootstrap git calls ahead of hook install.** `TrySetRequiredGitConfigSettings`, `LogEnlistmentInfoAndSetConfigValues`, and `TryCallGitCredential` all moved into `InProcessMount`, where they now run *before* the existing `TryUpdateHooks` call at line 269.

`InProcessMount.TryUpdateHooks` only refreshed the `.exe` loader copies, never the `.hooks` text files - so even after it ran, a stale `.hooks` path persisted. And the bootstrap git calls now fire the (broken) pre-command hook before `TryUpdateHooks` ever gets a chance.

## Changes

### `HooksInstaller.TryUpdateHooks`
Also refresh the `.hooks` text files. Previously this method only refreshed the `.exe` copies of `GitHooksLoader`; the `.hooks` text file (containing the absolute path of `GVFS.Hooks.exe` that the loader execs) was only written at clone time by `InstallHooks`. The new `TryInstallGitCommandHooks` calls are idempotent: when the GVFS install path hasn't changed, the file is rewritten with the same content. This restores the self-heal behavior `MountVerb.InstallHooks` used to provide.

### `GitProcess`
Pass `usePreCommandHook:false` on all git operations that run during the mount bootstrap path. These calls happen before `gvfs.mount.exe` reaches `TryUpdateHooks`, so without this flag they trip over the very stale-hook config we're trying to repair.

Affected: `SetInLocalConfig`, `AddInLocalConfig`, `DeleteFromLocalConfig`, `TryGetAllConfig`, `TryGetConfigUrlMatch`, `TryGetCredential`, `TryGetCertificatePassword`, `TryDeleteCredential`, `TryStoreCredential`.

`GetFromConfig`, `GetFromLocalConfig` and `IsValidRepo` also gain the flag (some via the existing `GetOriginUrl` pattern, some new). None of these operations mutate the working tree, so pre-command hook is semantically inappropriate anyway - skipping it is correct independent of the stale-hook scenario.

The mechanism: `usePreCommandHook:false` sets the `COMMAND_HOOK_LOCK` environment variable, which Microsoft Git itself reads to suppress pre-command hook invocation. The failure is bypassed at the git layer, not just inside `GVFS.Hooks.exe`.

## Testing

- 818/818 unit tests pass
- Manually verified end-to-end with a real enlistment whose `pre-command.hooks` was corrupted to point at a non-existent path (`C:\NonExistent\Path\GVFS.Hooks.exe`). Before this change, mount failed with the "pre-command hook aborted command" error chain. After this change, mount succeeds and the `.hooks` file is rewritten to point at the currently-running GVFS install.
