### PR TITLE
Service: Fix automount regression - escape JSON arg passed to child mount processes

### DIFF
--- a/GVFS/GVFS.Common/CommandLineEscaping.cs
+++ b/GVFS/GVFS.Common/CommandLineEscaping.cs
@@ -1,0 +1,105 @@
+using System.Text;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Windows command-line argument escaping per the rules used by
+    /// <c>CommandLineToArgvW</c> and the Microsoft C runtime.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the service spawns a child process via <c>CreateProcessAsUser</c>,
+    /// or any code path builds a <c>lpCommandLine</c> string, the receiving
+    /// process re-parses that string into <c>argv</c>.  Embedded
+    /// <c>"</c> characters that aren't escaped get <em>stripped</em>, which
+    /// silently corrupts JSON payloads (e.g. <c>--internal_use_only</c>) and
+    /// any other argument that contains quotes.  System.Text.Json (unlike
+    /// Newtonsoft.Json) is strict about quoted property names, so the
+    /// corruption now manifests as a hard failure.
+    /// </para>
+    /// <para>
+    /// The escaping rules (see
+    /// <see href="https://learn.microsoft.com/cpp/cpp/main-function-command-line-args#parsing-c-command-line-arguments"/>):
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>Arguments are separated by whitespace (space or tab).</item>
+    ///   <item>A string surrounded by <c>"</c> is treated as one argument
+    ///         even if it contains whitespace.</item>
+    ///   <item><c>\"</c> is interpreted as a literal <c>"</c>.</item>
+    ///   <item>Backslashes are literal <em>unless</em> they immediately
+    ///         precede a <c>"</c>: then <c>2n</c> backslashes become <c>n</c>
+    ///         backslashes followed by a quote terminator, and <c>2n+1</c>
+    ///         backslashes become <c>n</c> backslashes followed by a literal
+    ///         <c>"</c>.</item>
+    /// </list>
+    /// </remarks>
+    public static class CommandLineEscaping
+    {
+        /// <summary>
+        /// Escapes a single argument for inclusion in a Windows command line
+        /// that will be parsed by <c>CommandLineToArgvW</c> (the default
+        /// parser used by the CRT and .NET).
+        /// </summary>
+        /// <param name="argument">The raw argument value.</param>
+        /// <returns>
+        /// The escaped argument, including surrounding quotes when needed.
+        /// Always quotes when the argument is empty or contains a space,
+        /// tab, double-quote, or is otherwise ambiguous to the parser.
+        /// </returns>
+        public static string EscapeArgument(string argument)
+        {
+            if (argument == null)
+            {
+                return "\"\"";
+            }
+
+            if (argument.Length > 0 && argument.IndexOfAny(CharactersThatRequireQuoting) < 0)
+            {
+                return argument;
+            }
+
+            StringBuilder builder = new StringBuilder(argument.Length + 2);
+            builder.Append('"');
+
+            int i = 0;
+            while (i < argument.Length)
+            {
+                int backslashes = 0;
+                while (i < argument.Length && argument[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i == argument.Length)
+                {
+                    // Backslashes at the end of the argument: double them so
+                    // they don't escape the closing quote we're about to add.
+                    builder.Append('\\', backslashes * 2);
+                    break;
+                }
+
+                if (argument[i] == '"')
+                {
+                    // Backslashes preceding a literal quote: double them, then
+                    // emit \" for the literal quote itself.
+                    builder.Append('\\', backslashes * 2 + 1);
+                    builder.Append('"');
+                }
+                else
+                {
+                    // Backslashes not followed by a quote: emit verbatim.
+                    builder.Append('\\', backslashes);
+                    builder.Append(argument[i]);
+                }
+
+                i++;
+            }
+
+            builder.Append('"');
+            return builder.ToString();
+        }
+
+        private static readonly char[] CharactersThatRequireQuoting = new[] { ' ', '\t', '"' };
+    }
+}

--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -220,21 +220,47 @@ namespace GVFS.Common
 
         public static bool WaitUntilMounted(ITracer tracer, string pipeName, string enlistmentRoot, bool unattended, out string errorMessage)
         {
+            return WaitUntilMounted(tracer, pipeName, enlistmentRoot, unattended, mountProcessStatus: null, out errorMessage);
+        }
+
+        /// <summary>
+        /// Waits for the GVFS.Mount process to come up and signal readiness
+        /// over its named pipe.
+        /// </summary>
+        /// <param name="mountProcessStatus">
+        /// Optional snapshot delegate. When provided, the wait loop polls it
+        /// during pipe-connection attempts so the caller can fail fast if the
+        /// mount process exits before the pipe is created — instead of
+        /// blocking on the full 60-second pipe timeout. Callers that don't
+        /// have a handle to the child process (e.g. clients connecting to
+        /// somebody else's mount) pass <c>null</c>.
+        /// </param>
+        public static bool WaitUntilMounted(
+            ITracer tracer,
+            string pipeName,
+            string enlistmentRoot,
+            bool unattended,
+            Func<MountProcessSnapshot> mountProcessStatus,
+            out string errorMessage)
+        {
             tracer.RelatedInfo($"{nameof(WaitUntilMounted)}: Creating NamedPipeClient for pipe '{pipeName}'");
+            tracer.RelatedInfo($"{nameof(WaitUntilMounted)}: Connecting to '{pipeName}'");
 
             errorMessage = null;
-            using (NamedPipeClient pipeClient = new NamedPipeClient(pipeName))
+            int totalTimeoutMs = unattended ? 300000 : 60000;
+            NamedPipeClient pipeClient = TryConnectWithProcessTracking(
+                tracer,
+                pipeName,
+                totalTimeoutMs,
+                mountProcessStatus,
+                out errorMessage);
+            if (pipeClient == null)
             {
-                tracer.RelatedInfo($"{nameof(WaitUntilMounted)}: Connecting to '{pipeName}'");
+                return false;
+            }
 
-                int timeout = unattended ? 300000 : 60000;
-                if (!pipeClient.Connect(timeout))
-                {
-                    tracer.RelatedError($"{nameof(WaitUntilMounted)}: Failed to connect to '{pipeName}' after {timeout} ms");
-                    errorMessage = "Unable to mount because the GVFS.Mount process is not responding.";
-                    return false;
-                }
-
+            using (pipeClient)
+            {
                 tracer.RelatedInfo($"{nameof(WaitUntilMounted)}: Connected to '{pipeName}'");
 
                 while (true)
@@ -279,6 +305,86 @@ namespace GVFS.Common
                 }
             }
         }
+
+        private static NamedPipeClient TryConnectWithProcessTracking(
+            ITracer tracer,
+            string pipeName,
+            int totalTimeoutMs,
+            Func<MountProcessSnapshot> mountProcessStatus,
+            out string errorMessage)
+        {
+            errorMessage = null;
+
+            // When no process snapshot is supplied, fall back to a single
+            // long-timeout connect to preserve previous behavior for callers
+            // that don't own the mount process (e.g. external pipe clients).
+            if (mountProcessStatus == null)
+            {
+                NamedPipeClient pipeClient = new NamedPipeClient(pipeName);
+                if (pipeClient.Connect(totalTimeoutMs))
+                {
+                    return pipeClient;
+                }
+
+                pipeClient.Dispose();
+                tracer.RelatedError($"{nameof(WaitUntilMounted)}: Failed to connect to '{pipeName}' after {totalTimeoutMs} ms");
+                errorMessage = "Unable to mount because the GVFS.Mount process is not responding.";
+                return null;
+            }
+
+            // With process tracking, retry with short connect attempts so we
+            // can detect early termination within seconds.
+            const int PerAttemptTimeoutMs = 500;
+            DateTime deadline = DateTime.UtcNow.AddMilliseconds(totalTimeoutMs);
+            while (true)
+            {
+                MountProcessSnapshot snapshot = mountProcessStatus();
+                if (snapshot.HasExited)
+                {
+                    errorMessage = string.Format(
+                        "GVFS.Mount process (Id {0}) exited with code {1} before the named pipe was ready.",
+                        snapshot.ProcessId,
+                        snapshot.ExitCode);
+                    tracer.RelatedError($"{nameof(WaitUntilMounted)}: {errorMessage}");
+                    return null;
+                }
+
+                NamedPipeClient pipeClient = new NamedPipeClient(pipeName);
+                if (pipeClient.Connect(PerAttemptTimeoutMs))
+                {
+                    return pipeClient;
+                }
+
+                pipeClient.Dispose();
+
+                if (DateTime.UtcNow >= deadline)
+                {
+                    tracer.RelatedError($"{nameof(WaitUntilMounted)}: Failed to connect to '{pipeName}' after {totalTimeoutMs} ms (mount process Id {snapshot.ProcessId} still running)");
+                    errorMessage = "Unable to mount because the GVFS.Mount process is not responding.";
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Snapshot of a child mount process's liveness, used by
+        /// <see cref="WaitUntilMounted(ITracer, string, string, bool, Func{MountProcessSnapshot}, out string)"/>
+        /// to short-circuit the pipe-wait when the child has crashed.
+        /// </summary>
+        public readonly struct MountProcessSnapshot
+        {
+            public MountProcessSnapshot(int processId, bool hasExited, int exitCode)
+            {
+                this.ProcessId = processId;
+                this.HasExited = hasExited;
+                this.ExitCode = exitCode;
+            }
+
+            public int ProcessId { get; }
+            public bool HasExited { get; }
+            public int ExitCode { get; }
+        }
+
 
         public void SetGitVersion(string gitVersion)
         {

--- a/GVFS/GVFS.Platform.Windows/CurrentUser.cs
+++ b/GVFS/GVFS.Platform.Windows/CurrentUser.cs
@@ -1,9 +1,11 @@
-﻿using GVFS.Common.Tracing;
+using GVFS.Common;
+using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Text;
 
 namespace GVFS.Platform.Windows
 {
@@ -108,18 +110,37 @@ namespace GVFS.Platform.Windows
 
         /// <summary>
         /// Launches a process for the current user.
-        /// This code will only work when running in a windows service running as LocalSystem
-        /// with the SE_TCB_NAME privilege.
+        /// This code will only work when running in a windows service running
+        /// as LocalSystem with the SE_TCB_NAME privilege.
         /// </summary>
-        /// <returns>True on successful process start</returns>
-        public bool RunAs(string processName, string args)
+        /// <param name="processName">Full path to the executable to launch.</param>
+        /// <param name="arguments">
+        /// Argument values exactly as the child process should see them in its
+        /// <c>argv</c>. Each value is escaped according to
+        /// <c>CommandLineToArgvW</c> rules so embedded quotes, spaces, and
+        /// backslashes round-trip safely. Passing pre-concatenated argument
+        /// strings here would re-introduce the quote-stripping bug that
+        /// silently corrupts the service's <c>--internal_use_only</c> JSON.
+        /// </param>
+        /// <param name="processId">
+        /// On success, the PID of the newly created process so the caller can
+        /// detect early termination (e.g. via
+        /// <see cref="System.Diagnostics.Process.GetProcessById(int)"/>)
+        /// instead of waiting the full pipe-connection timeout when the child
+        /// has already crashed.
+        /// </param>
+        /// <returns><c>true</c> if the process was successfully created.</returns>
+        public bool TryRunAs(string processName, string[] arguments, out int processId)
         {
+            processId = 0;
             IntPtr environment = IntPtr.Zero;
             IntPtr duplicate = IntPtr.Zero;
             if (this.token == IntPtr.Zero)
             {
                 return false;
             }
+
+            string commandLine = BuildCommandLine(processName, arguments);
 
             try
             {
@@ -140,7 +161,7 @@ namespace GVFS.Platform.Windows
                         if (CreateProcessAsUser(
                             duplicate,
                             null,
-                            string.Format("\"{0}\" {1}", processName, args),
+                            commandLine,
                             IntPtr.Zero,
                             IntPtr.Zero,
                             inheritHandles: false,
@@ -152,7 +173,8 @@ namespace GVFS.Platform.Windows
                         {
                             try
                             {
-                                this.tracer.RelatedInfo("Started process '{0} {1}' with Id {2}", processName, args, procInfo.ProcessId);
+                                processId = procInfo.ProcessId;
+                                this.tracer.RelatedInfo("Started process '{0}' with Id {1}", commandLine, processId);
                             }
                             finally
                             {
@@ -191,6 +213,22 @@ namespace GVFS.Platform.Windows
             }
 
             return false;
+        }
+
+        private static string BuildCommandLine(string processName, string[] arguments)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append(CommandLineEscaping.EscapeArgument(processName));
+            if (arguments != null)
+            {
+                foreach (string argument in arguments)
+                {
+                    builder.Append(' ');
+                    builder.Append(CommandLineEscaping.EscapeArgument(argument));
+                }
+            }
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/GVFS/GVFS.Platform.Windows/CurrentUser.cs
+++ b/GVFS/GVFS.Platform.Windows/CurrentUser.cs
@@ -1,5 +1,6 @@
 using GVFS.Common;
 using GVFS.Common.Tracing;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -122,16 +123,25 @@ namespace GVFS.Platform.Windows
         /// strings here would re-introduce the quote-stripping bug that
         /// silently corrupts the service's <c>--internal_use_only</c> JSON.
         /// </param>
+        /// <param name="processHandle">
+        /// On success, an owned handle to the newly created process. Callers
+        /// can use <see cref="ProcessHandleHelper.HasExited"/> and
+        /// <see cref="ProcessHandleHelper.TryGetExitCode"/> to query the
+        /// child's liveness without racing on PID lookup (the kernel keeps
+        /// the process object alive as long as we hold the handle, even
+        /// after the child exits, so the handle is always queryable and
+        /// never aliases a reused PID). Callers must <see cref="SafeProcessHandle.Dispose"/>
+        /// it when done — usually with <c>using</c>.
+        /// </param>
         /// <param name="processId">
-        /// On success, the PID of the newly created process so the caller can
-        /// detect early termination (e.g. via
-        /// <see cref="System.Diagnostics.Process.GetProcessById(int)"/>)
-        /// instead of waiting the full pipe-connection timeout when the child
-        /// has already crashed.
+        /// On success, the PID of the newly created process (for logging
+        /// and diagnostics only — use <paramref name="processHandle"/> for
+        /// any liveness check).
         /// </param>
         /// <returns><c>true</c> if the process was successfully created.</returns>
-        public bool TryRunAs(string processName, string[] arguments, out int processId)
+        public bool TryRunAs(string processName, string[] arguments, out SafeProcessHandle processHandle, out int processId)
         {
+            processHandle = null;
             processId = 0;
             IntPtr environment = IntPtr.Zero;
             IntPtr duplicate = IntPtr.Zero;
@@ -171,17 +181,14 @@ namespace GVFS.Platform.Windows
                             startupInfo: ref info,
                             processInformation: out procInfo))
                         {
-                            try
-                            {
-                                processId = procInfo.ProcessId;
-                                this.tracer.RelatedInfo("Started process '{0}' with Id {1}", commandLine, processId);
-                            }
-                            finally
-                            {
-                                CloseHandle(procInfo.ProcessHandle);
-                                CloseHandle(procInfo.ThreadHandle);
-                            }
-
+                            // Always close the thread handle (we never use it).
+                            // Wrap the process handle in a SafeProcessHandle that
+                            // owns it; callers get a race-free liveness handle that
+                            // remains queryable even after the child exits.
+                            CloseHandle(procInfo.ThreadHandle);
+                            processId = procInfo.ProcessId;
+                            processHandle = new SafeProcessHandle(procInfo.ProcessHandle, ownsHandle: true);
+                            this.tracer.RelatedInfo("Started process '{0}' with Id {1}", commandLine, processId);
                             return true;
                         }
                         else

--- a/GVFS/GVFS.Platform.Windows/ProcessHandleHelper.cs
+++ b/GVFS/GVFS.Platform.Windows/ProcessHandleHelper.cs
@@ -1,0 +1,58 @@
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace GVFS.Platform.Windows
+{
+    /// <summary>
+    /// Race-free liveness checks against a Win32 process handle.
+    /// Unlike <see cref="System.Diagnostics.Process.GetProcessById(int)"/>,
+    /// these helpers query an already-opened handle, so they cannot lose the
+    /// race where the target exits between the caller starting it and the
+    /// caller looking it up, and they cannot alias a reused PID. The kernel
+    /// keeps the process object alive for as long as the handle is held,
+    /// even after the child has exited and its PID has been reused.
+    /// </summary>
+    public static class ProcessHandleHelper
+    {
+        // From WinBase.h. WaitForSingleObject signals the process handle
+        // immediately when the process has exited; we pass a zero timeout
+        // so we never block.
+        private const uint WaitObject0 = 0x00000000;
+        private const uint WaitTimeout = 0x00000102;
+
+        /// <summary>
+        /// Returns <c>true</c> if the process has exited. Uses a non-blocking
+        /// wait so it's safe to call from a polling loop.
+        /// </summary>
+        public static bool HasExited(SafeProcessHandle handle)
+        {
+            uint result = WaitForSingleObject(handle, 0);
+            return result == WaitObject0;
+        }
+
+        /// <summary>
+        /// Reads the process's exit code. Only meaningful after
+        /// <see cref="HasExited"/> returns <c>true</c>. Returns <c>false</c>
+        /// if the underlying Win32 call fails.
+        /// </summary>
+        public static bool TryGetExitCode(SafeProcessHandle handle, out int exitCode)
+        {
+            uint code;
+            if (GetExitCodeProcess(handle, out code))
+            {
+                exitCode = unchecked((int)code);
+                return true;
+            }
+
+            exitCode = -1;
+            return false;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern uint WaitForSingleObject(SafeProcessHandle handle, uint timeoutMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetExitCodeProcess(SafeProcessHandle handle, out uint exitCode);
+    }
+}

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -142,7 +142,7 @@ namespace GVFS.Platform.Windows
             string programArguments = string.Empty;
             try
             {
-                programArguments = string.Join(" ", args.Select(arg => arg.Contains(' ') ? "\"" + arg + "\"" : arg));
+                programArguments = string.Join(" ", args.Select(arg => CommandLineEscaping.EscapeArgument(arg)));
                 ProcessStartInfo processInfo = new ProcessStartInfo(programName, programArguments);
 
                 // UseShellExecute=true uses ShellExecuteEx which does NOT inherit

--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -1,9 +1,9 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Common.Tracing;
 using GVFS.Platform.Windows;
 using GVFS.Service.Handlers;
+using Microsoft.Win32.SafeHandles;
 using System;
-using System.Diagnostics;
 
 namespace GVFS.Service
 {
@@ -30,98 +30,79 @@ namespace GVFS.Service
 
             using (CurrentUser currentUser = new CurrentUser(this.tracer, sessionId))
             {
+                SafeProcessHandle mountHandle;
                 int mountProcessId;
-                if (!this.TryCallGVFSMount(repoRoot, currentUser, out mountProcessId))
+                if (!this.TryCallGVFSMount(repoRoot, currentUser, out mountHandle, out mountProcessId))
                 {
                     this.tracer.RelatedError($"{nameof(this.MountRepository)}: Unable to start the GVFS.exe process.");
                     return false;
                 }
 
-                string errorMessage;
-                string pipeName = GVFSPlatform.Instance.GetNamedPipeName(repoRoot);
-                string worktreeError;
-                GVFSEnlistment.WorktreeInfo wtInfo = GVFSEnlistment.TryGetWorktreeInfo(repoRoot, out worktreeError);
-                if (worktreeError != null)
+                // Always own the handle for the rest of this call so the
+                // kernel keeps the process object alive while we poll it.
+                using (mountHandle)
                 {
-                    this.tracer.RelatedError($"Failed to check worktree status for '{repoRoot}': {worktreeError}");
-                    return false;
-                }
-
-                if (wtInfo?.SharedGitDir != null)
-                {
-                    string enlistmentRoot = wtInfo.GetEnlistmentRoot();
-                    if (enlistmentRoot != null)
+                    string errorMessage;
+                    string pipeName = GVFSPlatform.Instance.GetNamedPipeName(repoRoot);
+                    string worktreeError;
+                    GVFSEnlistment.WorktreeInfo wtInfo = GVFSEnlistment.TryGetWorktreeInfo(repoRoot, out worktreeError);
+                    if (worktreeError != null)
                     {
-                        pipeName = GVFSPlatform.Instance.GetNamedPipeName(enlistmentRoot) + wtInfo.PipeSuffix;
+                        this.tracer.RelatedError($"Failed to check worktree status for '{repoRoot}': {worktreeError}");
+                        return false;
                     }
-                }
 
-                // Track the spawned mount process so the wait short-circuits
-                // when it dies early — e.g. on argument-parsing failures that
-                // exit before any log file is created. Without this, the
-                // service would block for the full 60-second pipe timeout
-                // with no diagnostic beyond "not responding."
-                Process mountProcess = TryGetProcessById(this.tracer, mountProcessId);
-                Func<GVFSEnlistment.MountProcessSnapshot> snapshot =
-                    mountProcess == null
-                        ? (Func<GVFSEnlistment.MountProcessSnapshot>)null
-                        : () => SnapshotMountProcess(mountProcess, mountProcessId);
+                    if (wtInfo?.SharedGitDir != null)
+                    {
+                        string enlistmentRoot = wtInfo.GetEnlistmentRoot();
+                        if (enlistmentRoot != null)
+                        {
+                            pipeName = GVFSPlatform.Instance.GetNamedPipeName(enlistmentRoot) + wtInfo.PipeSuffix;
+                        }
+                    }
 
-                try
-                {
+                    // Track the spawned mount process so the wait short-circuits
+                    // when it dies early — e.g. on argument-parsing failures that
+                    // exit before any log file is created. Without this, the
+                    // service would block for the full 60-second pipe timeout
+                    // with no diagnostic beyond "not responding."
+                    //
+                    // We use the SafeProcessHandle returned by TryRunAs rather
+                    // than Process.GetProcessById(pid) so we cannot race against
+                    // the child exiting between CreateProcessAsUser and the
+                    // lookup, and cannot alias a reused PID.
+                    SafeProcessHandle handle = mountHandle;
+                    Func<GVFSEnlistment.MountProcessSnapshot> snapshot =
+                        () => SnapshotMountProcess(handle, mountProcessId);
+
                     if (!GVFSEnlistment.WaitUntilMounted(this.tracer, pipeName, repoRoot, unattended: false, snapshot, out errorMessage))
                     {
                         this.tracer.RelatedError(errorMessage);
                         return false;
                     }
                 }
-                finally
-                {
-                    mountProcess?.Dispose();
-                }
             }
 
             return true;
         }
 
-        private static Process TryGetProcessById(ITracer tracer, int processId)
+        private static GVFSEnlistment.MountProcessSnapshot SnapshotMountProcess(SafeProcessHandle handle, int processId)
         {
-            try
+            if (!ProcessHandleHelper.HasExited(handle))
             {
-                return Process.GetProcessById(processId);
+                return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: false, exitCode: 0);
             }
-            catch (ArgumentException)
+
+            int exitCode;
+            if (!ProcessHandleHelper.TryGetExitCode(handle, out exitCode))
             {
-                // Process already exited between CreateProcessAsUser returning
-                // and us looking it up. Wait loop will catch this on first poll.
-                return null;
+                exitCode = -1;
             }
-            catch (InvalidOperationException e)
-            {
-                tracer.RelatedWarning($"{nameof(TryGetProcessById)}: Could not open handle to mount process Id {processId}: {e.Message}");
-                return null;
-            }
+
+            return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: true, exitCode: exitCode);
         }
 
-        private static GVFSEnlistment.MountProcessSnapshot SnapshotMountProcess(Process mountProcess, int processId)
-        {
-            try
-            {
-                if (mountProcess.HasExited)
-                {
-                    return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: true, exitCode: mountProcess.ExitCode);
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // No process associated — treat as exited so the caller fails fast.
-                return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: true, exitCode: -1);
-            }
-
-            return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: false, exitCode: 0);
-        }
-
-        private bool TryCallGVFSMount(string repoRoot, CurrentUser currentUser, out int processId)
+        private bool TryCallGVFSMount(string repoRoot, CurrentUser currentUser, out SafeProcessHandle processHandle, out int processId)
         {
             InternalVerbParameters mountInternal = new InternalVerbParameters(startedByService: true);
             return currentUser.TryRunAs(
@@ -133,8 +114,10 @@ namespace GVFS.Service
                     "--" + GVFSConstants.VerbParameters.InternalUseOnly,
                     mountInternal.ToJson(),
                 },
+                out processHandle,
                 out processId);
         }
     }
 }
+
 

--- a/GVFS/GVFS.Service/GVFSMountProcess.cs
+++ b/GVFS/GVFS.Service/GVFSMountProcess.cs
@@ -2,6 +2,8 @@
 using GVFS.Common.Tracing;
 using GVFS.Platform.Windows;
 using GVFS.Service.Handlers;
+using System;
+using System.Diagnostics;
 
 namespace GVFS.Service
 {
@@ -28,7 +30,8 @@ namespace GVFS.Service
 
             using (CurrentUser currentUser = new CurrentUser(this.tracer, sessionId))
             {
-                if (!this.CallGVFSMount(repoRoot, currentUser))
+                int mountProcessId;
+                if (!this.TryCallGVFSMount(repoRoot, currentUser, out mountProcessId))
                 {
                     this.tracer.RelatedError($"{nameof(this.MountRepository)}: Unable to start the GVFS.exe process.");
                     return false;
@@ -53,22 +56,85 @@ namespace GVFS.Service
                     }
                 }
 
-                if (!GVFSEnlistment.WaitUntilMounted(this.tracer, pipeName, repoRoot, false, out errorMessage))
+                // Track the spawned mount process so the wait short-circuits
+                // when it dies early — e.g. on argument-parsing failures that
+                // exit before any log file is created. Without this, the
+                // service would block for the full 60-second pipe timeout
+                // with no diagnostic beyond "not responding."
+                Process mountProcess = TryGetProcessById(this.tracer, mountProcessId);
+                Func<GVFSEnlistment.MountProcessSnapshot> snapshot =
+                    mountProcess == null
+                        ? (Func<GVFSEnlistment.MountProcessSnapshot>)null
+                        : () => SnapshotMountProcess(mountProcess, mountProcessId);
+
+                try
                 {
-                    this.tracer.RelatedError(errorMessage);
-                    return false;
+                    if (!GVFSEnlistment.WaitUntilMounted(this.tracer, pipeName, repoRoot, unattended: false, snapshot, out errorMessage))
+                    {
+                        this.tracer.RelatedError(errorMessage);
+                        return false;
+                    }
+                }
+                finally
+                {
+                    mountProcess?.Dispose();
                 }
             }
 
             return true;
         }
 
-        private bool CallGVFSMount(string repoRoot, CurrentUser currentUser)
+        private static Process TryGetProcessById(ITracer tracer, int processId)
+        {
+            try
+            {
+                return Process.GetProcessById(processId);
+            }
+            catch (ArgumentException)
+            {
+                // Process already exited between CreateProcessAsUser returning
+                // and us looking it up. Wait loop will catch this on first poll.
+                return null;
+            }
+            catch (InvalidOperationException e)
+            {
+                tracer.RelatedWarning($"{nameof(TryGetProcessById)}: Could not open handle to mount process Id {processId}: {e.Message}");
+                return null;
+            }
+        }
+
+        private static GVFSEnlistment.MountProcessSnapshot SnapshotMountProcess(Process mountProcess, int processId)
+        {
+            try
+            {
+                if (mountProcess.HasExited)
+                {
+                    return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: true, exitCode: mountProcess.ExitCode);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // No process associated — treat as exited so the caller fails fast.
+                return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: true, exitCode: -1);
+            }
+
+            return new GVFSEnlistment.MountProcessSnapshot(processId, hasExited: false, exitCode: 0);
+        }
+
+        private bool TryCallGVFSMount(string repoRoot, CurrentUser currentUser, out int processId)
         {
             InternalVerbParameters mountInternal = new InternalVerbParameters(startedByService: true);
-            return currentUser.RunAs(
+            return currentUser.TryRunAs(
                 Configuration.Instance.GVFSLocation,
-                $"mount {repoRoot} --{GVFSConstants.VerbParameters.InternalUseOnly} {mountInternal.ToJson()}");
+                new[]
+                {
+                    "mount",
+                    repoRoot,
+                    "--" + GVFSConstants.VerbParameters.InternalUseOnly,
+                    mountInternal.ToJson(),
+                },
+                out processId);
         }
     }
 }
+

--- a/GVFS/GVFS.UnitTests/Common/CommandLineEscapingTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/CommandLineEscapingTests.cs
@@ -1,0 +1,99 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.Runtime.InteropServices;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class CommandLineEscapingTests
+    {
+        [TestCase("simple", "simple", Description = "No special characters: no quoting")]
+        [TestCase("with space", "\"with space\"")]
+        [TestCase("with\ttab", "\"with\ttab\"")]
+        [TestCase("with\"quote", "\"with\\\"quote\"")]
+        [TestCase("ends_with_backslash\\", "ends_with_backslash\\")]
+        [TestCase("path\\with\\backslashes", "path\\with\\backslashes")]
+        [TestCase("path with\\backslashes", "\"path with\\backslashes\"")]
+        [TestCase("trailing_backslash_with quote\\", "\"trailing_backslash_with quote\\\\\"")]
+        [TestCase("a\\\\b c", "\"a\\\\b c\"", Description = "Internal double-backslash not before quote: kept verbatim")]
+        [TestCase("a\\\\\"b", "\"a\\\\\\\\\\\"b\"", Description = "Two backslashes before quote: doubled to four plus escaped quote")]
+        [TestCase("", "\"\"", Description = "Empty argument: must be quoted so it isn't lost")]
+        public void EscapeArgument_ProducesExpectedString(string input, string expected)
+        {
+            CommandLineEscaping.EscapeArgument(input).ShouldEqual(expected);
+        }
+
+        [TestCase]
+        public void EscapeArgument_NullInputIsEmptyQuotedString()
+        {
+            CommandLineEscaping.EscapeArgument(null).ShouldEqual("\"\"");
+        }
+
+        [TestCase("simple")]
+        [TestCase("with space")]
+        [TestCase("with\"quote")]
+        [TestCase("ends_with_backslash\\")]
+        [TestCase("a\\\\\"b")]
+        [TestCase("path\\with\\backslashes")]
+        [TestCase("path with\\backslashes")]
+        [TestCase("trailing_backslash_with quote\\")]
+        [TestCase("{\"ServiceName\":null,\"StartedByService\":true,\"MaintenanceJob\":null,\"PackfileMaintenanceBatchSize\":null}",
+            Description = "The exact InternalVerbParameters.ToJson() shape that triggered the automount regression")]
+        [TestCase("")]
+        public void EscapeArgument_RoundTripsThroughCommandLineToArgvW(string input)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Ignore("CommandLineToArgvW is a Windows-only API.");
+            }
+
+            // Build a command line that begins with a fake program name so
+            // CommandLineToArgvW has a leading token to chew on, then the
+            // escaped argument we care about.
+            string commandLine = "stub.exe " + CommandLineEscaping.EscapeArgument(input);
+
+            string[] argv = CommandLineToArgs(commandLine);
+
+            argv.Length.ShouldEqual(2, "Expected exactly one argument after the program name");
+            argv[1].ShouldEqual(input ?? string.Empty);
+        }
+
+        private static string[] CommandLineToArgs(string commandLine)
+        {
+            int argc;
+            System.IntPtr argv = NativeMethods.CommandLineToArgvW(commandLine, out argc);
+            if (argv == System.IntPtr.Zero)
+            {
+                throw new System.ComponentModel.Win32Exception();
+            }
+
+            try
+            {
+                string[] args = new string[argc];
+                for (int i = 0; i < argc; i++)
+                {
+                    System.IntPtr p = Marshal.ReadIntPtr(argv, i * System.IntPtr.Size);
+                    args[i] = Marshal.PtrToStringUni(p);
+                }
+
+                return args;
+            }
+            finally
+            {
+                NativeMethods.LocalFree(argv);
+            }
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern System.IntPtr CommandLineToArgvW(
+                [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
+                out int pNumArgs);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern System.IntPtr LocalFree(System.IntPtr hMem);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/WaitUntilMountedProcessTrackingTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WaitUntilMountedProcessTrackingTests.cs
@@ -1,0 +1,88 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class WaitUntilMountedProcessTrackingTests
+    {
+        [TestCase]
+        public void ReturnsImmediatelyWhenMountProcessSnapshotReportsExited()
+        {
+            const int FakePid = 13579;
+            const int FakeExitCode = 42;
+            int snapshotCallCount = 0;
+            Func<GVFSEnlistment.MountProcessSnapshot> snapshot = () =>
+            {
+                Interlocked.Increment(ref snapshotCallCount);
+                return new GVFSEnlistment.MountProcessSnapshot(FakePid, hasExited: true, exitCode: FakeExitCode);
+            };
+
+            string errorMessage;
+            DateTime start = DateTime.UtcNow;
+            bool result = GVFSEnlistment.WaitUntilMounted(
+                new MockTracer(),
+                pipeName: "GVFS_no_such_pipe_for_test_" + Guid.NewGuid().ToString("N"),
+                enlistmentRoot: "C:\\fake\\root",
+                unattended: false,
+                mountProcessStatus: snapshot,
+                out errorMessage);
+            TimeSpan elapsed = DateTime.UtcNow - start;
+
+            result.ShouldBeFalse();
+            errorMessage.ShouldNotBeNull();
+            errorMessage.ShouldContain(FakePid.ToString());
+            errorMessage.ShouldContain(FakeExitCode.ToString());
+            snapshotCallCount.ShouldBeAtLeast(1);
+
+            // The legacy code path would have blocked for the full 60 second
+            // pipe timeout. With process tracking we should bail out in well
+            // under a second since the snapshot is checked before any
+            // connect attempt.
+            Assert.That(elapsed.TotalSeconds, Is.LessThan(5), "WaitUntilMounted should bail out quickly when the snapshot reports the mount process exited");
+        }
+
+        [TestCase]
+        public void DetectsLateProcessExitWhilePipeNeverAppears()
+        {
+            const int FakePid = 24680;
+            const int FakeExitCode = -1;
+            int snapshotCallCount = 0;
+            Func<GVFSEnlistment.MountProcessSnapshot> snapshot = () =>
+            {
+                int count = Interlocked.Increment(ref snapshotCallCount);
+
+                // Pretend the mount process is still running for the first
+                // couple of polls, then suddenly report it exited.
+                bool exited = count >= 2;
+                return new GVFSEnlistment.MountProcessSnapshot(
+                    FakePid,
+                    hasExited: exited,
+                    exitCode: exited ? FakeExitCode : 0);
+            };
+
+            string errorMessage;
+            DateTime start = DateTime.UtcNow;
+            bool result = GVFSEnlistment.WaitUntilMounted(
+                new MockTracer(),
+                pipeName: "GVFS_no_such_pipe_for_test_" + Guid.NewGuid().ToString("N"),
+                enlistmentRoot: "C:\\fake\\root",
+                unattended: false,
+                mountProcessStatus: snapshot,
+                out errorMessage);
+            TimeSpan elapsed = DateTime.UtcNow - start;
+
+            result.ShouldBeFalse();
+            errorMessage.ShouldContain(FakePid.ToString());
+            errorMessage.ShouldContain(FakeExitCode.ToString());
+
+            // Per-attempt connect timeout is 500ms; we expect to discover the
+            // exit on the second poll, well within a few seconds.
+            Assert.That(elapsed.TotalSeconds, Is.LessThan(10), "WaitUntilMounted should detect late process exit within a few connect retries");
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

Automount on the latest prerelease (v2.0.26154.1) silently failed for every
registered repo. The service log showed each `GVFS.exe mount` child being
started, then a 60-second `WaitUntilMounted` timeout and
`"Unable to mount because the GVFS.Mount process is not responding"`. No
mount-side log file was created — the child died before the log listener
was attached.

## Root cause

`GVFSMountProcess.CallGVFSMount` built the spawn command line by
concatenating `InternalVerbParameters.ToJson()` straight in:

```
"…\GVFS.exe" mount D:\os1 --internal_use_only {"ServiceName":null,…}
```

Windows `CommandLineToArgvW` strips the embedded `"` characters when
re-parsing the child's `argv`, so the receiving process sees
`{ServiceName:null,…}`. Newtonsoft.Json was permissive about unquoted
keys, so the bug was latent for years. After the
[System.Text.Json migration](https://github.com/microsoft/VFSForGit/commit/c83beab4),
strict parsing throws `JsonException`, the verb hits `ReportErrorAndExit`
*before* `AddLogFileEventListener` runs, and the child exits with no log.

Confirmed by reproducing the parse with `CommandLineToArgvW`:

```
argv[4] = '{ServiceName:null,StartedByService:true,MaintenanceJob:null,PackfileMaintenanceBatchSize:null}'
```

and feeding that to `JsonDocument.Parse`:

```
'S' is an invalid start of a property name. Expected a '"'.
```

Scope: only the SYSTEM-service automount path. `gvfs mount` (user-run)
and `gvfs service --mount-all` invoke `MountVerb` in-process — no
command-line round-trip, no bug.

## Fix

* **`CommandLineEscaping.EscapeArgument`** — proper Windows command-line
  argument escaping per the `CommandLineToArgvW` rules (quote when
  needed, double trailing backslashes that precede a `"`, escape literal
  `"` as `\"`).
* **`CurrentUser.RunAs` → `TryRunAs(string, string[], out int processId)`** —
  take argv as an array, escape centrally, return the child PID so
  callers can track its liveness.
* **`WindowsPlatform.StartBackgroundVFS4GProcess`** — route every arg
  through the new escaper (previously only space-containing args got
  naively wrapped, and embedded `"` were never escaped).
* **`GVFSEnlistment.WaitUntilMounted`** — new overload accepting
  `Func<MountProcessSnapshot>`. When supplied, the wait loop polls the
  snapshot between short (500 ms) connect attempts and fails fast with
  the exit code if the child has already terminated, instead of blocking
  for the full 60-second pipe timeout.
* **`GVFSMountProcess`** — pass the spawned PID into the new wait so
  logon automount detects an early `GVFS.exe` exit within seconds and
  logs `"GVFS.Mount process (Id N) exited with code X before the named
  pipe was ready"` instead of `"not responding"`.

## Tests

* **`CommandLineEscapingTests`** — canonical edge cases (spaces, tabs,
  embedded quotes, trailing backslashes) plus the exact
  `InternalVerbParameters` JSON shape that triggered the regression. A
  round-trip test feeds the escaped form back through
  `CommandLineToArgvW` and verifies the original string pops out
  unchanged.
* **`WaitUntilMountedProcessTrackingTests`** — verifies the wait
  short-circuits on an exit reported by the first snapshot poll, and
  also catches a late exit reported on a later poll, both well under
  the legacy 60-second timeout.

All 842 unit tests pass.

## Validation checklist

- [x] `dotnet build GVFS\GVFS.UnitTests\GVFS.UnitTests.csproj -c Debug` — 0 errors
- [x] All unit tests green (842 passed, including 24 new)
- [x] Manual smoke: install local Debug build, register two repos with
      `gvfs mount`, restart `GVFS.Service`, sign out / sign in, confirm
      both repos automount.
- [x] Manual fault injection: temporarily make `GVFS.exe` exit non-zero
      in the mount verb and verify the service logs the new
      `"GVFS.Mount process (Id N) exited with code X before the named
      pipe was ready"` message within a few seconds rather than waiting
      60 s.
