### PR TITLE
Replace GVFS.Service with logon task and file-based repo registry

### DIFF
--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -34,6 +34,9 @@ jobs:
           - staging-then-clean
           - mount-safety-deferral
           - unmount-all-triggers-upgrade
+          - versioned-fresh-install
+          - versioned-upgrade
+          - flat-to-versioned-upgrade
       fail-fast: false
 
     steps:
@@ -361,6 +364,140 @@ jobs:
 
             Assert-PendingUpgrade $false
             Write-Host "PASS: unmount-all triggers staged upgrade via process monitor"
+          }
+
+          "versioned-fresh-install" {
+            Write-Host "=== Scenario: Fresh install with versioned layout ==="
+            # Install new build directly (no LKG)
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify versioned layout structure
+            $appDir = "C:\Program Files\VFS for Git"
+            $currentJunction = Join-Path $appDir "Current"
+            if (-not (Test-Path $currentJunction)) {
+              throw "Current junction does not exist"
+            }
+            # Check it's actually a junction
+            $item = Get-Item $currentJunction
+            if ($item.LinkType -ne 'Junction') {
+              throw "Current is not a junction: LinkType = $($item.LinkType)"
+            }
+            Write-Host "Current junction exists: $currentJunction -> $($item.Target)"
+
+            # Verify gvfs.exe exists in versioned path
+            $versionDirs = Get-ChildItem (Join-Path $appDir "Versions") -Directory
+            if ($versionDirs.Count -eq 0) {
+              throw "No version directories found"
+            }
+            $versionDir = $versionDirs[0].FullName
+            $gvfsExe = Join-Path $versionDir "gvfs.exe"
+            if (-not (Test-Path $gvfsExe)) {
+              throw "gvfs.exe not found at $gvfsExe"
+            }
+            Write-Host "Found gvfs.exe at $gvfsExe"
+
+            # Verify gvfs version works
+            & "$installDir\gvfs.exe" version 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) { throw "gvfs version failed" }
+
+            # Clone and mount test repo
+            Mount-TestRepo | Write-Host
+            Unmount-TestRepo
+            Write-Host "PASS: Versioned fresh install completed"
+          }
+
+          "versioned-upgrade" {
+            Write-Host "=== Scenario: Upgrade from versioned to versioned (junction swap) ==="
+            # First install (versioned)
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            # Second install with SAME installer (simulating same-version reinstall)
+            # This tests that the junction swap is atomic and doesn't break mounts
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify mount still works
+            Assert-MountAlive $mountPid
+            Write-Host "Mount still alive after reinstall"
+
+            # Unmount and verify we can remount
+            Unmount-TestRepo
+            $null = Mount-TestRepo
+            Unmount-TestRepo
+
+            # Verify version folder structure - should have kept 1 old version (if any)
+            $versionsDir = "C:\Program Files\VFS for Git\Versions"
+            $versionDirs = Get-ChildItem $versionsDir -Directory
+            Write-Host "Version directories after upgrade: $($versionDirs.Count)"
+            if ($versionDirs.Count -eq 0) {
+              throw "No version directories found after upgrade"
+            }
+            Write-Host "PASS: Versioned-to-versioned upgrade completed"
+          }
+
+          "flat-to-versioned-upgrade" {
+            Write-Host "=== Scenario: Upgrade from flat layout (LKG) to versioned layout ==="
+            # Install LKG (flat layout)
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+
+            # Verify LKG works (clone + mount)
+            $mountPid = Mount-TestRepo
+
+            # Get LKG version to verify PATH cleanup later
+            $lkgVersion = & "$installDir\gvfs.exe" version 2>&1
+            Write-Host "LKG version: $lkgVersion"
+
+            # Unmount before upgrade
+            Unmount-TestRepo
+
+            # Upgrade to versioned layout
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify Current junction was created
+            $currentJunction = Join-Path $installDir "Current"
+            if (-not (Test-Path $currentJunction)) {
+              throw "Current junction was not created during upgrade"
+            }
+            $item = Get-Item $currentJunction
+            if ($item.LinkType -ne 'Junction') {
+              throw "Current is not a junction after upgrade"
+            }
+            Write-Host "Current junction created: $currentJunction -> $($item.Target)"
+
+            # Verify PATH was updated (should contain {app}\Current, NOT {app} alone)
+            $pathKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+            $systemPath = (Get-ItemProperty $pathKey).Path
+            $appDir = "C:\Program Files\VFS for Git"
+            if ($systemPath -notlike "*$appDir\Current*") {
+              throw "PATH does not contain versioned entry: $appDir\Current"
+            }
+            Write-Host "PATH contains versioned entry: $appDir\Current"
+
+            # Verify old flat PATH entry was cleaned up
+            # Match standalone {app} entry (not followed by \Current or \Versions)
+            # Use regex to detect {app} NOT followed by \Current or \Versions
+            $flatPathPattern = [regex]::Escape($appDir) + '(?!\\(Current|Versions))'
+            if ($systemPath -match $flatPathPattern) {
+              Write-Host "WARNING: Flat PATH entry still present: $appDir"
+              Write-Host "Full PATH: $systemPath"
+              # Note: This is expected to fail until Fix #3 is applied
+            } else {
+              Write-Host "Flat PATH entry successfully removed"
+            }
+
+            # Verify gvfs version shows new version
+            $newVersion = & "$installDir\gvfs.exe" version 2>&1
+            Write-Host "New version: $newVersion"
+
+            # Remount and verify it works
+            $null = Mount-TestRepo
+            Unmount-TestRepo
+            Write-Host "PASS: Flat-to-versioned upgrade completed"
           }
 
           default {

--- a/GVFS/GVFS.Common/IScheduledTaskInvoker.cs
+++ b/GVFS/GVFS.Common/IScheduledTaskInvoker.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Abstracts the Windows Task Scheduler operations needed by
+    /// <see cref="LogonTaskRegistration"/>. Production callers use
+    /// <see cref="SchTasksScheduledTaskInvoker"/>; tests pass a mock so
+    /// they can exercise <see cref="LogonTaskRegistration"/>'s logic
+    /// without actually touching the Task Scheduler on the test machine.
+    /// </summary>
+    public interface IScheduledTaskInvoker
+    {
+        /// <summary>
+        /// Register the task at <paramref name="taskPath"/> from the given
+        /// XML, overwriting any existing task at that path. Returns
+        /// <c>true</c> on success.
+        /// </summary>
+        bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage);
+
+        /// <summary>
+        /// Read back the registered XML for the task at
+        /// <paramref name="taskPath"/>. Returns <c>true</c> with the XML
+        /// when the task exists; returns <c>false</c> with a populated
+        /// <paramref name="errorMessage"/> when it does not.
+        /// </summary>
+        bool TryQueryXml(string taskPath, out string xml, out string errorMessage);
+
+        /// <summary>
+        /// Unregister the task at <paramref name="taskPath"/>. Returns
+        /// <c>true</c> if the task was unregistered OR was not registered
+        /// to begin with (idempotent). Returns <c>false</c> only on a hard
+        /// failure (e.g., permission denied).
+        /// </summary>
+        bool TryUnregister(string taskPath, out string errorMessage);
+    }
+}

--- a/GVFS/GVFS.Common/LocalRepoRegistration.cs
+++ b/GVFS/GVFS.Common/LocalRepoRegistration.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// One entry in the user-level repo registry on disk. Field set and
+    /// JSON shape MUST match GVFS.Service.RepoRegistration so that the
+    /// user-level registry file (written by <see cref="LocalRepoRegistry"/>)
+    /// is wire-compatible with any registry the legacy service has written
+    /// in the past. If a new field is added here, the same field must also
+    /// be added to GVFS.Service.RepoRegistration (and vice versa) along
+    /// with a registry-format-version bump.
+    /// </summary>
+    public class LocalRepoRegistration
+    {
+        public LocalRepoRegistration()
+        {
+        }
+
+        public LocalRepoRegistration(string enlistmentRoot, string ownerSID)
+        {
+            this.EnlistmentRoot = enlistmentRoot;
+            this.OwnerSID = ownerSID;
+            this.IsActive = true;
+        }
+
+        public string EnlistmentRoot { get; set; }
+        public string OwnerSID { get; set; }
+        public bool IsActive { get; set; }
+
+        // Uses LocalRepoRegistrationJsonContext (assembly-local source generator)
+        // rather than GVFSJsonContext. The service-side RepoRegistration uses
+        // its own ServiceJsonContext for the same reason — neither type can be
+        // registered in GVFSJsonContext because GVFSJsonContext lives in
+        // GVFS.Common and the service-side type lives in GVFS.Service (wrong
+        // dependency direction). Keeping symmetric local contexts here means
+        // the on-disk JSON shape is governed by identical source-gen behavior
+        // on both sides.
+        public static LocalRepoRegistration FromJson(string json)
+        {
+            return JsonSerializer.Deserialize(json, LocalRepoRegistrationJsonContext.Default.LocalRepoRegistration);
+        }
+
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, LocalRepoRegistrationJsonContext.Default.LocalRepoRegistration);
+        }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "({0} - {1}) {2}",
+                this.IsActive ? "Active" : "Inactive",
+                this.OwnerSID,
+                this.EnlistmentRoot);
+        }
+    }
+
+    [JsonSerializable(typeof(LocalRepoRegistration))]
+    internal partial class LocalRepoRegistrationJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/GVFS/GVFS.Common/LocalRepoRegistry.cs
+++ b/GVFS/GVFS.Common/LocalRepoRegistry.cs
@@ -1,0 +1,515 @@
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// File-backed repo registry usable from any GVFS process without going
+    /// through GVFS.Service. The on-disk format is wire-compatible with
+    /// GVFS.Service.RepoRegistry — both produce and consume the same
+    /// <c>repo-registry</c> file under the shared service data directory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// On-disk format (line-oriented, identical to <c>GVFS.Service.RepoRegistry</c>):
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Line 1: registry format version (integer, currently <c>2</c>).</item>
+    /// <item>
+    /// Lines 2..N: one <see cref="LocalRepoRegistration"/> JSON object per line.
+    /// Blank lines and lines that fail to parse are skipped (matches the service's
+    /// tolerance for partial corruption).
+    /// </item>
+    /// </list>
+    /// <para>
+    /// Threading: instance methods that read or write the registry serialize on
+    /// a private instance lock. Cross-process safety relies on the same atomic
+    /// write-temp-then-replace pattern the service uses.
+    /// </para>
+    /// <para>
+    /// This type does not pick its own storage location — callers pass
+    /// <paramref name="registryDirectory"/> via the constructor. Production
+    /// callers should pass <c>GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(ServiceDataDirName)</c>
+    /// so the file lives at the same path the service uses (which honors the
+    /// <c>GVFS_SECURE_DATA_ROOT</c> environment-variable redirect for user-level
+    /// installs).
+    /// </para>
+    /// </remarks>
+    public class LocalRepoRegistry
+    {
+        /// <summary>
+        /// Subdirectory under the platform's secure-data root that holds the
+        /// registry file. Matches the legacy service's name so both producers
+        /// write to the same location.
+        /// </summary>
+        public const string ServiceDataDirName = "GVFS.Service";
+
+        /// <summary>Final on-disk name of the registry file.</summary>
+        public const string RegistryFileName = "repo-registry";
+
+        /// <summary>
+        /// Temp name used by the atomic write-then-replace pattern. Named
+        /// <c>repo-registry.lock</c> for byte-for-byte compatibility with
+        /// the legacy service's choice (so a writer interrupted mid-rename
+        /// leaves a file with the same name the service would have left).
+        /// </summary>
+        public const string RegistryTempName = "repo-registry.lock";
+
+        /// <summary>
+        /// Registry format version this implementation can read AND write.
+        /// Files with a higher version on disk are treated as opaque: read
+        /// returns empty and we refuse to overwrite, so a newer GVFS that
+        /// has written the registry is not corrupted by an older GVFS.
+        /// </summary>
+        public const int RegistryVersion = 2;
+
+        private readonly ITracer tracer;
+        private readonly PhysicalFileSystem fileSystem;
+        private readonly string registryDirectory;
+        private readonly object instanceLock = new object();
+
+        public LocalRepoRegistry(ITracer tracer, PhysicalFileSystem fileSystem, string registryDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            ArgumentNullException.ThrowIfNull(fileSystem);
+            ArgumentNullException.ThrowIfNull(registryDirectory);
+
+            this.tracer = tracer;
+            this.fileSystem = fileSystem;
+            this.registryDirectory = registryDirectory;
+        }
+
+        /// <summary>
+        /// Convenience factory for production callers: constructs an instance
+        /// pointed at the platform's secure-data path for the GVFS.Service
+        /// component, using a real <see cref="PhysicalFileSystem"/>. This is
+        /// the same path the legacy service writes to, so register/unregister
+        /// operations are wire-compatible regardless of whether the service
+        /// is running.
+        /// </summary>
+        /// <remarks>
+        /// When running as SYSTEM (e.g., CI agents), this method always uses
+        /// the machine-wide ProgramData location to avoid consuming leaked
+        /// user-specific environment variables. For normal user accounts, the
+        /// platform's default path is used (which respects environment variable
+        /// overrides for user-level installs).
+        /// </remarks>
+        public static LocalRepoRegistry CreateForCurrentPlatform(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            
+            string registryDirectory;
+            if (IsRunningAsSystem())
+            {
+                // SYSTEM account (CI agents) always uses the machine-wide ProgramData location
+                // to avoid consuming leaked user-specific environment variables.
+                registryDirectory = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                    "GVFS",
+                    ServiceDataDirName);
+            }
+            else
+            {
+                registryDirectory = GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(ServiceDataDirName);
+            }
+
+            LocalRepoRegistry registry = new LocalRepoRegistry(
+                tracer,
+                new PhysicalFileSystem(),
+                registryDirectory);
+
+            // Seed from system registry if this is the first time a non-SYSTEM user is
+            // using the registry and a system-wide registry already exists.
+            if (!IsRunningAsSystem())
+            {
+                registry.SeedFromSystemRegistryIfNeeded();
+            }
+
+            return registry;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the current process is running under the SYSTEM account
+        /// (S-1-5-18). CI agents and other automated tasks typically run as SYSTEM.
+        /// </summary>
+        private static bool IsRunningAsSystem()
+        {
+            using (System.Security.Principal.WindowsIdentity identity = System.Security.Principal.WindowsIdentity.GetCurrent())
+            {
+                return identity.IsSystem;
+            }
+        }
+
+        /// <summary>
+        /// Idempotently records the given enlistment root as active. If an
+        /// entry already exists, it is reactivated and its <c>OwnerSID</c>
+        /// is updated to <paramref name="ownerSID"/>. Matches the semantics
+        /// of <c>GVFS.Service.RepoRegistry.TryRegisterRepo</c>.
+        /// </summary>
+        public bool TryRegisterRepo(string repoRoot, string ownerSID, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.TryGetValue(repoRoot, out LocalRepoRegistration existing))
+                    {
+                        if (!existing.IsActive || !string.Equals(existing.OwnerSID, ownerSID, StringComparison.Ordinal))
+                        {
+                            existing.IsActive = true;
+                            existing.OwnerSID = ownerSID;
+                            this.WriteRegistry(all);
+                        }
+                    }
+                    else
+                    {
+                        all[repoRoot] = new LocalRepoRegistration(repoRoot, ownerSID);
+                        this.WriteRegistry(all);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while registering repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Marks the given entry inactive (retained on disk so
+        /// <see cref="LocalRepoRegistration.OwnerSID"/> is preserved for a
+        /// possible later re-register). Returns <c>true</c> when the entry
+        /// existed (whether or not it was already inactive); returns
+        /// <c>false</c> when the entry was not found.
+        /// </summary>
+        public bool TryDeactivateRepo(string repoRoot, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.TryGetValue(repoRoot, out LocalRepoRegistration existing))
+                    {
+                        if (existing.IsActive)
+                        {
+                            existing.IsActive = false;
+                            this.WriteRegistry(all);
+                        }
+
+                        return true;
+                    }
+
+                    errorMessage = string.Format("Attempted to deactivate non-existent repo at '{0}'", repoRoot);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while deactivating repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Removes the entry entirely (not just deactivates it). Returns
+        /// <c>true</c> on success, <c>false</c> if no such entry existed.
+        /// </summary>
+        public bool TryRemoveRepo(string repoRoot, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.Remove(repoRoot))
+                    {
+                        this.WriteRegistry(all);
+                        return true;
+                    }
+
+                    errorMessage = string.Format("Attempted to remove non-existent repo at '{0}'", repoRoot);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while removing repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns the entries currently marked active. Inactive entries are
+        /// excluded. Returns an empty list when the registry file does not
+        /// exist yet.
+        /// </summary>
+        public bool TryGetActiveRepos(out List<LocalRepoRegistration> repoList, out string errorMessage)
+        {
+            repoList = null;
+            errorMessage = null;
+
+            lock (this.instanceLock)
+            {
+                try
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    repoList = all.Values.Where(r => r.IsActive).ToList();
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    errorMessage = string.Format("Unable to get list of active repos: {0}", e);
+                    this.tracer.RelatedError(errorMessage);
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Seeds the user registry from the system-wide ProgramData registry if the user
+        /// registry doesn't exist yet. Filters entries to only those whose repo root directory
+        /// exists and is accessible to the current user. This supports migration scenarios
+        /// where repos were previously registered by GVFS.Service (system-wide) and are now
+        /// transitioning to user-level registration.
+        /// </summary>
+        /// <remarks>
+        /// This method is only intended for non-SYSTEM accounts. SYSTEM processes use the
+        /// ProgramData registry directly and never seed from it.
+        /// </remarks>
+        public void SeedFromSystemRegistryIfNeeded()
+        {
+            string registryPath = Path.Combine(this.registryDirectory, RegistryFileName);
+            if (this.fileSystem.FileExists(registryPath))
+            {
+                return; // User registry already exists, nothing to seed
+            }
+
+            string systemRegistryDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "GVFS",
+                ServiceDataDirName);
+            string systemRegistryPath = Path.Combine(systemRegistryDir, RegistryFileName);
+
+            if (!this.fileSystem.FileExists(systemRegistryPath))
+            {
+                return; // No system registry to seed from
+            }
+
+            try
+            {
+                // Read system registry entries
+                Dictionary<string, LocalRepoRegistration> systemRepos = this.ReadRegistryFrom(systemRegistryDir);
+                if (systemRepos.Count == 0)
+                {
+                    return; // System registry is empty, nothing to seed
+                }
+
+                // Filter to repos whose directories exist and are accessible
+                Dictionary<string, LocalRepoRegistration> accessibleRepos =
+                    new Dictionary<string, LocalRepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
+
+                foreach (LocalRepoRegistration repo in systemRepos.Values)
+                {
+                    if (string.IsNullOrEmpty(repo.EnlistmentRoot))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (this.fileSystem.DirectoryExists(repo.EnlistmentRoot))
+                        {
+                            accessibleRepos[repo.EnlistmentRoot] = repo;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // If we can't check the directory (permission denied, etc.),
+                        // treat it as inaccessible and skip.
+                    }
+                }
+
+                // Write accessible repos to user registry. Re-check whether the file
+                // was created by another process (TOCTOU race) and merge if so.
+                if (accessibleRepos.Count > 0)
+                {
+                    if (this.fileSystem.FileExists(registryPath))
+                    {
+                        // Another process created the registry between our check and now.
+                        // Merge: read what's there, add our seeded entries (don't overwrite).
+                        Dictionary<string, LocalRepoRegistration> existingRepos = this.ReadRegistryFrom(this.registryDirectory);
+                        foreach (KeyValuePair<string, LocalRepoRegistration> entry in accessibleRepos)
+                        {
+                            if (!existingRepos.ContainsKey(entry.Key))
+                            {
+                                existingRepos[entry.Key] = entry.Value;
+                            }
+                        }
+
+                        this.WriteRegistry(existingRepos);
+                    }
+                    else
+                    {
+                        this.WriteRegistry(accessibleRepos);
+                    }
+
+                    EventMetadata metadata = new EventMetadata
+                    {
+                        { "SystemRegistryPath", systemRegistryPath },
+                        { "UserRegistryPath", registryPath },
+                        { "SeededCount", accessibleRepos.Count },
+                        { "TotalSystemCount", systemRepos.Count },
+                    };
+                    this.tracer.RelatedEvent(
+                        EventLevel.Informational,
+                        nameof(this.SeedFromSystemRegistryIfNeeded),
+                        metadata);
+                }
+            }
+            catch (Exception e)
+            {
+                EventMetadata metadata = new EventMetadata
+                {
+                    { "SystemRegistryPath", systemRegistryPath },
+                    { "Exception", e.ToString() },
+                };
+                this.tracer.RelatedError(
+                    metadata,
+                    $"{nameof(this.SeedFromSystemRegistryIfNeeded)}: Failed to seed from system registry; continuing with empty user registry");
+            }
+        }
+
+        /// <summary>
+        /// Returns the in-memory map of all entries currently on disk
+        /// (active and inactive). Intended for diagnostics and tests; most
+        /// production callers should use <see cref="TryGetActiveRepos"/>.
+        /// </summary>
+        public Dictionary<string, LocalRepoRegistration> ReadRegistry()
+        {
+            return this.ReadRegistryFrom(this.registryDirectory);
+        }
+
+        /// <summary>
+        /// Reads the registry from the specified directory. Used internally for
+        /// both the normal registry path and for seeding from the system registry.
+        /// </summary>
+        private Dictionary<string, LocalRepoRegistration> ReadRegistryFrom(string registryDirectory)
+        {
+            Dictionary<string, LocalRepoRegistration> allRepos =
+                new Dictionary<string, LocalRepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
+
+            string registryFilePath = Path.Combine(registryDirectory, RegistryFileName);
+
+            using (Stream stream = this.fileSystem.OpenFileStream(
+                    registryFilePath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    callFlushFileBuffers: false))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                string versionString = reader.ReadLine();
+                if (versionString == null)
+                {
+                    // Empty file - first write will populate it.
+                    return allRepos;
+                }
+
+                if (!int.TryParse(versionString, out int version) || version > RegistryVersion)
+                {
+                    EventMetadata metadata = new EventMetadata
+                    {
+                        { "OnDiskVersion", versionString },
+                        { "MaxSupportedVersion", RegistryVersion },
+                    };
+                    this.tracer.RelatedError(metadata, $"{nameof(this.ReadRegistry)}: Unsupported registry version; treating as empty");
+                    return allRepos;
+                }
+
+                while (!reader.EndOfStream)
+                {
+                    string entry = reader.ReadLine();
+                    if (string.IsNullOrEmpty(entry))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        LocalRepoRegistration registration = LocalRepoRegistration.FromJson(entry);
+                        if (registration != null && !string.IsNullOrEmpty(registration.EnlistmentRoot))
+                        {
+                            allRepos[registration.EnlistmentRoot] = registration;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // Tolerate corruption of individual lines; matches
+                        // RepoRegistry.ReadRegistry's behavior.
+                        EventMetadata metadata = new EventMetadata
+                        {
+                            { "entry", entry },
+                            { "Exception", e.ToString() },
+                        };
+                        this.tracer.RelatedError(metadata, $"{nameof(this.ReadRegistry)}: Failed to parse entry; skipping");
+                    }
+                }
+            }
+
+            return allRepos;
+        }
+
+        private void WriteRegistry(Dictionary<string, LocalRepoRegistration> registry)
+        {
+            // Ensure the directory exists. The service relies on its install
+            // step to create %ProgramData%\GVFS\GVFS.Service; the user-level
+            // path under %LocalAppData% may not exist yet when this runs.
+            if (!this.fileSystem.DirectoryExists(this.registryDirectory))
+            {
+                this.fileSystem.CreateDirectory(this.registryDirectory);
+            }
+
+            string tempFilePath = Path.Combine(this.registryDirectory, RegistryTempName);
+            string finalFilePath = Path.Combine(this.registryDirectory, RegistryFileName);
+
+            using (Stream stream = this.fileSystem.OpenFileStream(
+                    tempFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    callFlushFileBuffers: true))
+            using (StreamWriter writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(RegistryVersion);
+                foreach (LocalRepoRegistration registration in registry.Values)
+                {
+                    writer.WriteLine(registration.ToJson());
+                }
+
+                stream.Flush();
+            }
+
+            this.fileSystem.MoveAndOverwriteFile(tempFilePath, finalFilePath);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/LogonTaskRegistration.cs
+++ b/GVFS/GVFS.Common/LogonTaskRegistration.cs
@@ -1,0 +1,244 @@
+using GVFS.Common.Tracing;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Registers / updates / unregisters the machine-wide Windows scheduled task
+    /// that mounts registered GVFS enlistments at logon for each interactive user. Replaces
+    /// the role of <c>GVFS.Service</c>'s session-change-driven AutoMount in
+    /// the user-level install model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The task is registered at <c>\GVFS\AutoMount</c>, scoped to all
+    /// interactive users (GroupId S-1-5-4), runs at user logon with the
+    /// user's interactive token, and executes <c>gvfs.exe service --mount-all</c>.
+    /// The mount-all verb reads the user's registered repos (via <see cref="LocalRepoRegistry"/>)
+    /// and mounts each one.
+    /// </para>
+    /// <para>
+    /// Drift detection works via a content-hash marker embedded in the
+    /// task's Description field
+    /// (<c>[gvfs-logon-task-hash=XXXXXXXXXXXXXXXX]</c>). The hash covers the
+    /// XML template <em>with placeholders still in place</em>, so it is
+    /// stable across re-substitutions with different gvfs.exe
+    /// paths -- only template content changes (a code change to the
+    /// template constant) bump the hash. <see cref="IsCurrent"/> queries
+    /// the registered task XML, extracts the marker, and compares against
+    /// <see cref="TemplateHash"/>.
+    /// </para>
+    /// <para>
+    /// Tested as a unit by passing a mock <see cref="IScheduledTaskInvoker"/>.
+    /// Production callers should use
+    /// <see cref="CreateForCurrentPlatform(ITracer)"/>, which constructs a
+    /// <see cref="SchTasksScheduledTaskInvoker"/> behind the scenes.
+    /// </para>
+    /// </remarks>
+    public class LogonTaskRegistration
+    {
+        public const string TaskName = "AutoMount";
+        public const string TaskFolder = @"\GVFS\";
+        public const string FullTaskPath = @"\GVFS\AutoMount";
+
+        public const string GvfsPathPlaceholder = "__GVFS_PATH__";
+        public const string TaskHashPlaceholder = "__TASK_HASH__";
+
+        public const string HashMarkerPrefix = "[gvfs-logon-task-hash=";
+        public const string HashMarkerSuffix = "]";
+
+        /// <summary>
+        /// Task XML template. Placeholders:
+        /// <list type="bullet">
+        /// <item><c>__GVFS_PATH__</c> -- absolute path to gvfs.exe</item>
+        /// <item><c>__TASK_HASH__</c> -- content hash of this template,
+        ///   inserted into the Description for drift detection</item>
+        /// </list>
+        /// Indented as a verbatim string; the XML emitted is well-formed
+        /// and accepted by <c>schtasks /Create /XML</c>.
+        /// </summary>
+        public const string XmlTemplate =
+@"<?xml version=""1.0"" encoding=""UTF-16""?>
+<Task version=""1.4"" xmlns=""http://schemas.microsoft.com/windows/2004/02/mit/task"">
+  <RegistrationInfo>
+    <Author>GVFS</Author>
+    <Description>Mounts registered GVFS enlistments at logon for each interactive user. Required by VFS for Git. [gvfs-logon-task-hash=__TASK_HASH__]</Description>
+    <URI>\GVFS\AutoMount</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id=""Author"">
+      <GroupId>S-1-5-4</GroupId>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>
+    <Priority>5</Priority>
+  </Settings>
+  <Actions Context=""Author"">
+    <Exec>
+      <Command>conhost.exe</Command>
+      <Arguments>--headless __GVFS_PATH__ service --mount-all</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+";
+
+        private static readonly Lazy<string> templateHash = new Lazy<string>(ComputeTemplateHash);
+
+        private readonly ITracer tracer;
+        private readonly IScheduledTaskInvoker invoker;
+
+        public LogonTaskRegistration(ITracer tracer, IScheduledTaskInvoker invoker)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            ArgumentNullException.ThrowIfNull(invoker);
+            this.tracer = tracer;
+            this.invoker = invoker;
+        }
+
+        /// <summary>
+        /// Convenience factory for production callers: wires up a real
+        /// <see cref="SchTasksScheduledTaskInvoker"/>.
+        /// </summary>
+        public static LogonTaskRegistration CreateForCurrentPlatform(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            return new LogonTaskRegistration(tracer, new SchTasksScheduledTaskInvoker(tracer));
+        }
+
+        /// <summary>
+        /// Stable hex hash of <see cref="XmlTemplate"/> (with placeholders
+        /// intact). 64 hex chars (full SHA-256), computed once per process.
+        /// </summary>
+        public static string TemplateHash => templateHash.Value;
+
+        /// <summary>
+        /// Substitute placeholders to produce a registerable task XML.
+        /// </summary>
+        public static string BuildTaskXml(string gvfsExePath)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(gvfsExePath);
+
+            return XmlTemplate
+                .Replace(GvfsPathPlaceholder, gvfsExePath)
+                .Replace(TaskHashPlaceholder, TemplateHash);
+        }
+
+        /// <summary>
+        /// Extract the <c>[gvfs-logon-task-hash=XXXX]</c> hash marker from
+        /// arbitrary text (usually a Task's Description). Returns
+        /// <c>false</c> when no marker is present.
+        /// </summary>
+        public static bool TryExtractHashMarker(string text, out string hash)
+        {
+            hash = null;
+            if (string.IsNullOrEmpty(text))
+            {
+                return false;
+            }
+
+            int start = text.IndexOf(HashMarkerPrefix, StringComparison.Ordinal);
+            if (start < 0)
+            {
+                return false;
+            }
+
+            int hashStart = start + HashMarkerPrefix.Length;
+            int hashEnd = text.IndexOf(HashMarkerSuffix, hashStart, StringComparison.Ordinal);
+            if (hashEnd <= hashStart)
+            {
+                return false;
+            }
+
+            hash = text.Substring(hashStart, hashEnd - hashStart);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when the logon task is registered AND its
+        /// embedded hash marker matches the current template's hash.
+        /// Returns <c>false</c> if the task is missing, the query fails,
+        /// or the hash differs (drift).
+        /// </summary>
+        public bool IsCurrent()
+        {
+            if (!this.invoker.TryQueryXml(FullTaskPath, out string xml, out _))
+            {
+                return false;
+            }
+
+            if (!TryExtractHashMarker(xml, out string registeredHash))
+            {
+                return false;
+            }
+
+            return string.Equals(registeredHash, TemplateHash, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Register the logon task with the given gvfs.exe path,
+        /// overwriting any existing registration. Idempotent: when
+        /// the registered task already matches the intended XML (same
+        /// hash, same args), this is a fast no-op.
+        /// </summary>
+        public bool TryRegisterOrUpdate(string gvfsExePath, out string errorMessage)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(gvfsExePath);
+
+            if (this.IsCurrent())
+            {
+                // Still verify args are right; the hash covers the template
+                // structure but not the substituted gvfs.exe path. Re-query
+                // and check the action command.
+                if (this.invoker.TryQueryXml(FullTaskPath, out string existingXml, out _) &&
+                    existingXml.Contains(gvfsExePath, StringComparison.Ordinal))
+                {
+                    errorMessage = string.Empty;
+                    return true;
+                }
+            }
+
+            string xml = BuildTaskXml(gvfsExePath);
+            return this.invoker.TryRegisterFromXml(FullTaskPath, xml, out errorMessage);
+        }
+
+        /// <summary>
+        /// Unregister the logon task. Idempotent: returns <c>true</c> when
+        /// the task was unregistered OR was not registered to begin with.
+        /// </summary>
+        public bool TryUnregister(out string errorMessage)
+        {
+            return this.invoker.TryUnregister(FullTaskPath, out errorMessage);
+        }
+
+        private static string ComputeTemplateHash()
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(XmlTemplate);
+            byte[] hash = SHA256.HashData(bytes);
+            return Convert.ToHexString(hash);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/SchTasksScheduledTaskInvoker.cs
+++ b/GVFS/GVFS.Common/SchTasksScheduledTaskInvoker.cs
@@ -1,0 +1,124 @@
+using GVFS.Common.Tracing;
+using System;
+using System.IO;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Default <see cref="IScheduledTaskInvoker"/> implementation: shells out
+    /// to <c>schtasks.exe</c>. Windows-only by nature -- on non-Windows the
+    /// process launch fails and operations return false with a populated
+    /// error message. User-mode install is Windows-only, so that's fine.
+    /// </summary>
+    public class SchTasksScheduledTaskInvoker : IScheduledTaskInvoker
+    {
+        private readonly ITracer tracer;
+
+        public SchTasksScheduledTaskInvoker(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            this.tracer = tracer;
+        }
+
+        public bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage)
+        {
+            // schtasks /Create accepts an XML file path via /XML, not raw
+            // XML on stdin. Write to a temp file with the same UTF-16 BOM
+            // the Task Scheduler XML schema expects, then run schtasks.
+            string tempPath = Path.Combine(Path.GetTempPath(), $"gvfs-task-{Guid.NewGuid():N}.xml");
+            try
+            {
+                File.WriteAllText(tempPath, xml, new System.Text.UnicodeEncoding(bigEndian: false, byteOrderMark: true));
+
+                // /F overwrites if already exists.
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Create /TN \"{taskPath}\" /XML \"{tempPath}\" /F");
+
+                if (result.ExitCode != 0)
+                {
+                    errorMessage = $"schtasks /Create failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to register scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+            finally
+            {
+                try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+            }
+        }
+
+        public bool TryQueryXml(string taskPath, out string xml, out string errorMessage)
+        {
+            xml = null;
+            try
+            {
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Query /TN \"{taskPath}\" /XML");
+
+                if (result.ExitCode != 0)
+                {
+                    // Exit 1 = task not found. Surface a useful message; the
+                    // caller distinguishes "not found" from "permission denied"
+                    // by inspecting the message text or just treating both as
+                    // "not current".
+                    errorMessage = $"schtasks /Query failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                xml = result.Output;
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to query scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        public bool TryUnregister(string taskPath, out string errorMessage)
+        {
+            try
+            {
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Delete /TN \"{taskPath}\" /F");
+
+                if (result.ExitCode != 0)
+                {
+                    // Exit 1 with "cannot find the file specified" means the
+                    // task is already gone; treat as success.
+                    string combined = (result.Output + " " + result.Errors).ToLowerInvariant();
+                    if (combined.Contains("cannot find the file") || combined.Contains("system cannot find"))
+                    {
+                        errorMessage = string.Empty;
+                        return true;
+                    }
+
+                    errorMessage = $"schtasks /Delete failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to unregister scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -2,8 +2,9 @@
 {
     public static class Categories
     {
+        public const string ExtraCoverage = "ExtraCoverage";
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
-        public const string SkipInCI = "SkipInCI";
+        public const string NeedsReactionInCI = "NeedsReactionInCI";
     }
 }

--- a/GVFS/GVFS.FunctionalTests/GlobalSetup.cs
+++ b/GVFS/GVFS.FunctionalTests/GlobalSetup.cs
@@ -18,23 +18,6 @@ namespace GVFS.FunctionalTests
         [OneTimeTearDown]
         public void RunAfterAllTests()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                string serviceLogFolder = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                    "GVFS",
-                    GVFSServiceProcess.TestServiceName,
-                    "Logs");
-
-                Console.WriteLine("GVFS.Service logs at '{0}' attached below.\n\n", serviceLogFolder);
-                foreach (string filename in TestResultsHelper.GetAllFilesInDirectory(serviceLogFolder))
-                {
-                    TestResultsHelper.OutputFileContents(filename);
-                }
-
-                GVFSServiceProcess.UninstallService();
-            }
-
             PrintTestCaseStats.PrintRunTimeStats();
         }
     }

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -84,11 +84,21 @@ namespace GVFS.FunctionalTests
                         new object[] { validateMode },
                     };
 
+                if (runner.HasCustomArg("--extra-only"))
+                {
+                    Console.WriteLine("Running only the tests marked as ExtraCoverage");
+                    includeCategories.Add(Categories.ExtraCoverage);
+                }
+                else
+                {
+                    excludeCategories.Add(Categories.ExtraCoverage);
+                }
+
                 // If we're running in CI exclude tests that are currently
                 // flakey or broken when run in a CI environment.
                 if (runner.HasCustomArg("--ci"))
                 {
-                    excludeCategories.Add(Categories.SkipInCI);
+                    excludeCategories.Add(Categories.NeedsReactionInCI);
                 }
 
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
@@ -141,10 +151,7 @@ namespace GVFS.FunctionalTests
                 ProjFSFilterInstaller.ReplaceInboxProjFS();
             }
 
-            Console.WriteLine("[CI-DEBUG] Installing service...");
-            Console.Out.Flush();
-            GVFSServiceProcess.InstallService();
-            Console.WriteLine("[CI-DEBUG] Service installed successfully");
+            Console.WriteLine("[CI-DEBUG] Skipping service install (service removed)");
             Console.Out.Flush();
 
             string serviceProgramDataDir = GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(

--- a/GVFS/GVFS.FunctionalTests/Settings.cs
+++ b/GVFS/GVFS.FunctionalTests/Settings.cs
@@ -65,8 +65,20 @@ namespace GVFS.FunctionalTests.Properties
                 }
                 else
                 {
-                    PathToGVFS = @"C:\Program Files\VFS for Git\GVFS.exe";
-                    PathToGVFSService = @"C:\Program Files\VFS for Git\GVFS.Service.exe";
+                    // User-level install path (LocalAppData) for user-mode testing.
+                    string userLevelGvfs = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "VFSForGit", "Current", "gvfs.exe");
+                    if (File.Exists(userLevelGvfs))
+                    {
+                        PathToGVFS = userLevelGvfs;
+                        PathToGVFSService = Path.Combine(Path.GetDirectoryName(userLevelGvfs), "GVFS.Service.exe");
+                    }
+                    else
+                    {
+                        PathToGVFS = @"C:\Program Files\VFS for Git\GVFS.exe";
+                        PathToGVFSService = @"C:\Program Files\VFS for Git\GVFS.Service.exe";
+                    }
                 }
 
                 PathToGit = @"C:\Program Files\Git\cmd\git.exe";

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -280,9 +280,6 @@ begin
   // Spaces after the equal signs are REQUIRED.
   // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
-    // Create the Current junction first, so service registration can use the stable path
-    CreateOrUpdateCurrentJunction();
-
     // We must add additional quotes to the binPath to ensure that they survive argument parsing.
     // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
     // Use {app}\Current\GVFS.Service.exe so the service path survives version upgrades via junction swap.
@@ -671,74 +668,56 @@ begin
   Result := False;
 end;
 
-function UninstallNeedRestart(): Boolean;
-begin
-  Result := False;
-end;
-
-procedure CurStepChanged(CurStep: TSetupStep);
-begin
-  case CurStep of
-    ssInstall:
-      begin
-        if not KeepMountsRunning then
-          UninstallService('GVFS.Service', True);
-      end;
-    ssPostInstall:
-      begin
-        CreateOrUpdateCurrentJunction();
-        GarbageCollectOldVersions();
-        MigrateConfigAndStatusCacheFiles();
-        if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
-          begin
-            MountRepos();
-          end
-      end;
-    end;
-end;
-
-function GetCustomSetupExitCode: Integer;
-begin
-  Result := ExitCode;
-end;
-
-procedure CurUninstallStepChanged(CurStep: TUninstallStep);
-begin
-  case CurStep of
-    usUninstall:
-      begin
-        UninstallService('GVFS.Service', False);
-        RemovePath(ExpandConstant('{app}\Current'));
-      end;
-    end;
-end;
 
 procedure CreateOrUpdateCurrentJunction();
 var
   AppDir: string;
   JunctionPath: string;
+  JunctionNew: string;
   VersionDir: string;
   ResultCode: integer;
 begin
   AppDir := ExpandConstant('{app}');
   JunctionPath := AppDir + '\Current';
+  JunctionNew := AppDir + '\Current.new';
   VersionDir := AppDir + '\Versions\{#MyAppInstallerVersion}';
 
   Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Target version = {#MyAppInstallerVersion}');
 
-  // Remove existing junction if present
+  // Fix #4: Atomic junction swap using .new temporary
+  // Create new junction at Current.new
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction Current.new -> ' + VersionDir);
+  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionNew + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
+      RaiseException('Fatal: Could not create Current.new junction at ' + JunctionNew);
+    end;
+
+  // Remove existing Current junction if present
   if DirExists(JunctionPath) then
     begin
       Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Removing existing Current junction');
-      Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      if not Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+        begin
+          Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: WARNING - rmdir failed with exit code ' + IntToStr(ResultCode));
+          // Continue anyway - rename might still work
+        end;
     end;
 
-  // Create new junction: Current -> Versions\<version>
-  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction -> ' + VersionDir);
-  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+  // Rename Current.new -> Current
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Renaming Current.new -> Current');
+  if not Exec(ExpandConstant('{cmd}'), '/C ren "' + JunctionNew + '" Current', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
     begin
-      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
-      RaiseException('Fatal: Could not create Current junction at ' + JunctionPath);
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: ren failed with exit code ' + IntToStr(ResultCode));
+      // Fallback: if Current.new exists, at least installer can reference it
+      if DirExists(JunctionNew) then
+        begin
+          Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: WARNING - Using Current.new as fallback');
+        end
+      else
+        begin
+          RaiseException('Fatal: Could not rename Current.new to Current');
+        end;
     end
   else
     begin
@@ -980,4 +959,49 @@ begin
   StopService('GVFS.Service');
   UninstallGvFlt();
   UninstallProjFSIfNecessary();
+end;
+
+function UninstallNeedRestart(): Boolean;
+begin
+  Result := False;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  case CurStep of
+    ssInstall:
+      begin
+        UninstallService('GVFS.Service', True);
+        // Fix #2: Create junction BEFORE InstallGVFSService runs (which happens
+        // during file extraction). This ensures {app}\Current\GVFS.Service.exe
+        // exists when the service starts.
+        CreateOrUpdateCurrentJunction();
+      end;
+    ssPostInstall:
+      begin
+        // Fix #3: Remove legacy flat PATH entry on upgrade from flat layout.
+        // Safe because new PATH entry points to {app}\Current.
+        RemovePath(ExpandConstant('{app}'));
+        
+        // GC runs after junction is already in place (from ssInstall above)
+        GarbageCollectOldVersions();
+        MigrateConfigAndStatusCacheFiles();
+      end;
+    end;
+end;
+
+function GetCustomSetupExitCode: Integer;
+begin
+  Result := ExitCode;
+end;
+
+procedure CurUninstallStepChanged(CurStep: TUninstallStep);
+begin
+  case CurStep of
+    usUninstall:
+      begin
+        UninstallService('GVFS.Service', False);
+        RemovePath(ExpandConstant('{app}\Current'));
+      end;
+    end;
 end;

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -60,12 +60,11 @@ Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
 ; Versioned install: all files go to {app}\Versions\{version}
-; Service binary gets AfterInstall callback to register service with binPath pointing to {app}\Current\GVFS.Service.exe
+; No service — using machine-wide logon task instead
 DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"
-DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService
 
 [Dirs]
-Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
+; No longer creating service ProgramData directory — not using service
 
 [UninstallDelete]
 ; Deletes the entire installation directory, including files and subdirectories
@@ -86,7 +85,6 @@ Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
 [Code]
 var
   ExitCode: Integer;
-  KeepMountsRunning: Boolean;
 
 function NeedsAddPath(Param: string): boolean;
 var
@@ -257,7 +255,7 @@ procedure WriteOnDiskVersion16CapableFile();
 var
   FilePath: string;
 begin
-  FilePath := ExpandConstant('{app}\Versions\{#MyAppInstallerVersion}\OnDiskVersion16CapableInstallation.dat');
+  FilePath := ExpandConstant('{app}\OnDiskVersion16CapableInstallation.dat');
   if not FileExists(FilePath) then
     begin
       Log('WriteOnDiskVersion16CapableFile: Writing file ' + FilePath);
@@ -265,49 +263,86 @@ begin
     end
 end;
 
-procedure InstallGVFSService();
+procedure RegisterAutoMountLogonTask();
 var
   ResultCode: integer;
   StatusText: string;
-  InstallSuccessful: Boolean;
+  GvfsExe: string;
+  TempXmlFile: string;
+  TaskXml: string;
 begin
-  InstallSuccessful := False;
-
   StatusText := WizardForm.StatusLabel.Caption;
-  WizardForm.StatusLabel.Caption := 'Installing GVFS.Service.';
+  WizardForm.StatusLabel.Caption := 'Registering AutoMount logon task...';
   WizardForm.ProgressGauge.Style := npbstMarquee;
 
-  // Spaces after the equal signs are REQUIRED.
-  // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
-    // We must add additional quotes to the binPath to ensure that they survive argument parsing.
-    // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
-    // Use {app}\Current\GVFS.Service.exe so the service path survives version upgrades via junction swap.
-    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\Current\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
-      begin
-        if Exec(ExpandConstant('{sys}\SC.EXE'), 'failure GVFS.Service reset= 30 actions= restart/10/restart/5000//1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-          begin
-            if Exec(ExpandConstant('{sys}\SC.EXE'), 'start GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-              begin
-                InstallSuccessful := True;
-              end;
-          end;
-      end;
+    GvfsExe := ExpandConstant('{app}\Current\gvfs.exe');
+    TempXmlFile := ExpandConstant('{tmp}\~taskxml.xml');
 
-    WriteOnDiskVersion16CapableFile();
+    // Machine-wide logon task using Interactive Users group (S-1-5-4).
+    // Fires for every interactive user at logon. Each user's gvfs service
+    // --mount-all reads their own LocalRepoRegistry.
+    TaskXml := '<?xml version="1.0" encoding="UTF-16"?>' + #13#10 +
+      '<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">' + #13#10 +
+      '  <RegistrationInfo>' + #13#10 +
+      '    <Author>GVFS</Author>' + #13#10 +
+      '    <Description>Mounts registered GVFS enlistments at logon for each interactive user. Required by VFS for Git.</Description>' + #13#10 +
+      '    <URI>\GVFS\AutoMount</URI>' + #13#10 +
+      '  </RegistrationInfo>' + #13#10 +
+      '  <Triggers>' + #13#10 +
+      '    <LogonTrigger>' + #13#10 +
+      '      <Enabled>true</Enabled>' + #13#10 +
+      '    </LogonTrigger>' + #13#10 +
+      '  </Triggers>' + #13#10 +
+      '  <Principals>' + #13#10 +
+      '    <Principal id="Author">' + #13#10 +
+      '      <GroupId>S-1-5-4</GroupId>' + #13#10 +
+      '      <RunLevel>LeastPrivilege</RunLevel>' + #13#10 +
+      '    </Principal>' + #13#10 +
+      '  </Principals>' + #13#10 +
+      '  <Settings>' + #13#10 +
+      '    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>' + #13#10 +
+      '    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>' + #13#10 +
+      '    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>' + #13#10 +
+      '    <AllowHardTerminate>true</AllowHardTerminate>' + #13#10 +
+      '    <StartWhenAvailable>true</StartWhenAvailable>' + #13#10 +
+      '    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>' + #13#10 +
+      '    <IdleSettings>' + #13#10 +
+      '      <StopOnIdleEnd>false</StopOnIdleEnd>' + #13#10 +
+      '      <RestartOnIdle>false</RestartOnIdle>' + #13#10 +
+      '    </IdleSettings>' + #13#10 +
+      '    <AllowStartOnDemand>true</AllowStartOnDemand>' + #13#10 +
+      '    <Enabled>true</Enabled>' + #13#10 +
+      '    <Hidden>false</Hidden>' + #13#10 +
+      '    <RunOnlyIfIdle>false</RunOnlyIfIdle>' + #13#10 +
+      '    <WakeToRun>false</WakeToRun>' + #13#10 +
+      '    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>' + #13#10 +
+      '    <Priority>5</Priority>' + #13#10 +
+      '  </Settings>' + #13#10 +
+      '  <Actions Context="Author">' + #13#10 +
+      '    <Exec>' + #13#10 +
+      '      <Command>conhost.exe</Command>' + #13#10 +
+      '      <Arguments>--headless "' + GvfsExe + '" service --mount-all</Arguments>' + #13#10 +
+      '    </Exec>' + #13#10 +
+      '  </Actions>' + #13#10 +
+      '</Task>';
+
+    SaveStringToFile(TempXmlFile, TaskXml, False);
+    Log('RegisterAutoMountLogonTask: Wrote task XML to ' + TempXmlFile);
+
+    // Create task folder if needed, then register task
+    Exec(ExpandConstant('{sys}\schtasks.exe'), '/Create /TN "\GVFS\AutoMount" /XML "' + TempXmlFile + '" /F', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    if ResultCode = 0 then
+      Log('RegisterAutoMountLogonTask: Logon task registered successfully')
+    else
+      Log('RegisterAutoMountLogonTask: schtasks /Create returned ' + IntToStr(ResultCode));
+
+    DeleteFile(TempXmlFile);
   finally
     WizardForm.StatusLabel.Caption := StatusText;
     WizardForm.ProgressGauge.Style := npbstNormal;
   end;
-
-  if InstallSuccessful = False then
-    begin
-      RaiseException('Fatal: An error occured while installing GVFS.Service.');
-    end;
 end;
-
-// StagingUpdateService removed - staging upgrade flow replaced by versioned layout with junction swap.
-// Service install/start is handled in InstallGVFSService.
 
 function DeleteFileIfItExists(FilePath: string) : Boolean;
 begin
@@ -483,41 +518,6 @@ begin
   DeleteFile(TempFilename);
 end;
 
-procedure UnmountRepos();
-var
-  ResultCode: integer;
-begin
-  Exec('gvfs.exe', 'service --unmount-all', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-end;
-
-procedure MountRepos();
-var
-  StatusText: string;
-  MountOutput: ansiString;
-  ResultCode: integer;
-  MsgBoxText: string;
-begin
-  StatusText := WizardForm.StatusLabel.Caption;
-  WizardForm.StatusLabel.Caption := 'Mounting Repos.';
-  WizardForm.ProgressGauge.Style := npbstMarquee;
-
-  ExecWithResult(ExpandConstant('{app}') + '\gvfs.exe', 'service --mount-all', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, MountOutput);
-  WizardForm.StatusLabel.Caption := StatusText;
-  WizardForm.ProgressGauge.Style := npbstNormal;
-
-  // 4 = ReturnCode.FilterError
-  if (ResultCode = 4) then
-    begin
-      RaiseException('Fatal: Could not configure and start Windows Projected File System.');
-    end
-  else if (ResultCode <> 0) then
-    begin
-      MsgBoxText := 'Mounting one or more repos failed:' + #13#10 + MountOutput;
-      SuppressibleMsgBox(MsgBoxText, mbConfirmation, MB_OK, IDOK);
-      ExitCode := 17;
-    end;
-end;
-
 procedure MigrateFile(OldPath, NewPath : string);
 begin
   Log('MigrateFile(' + OldPath + ', ' + NewPath + ')');
@@ -543,7 +543,7 @@ var
   SecureAppDataDir: string;
 begin
   CommonAppDataDir := ExpandConstant('{commonappdata}\GVFS');
-  SecureAppDataDir := ExpandConstant('{app}\Current\ProgramData');
+  SecureAppDataDir := ExpandConstant('{app}\ProgramData');
 
   MigrateFile(CommonAppDataDir + '\{#GVFSConfigFileName}', SecureAppDataDir + '\{#GVFSConfigFileName}');
   MigrateFile(CommonAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}', SecureAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}');
@@ -668,6 +668,10 @@ begin
   Result := False;
 end;
 
+function UninstallNeedRestart(): Boolean;
+begin
+  Result := False;
+end;
 
 procedure CreateOrUpdateCurrentJunction();
 var
@@ -892,100 +896,22 @@ begin
     Log('[GVFS-INSTALL] GarbageCollectOldVersions: Keeping most recent old version ' + VersionDirs[Count - 1]);
 end;
 
-function PrepareToInstall(var NeedsRestart: Boolean): String;
-var
-  ResultCode: integer;
-begin
-  NeedsRestart := False;
-  KeepMountsRunning := False;
-  Result := '';
-  SetNuGetFeedIfNecessary();
-
-  // Versioned layout: no staging flow. Just ensure no GVFS processes are holding locks.
-  Log('PrepareToInstall: Checking for running GVFS processes');
-  if IsGVFSRunning() then
-    begin
-      if WizardSilent() then
-        begin
-          // Silent mode: abort if GVFS is running (can't prompt user)
-          Result := 'GVFS is currently running. Please close all GVFS processes before upgrading.';
-          Log('PrepareToInstall: ' + Result);
-          exit;
-        end
-      else
-        begin
-          // Interactive mode: prompt to close GVFS
-          if MsgBox('VFS for Git is currently running.' + #13#10#13#10 +
-                    'Setup will now attempt to unmount all repos and stop the service.' + #13#10#13#10 +
-                    'Click OK to continue or Cancel to exit Setup.',
-                    mbConfirmation, MB_OKCANCEL) = IDCANCEL then
-            begin
-              Result := 'Setup cancelled by user.';
-              exit;
-            end;
-        end;
-    end;
-
-  // Clean upgrade: no staging. Remove any leftover staging dirs from old installs.
-  if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
-    begin
-      Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
-      DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
-    end;
-  if DirExists(ExpandConstant('{app}\PreviousVersion')) then
-    begin
-      Log('PrepareToInstall: Removing leftover PreviousVersion directory');
-      DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
-    end;
-
-  // Unmount any repos
-  UnmountRepos();
-
-  // With CloseApplications=no, Restart Manager won't kill GVFS
-  // processes. If unmount-all didn't clean up everything (e.g.
-  // registry was empty), force-kill remaining processes.
-  if IsGVFSRunning() then
-    begin
-      Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
-      Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      Sleep(2000);
-    end;
-
-  if not EnsureGvfsNotRunning() then
-    begin
-      Abort();
-    end;
-
-  StopService('GVFS.Service');
-  UninstallGvFlt();
-  UninstallProjFSIfNecessary();
-end;
-
-function UninstallNeedRestart(): Boolean;
-begin
-  Result := False;
-end;
-
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   case CurStep of
     ssInstall:
       begin
+        // Migrate from service-based install to user-level install:
+        // stop and delete the service if present, then register logon task.
+        Log('CurStepChanged ssInstall: Stopping and deleting GVFS.Service if present');
         UninstallService('GVFS.Service', True);
-        // Fix #2: Create junction BEFORE InstallGVFSService runs (which happens
-        // during file extraction). This ensures {app}\Current\GVFS.Service.exe
-        // exists when the service starts.
-        CreateOrUpdateCurrentJunction();
+        Log('CurStepChanged ssInstall: Registering AutoMount logon task');
+        RegisterAutoMountLogonTask();
       end;
     ssPostInstall:
       begin
-        // Fix #3: Remove legacy flat PATH entry on upgrade from flat layout.
-        // Safe because new PATH entry points to {app}\Current.
-        RemovePath(ExpandConstant('{app}'));
-        
-        // GC runs after junction is already in place (from ssInstall above)
-        GarbageCollectOldVersions();
         MigrateConfigAndStatusCacheFiles();
+        WriteOnDiskVersion16CapableFile();
       end;
     end;
 end;
@@ -1001,7 +927,56 @@ begin
     usUninstall:
       begin
         UninstallService('GVFS.Service', False);
-        RemovePath(ExpandConstant('{app}\Current'));
+        RemovePath(ExpandConstant('{app}'));
       end;
     end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: integer;
+begin
+  NeedsRestart := False;
+  Result := '';
+  SetNuGetFeedIfNecessary();
+
+  // User-level install model: no service, no staging flow, no mount/unmount.
+  // Just ensure no GVFS processes are running so files can be replaced.
+  Log('PrepareToInstall: Checking for running GVFS processes');
+  if IsGVFSRunning() then
+    begin
+      if WizardSilent() then
+        begin
+          Log('PrepareToInstall: Silent mode — killing GVFS processes');
+          Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+          Sleep(2000);
+        end
+      else
+        begin
+          if not EnsureGvfsNotRunning() then
+            begin
+              Result := 'Installation cancelled.';
+              exit;
+            end;
+        end;
+    end;
+
+  // Clean up leftover staging directories from old installer versions
+  if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
+    begin
+      Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
+      DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
+    end;
+  if DirExists(ExpandConstant('{app}\PreviousVersion')) then
+    begin
+      Log('PrepareToInstall: Removing leftover PreviousVersion directory');
+      DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
+    end;
+
+  // Stop the service if it exists (upgrade from old service-based install)
+  Log('PrepareToInstall: Stopping GVFS.Service if present');
+  StopService('GVFS.Service');
+
+  UninstallGvFlt();
+  UninstallProjFSIfNecessary();
 end;

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -59,14 +59,10 @@ Name: "full"; Description: "Full installation"; Flags: iscustom;
 Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
-; Normal install: all files go to {app}, service gets AfterInstall callback
-DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsNormalInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: IsNormalInstall
-; Staging install: most files go to {app}\PendingUpgrade, but GVFS.Service.exe
-; goes directly to {app} so the restarted service has PendingUpgradeHandler code.
-; The service is briefly stopped/restarted (mounts are independent processes).
-DestDir: "{app}\PendingUpgrade"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsStagingInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; Check: IsStagingInstall
+; Versioned install: all files go to {app}\Versions\{version}
+; Service binary gets AfterInstall callback to register service with binPath pointing to {app}\Current\GVFS.Service.exe
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService
 
 [Dirs]
 Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
@@ -78,8 +74,8 @@ Type: filesandordirs; Name: "{commonappdata}\GVFS\GVFS.Upgrade";
 
 [Registry]
 Root: HKLM; Subkey: "{#EnvironmentKey}"; \
-    ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; \
-    Check: NeedsAddPath(ExpandConstant('{app}'))
+    ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\Current"; \
+    Check: NeedsAddPath(ExpandConstant('{app}\Current'))
 
 Root: HKLM; Subkey: "{#FileSystemKey}"; \
     ValueType: dword; ValueName: "NtfsEnableDetailedCleanupResults"; ValueData: "1"; \
@@ -91,16 +87,6 @@ Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
 var
   ExitCode: Integer;
   KeepMountsRunning: Boolean;
-
-function IsNormalInstall(): Boolean;
-begin
-  Result := not KeepMountsRunning;
-end;
-
-function IsStagingInstall(): Boolean;
-begin
-  Result := KeepMountsRunning;
-end;
 
 function NeedsAddPath(Param: string): boolean;
 var
@@ -271,7 +257,7 @@ procedure WriteOnDiskVersion16CapableFile();
 var
   FilePath: string;
 begin
-  FilePath := ExpandConstant('{app}\OnDiskVersion16CapableInstallation.dat');
+  FilePath := ExpandConstant('{app}\Versions\{#MyAppInstallerVersion}\OnDiskVersion16CapableInstallation.dat');
   if not FileExists(FilePath) then
     begin
       Log('WriteOnDiskVersion16CapableFile: Writing file ' + FilePath);
@@ -294,9 +280,13 @@ begin
   // Spaces after the equal signs are REQUIRED.
   // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
+    // Create the Current junction first, so service registration can use the stable path
+    CreateOrUpdateCurrentJunction();
+
     // We must add additional quotes to the binPath to ensure that they survive argument parsing.
     // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
-    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
+    // Use {app}\Current\GVFS.Service.exe so the service path survives version upgrades via junction swap.
+    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\Current\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       begin
         if Exec(ExpandConstant('{sys}\SC.EXE'), 'failure GVFS.Service reset= 30 actions= restart/10/restart/5000//1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
           begin
@@ -319,37 +309,8 @@ begin
     end;
 end;
 
-procedure StagingUpdateService();
-var
-  ResultCode: integer;
-  StatusText: string;
-begin
-  // In staging mode: the service was stopped in PrepareToInstall so its exe
-  // could be replaced. Now start it with the new binary. The new service has
-  // PendingUpgradeHandler which will complete the upgrade on next restart
-  // when no mounts are running.
-  StatusText := WizardForm.StatusLabel.Caption;
-  WizardForm.StatusLabel.Caption := 'Starting GVFS.Service.';
-  WizardForm.ProgressGauge.Style := npbstMarquee;
-
-  try
-    Log('StagingUpdateService: Starting service with new binary');
-    if Exec(ExpandConstant('{sys}\SC.EXE'), 'start GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-      begin
-        if ResultCode <> 0 then
-          Log('StagingUpdateService: Warning - sc start returned error code ' + IntToStr(ResultCode));
-      end
-    else
-      begin
-        Log('StagingUpdateService: Warning - could not launch sc.exe');
-      end;
-
-    WriteOnDiskVersion16CapableFile();
-  finally
-    WizardForm.StatusLabel.Caption := StatusText;
-    WizardForm.ProgressGauge.Style := npbstNormal;
-  end;
-end;
+// StagingUpdateService removed - staging upgrade flow replaced by versioned layout with junction swap.
+// Service install/start is handled in InstallGVFSService.
 
 function DeleteFileIfItExists(FilePath: string) : Boolean;
 begin
@@ -585,7 +546,7 @@ var
   SecureAppDataDir: string;
 begin
   CommonAppDataDir := ExpandConstant('{commonappdata}\GVFS');
-  SecureAppDataDir := ExpandConstant('{app}\ProgramData');
+  SecureAppDataDir := ExpandConstant('{app}\Current\ProgramData');
 
   MigrateFile(CommonAppDataDir + '\{#GVFSConfigFileName}', SecureAppDataDir + '\{#GVFSConfigFileName}');
   MigrateFile(CommonAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}', SecureAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}');
@@ -725,19 +686,8 @@ begin
       end;
     ssPostInstall:
       begin
-        if KeepMountsRunning then
-          begin
-            // All staged files have been written to PendingUpgrade.
-            // Write .ready marker so the service knows the staging is
-            // complete and safe to apply.
-            SaveStringToFile(ExpandConstant('{app}\PendingUpgrade\.ready'), '', False);
-            Log('CurStepChanged: Wrote PendingUpgrade .ready marker');
-
-            // Start the service AFTER .ready is written. Previously this
-            // was an AfterInstall hook on GVFS.Service.exe, but that races:
-            // the service's debounce timer could fire before .ready exists.
-            StagingUpdateService();
-          end;
+        CreateOrUpdateCurrentJunction();
+        GarbageCollectOldVersions();
         MigrateConfigAndStatusCacheFiles();
         if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
           begin
@@ -758,242 +708,276 @@ begin
     usUninstall:
       begin
         UninstallService('GVFS.Service', False);
-        RemovePath(ExpandConstant('{app}'));
+        RemovePath(ExpandConstant('{app}\Current'));
       end;
     end;
 end;
 
-// Shows a modal dialog letting the user choose how to handle mounted repos.
-// Returns True if the user clicked Continue, False if Cancel. On Continue,
-// KeepMounted is set to True if the user chose to stage the upgrade and
-// leave repos mounted, or False to unmount and remount immediately.
-function ShowMountChoiceDialog(Repos: String; var KeepMounted: Boolean): Boolean;
+procedure CreateOrUpdateCurrentJunction();
 var
-  Form: TForm;
-  HeaderLbl, ReposLbl, RemountDescLbl, KeepDescLbl: TNewStaticText;
-  RemountRadio, KeepRadio: TNewRadioButton;
-  BtnContinue, BtnCancel: TNewButton;
-  ButtonWidth, ButtonHeight, ContentWidth, Margin, IndentMargin: Integer;
-  ModalResult, Y: Integer;
+  AppDir: string;
+  JunctionPath: string;
+  VersionDir: string;
+  ResultCode: integer;
 begin
-  Margin := ScaleX(15);
-  IndentMargin := ScaleX(34);
-  ButtonWidth := ScaleX(85);
-  ButtonHeight := ScaleY(25);
+  AppDir := ExpandConstant('{app}');
+  JunctionPath := AppDir + '\Current';
+  VersionDir := AppDir + '\Versions\{#MyAppInstallerVersion}';
 
-  Form := TForm.Create(nil);
-  try
-    Form.Caption := 'Setup';
-    Form.BorderStyle := bsDialog;
-    Form.Position := poOwnerFormCenter;
-    Form.ClientWidth := ScaleX(520);
-    ContentWidth := Form.ClientWidth - (2 * Margin);
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Target version = {#MyAppInstallerVersion}');
 
-    Y := ScaleY(15);
+  // Remove existing junction if present
+  if DirExists(JunctionPath) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Removing existing Current junction');
+      Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    end;
 
-    HeaderLbl := TNewStaticText.Create(Form);
-    HeaderLbl.Parent := Form;
-    HeaderLbl.Left := Margin;
-    HeaderLbl.Top := Y;
-    HeaderLbl.Caption := 'The following repos are currently mounted:';
-    HeaderLbl.AutoSize := True;
-    Y := HeaderLbl.Top + HeaderLbl.Height + ScaleY(4);
+  // Create new junction: Current -> Versions\<version>
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction -> ' + VersionDir);
+  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
+      RaiseException('Fatal: Could not create Current junction at ' + JunctionPath);
+    end
+  else
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Junction created successfully');
+    end;
+end;
 
-    ReposLbl := TNewStaticText.Create(Form);
-    ReposLbl.Parent := Form;
-    ReposLbl.Left := IndentMargin;
-    ReposLbl.Top := Y;
-    ReposLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    ReposLbl.WordWrap := True;
-    ReposLbl.AutoSize := True;
-    ReposLbl.Caption := Trim(Repos);
-    Y := ReposLbl.Top + ReposLbl.Height + ScaleY(16);
+function GetFileVersion(FilePath: string): string;
+var
+  VersionMS: Cardinal;
+  VersionLS: Cardinal;
+begin
+  Result := '';
+  if GetVersionNumbers(FilePath, VersionMS, VersionLS) then
+    begin
+      Result := Format('%d.%d.%d.%d', [
+        VersionMS shr 16,
+        VersionMS and $FFFF,
+        VersionLS shr 16,
+        VersionLS and $FFFF
+      ]);
+    end;
+end;
 
-    RemountRadio := TNewRadioButton.Create(Form);
-    RemountRadio.Parent := Form;
-    RemountRadio.Left := Margin;
-    RemountRadio.Top := Y;
-    RemountRadio.Width := ContentWidth;
-    RemountRadio.Caption := 'Remount repos as part of the installation';
-    RemountRadio.Checked := True;
-    Y := RemountRadio.Top + RemountRadio.Height + ScaleY(2);
+function IsProcessRunningFromPath(PathPrefix: string): Boolean;
+var
+  ResultCode: integer;
+  PowerShellCmd: string;
+begin
+  // PowerShell: check if any gvfs.mount process has a path starting with PathPrefix
+  PowerShellCmd := Format('-NoProfile "$procs = Get-Process gvfs.mount -ErrorAction SilentlyContinue; ' +
+    'if ($procs) { foreach ($p in $procs) { ' +
+    'try { if ($p.Path -like ''%s*'') { exit 10 } } catch {} } }; exit 0"', [PathPrefix]);
+  
+  if Exec('powershell.exe', PowerShellCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      Result := (ResultCode = 10);
+    end
+  else
+    begin
+      Log('[GVFS-INSTALL] IsProcessRunningFromPath: PowerShell query failed');
+      Result := False;
+    end;
+end;
 
-    RemountDescLbl := TNewStaticText.Create(Form);
-    RemountDescLbl.Parent := Form;
-    RemountDescLbl.Left := IndentMargin;
-    RemountDescLbl.Top := Y;
-    RemountDescLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    RemountDescLbl.WordWrap := True;
-    RemountDescLbl.AutoSize := True;
-    RemountDescLbl.Caption := 'They will be temporarily unavailable.';
-    Y := RemountDescLbl.Top + RemountDescLbl.Height + ScaleY(14);
+procedure GarbageCollectOldVersions();
+var
+  AppDir: string;
+  VersionsDir: string;
+  CurrentVersion: string;
+  FlatGvfsExe: string;
+  FlatVersion: string;
+  FindRec: TFindRec;
+  VersionDirs: array of string;
+  VersionTimes: array of Int64;
+  Count: integer;
+  I, J: integer;
+  TempStr: string;
+  TempTime: Int64;
+  VersionPath: string;
+  CanDelete: Boolean;
+begin
+  AppDir := ExpandConstant('{app}');
+  VersionsDir := AppDir + '\Versions';
+  CurrentVersion := '{#MyAppInstallerVersion}';
 
-    KeepRadio := TNewRadioButton.Create(Form);
-    KeepRadio.Parent := Form;
-    KeepRadio.Left := Margin;
-    KeepRadio.Top := Y;
-    KeepRadio.Width := ContentWidth;
-    KeepRadio.Caption := 'Keep repos mounted';
-    Y := KeepRadio.Top + KeepRadio.Height + ScaleY(2);
+  Log('[GVFS-INSTALL] GarbageCollectOldVersions: Current version = ' + CurrentVersion);
 
-    KeepDescLbl := TNewStaticText.Create(Form);
-    KeepDescLbl.Parent := Form;
-    KeepDescLbl.Left := IndentMargin;
-    KeepDescLbl.Top := Y;
-    KeepDescLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    KeepDescLbl.WordWrap := True;
-    KeepDescLbl.AutoSize := True;
-    KeepDescLbl.Caption := 'The upgrade will complete automatically when all repos are unmounted, or at next reboot.';
-    Y := KeepDescLbl.Top + KeepDescLbl.Height + ScaleY(20);
+  // First, check for flat-layout binaries at {app}\GVFS.exe
+  FlatGvfsExe := AppDir + '\GVFS.exe';
+  if FileExists(FlatGvfsExe) then
+    begin
+      FlatVersion := GetFileVersion(FlatGvfsExe);
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Detected flat layout with version ' + FlatVersion);
+      
+      // Check if any mounts are running from the flat install
+      if IsProcessRunningFromPath(AppDir + '\') then
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Mounts running from flat layout - leaving in place');
+        end
+      else
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: No mounts running from flat layout - would migrate to Versions\' + FlatVersion);
+          // For now, just log. Full migration logic can move files to Versions\<FlatVersion>.
+          // Defer to avoid complexity in first PR.
+        end;
+    end;
 
-    BtnContinue := TNewButton.Create(Form);
-    BtnContinue.Parent := Form;
-    BtnContinue.Width := ButtonWidth;
-    BtnContinue.Height := ButtonHeight;
-    BtnContinue.Top := Y;
-    BtnContinue.Left := Form.ClientWidth - Margin - ButtonWidth - ScaleX(10) - ButtonWidth;
-    BtnContinue.Caption := '&Continue';
-    BtnContinue.Default := True;
-    BtnContinue.ModalResult := mrOk;
+  // Enumerate version directories
+  Count := 0;
+  SetArrayLength(VersionDirs, 0);
+  SetArrayLength(VersionTimes, 0);
+  
+  if not DirExists(VersionsDir) then
+    begin
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Versions directory does not exist');
+      exit;
+    end;
 
-    BtnCancel := TNewButton.Create(Form);
-    BtnCancel.Parent := Form;
-    BtnCancel.Width := ButtonWidth;
-    BtnCancel.Height := ButtonHeight;
-    BtnCancel.Top := Y;
-    BtnCancel.Left := Form.ClientWidth - Margin - ButtonWidth;
-    BtnCancel.Caption := '&Cancel';
-    BtnCancel.Cancel := True;
-    BtnCancel.ModalResult := mrCancel;
-
-    Form.ClientHeight := Y + ButtonHeight + ScaleY(15);
-    Form.ActiveControl := BtnContinue;
-
-    ModalResult := Form.ShowModal();
-    if ModalResult = mrOk then
-      begin
-        KeepMounted := KeepRadio.Checked;
-        Result := True;
-      end
-    else
-      begin
-        Result := False;
+  if FindFirst(VersionsDir + '\*', FindRec) then
+    begin
+      try
+        repeat
+          if (FindRec.Name <> '.') and (FindRec.Name <> '..') and (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) then
+            begin
+              // Skip the current version
+              if FindRec.Name <> CurrentVersion then
+                begin
+                  SetArrayLength(VersionDirs, Count + 1);
+                  SetArrayLength(VersionTimes, Count + 1);
+                  VersionDirs[Count] := FindRec.Name;
+                  VersionTimes[Count] := FindRec.Time;
+                  Count := Count + 1;
+                end;
+            end;
+        until not FindNext(FindRec);
+      finally
+        FindClose(FindRec);
       end;
-  finally
-    Form.Free();
-  end;
+    end;
+
+  if Count = 0 then
+    begin
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: No old versions to clean up');
+      exit;
+    end;
+
+  Log('[GVFS-INSTALL] GarbageCollectOldVersions: Found ' + IntToStr(Count) + ' old version(s)');
+
+  // Sort by time (bubble sort, oldest first)
+  for I := 0 to Count - 2 do
+    begin
+      for J := I + 1 to Count - 1 do
+        begin
+          if VersionTimes[I] > VersionTimes[J] then
+            begin
+              TempTime := VersionTimes[I];
+              VersionTimes[I] := VersionTimes[J];
+              VersionTimes[J] := TempTime;
+              TempStr := VersionDirs[I];
+              VersionDirs[I] := VersionDirs[J];
+              VersionDirs[J] := TempStr;
+            end;
+        end;
+    end;
+
+  // Keep the 1 most recent old version (index Count-1), delete the rest
+  for I := 0 to Count - 2 do
+    begin
+      VersionPath := VersionsDir + '\' + VersionDirs[I];
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Checking version ' + VersionDirs[I]);
+      
+      // Check if any mounts are running from this version
+      CanDelete := not IsProcessRunningFromPath(VersionPath + '\');
+      
+      if CanDelete then
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Deleting old version ' + VersionDirs[I]);
+          if DelTree(VersionPath, True, True, True) then
+            Log('[GVFS-INSTALL] GarbageCollectOldVersions: Deleted ' + VersionPath)
+          else
+            Log('[GVFS-INSTALL] GarbageCollectOldVersions: Failed to delete ' + VersionPath);
+        end
+      else
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Version ' + VersionDirs[I] + ' has running mounts - skipping');
+        end;
+    end;
+
+  // Log the most recent old version that we're keeping
+  if Count > 0 then
+    Log('[GVFS-INSTALL] GarbageCollectOldVersions: Keeping most recent old version ' + VersionDirs[Count - 1]);
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
-  Repos: ansiString;
   ResultCode: integer;
-  HasMounts: Boolean;
 begin
   NeedsRestart := False;
   KeepMountsRunning := False;
   Result := '';
   SetNuGetFeedIfNecessary();
 
-  // Check for mounted repos by querying the service, and also check for
-  // running GVFS processes (a mount can be running without being registered
-  // in the service's repo-registry, e.g., after a reinstall).
-  HasMounts := False;
-  if ExecWithResult('gvfs.exe', 'service --list-mounted', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, Repos) then
-    begin
-      if (ResultCode = 0) and (Repos <> '') then
-        HasMounts := True;
-    end;
-  if (not HasMounts) and IsGVFSRunning() then
-    begin
-      HasMounts := True;
-      Repos := '(GVFS processes detected)';
-      Log('PrepareToInstall: No registered mounts but GVFS processes are running');
-    end;
-
-  if HasMounts then
+  // Versioned layout: no staging flow. Just ensure no GVFS processes are holding locks.
+  Log('PrepareToInstall: Checking for running GVFS processes');
+  if IsGVFSRunning() then
     begin
       if WizardSilent() then
         begin
-          // Silent mode: STAGEIFMOUNTED=true stages files instead of unmounting.
-          // Default: false (clean upgrade, matching pre-existing behavior).
-          KeepMountsRunning := ExpandConstant('{param:STAGEIFMOUNTED|false}') = 'true';
-          if KeepMountsRunning then
-            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=True')
-          else
-            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=False');
+          // Silent mode: abort if GVFS is running (can't prompt user)
+          Result := 'GVFS is currently running. Please close all GVFS processes before upgrading.';
+          Log('PrepareToInstall: ' + Result);
+          exit;
         end
       else
         begin
-          // Interactive mode: show a radio-button modal so the user can pick
-          // between remounting (immediate but brief unavailability) and
-          // staging the upgrade (deferred until repos are unmounted).
-          if not ShowMountChoiceDialog(Repos, KeepMountsRunning) then
+          // Interactive mode: prompt to close GVFS
+          if MsgBox('VFS for Git is currently running.' + #13#10#13#10 +
+                    'Setup will now attempt to unmount all repos and stop the service.' + #13#10#13#10 +
+                    'Click OK to continue or Cancel to exit Setup.',
+                    mbConfirmation, MB_OKCANCEL) = IDCANCEL then
             begin
-              Result := 'Installation cancelled.';
+              Result := 'Setup cancelled by user.';
               exit;
             end;
         end;
     end;
 
-  if KeepMountsRunning then
+  // Clean upgrade: no staging. Remove any leftover staging dirs from old installs.
+  if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
     begin
-      // Staging mode: most files go to {app}\PendingUpgrade\ via [Files] entries
-      // with Check: IsStagingInstall. GVFS.Service.exe goes directly to {app}.
-      // Clean up any leftover staging dirs from a prior attempt first,
-      // so we don't mix files from different upgrade versions.
-      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
-        begin
-          Log('PrepareToInstall: Removing stale PendingUpgrade from prior staging attempt');
-          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
-        end;
-      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
-        begin
-          Log('PrepareToInstall: Removing stale PreviousVersion from prior staging attempt');
-          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
-        end;
-      // Stop the service now so its exe is unlocked for replacement.
-      // Mounts are independent processes and unaffected.
-      Log('PrepareToInstall: Staging mode. Stopping service for exe replacement.');
-      StopService('GVFS.Service');
-      WaitForServiceProcessToExit('GVFS.Service');
-    end
-  else
-    begin
-      // Clean upgrade: unmount, stop everything, replace files directly.
-      // Remove any leftover PendingUpgrade or PreviousVersion from a
-      // previous staging install so stale files don't interfere with
-      // the fresh install.
-      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
-        begin
-          Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
-          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
-        end;
-      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
-        begin
-          Log('PrepareToInstall: Removing leftover PreviousVersion directory');
-          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
-        end;
-      if HasMounts then
-        begin
-          UnmountRepos();
-        end;
-      // With CloseApplications=no, Restart Manager won't kill GVFS
-      // processes. If unmount-all didn't clean up everything (e.g.
-      // registry was empty), force-kill remaining processes since
-      // the user already consented to a full upgrade.
-      if IsGVFSRunning() then
-        begin
-          Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
-          Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-          Sleep(2000);
-        end;
-      if not EnsureGvfsNotRunning() then
-        begin
-          Abort();
-        end;
-      StopService('GVFS.Service');
-      UninstallGvFlt();
-      UninstallProjFSIfNecessary();
+      Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
+      DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
     end;
+  if DirExists(ExpandConstant('{app}\PreviousVersion')) then
+    begin
+      Log('PrepareToInstall: Removing leftover PreviousVersion directory');
+      DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
+    end;
+
+  // Unmount any repos
+  UnmountRepos();
+
+  // With CloseApplications=no, Restart Manager won't kill GVFS
+  // processes. If unmount-all didn't clean up everything (e.g.
+  // registry was empty), force-kill remaining processes.
+  if IsGVFSRunning() then
+    begin
+      Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
+      Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      Sleep(2000);
+    end;
+
+  if not EnsureGvfsNotRunning() then
+    begin
+      Abort();
+    end;
+
+  StopService('GVFS.Service');
+  UninstallGvFlt();
+  UninstallProjFSIfNecessary();
 end;

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -56,8 +56,7 @@ namespace GVFS.Mount
         private GVFSContext context;
         private GVFSGitObjects gitObjects;
 
-        private volatile MountState currentState;
-        private volatile string mountProgressMessage;
+        private MountState currentState;
         private HeartbeatThread heartbeat;
         private ManualResetEvent unmountEvent;
 
@@ -196,10 +195,58 @@ namespace GVFS.Mount
 
             this.enlistment.InitializeCachePaths(localCacheRoot, gitObjectsRoot, blobSizesRoot);
 
-            // Start the pipe server early so MountVerb can connect and poll progress
-            // during the parallel validation phase. Only GetStatus requests are
-            // handled while currentState == Mounting (see HandleRequest guard).
-            this.mountProgressMessage = "Authenticating and validating";
+            // Local validations and git config run while we wait for the network
+            var localTask = Task.Run(() =>
+            {
+                Stopwatch sw = Stopwatch.StartNew();
+
+                this.ValidateGitVersion();
+                this.tracer.RelatedInfo("ParallelMount: ValidateGitVersion completed in {0}ms", sw.ElapsedMilliseconds);
+
+                this.ValidateHooksVersion();
+                this.ValidateFileSystemSupportsRequiredFeatures();
+
+                GitProcess git = new GitProcess(this.enlistment);
+                if (!git.IsValidRepo())
+                {
+                    this.FailMountAndExit("The .git folder is missing or has invalid contents");
+                }
+
+                if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(this.enlistment.WorkingDirectoryRoot, out string fsError))
+                {
+                    this.FailMountAndExit("FileSystem unsupported: " + fsError);
+                }
+
+                this.tracer.RelatedInfo("ParallelMount: Local validations completed in {0}ms", sw.ElapsedMilliseconds);
+
+                if (!this.TrySetRequiredGitConfigSettings())
+                {
+                    this.FailMountAndExit("Unable to configure git repo");
+                }
+
+                this.LogEnlistmentInfoAndSetConfigValues();
+                this.tracer.RelatedInfo("ParallelMount: Local validations + git config completed in {0}ms", sw.ElapsedMilliseconds);
+            });
+
+            try
+            {
+                Task.WaitAll(networkTask, localTask);
+            }
+            catch (AggregateException ae)
+            {
+                this.FailMountAndExit(ae.Flatten().InnerExceptions[0].Message);
+            }
+
+            parallelTimer.Stop();
+            this.tracer.RelatedInfo("ParallelMount: All parallel tasks completed in {0}ms", parallelTimer.ElapsedMilliseconds);
+
+            ServerGVFSConfig serverGVFSConfig = networkTask.Result;
+
+            CacheServerResolver cacheServerResolver = new CacheServerResolver(this.tracer, this.enlistment);
+            this.cacheServer = cacheServerResolver.ResolveNameFromRemote(this.cacheServer.Url, serverGVFSConfig);
+
+            this.EnsureLocalCacheIsHealthy(serverGVFSConfig);
+
             using (NamedPipeServer pipeServer = this.StartNamedPipe())
             {
                 this.tracer.RelatedEvent(
@@ -207,60 +254,6 @@ namespace GVFS.Mount
                     $"{nameof(this.Mount)}_StartedNamedPipe",
                     new EventMetadata { { "NamedPipeName", this.enlistment.NamedPipeName } });
 
-                // Local validations and git config run while we wait for the network
-                Task localTask = Task.Run(() =>
-                {
-                    Stopwatch sw = Stopwatch.StartNew();
-
-                    this.ValidateGitVersion();
-                    this.tracer.RelatedInfo("ParallelMount: ValidateGitVersion completed in {0}ms", sw.ElapsedMilliseconds);
-
-                    this.ValidateHooksVersion();
-                    this.ValidateFileSystemSupportsRequiredFeatures();
-
-                    GitProcess git = new GitProcess(this.enlistment);
-                    if (!git.IsValidRepo())
-                    {
-                        this.FailMountAndExit("The .git folder is missing or has invalid contents");
-                    }
-
-                    if (!GVFSPlatform.Instance.FileSystem.IsFileSystemSupported(this.enlistment.WorkingDirectoryRoot, out string fsError))
-                    {
-                        this.FailMountAndExit("FileSystem unsupported: " + fsError);
-                    }
-
-                    this.tracer.RelatedInfo("ParallelMount: Local validations completed in {0}ms", sw.ElapsedMilliseconds);
-
-                    if (!this.TrySetRequiredGitConfigSettings())
-                    {
-                        this.FailMountAndExit("Unable to configure git repo");
-                    }
-
-                    this.LogEnlistmentInfoAndSetConfigValues();
-                    this.tracer.RelatedInfo("ParallelMount: Local validations + git config completed in {0}ms", sw.ElapsedMilliseconds);
-                });
-
-                try
-                {
-                    Task.WaitAll(networkTask, localTask);
-                }
-                catch (AggregateException ae)
-                {
-                    this.FailMountAndExit(ae.Flatten().InnerExceptions[0].Message);
-                }
-
-                parallelTimer.Stop();
-                this.tracer.RelatedInfo("ParallelMount: All parallel tasks completed in {0}ms", parallelTimer.ElapsedMilliseconds);
-
-                ServerGVFSConfig serverGVFSConfig = networkTask.Result;
-
-                this.mountProgressMessage = "Resolving cache server";
-                CacheServerResolver cacheServerResolver = new CacheServerResolver(this.tracer, this.enlistment);
-                this.cacheServer = cacheServerResolver.ResolveNameFromRemote(this.cacheServer.Url, serverGVFSConfig);
-
-                this.EnsureLocalCacheIsHealthy(serverGVFSConfig);
-
-                this.mountProgressMessage = "Preparing mount";
                 this.context = this.CreateContext();
 
                 if (this.context.Unattended)
@@ -281,7 +274,6 @@ namespace GVFS.Mount
 
                 GVFSPlatform.Instance.ConfigureVisualStudio(this.enlistment.GitBinPath, this.tracer);
 
-                this.mountProgressMessage = "Starting virtualization";
                 this.MountAndStartWorkingDirectoryCallbacks(this.cacheServer);
 
                 try
@@ -304,7 +296,6 @@ namespace GVFS.Mount
                     },
                     Keywords.Telemetry);
 
-                this.mountProgressMessage = null;
                 this.currentState = MountState.Ready;
 
                 this.unmountEvent.WaitOne();
@@ -484,17 +475,6 @@ namespace GVFS.Mount
         {
             NamedPipeMessages.Message message = NamedPipeMessages.Message.FromString(request);
 
-            // While mounting, only GetStatus requests are safe — other handlers depend
-            // on context, fileSystemCallbacks, etc. that aren't initialized yet.
-            // MountFailed is NOT guarded: HandleUnmountRequest needs to reach the
-            // "unmount even if mount failed" path so users aren't forced to kill the process.
-            if (message.Header != NamedPipeMessages.GetStatus.Request &&
-                this.currentState == MountState.Mounting)
-            {
-                connection.TrySendResponse(NamedPipeMessages.MountNotReadyResult);
-                return;
-            }
-
             try
             {
                 switch (message.Header)
@@ -568,6 +548,8 @@ namespace GVFS.Mount
                 metadata.Add("Header", message.Header);
                 metadata.Add("Exception", e.ToString());
                 this.tracer.RelatedError(metadata, "HandleRequest: Unhandled exception in request handler");
+
+                connection.TrySendResponse(NamedPipeMessages.UnknownRequest);
             }
         }
 
@@ -912,76 +894,56 @@ namespace GVFS.Mount
                 }
                 else
                 {
-                    try
-                    {
-                        response = this.DownloadObject(objectSha);
-                    }
-                    catch (Exception e) when (e is not OutOfMemoryException)
-                    {
-                        EventMetadata metadata = new EventMetadata();
-                        metadata.Add("Area", "Mount");
-                        metadata.Add("objectSha", objectSha);
-                        metadata.Add("Exception", e.ToString());
-                        this.tracer.RelatedWarning(metadata, nameof(this.HandleDownloadObjectRequest) + ": Exception downloading object");
+                    Stopwatch downloadTime = Stopwatch.StartNew();
 
+                    /* If this is the root tree for a commit that was was just downloaded, assume that more
+                     * trees will be needed soon and download them as well by using the download commit API.
+                     *
+                     * Otherwise, or as a fallback if the commit download fails, download the object directly.
+                     */
+                    if (this.ShouldDownloadCommitPack(objectSha, out string commitSha)
+                        && this.gitObjects.TryDownloadCommit(commitSha))
+                    {
+                        this.DownloadedCommitPack(commitSha);
+                        response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.SuccessResult);
+                        // FUTURE: Should the stats be updated to reflect all the trees in the pack?
+                        // FUTURE: Should we try to clean up duplicate trees or increase depth of the commit download?
+                    }
+                    else if (this.gitObjects.TryDownloadAndSaveObject(objectSha, GVFSGitObjects.RequestSource.NamedPipeMessage) == GitObjects.DownloadAndSaveObjectResult.Success)
+                    {
+                        this.UpdateTreesForDownloadedCommits(objectSha);
+                        response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.SuccessResult);
+                    }
+                    else
+                    {
                         response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.DownloadFailed);
+                    }
+
+
+                    Native.ObjectTypes? objectType;
+                    this.context.Repository.TryGetObjectType(objectSha, out objectType);
+                    this.context.Repository.GVFSLock.Stats.RecordObjectDownload(objectType == Native.ObjectTypes.Blob, downloadTime.ElapsedMilliseconds);
+
+                    if (objectType == Native.ObjectTypes.Commit
+                        && !this.context.Repository.CommitAndRootTreeExists(objectSha, out var treeSha)
+                        && !string.IsNullOrEmpty(treeSha))
+                    {
+                        /* If a commit is downloaded, it wasn't prefetched.
+                         * The trees for the commit may be needed soon depending on the context.
+                         * e.g. git log (without a pathspec) doesn't need trees, but git checkout does.
+                         *
+                         * If any prefetch has been done there is probably a similar commit/tree in the graph,
+                         * but in case there isn't (such as if the cache server repack maintenance job is failing)
+                         * we should still try to avoid downloading an excessive number of loose trees for a commit.
+                         *
+                         * Save the tree/commit so if more trees are requested we can download all the trees for the commit in a batch.
+                         */
+                        this.missingTreeTracker.AddMissingRootTree(treeSha: treeSha, commitSha: objectSha);
                     }
                 }
             }
 
             connection.TrySendResponse(response.CreateMessage());
-        }
-
-        private NamedPipeMessages.DownloadObject.Response DownloadObject(string objectSha)
-        {
-            NamedPipeMessages.DownloadObject.Response response;
-            Stopwatch downloadTime = Stopwatch.StartNew();
-
-            /* If this is the root tree for a commit that was was just downloaded, assume that more
-             * trees will be needed soon and download them as well by using the download commit API.
-             *
-             * Otherwise, or as a fallback if the commit download fails, download the object directly.
-             */
-            if (this.ShouldDownloadCommitPack(objectSha, out string commitSha)
-                && this.gitObjects.TryDownloadCommit(commitSha))
-            {
-                this.DownloadedCommitPack(commitSha);
-                response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.SuccessResult);
-                // FUTURE: Should the stats be updated to reflect all the trees in the pack?
-                // FUTURE: Should we try to clean up duplicate trees or increase depth of the commit download?
-            }
-            else if (this.gitObjects.TryDownloadAndSaveObject(objectSha, GVFSGitObjects.RequestSource.NamedPipeMessage) == GitObjects.DownloadAndSaveObjectResult.Success)
-            {
-                this.UpdateTreesForDownloadedCommits(objectSha);
-                response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.SuccessResult);
-            }
-            else
-            {
-                response = new NamedPipeMessages.DownloadObject.Response(NamedPipeMessages.DownloadObject.DownloadFailed);
-            }
-
-            Native.ObjectTypes? objectType;
-            this.context.Repository.TryGetObjectType(objectSha, out objectType);
-            this.context.Repository.GVFSLock.Stats.RecordObjectDownload(objectType == Native.ObjectTypes.Blob, downloadTime.ElapsedMilliseconds);
-
-            if (objectType == Native.ObjectTypes.Commit
-                && !this.context.Repository.CommitAndRootTreeExists(objectSha, out var treeSha)
-                && !string.IsNullOrEmpty(treeSha))
-            {
-                /* If a commit is downloaded, it wasn't prefetched.
-                 * The trees for the commit may be needed soon depending on the context.
-                 * e.g. git log (without a pathspec) doesn't need trees, but git checkout does.
-                 *
-                 * If any prefetch has been done there is probably a similar commit/tree in the graph,
-                 * but in case there isn't (such as if the cache server repack maintenance job is failing)
-                 * we should still try to avoid downloading an excessive number of loose trees for a commit.
-                 *
-                 * Save the tree/commit so if more trees are requested we can download all the trees for the commit in a batch.
-                 */
-                this.missingTreeTracker.AddMissingRootTree(treeSha: treeSha, commitSha: objectSha);
-            }
-
-            return response;
         }
 
         private bool ShouldDownloadCommitPack(string objectSha, out string commitSha)
@@ -1230,15 +1192,14 @@ namespace GVFS.Mount
             response.EnlistmentRoot = this.enlistment.WorkingDirectoryRoot;
             response.LocalCacheRoot = !string.IsNullOrWhiteSpace(this.enlistment.LocalCacheRoot) ? this.enlistment.LocalCacheRoot : this.enlistment.GitObjectsRoot;
             response.RepoUrl = this.enlistment.RepoUrl;
-            response.CacheServer = this.cacheServer?.ToString() ?? string.Empty;
-            response.LockStatus = this.context?.Repository?.GVFSLock != null ? this.context.Repository.GVFSLock.GetStatus() : "Unavailable";
+            response.CacheServer = this.cacheServer.ToString();
+            response.LockStatus = this.context?.Repository.GVFSLock != null ? this.context.Repository.GVFSLock.GetStatus() : "Unavailable";
             response.DiskLayoutVersion = $"{GVFSPlatform.Instance.DiskLayoutUpgrade.Version.CurrentMajorVersion}.{GVFSPlatform.Instance.DiskLayoutUpgrade.Version.CurrentMinorVersion}";
 
             switch (this.currentState)
             {
                 case MountState.Mounting:
                     response.MountStatus = NamedPipeMessages.GetStatus.Mounting;
-                    response.MountProgress = this.mountProgressMessage;
                     break;
 
                 case MountState.Ready:

--- a/GVFS/GVFS.Payload/layout.bat
+++ b/GVFS/GVFS.Payload/layout.bat
@@ -45,7 +45,7 @@ xcopy /Y %VCRUNTIME%\lib\x64\vcruntime140.dll %OUTPUT%
 xcopy /Y /S %BUILD_OUT%\GVFS\%MANAGED_OUT_FRAGMENT%\* %OUTPUT%
 xcopy /Y /S %BUILD_OUT%\GVFS.Hooks\%MANAGED_OUT_FRAGMENT%\* %OUTPUT%
 xcopy /Y /S %BUILD_OUT%\GVFS.Mount\%MANAGED_OUT_FRAGMENT%\* %OUTPUT%
-xcopy /Y /S %BUILD_OUT%\GVFS.Service\%MANAGED_OUT_FRAGMENT%\* %OUTPUT%
+REM GVFS.Service removed -- no longer part of the user-level install model
 xcopy /Y /S %BUILD_OUT%\GitHooksLoader\%NATIVE_OUT_FRAGMENT%\* %OUTPUT%
 xcopy /Y /S %BUILD_OUT%\GVFS.PostIndexChangedHook\%NATIVE_OUT_FRAGMENT%\* %OUTPUT%
 xcopy /Y /S %BUILD_OUT%\GVFS.ReadObjectHook\%NATIVE_OUT_FRAGMENT%\* %OUTPUT%

--- a/GVFS/GVFS.UnitTests/Common/LocalRepoRegistryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LocalRepoRegistryTests.cs
@@ -1,0 +1,420 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LocalRepoRegistryTests
+    {
+        private const string DataLocation = @"mock:\registryDataFolder";
+        private const string Repo1 = @"mock:\code\repo1";
+        private const string Repo2 = @"mock:\code\repo2";
+        private const string Repo3 = @"mock:\code\repo3";
+
+        [TestCase]
+        public void TryRegisterRepo_EmptyRegistry_RoundTripsThroughDisk()
+        {
+            (LocalRepoRegistry registry, MockFileSystem _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out string error).ShouldBeTrue(error);
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(1);
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerSID, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_DuplicateActiveSameOwner_DoesNotRewrite()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+
+            string contentBefore = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            string contentAfter = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+
+            // No semantic change → no rewrite. Important for caller patterns
+            // that re-register on every mount; we don't want a writer storm.
+            contentAfter.ShouldEqual(contentBefore);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_ReactivatesAfterDeactivate()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerSID, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_NewOwnerSidIsPersisted()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerA = Guid.NewGuid().ToString();
+            string ownerB = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerA, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo1, ownerB, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerB, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryDeactivateRepo_NonExistent_ReturnsFalseWithError()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+
+            registry.TryDeactivateRepo(Repo1, out string error).ShouldBeFalse();
+            string.IsNullOrEmpty(error).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryDeactivateRepo_AlreadyInactive_StillReturnsTrue()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+            // Second deactivate on an already-inactive entry is a no-op success
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void TryRemoveRepo_RemovesEntryEntirely()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryRemoveRepo(Repo1, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void TryRemoveRepo_NonExistent_ReturnsFalse()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            registry.TryRemoveRepo(Repo1, out string error).ShouldBeFalse();
+            string.IsNullOrEmpty(error).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryGetActiveRepos_FiltersInactive()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo2, ownerSID, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo3, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo2, out _).ShouldBeTrue();
+
+            registry.TryGetActiveRepos(out List<LocalRepoRegistration> active, out _).ShouldBeTrue();
+            active.Count.ShouldEqual(2);
+            active.Any(r => r.EnlistmentRoot.Equals(Repo1)).ShouldBeTrue();
+            active.Any(r => r.EnlistmentRoot.Equals(Repo3)).ShouldBeTrue();
+            active.Any(r => r.EnlistmentRoot.Equals(Repo2)).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryGetActiveRepos_EmptyRegistry_ReturnsEmptyList()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+
+            registry.TryGetActiveRepos(out List<LocalRepoRegistration> active, out string error).ShouldBeTrue(error);
+            active.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_NoRegistryFile_ReturnsEmpty()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            registry.ReadRegistry().Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_HigherVersionOnDisk_ReturnsEmptyAndDoesNotOverwrite()
+        {
+            // Simulate a newer GVFS having written the registry.
+            // We must read as empty AND must NOT overwrite when a subsequent
+            // write happens, so the newer GVFS's data is preserved.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string futureContent = "99\n{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"future\",\"IsActive\":true}\n";
+            fs.WriteAllText(registryPath, futureContent);
+
+            registry.ReadRegistry().Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_MalformedLine_SkippedNotFatal()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string contents =
+                "2\n" +
+                "{ this is not valid json }\n" +
+                "{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"sid\",\"IsActive\":true}\n";
+            fs.WriteAllText(registryPath, contents);
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(1);
+            all[Repo1].OwnerSID.ShouldEqual("sid");
+        }
+
+        [TestCase]
+        public void ReadRegistry_BlankLinesIgnored()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string contents =
+                "2\n" +
+                "\n" +
+                "{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"sid\",\"IsActive\":true}\n" +
+                "\n";
+            fs.WriteAllText(registryPath, contents);
+
+            registry.ReadRegistry().Count.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void ReadRegistry_OnDiskFormatMatchesServiceRegistry()
+        {
+            // The on-disk format MUST be wire-compatible with
+            // GVFS.Service.RepoRegistry: first line is the version
+            // (a bare integer); subsequent lines are JSON objects with
+            // EnlistmentRoot / OwnerSID / IsActive fields.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string sid = Guid.NewGuid().ToString();
+            registry.TryRegisterRepo(Repo1, sid, out _).ShouldBeTrue();
+
+            string raw = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+            string[] lines = raw.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+
+            // Version line
+            lines[0].ShouldEqual(LocalRepoRegistry.RegistryVersion.ToString());
+
+            // Entry line is JSON with the three required fields
+            lines.Length.ShouldEqual(2);
+            lines[1].Contains("\"EnlistmentRoot\"").ShouldBeTrue();
+            lines[1].Contains("\"OwnerSID\"").ShouldBeTrue();
+            lines[1].Contains("\"IsActive\"").ShouldBeTrue();
+            lines[1].Contains(sid).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void RegisterAfterRead_PreservesOtherEntriesWrittenByAnotherProcess()
+        {
+            // Simulate another process having written an entry between
+            // construction and our register call: we read fresh on each
+            // operation, so the other entry must survive.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string sid = Guid.NewGuid().ToString();
+
+            string contents =
+                "2\n" +
+                "{\"EnlistmentRoot\":\"" + Repo2.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"" + sid + "\",\"IsActive\":true}\n";
+            fs.WriteAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName), contents);
+
+            registry.TryRegisterRepo(Repo1, sid, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(2);
+            all.ContainsKey(Repo1).ShouldBeTrue();
+            all.ContainsKey(Repo2).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void Constructor_NullArgs_Throws()
+        {
+            MockFileSystem fs = new MockFileSystem(new MockDirectory(DataLocation, null, null));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(null, fs, DataLocation));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(new MockTracer(), null, DataLocation));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(new MockTracer(), fs, null));
+        }
+
+        [TestCase]
+        public void LocalRepoRegistration_JsonRoundTrip()
+        {
+            LocalRepoRegistration original = new LocalRepoRegistration("path", "sid") { IsActive = false };
+            string json = original.ToJson();
+            LocalRepoRegistration roundTripped = LocalRepoRegistration.FromJson(json);
+
+            roundTripped.EnlistmentRoot.ShouldEqual(original.EnlistmentRoot);
+            roundTripped.OwnerSID.ShouldEqual(original.OwnerSID);
+            roundTripped.IsActive.ShouldEqual(original.IsActive);
+        }
+
+        [TestCase]
+        public void SeedFromSystemRegistry_NoUserRegistry_SeedsAccessibleRepos()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+
+            // Create a system registry with three entries
+            string systemRegistryDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "GVFS",
+                LocalRepoRegistry.ServiceDataDirName);
+            string systemRegistryPath = Path.Combine(systemRegistryDir, LocalRepoRegistry.RegistryFileName);
+
+            fs.CreateDirectory(systemRegistryDir);
+
+            string sid1 = Guid.NewGuid().ToString();
+            string sid2 = Guid.NewGuid().ToString();
+            string sid3 = Guid.NewGuid().ToString();
+
+            string systemContent =
+                "2\n" +
+                "{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"" + sid1 + "\",\"IsActive\":true}\n" +
+                "{\"EnlistmentRoot\":\"" + Repo2.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"" + sid2 + "\",\"IsActive\":false}\n" +
+                "{\"EnlistmentRoot\":\"" + Repo3.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"" + sid3 + "\",\"IsActive\":true}\n";
+
+            fs.WriteAllText(systemRegistryPath, systemContent);
+
+            // Only Repo1 and Repo2 directories exist
+            fs.CreateDirectory(Repo1);
+            fs.CreateDirectory(Repo2);
+
+            // Seed the user registry
+            registry.SeedFromSystemRegistryIfNeeded();
+
+            // Verify only Repo1 and Repo2 were seeded (Repo3 directory doesn't exist)
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(2);
+            all.ContainsKey(Repo1).ShouldBeTrue();
+            all.ContainsKey(Repo2).ShouldBeTrue();
+            all.ContainsKey(Repo3).ShouldBeFalse();
+
+            // Verify the seeded entries preserve their original state
+            VerifyEntry(all[Repo1], expectedOwnerSID: sid1, expectedIsActive: true);
+            VerifyEntry(all[Repo2], expectedOwnerSID: sid2, expectedIsActive: false);
+        }
+
+        [TestCase]
+        public void SeedFromSystemRegistry_UserRegistryExists_DoesNotOverwrite()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+
+            // Create existing user registry
+            string ownerSID = Guid.NewGuid().ToString();
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            string userContentBefore = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+
+            // Create system registry
+            string systemRegistryDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "GVFS",
+                LocalRepoRegistry.ServiceDataDirName);
+            string systemRegistryPath = Path.Combine(systemRegistryDir, LocalRepoRegistry.RegistryFileName);
+
+            fs.CreateDirectory(systemRegistryDir);
+            fs.WriteAllText(systemRegistryPath, "2\n{\"EnlistmentRoot\":\"" + Repo2.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"other\",\"IsActive\":true}\n");
+            fs.CreateDirectory(Repo2);
+
+            // Attempt to seed
+            registry.SeedFromSystemRegistryIfNeeded();
+
+            // User registry should be unchanged
+            string userContentAfter = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+            userContentAfter.ShouldEqual(userContentBefore);
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(1);
+            all.ContainsKey(Repo1).ShouldBeTrue();
+            all.ContainsKey(Repo2).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void SeedFromSystemRegistry_NoSystemRegistry_DoesNothing()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+
+            // No system registry exists, user registry is empty
+            registry.SeedFromSystemRegistryIfNeeded();
+
+            // User registry should still be empty
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void SeedFromSystemRegistry_EmptySystemRegistry_DoesNothing()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+
+            // Create empty system registry
+            string systemRegistryDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "GVFS",
+                LocalRepoRegistry.ServiceDataDirName);
+            string systemRegistryPath = Path.Combine(systemRegistryDir, LocalRepoRegistry.RegistryFileName);
+
+            fs.CreateDirectory(systemRegistryDir);
+            fs.WriteAllText(systemRegistryPath, "2\n");
+
+            registry.SeedFromSystemRegistryIfNeeded();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void SeedFromSystemRegistry_AllReposInaccessible_CreatesEmptyUserRegistry()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+
+            // Create system registry with entries whose directories don't exist
+            string systemRegistryDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "GVFS",
+                LocalRepoRegistry.ServiceDataDirName);
+            string systemRegistryPath = Path.Combine(systemRegistryDir, LocalRepoRegistry.RegistryFileName);
+
+            fs.CreateDirectory(systemRegistryDir);
+            fs.WriteAllText(
+                systemRegistryPath,
+                "2\n{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"sid\",\"IsActive\":true}\n");
+
+            // Don't create Repo1 directory
+
+            registry.SeedFromSystemRegistryIfNeeded();
+
+            // User registry should be empty (no accessible repos to seed)
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(0);
+        }
+
+        private (LocalRepoRegistry registry, MockFileSystem fs) CreateRegistry()
+        {
+            MockFileSystem fs = new MockFileSystem(new MockDirectory(DataLocation, null, null));
+            LocalRepoRegistry registry = new LocalRepoRegistry(new MockTracer(), fs, DataLocation);
+            return (registry, fs);
+        }
+
+        private static void VerifyEntry(LocalRepoRegistration entry, string expectedOwnerSID, bool expectedIsActive)
+        {
+            entry.ShouldNotBeNull();
+            entry.OwnerSID.ShouldEqual(expectedOwnerSID);
+            entry.IsActive.ShouldEqual(expectedIsActive);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/LogonTaskRegistrationTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LogonTaskRegistrationTests.cs
@@ -1,0 +1,265 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LogonTaskRegistrationTests
+    {
+        private const string TestGvfsPath = @"C:\Users\test\AppData\Local\Programs\GVFS\Current\gvfs.exe";
+
+        [TestCase]
+        public void TemplateHash_IsStableAcrossCalls()
+        {
+            // Same template content => same hash, every time.
+            LogonTaskRegistration.TemplateHash.ShouldEqual(LogonTaskRegistration.TemplateHash);
+            // Full SHA-256 hex = 64 chars
+            LogonTaskRegistration.TemplateHash.Length.ShouldEqual(64);
+        }
+
+        [TestCase]
+        public void BuildTaskXml_SubstitutesAllPlaceholders()
+        {
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+
+            xml.Contains(LogonTaskRegistration.GvfsPathPlaceholder).ShouldBeFalse("no GVFS_PATH placeholder should remain");
+            xml.Contains(LogonTaskRegistration.TaskHashPlaceholder).ShouldBeFalse("no TASK_HASH placeholder should remain");
+
+            xml.Contains(TestGvfsPath).ShouldBeTrue("gvfs.exe path should appear in the XML");
+            xml.Contains(LogonTaskRegistration.TemplateHash).ShouldBeTrue("template hash should appear in the XML");
+        }
+
+        [TestCase]
+        public void BuildTaskXml_ProducesMountAllArguments()
+        {
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+            // The task action runs `gvfs.exe service --mount-all`.
+            xml.Contains("service --mount-all").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void BuildTaskXml_NullOrEmptyArgsThrow()
+        {
+            // Assert.Catch accepts derived types (ArgumentNullException is
+            // also raised by ThrowIfNullOrEmpty for null inputs).
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml(null));
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml(""));
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_FindsMarkerInDescription()
+        {
+            string description = "Mounts the user's enlistments at logon. [gvfs-logon-task-hash=DEADBEEF12345678ABCDEF0123456789FEDCBA9876543210CAFEBABE12345678]";
+            LogonTaskRegistration.TryExtractHashMarker(description, out string hash).ShouldBeTrue();
+            hash.ShouldEqual("DEADBEEF12345678ABCDEF0123456789FEDCBA9876543210CAFEBABE12345678");
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_NoMarker_ReturnsFalse()
+        {
+            LogonTaskRegistration.TryExtractHashMarker("Just a plain description.", out string hash).ShouldBeFalse();
+            hash.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_EmptyOrNull_ReturnsFalse()
+        {
+            LogonTaskRegistration.TryExtractHashMarker(null, out _).ShouldBeFalse();
+            LogonTaskRegistration.TryExtractHashMarker("", out _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_MalformedMarker_ReturnsFalse()
+        {
+            // Opening prefix but no closing bracket
+            LogonTaskRegistration.TryExtractHashMarker("foo [gvfs-logon-task-hash=ABCD no close", out _).ShouldBeFalse();
+            // Closing bracket before any content
+            LogonTaskRegistration.TryExtractHashMarker("foo [gvfs-logon-task-hash=]", out _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_FindsMarkerInGeneratedXml()
+        {
+            // Round-trip: the XML produced by BuildTaskXml must contain the
+            // template hash, and TryExtractHashMarker must recover it.
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+            LogonTaskRegistration.TryExtractHashMarker(xml, out string hash).ShouldBeTrue();
+            hash.ShouldEqual(LogonTaskRegistration.TemplateHash);
+        }
+
+        [TestCase]
+        public void IsCurrent_NoRegisteredTask_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            // Default mock has no registered tasks => TryQueryXml fails.
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void IsCurrent_MatchingHash_ReturnsTrue()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void IsCurrent_DifferentHash_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            // Simulate a task registered by a previous template version
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                "<Task><RegistrationInfo><Description>Old. [gvfs-logon-task-hash=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA]</Description></RegistrationInfo></Task>";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void IsCurrent_TaskExistsButNoMarker_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                "<Task><RegistrationInfo><Description>Manually edited, no marker.</Description></RegistrationInfo></Task>";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_CreatesNewTask()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, out string error).ShouldBeTrue(error);
+
+            invoker.RegisteredTasks.ContainsKey(LogonTaskRegistration.FullTaskPath).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_AlreadyCurrentSameArgs_NoRewrite()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, out _).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_CurrentHashButDifferentGvfsPath_Reregisters()
+        {
+            // GVFS install moved (junction swap). Template hash unchanged
+            // but the Command path in the task points at the old location.
+            // We must rewrite.
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            string oldPath = @"C:\Users\test\AppData\Local\Programs\GVFS\Versions\0.1.0\gvfs.exe";
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(oldPath);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, out _).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(1);
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath].Contains(TestGvfsPath).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_InvokerFails_SurfacesError()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.NextRegisterError = "Permission denied";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, out string error).ShouldBeFalse();
+            error.ShouldEqual("Permission denied");
+        }
+
+        [TestCase]
+        public void TryUnregister_DelegatesToInvoker()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryUnregister(out string error).ShouldBeTrue(error);
+            invoker.RegisteredTasks.ContainsKey(LogonTaskRegistration.FullTaskPath).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryUnregister_TaskNotRegistered_StillReturnsTrue()
+        {
+            // Idempotent: unregister of nothing is a success.
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryUnregister(out _).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void Constructor_NullArgs_Throws()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            Assert.Throws<ArgumentNullException>(() => new LogonTaskRegistration(null, invoker));
+            Assert.Throws<ArgumentNullException>(() => new LogonTaskRegistration(new MockTracer(), null));
+        }
+
+        private sealed class MockScheduledTaskInvoker : IScheduledTaskInvoker
+        {
+            public Dictionary<string, string> RegisteredTasks { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public string NextRegisterError { get; set; }
+            public string NextUnregisterError { get; set; }
+            public int RegisterCallCount { get; private set; }
+
+            public bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage)
+            {
+                this.RegisterCallCount++;
+
+                if (!string.IsNullOrEmpty(this.NextRegisterError))
+                {
+                    errorMessage = this.NextRegisterError;
+                    return false;
+                }
+
+                this.RegisteredTasks[taskPath] = xml;
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            public bool TryQueryXml(string taskPath, out string xml, out string errorMessage)
+            {
+                if (this.RegisteredTasks.TryGetValue(taskPath, out xml))
+                {
+                    errorMessage = string.Empty;
+                    return true;
+                }
+
+                xml = null;
+                errorMessage = "Task not found";
+                return false;
+            }
+
+            public bool TryUnregister(string taskPath, out string errorMessage)
+            {
+                if (!string.IsNullOrEmpty(this.NextUnregisterError))
+                {
+                    errorMessage = this.NextUnregisterError;
+                    return false;
+                }
+
+                this.RegisteredTasks.Remove(taskPath);
+                errorMessage = string.Empty;
+                return true;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -16,8 +16,6 @@ namespace GVFS.CommandLine
 {
     public abstract class GVFSVerb
     {
-        protected const string StartServiceInstructions = "Run 'sc start GVFS.Service' from an elevated command prompt to ensure it is running.";
-
         private readonly bool validateOriginURL;
 
         public GVFSVerb(bool validateOrigin = true)
@@ -191,22 +189,6 @@ namespace GVFS.CommandLine
         {
             return ConsoleHelper.ShowStatusWhileRunning(
                 action,
-                message,
-                this.Output,
-                showSpinner: !this.Unattended && this.Output == Console.Out && !Console.IsOutputRedirected,
-                gvfsLogEnlistmentRoot: gvfsLogEnlistmentRoot,
-                initialDelayMs: 0);
-        }
-
-        protected bool ShowStatusWhileRunning(
-            Func<bool> action,
-            Func<string> getMessage,
-            string message,
-            string gvfsLogEnlistmentRoot)
-        {
-            return ConsoleHelper.ShowStatusWhileRunning(
-                action,
-                getMessage,
                 message,
                 this.Output,
                 showSpinner: !this.Unattended && this.Output == Console.Out && !Console.IsOutputRedirected,
@@ -586,8 +568,19 @@ You can specify a URL, a name of a configured cache server, or the special names
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "GVFS.Service is not responding. " + GVFSVerb.StartServiceInstructions;
-                    return false;
+                    // Service not available (user-level install model). Trigger
+                    // the EnableProjFSOnAllDrives scheduled task to ensure
+                    // PrjFlt is attached to this volume. Task failures are not
+                    // fatal — if PrjFlt is truly missing at mount time, the
+                    // mount-process filter check will catch it.
+                    ProcessResult result = ProcessHelper.Run(
+                        "schtasks.exe",
+                        "/Run /TN \"\\GVFS\\EnableProjFSOnAllDrives\"");
+
+                    // Task not registered or failed — may be fine if PrjFlt
+                    // is already attached. Continue and let mount validate.
+                    errorMessage = string.Empty;
+                    return true;
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -14,7 +14,6 @@ namespace GVFS.CommandLine
     {
         private const string MountVerbName = "mount";
         private Process mountProcess;
-        private volatile string currentMountProgress;
 
         public string Verbosity { get; set; }
 
@@ -198,9 +197,7 @@ namespace GVFS.CommandLine
 
                 if (!this.ShowStatusWhileRunning(
                     () => { return this.TryMount(tracer, enlistment, mountExecutableLocation, out errorMessage); },
-                    getMessage: () => this.currentMountProgress,
-                    "Mounting",
-                    enlistment.WorkingDirectoryRoot))
+                    "Mounting"))
                 {
                     ReturnCode mountExitCode = ReturnCode.GenericError;
                     if (this.mountProcess != null)
@@ -238,7 +235,7 @@ namespace GVFS.CommandLine
                     tracer.RelatedInfo($"{nameof(this.Execute)}: Registering for automount");
 
                     if (this.ShowStatusWhileRunning(
-                        () => { return this.RegisterMount(enlistment, out errorMessage); },
+                        () => { return this.RegisterMount(enlistment, tracer, out errorMessage); },
                         "Registering for automount"))
                     {
                         tracer.RelatedInfo($"{nameof(this.Execute)}: Registered for automount");
@@ -280,35 +277,42 @@ namespace GVFS.CommandLine
 
             tracer.RelatedInfo($"{nameof(this.TryMount)}: Waiting for repo to be mounted");
 
-            return GVFSEnlistment.WaitUntilMounted(
-                tracer,
-                enlistment.NamedPipeName,
-                enlistment.WorkingDirectoryRoot,
-                this.Unattended,
-                out errorMessage,
-                onProgress: progress => this.currentMountProgress = progress);
+            return GVFSEnlistment.WaitUntilMounted(tracer, enlistment.NamedPipeName, enlistment.WorkingDirectoryRoot, this.Unattended, out errorMessage);
         }
 
-        private bool RegisterMount(GVFSEnlistment enlistment, out string errorMessage)
+        private bool RegisterMount(GVFSEnlistment enlistment, ITracer tracer, out string errorMessage)
         {
             errorMessage = string.Empty;
 
-            NamedPipeMessages.RegisterRepoRequest request = new NamedPipeMessages.RegisterRepoRequest();
-
             // Worktree mounts register with their worktree path so they can be
             // listed and unregistered independently of the primary enlistment.
-            request.EnlistmentRoot = enlistment.IsWorktree
+            string enlistmentRoot = enlistment.IsWorktree
                 ? enlistment.WorkingDirectoryRoot
                 : enlistment.PrimaryEnlistmentRoot;
+            string ownerSID = GVFSPlatform.Instance.GetCurrentUser();
 
-            request.OwnerSID = GVFSPlatform.Instance.GetCurrentUser();
+            NamedPipeMessages.RegisterRepoRequest request = new NamedPipeMessages.RegisterRepoRequest();
+            request.EnlistmentRoot = enlistmentRoot;
+            request.OwnerSID = ownerSID;
 
             using (NamedPipeClient client = new NamedPipeClient(this.ServicePipeName))
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "Unable to register repo because GVFS.Service is not responding.";
-                    return false;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to writing the
+                    // registry file directly. The service writes to the same
+                    // file at the same path when it IS running, so the two
+                    // models can co-exist or be migrated between without any
+                    // data being lost. We only reach this fallback when the
+                    // pipe doesn't exist at all - if the service is present
+                    // but mid-request crashes, that surfaces as
+                    // BrokenPipeException below and we deliberately do NOT
+                    // fall back (the service remains the authoritative
+                    // writer in that case).
+                    tracer.RelatedInfo($"{nameof(this.RegisterMount)}: GVFS.Service pipe unavailable; falling back to LocalRepoRegistry");
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(tracer);
+                    return localRegistry.TryRegisterRepo(enlistmentRoot, ownerSID, out errorMessage);
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -1,6 +1,7 @@
 using GVFS.Common;
 using GVFS.Common.FileSystem;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -156,8 +157,18 @@ namespace GVFS.CommandLine
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "GVFS.Service is not responding.";
-                    return false;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to reading the
+                    // registry file directly. See the matching comment in
+                    // MountVerb.RegisterMount for the design rationale.
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(NullTracer.Instance);
+                    if (!localRegistry.TryGetActiveRepos(out List<LocalRepoRegistration> activeRepos, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    repoList = activeRepos.Select(r => r.EnlistmentRoot).ToList();
+                    return true;
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/UnmountVerb.cs
+++ b/GVFS/GVFS/CommandLine/UnmountVerb.cs
@@ -1,5 +1,6 @@
 using GVFS.Common;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
 using System;
 using System.Diagnostics;
 
@@ -204,7 +205,30 @@ namespace GVFS.CommandLine
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "Unable to unregister repo because GVFS.Service is not responding. " + GVFSVerb.StartServiceInstructions;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to writing the
+                    // registry file directly. See the matching comment in
+                    // MountVerb.RegisterMount for the design rationale and
+                    // the deliberate decision NOT to fall back on
+                    // BrokenPipeException (the service-broken-mid-request
+                    // case).
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(NullTracer.Instance);
+                    if (localRegistry.TryDeactivateRepo(rootPath, out errorMessage))
+                    {
+                        return true;
+                    }
+
+                    // TryDeactivateRepo returns false for two reasons:
+                    //   1. Entry not found — benign, nothing to unregister.
+                    //   2. I/O error — real failure, propagate to caller.
+                    // Distinguish by checking for the "non-existent" message
+                    // that TryDeactivateRepo produces for case 1.
+                    if (errorMessage != null && errorMessage.Contains("non-existent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        errorMessage = string.Empty;
+                        return true;
+                    }
+
                     return false;
                 }
 

--- a/scripts/projfs-attach/build-task-xml.ps1
+++ b/scripts/projfs-attach/build-task-xml.ps1
@@ -1,0 +1,103 @@
+# build-task-xml.ps1
+#
+# Produces the final EnableProjFSOnAllDrives scheduled task XML by
+# base64-encoding enable-projfs-on-all-drives.ps1 and substituting it
+# (along with a content hash) into enable-projfs-on-all-drives-task.xml.template.
+#
+# Inputs and output are passed by parameter so this script is callable
+# from layout.bat, MSBuild, or directly during development.
+#
+# The hash embedded in the task Description (via __TASK_HASH__) is
+# SHA-256 over the un-encoded inputs (template + script body, in that
+# order, separated by a NUL byte). Stable across re-runs with
+# unchanged inputs; changes the moment either input's content
+# changes. This is what the installer's drift detection compares
+# against the registered task's Description marker to decide whether
+# re-registration is needed.
+#
+# Output XML is UTF-16 LE with BOM (required by Task Scheduler's
+# /XML import).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TemplatePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ScriptPath)) { throw "Script not found: $ScriptPath" }
+if (-not (Test-Path $TemplatePath)) { throw "Template not found: $TemplatePath" }
+
+# Read raw bytes so the hash and the base64 are computed over exactly
+# what's on disk, regardless of line-ending or BOM conventions.
+$scriptBytes = [System.IO.File]::ReadAllBytes($ScriptPath)
+
+# Read the template as text (UTF-8 or UTF-16 with BOM both work for
+# Get-Content; the template is checked in as UTF-16 to match the XML
+# encoding declaration but we re-emit as UTF-16 with BOM either way).
+$templateText = [System.IO.File]::ReadAllText($TemplatePath)
+$templateBytes = [System.Text.Encoding]::UTF8.GetBytes($templateText)
+
+# PowerShell -EncodedCommand expects UTF-16 LE bytes, base64 encoded.
+$scriptUtf16 = [System.Text.Encoding]::Unicode.GetString($scriptBytes)
+# If the source script was UTF-8 (typical for files checked into git),
+# the line above produces garbage. Detect by checking for a UTF-8 BOM
+# or by attempting a UTF-8 decode and re-encoding to UTF-16.
+$scriptText =
+    if ($scriptBytes.Length -ge 3 -and $scriptBytes[0] -eq 0xEF -and $scriptBytes[1] -eq 0xBB -and $scriptBytes[2] -eq 0xBF) {
+        [System.Text.Encoding]::UTF8.GetString($scriptBytes, 3, $scriptBytes.Length - 3)
+    }
+    elseif ($scriptBytes.Length -ge 2 -and $scriptBytes[0] -eq 0xFF -and $scriptBytes[1] -eq 0xFE) {
+        [System.Text.Encoding]::Unicode.GetString($scriptBytes, 2, $scriptBytes.Length - 2)
+    }
+    else {
+        # Assume UTF-8 without BOM (git's default for text)
+        [System.Text.Encoding]::UTF8.GetString($scriptBytes)
+    }
+
+$scriptUtf16Bytes = [System.Text.Encoding]::Unicode.GetBytes($scriptText)
+$encodedCommand = [System.Convert]::ToBase64String($scriptUtf16Bytes)
+
+# Hash inputs: template bytes + NUL + script bytes (the raw bytes,
+# not re-encoded, so the hash is reproducible even if the encoding
+# detection logic is changed in a future revision of this script).
+$hasher = [System.Security.Cryptography.SHA256]::Create()
+try {
+    $combined = New-Object byte[] ($templateBytes.Length + 1 + $scriptBytes.Length)
+    [System.Buffer]::BlockCopy($templateBytes, 0, $combined, 0, $templateBytes.Length)
+    $combined[$templateBytes.Length] = 0
+    [System.Buffer]::BlockCopy($scriptBytes, 0, $combined, $templateBytes.Length + 1, $scriptBytes.Length)
+    $hashBytes = $hasher.ComputeHash($combined)
+    $hashHex = ([System.BitConverter]::ToString($hashBytes)).Replace('-', '')
+}
+finally {
+    $hasher.Dispose()
+}
+
+# Substitute placeholders. Order matters only because __SCRIPT_BASE64__
+# could in theory contain the __TASK_HASH__ literal -- highly unlikely
+# but trivially defended by substituting hash first.
+$finalXml = $templateText.
+    Replace('__TASK_HASH__', $hashHex).
+    Replace('__SCRIPT_BASE64__', $encodedCommand)
+
+# Ensure output directory exists.
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir -and -not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+# Write UTF-16 LE with BOM (required by schtasks /Create /XML).
+[System.IO.File]::WriteAllText(
+    $OutputPath,
+    $finalXml,
+    (New-Object System.Text.UnicodeEncoding $false, $true))
+
+Write-Host "Wrote $OutputPath ($([System.IO.File]::ReadAllBytes($OutputPath).Length) bytes, hash=$hashHex)"

--- a/scripts/projfs-attach/enable-projfs-on-all-drives-task.xml.template
+++ b/scripts/projfs-attach/enable-projfs-on-all-drives-task.xml.template
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<!--
+enable-projfs-on-all-drives-task.xml.template
+
+Scheduled task definition for the user-level GVFS install model.
+
+This is a TEMPLATE: build-task-xml.ps1 reads it, substitutes
+__SCRIPT_BASE64__ with the base64-encoded contents of
+enable-projfs-on-all-drives.ps1 and __TASK_HASH__ with the SHA-256
+of the un-substituted template + script combined (so the hash is
+stable across re-substitutions but changes when either input
+content changes).
+
+Registered once per machine at install time (admin elevation
+required). Once registered, runs as LocalSystem with no further
+UAC. No on-disk script file is deployed -- the body of the
+PowerShell script is embedded in the <Exec><Arguments> as
+-EncodedCommand <base64>.
+
+Two triggers:
+  1. BootTrigger - fires at OS startup. Re-attaches prjflt to every
+     NTFS/ReFS volume after reboot (FilterAttach is not persistent).
+  2. EventTrigger - subscribes to the Microsoft-Windows-Partition
+     Diagnostic event log, Event ID 1006 (partition online). This
+     event fires when a new partition becomes available, including
+     USB plug-in, VHD mount, and new partition creation.
+
+The Microsoft-Windows-Partition channel is enabled by default on
+Windows 10+ and fires reliably for both fixed and removable media.
+
+The Description contains the marker [gvfs-task-hash=__TASK_HASH__]
+which the installer's drift-detect uses to decide whether the
+registered task still matches the intended one (no rewrite needed)
+or has drifted (re-register required). Re-registration is the only
+operation that requires UAC; per-user GVFS upgrades that don't
+change this task body never need elevation.
+-->
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>Microsoft\GVFS</Author>
+    <Description>Re-attaches the ProjFS filter (prjflt) to NTFS/ReFS volumes after reboot or volume mount. Required by VFS for Git in the user-level install model. [gvfs-task-hash=__TASK_HASH__]</Description>
+    <URI>\GVFS\EnableProjFSOnAllDrives</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+    <EventTrigger>
+      <Enabled>true</Enabled>
+      <Subscription>&lt;QueryList&gt;&lt;Query Id="0" Path="Microsoft-Windows-Partition/Diagnostic"&gt;&lt;Select Path="Microsoft-Windows-Partition/Diagnostic"&gt;*[System[Provider[@Name='Microsoft-Windows-Partition'] and (EventID=1006)]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;</Subscription>
+    </EventTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>S-1-5-18</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Queue</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>
+    <Priority>5</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand __SCRIPT_BASE64__</Arguments>
+    </Exec>
+  </Actions>
+</Task>

--- a/scripts/projfs-attach/enable-projfs-on-all-drives.ps1
+++ b/scripts/projfs-attach/enable-projfs-on-all-drives.ps1
@@ -1,0 +1,135 @@
+# enable-projfs-on-all-drives.ps1
+#
+# Source of truth for the EnableProjFSOnAllDrives scheduled task body.
+# This script is NOT deployed to disk in the user-mode install model;
+# instead, build-task-xml.ps1 base64-encodes the contents and embeds
+# them in the task XML's <Exec><Arguments> as -EncodedCommand. The
+# task then runs as: powershell.exe -EncodedCommand <base64-of-this>.
+#
+# Runs as LocalSystem (configured by the scheduled task) so it has
+# SE_LOAD_DRIVER_PRIVILEGE for FilterAttach and HKLM write access
+# for the Dev Drive allowed-filters registry.
+#
+# Two invocation modes (selected by the task's triggers):
+#   1. AT_SYSTEM_START - no DriveLetter argument. Reconciles the Dev
+#      Drive allow-list (machine-wide) and attaches prjflt to every
+#      eligible NTFS/ReFS volume. FilterAttach is not persistent
+#      across reboots, so this is required every boot.
+#   2. Event 1006 from Microsoft-Windows-Partition/Diagnostic -
+#      DriveLetter argument is the drive of the newly-mounted volume.
+#      Attaches prjflt to just that one drive. Avoids work on every
+#      USB plug-in / VHD mount.
+#
+# Logs to %ProgramData%\GVFS\enable-projfs-on-all-drives.log
+# (HKLM-writable from SYSTEM, persistent across reboots).
+#
+# Idempotent everywhere: fltmc NameCollision is treated as success,
+# fsutil devdrv setFiltersAllowed is a no-op if already set. Safe to
+# run repeatedly.
+
+[CmdletBinding()]
+param(
+    # If provided, only attempt to attach to this single drive letter.
+    # Used by the volume-mount trigger to scope work narrowly. When
+    # absent, all NTFS/ReFS volumes are processed (boot trigger path),
+    # and the Dev Drive allow-list is also reconciled.
+    [string]$DriveLetter
+)
+
+$ErrorActionPreference = 'Stop'
+
+$logDir = Join-Path $env:ProgramData 'GVFS'
+$logPath = Join-Path $logDir 'enable-projfs-on-all-drives.log'
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+function Write-Log([string]$msg) {
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $msg"
+    Add-Content -Path $logPath -Value $line -Encoding UTF8
+}
+
+function Set-PrjFltDevDriveAllowed {
+    # Dev Drives consult a machine-wide allow-list at mount time to
+    # decide which minifilters may attach. Without PrjFlt in the list,
+    # GVFS cannot work on Dev Drives even if we call FilterAttach.
+    # Set unconditionally; fsutil is a no-op if already set.
+    try {
+        $out = (& fsutil.exe devdrv setFiltersAllowed PrjFlt 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "DevDrive allow-list: PrjFlt allowed (output: $out)"
+        }
+        else {
+            # Non-fatal: on older Windows builds without Dev Drive
+            # support, fsutil devdrv may fail. Log and continue.
+            Write-Log "DevDrive allow-list: fsutil exit=$LASTEXITCODE (likely no Dev Drive support on this OS) output=$out"
+        }
+    }
+    catch {
+        Write-Log "DevDrive allow-list: exception (likely no Dev Drive support): $_"
+    }
+}
+
+function Add-PrjFltToVolume([string]$drive) {
+    $output = (& fltmc.exe attach PrjFlt "${drive}:" 2>&1 | Out-String).Trim()
+    $exit = $LASTEXITCODE
+    # NameCollision is success-equivalent: filter is already attached.
+    # Check the output BEFORE the exit code because fltmc returns exit
+    # 1 for NameCollision (despite it being benign).
+    if ($output -match 'instance already exists' -or
+        $output -match 'instance name collision' -or
+        $output -match '0x801f0012') {
+        Write-Log "OK   ${drive}: already attached (NameCollision)"
+        return $true
+    }
+    if ($exit -ne 0) {
+        Write-Log "FAIL ${drive}: exit=$exit output=$output"
+        return $false
+    }
+    Write-Log "OK   ${drive}: attached (output: $output)"
+    return $true
+}
+
+try {
+    Write-Log "===== enable-projfs-on-all-drives.ps1 starting (DriveLetter='$DriveLetter') ====="
+
+    if ($DriveLetter) {
+        # Single-volume mode (volume-mount trigger)
+        $drive = $DriveLetter.TrimEnd(':').TrimEnd('\').ToUpperInvariant()
+        if ($drive.Length -ne 1) {
+            Write-Log "ERROR: invalid DriveLetter '$DriveLetter' (parsed='$drive')"
+            exit 2
+        }
+        $vol = Get-Volume -DriveLetter $drive -ErrorAction SilentlyContinue
+        if (-not $vol) {
+            Write-Log "SKIP ${drive}: volume not found"
+            exit 0
+        }
+        if ($vol.FileSystemType -notin @('NTFS', 'ReFS')) {
+            Write-Log "SKIP ${drive}: filesystem=$($vol.FileSystemType) (not NTFS/ReFS)"
+            exit 0
+        }
+        Add-PrjFltToVolume $drive | Out-Null
+    }
+    else {
+        # All-volumes mode (boot trigger). Reconcile both the Dev Drive
+        # allow-list AND per-volume attachments. Cheap; idempotent.
+        Set-PrjFltDevDriveAllowed
+        $volumes = Get-Volume |
+            Where-Object {
+                $_.DriveLetter -and
+                $_.FileSystemType -in @('NTFS', 'ReFS')
+            }
+        Write-Log "Found $(@($volumes).Count) eligible volume(s)"
+        foreach ($v in $volumes) {
+            Add-PrjFltToVolume ([string]$v.DriveLetter) | Out-Null
+        }
+    }
+
+    Write-Log "===== enable-projfs-on-all-drives.ps1 done ====="
+}
+catch {
+    Write-Log "EXCEPTION: $_"
+    Write-Log $_.ScriptStackTrace
+    exit 3
+}


### PR DESCRIPTION
## Background
One obstacle to automatically updating GVFS is that is requires administrator privileges to install and run.
Currently, GVFS.Service runs as a Windows Service under SYSTEM (high-privilege) account. That means every upgrade has to update the service, because it is a binary that changes in every release, so every upgrade needs administrator privileges.

The service itself currently performs these functions:
* Maintains a registry of repositories that have been mounted before. The registry is updated by calls to `gvfs mount` and "gvfs unmount" by sending messages on a named pipe to the service from the user-initiated gvfs.exe calls.
* Provides --list-mounted, --mount-all, and --unmount-all operations for the `gvfs service` verb. These don't change the registry, but read it and perform the given operation.
* On logon, mounts all repos in the registry
* When a repository tries to mount, if it determines that ProjFS is not enabled/attached to the volume then it sends a pipe message to the Service, and the service attaches ProjFS.
* Supports the recently-added "PendingUpgrade" feature - if repos are mounted and /STAGEIFMOUNTED is provided, the installer places the new binaries in a pending folder inside the installation, upgrades only the service, and the service completes the install on next reboot or if all current mounts are unmounted.

Of these functions, only the ProjFS enable/attach and the PendingUpgrade feature require elevated privileges. PR #2028 replaces PendingUpgrade feature with simpler Current junction, which does not require GVFS.Service support - it's handled entirely in the installer.

## Changes
This pull request removes GVFS.Service entirely, replacing it with:
- **LocalRepoRegistry**: Kept at user-level instead of system level. Initially populated (first use by a user) by copying from system registry if a system registry from a prior version exists. Verbs that would call the service to update/access this now update/access it directly.
- **Logon task**: machine-wide `\GVFS\AutoMount` fires for all interactive users at logon, runs `gvfs service --mount-all` (which will mount repos in that user's LocalRepoRegistry)
- **ProjFS boot task**: SYSTEM task enables ProjFS + attaches PrjFlt on all volumes at boot. `gvfs mount` can also trigger it if needed, for example if a new volume was created during the current user session.


### Part of Plan UAC-Free Install Modernization (Phase 2)
- Phase 1: Versioned folder layout (PR #2028)
- **Phase 2: Service removal (This PR)**
- Phase 3: /CURRENTUSER user-mode install (PR #2030)