### PR TITLE
Installer: transparent migration from legacy system install (PR-C)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -340,6 +340,15 @@ jobs:
     with:
       skip: ${{ needs.validate.outputs.skip }}
 
+  functional_tests_usermode:
+    name: Functional Tests (User-Mode)
+    needs: [validate, build]
+    uses: ./.github/workflows/functional-tests.yaml
+    with:
+      skip: ${{ needs.validate.outputs.skip }}
+      install_mode: user
+      output_prefix: UserMode
+
   upgrade_tests:
     name: Upgrade Tests
     needs: [validate, build]
@@ -350,7 +359,7 @@ jobs:
   result:
     runs-on: ubuntu-latest
     name: Build, Unit and Functional Tests Successful
-    needs: [functional_tests, upgrade_tests]
+    needs: [functional_tests, functional_tests_usermode, upgrade_tests]
 
     steps:
       - name: Success! # for easier identification of successful runs in the Checks Required for Pull Requests

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ''
+      install_mode:
+        description: 'Install mode: "system" (default, admin) or "user" (/CURRENTUSER, per-user)'
+        required: false
+        type: string
+        default: 'system'
     secrets:
       vfs_token:
         description: 'Token for downloading VFSForGit artifacts (required for cross-repository downloads; defaults to GITHUB_TOKEN)'
@@ -153,13 +158,35 @@ jobs:
       shell: cmd
       run: git\install.bat
 
-    - name: Install VFS for Git
-      if: steps.skip.outputs.result != 'true'
+    - name: Install VFS for Git (system)
+      if: steps.skip.outputs.result != 'true' && inputs.install_mode != 'user'
       shell: cmd
       run: gvfs\install.bat
 
-    - name: Verify GVFS installation
-      if: steps.skip.outputs.result != 'true'
+    - name: Install VFS for Git (user)
+      if: steps.skip.outputs.result != 'true' && inputs.install_mode == 'user'
+      shell: pwsh
+      run: |
+        $installer = (Get-ChildItem gvfs\SetupGVFS*.exe).FullName
+        $logDir = "gvfs\logs"
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        $logFile = Join-Path $logDir "gvfs.log"
+        $proc = Start-Process -FilePath $installer -ArgumentList @(
+          "/CURRENTUSER", "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART",
+          "/LOG=$logFile"
+        ) -PassThru
+        $proc.WaitForExit()
+        if ($proc.ExitCode -ne 0) {
+          Get-Content $logFile -Tail 30 -ErrorAction SilentlyContinue
+          throw "User-mode installer failed with exit code $($proc.ExitCode)"
+        }
+        # Add user-mode gvfs to PATH for subsequent steps
+        $gvfsDir = Join-Path $env:LOCALAPPDATA 'GVFS\Current'
+        Add-Content $env:GITHUB_PATH $gvfsDir
+        Write-Host "User-mode install succeeded, added $gvfsDir to GITHUB_PATH"
+
+    - name: Verify GVFS installation (system)
+      if: steps.skip.outputs.result != 'true' && inputs.install_mode != 'user'
       shell: cmd
       continue-on-error: true
       run: |
@@ -169,6 +196,17 @@ jobs:
         sc query GVFS.Service
         echo === List Mounted ===
         "C:\Program Files\VFS for Git\GVFS.exe" service --list-mounted
+
+    - name: Verify GVFS installation (user)
+      if: steps.skip.outputs.result != 'true' && inputs.install_mode == 'user'
+      shell: pwsh
+      continue-on-error: true
+      run: |
+        $gvfsExe = Join-Path $env:LOCALAPPDATA 'GVFS\Current\gvfs.exe'
+        Write-Host "=== GVFS Version ==="
+        & $gvfsExe version
+        Write-Host "=== List Mounted ==="
+        & $gvfsExe service --list-mounted
 
     - name: ProjFS details (post-install)
       if: steps.skip.outputs.result != 'true'
@@ -191,9 +229,14 @@ jobs:
       shell: cmd
       timeout-minutes: 60
       run: |
-        SET PATH=C:\Program Files\VFS for Git;%PATH%
-        SET GIT_TRACE2_PERF=C:\temp\git-trace2.log
-        ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci --slice=${{ matrix.nr }},10
+        if "${{ inputs.install_mode }}" == "user" (
+          SET GIT_TRACE2_PERF=C:\temp\git-trace2.log
+          ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci --no-service --slice=${{ matrix.nr }},10
+        ) else (
+          SET PATH=C:\Program Files\VFS for Git;%PATH%
+          SET GIT_TRACE2_PERF=C:\temp\git-trace2.log
+          ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci --slice=${{ matrix.nr }},10
+        )
 
     - name: Upload functional test results
       if: always() && steps.skip.outputs.result != 'true'

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -34,6 +34,7 @@ jobs:
           - staging-then-clean
           - mount-safety-deferral
           - unmount-all-triggers-upgrade
+          - user-mode-cold-install
       fail-fast: false
 
     steps:
@@ -363,6 +364,46 @@ jobs:
             Write-Host "PASS: unmount-all triggers staged upgrade via process monitor"
           }
 
+          "user-mode-cold-install" {
+            Write-Host "=== Scenario: User-mode cold install + clone + mount ==="
+            # No LKG install — start from a clean machine with only Git.
+            # Install the new build in user mode, clone a test repo, mount.
+            $userGvfsDir = Join-Path $env:LOCALAPPDATA 'GVFS'
+
+            Install-GVFS $newInstaller @("/CURRENTUSER")
+
+            # Verify payload deployed to user dir
+            $gvfsExe = Join-Path $userGvfsDir 'Current\gvfs.exe'
+            if (-not (Test-Path $gvfsExe)) {
+              throw "gvfs.exe not found at $gvfsExe after user-mode install"
+            }
+            Write-Host "gvfs.exe found at $gvfsExe"
+
+            # Verify version
+            $version = & $gvfsExe version 2>&1
+            Write-Host "gvfs version: $version"
+            if ($LASTEXITCODE -ne 0) { throw "gvfs version failed" }
+
+            # Clone
+            $userEnlistment = "C:\gvfs-usermode-test"
+            if (Test-Path $userEnlistment) { Remove-Item $userEnlistment -Recurse -Force }
+            & $gvfsExe clone $testRepo $userEnlistment 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) { throw "gvfs clone failed" }
+
+            # Verify mount is running
+            $readmePath = Join-Path $userEnlistment "src\Readme.md"
+            if (-not (Test-Path $readmePath)) {
+              throw "Clone succeeded but $readmePath not accessible"
+            }
+            Write-Host "Repo accessible at $userEnlistment"
+
+            # Unmount
+            & $gvfsExe unmount $userEnlistment 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) { throw "gvfs unmount failed" }
+
+            Write-Host "PASS: User-mode cold install + clone + mount + unmount succeeded"
+          }
+
           default {
             throw "Unknown scenario: ${{ matrix.scenario }}"
           }
@@ -377,3 +418,4 @@ jobs:
         path: |
           C:\ProgramData\GVFS\GVFS.Service\Logs\
           C:\temp\gvfs-install-logs\
+          ${{ env.LOCALAPPDATA }}\GVFS\Logs\

--- a/GVFS/GVFS.Common/IScheduledTaskInvoker.cs
+++ b/GVFS/GVFS.Common/IScheduledTaskInvoker.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Abstracts the Windows Task Scheduler operations needed by
+    /// <see cref="LogonTaskRegistration"/>. Production callers use
+    /// <see cref="SchTasksScheduledTaskInvoker"/>; tests pass a mock so
+    /// they can exercise <see cref="LogonTaskRegistration"/>'s logic
+    /// without actually touching the Task Scheduler on the test machine.
+    /// </summary>
+    public interface IScheduledTaskInvoker
+    {
+        /// <summary>
+        /// Register the task at <paramref name="taskPath"/> from the given
+        /// XML, overwriting any existing task at that path. Returns
+        /// <c>true</c> on success.
+        /// </summary>
+        bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage);
+
+        /// <summary>
+        /// Read back the registered XML for the task at
+        /// <paramref name="taskPath"/>. Returns <c>true</c> with the XML
+        /// when the task exists; returns <c>false</c> with a populated
+        /// <paramref name="errorMessage"/> when it does not.
+        /// </summary>
+        bool TryQueryXml(string taskPath, out string xml, out string errorMessage);
+
+        /// <summary>
+        /// Unregister the task at <paramref name="taskPath"/>. Returns
+        /// <c>true</c> if the task was unregistered OR was not registered
+        /// to begin with (idempotent). Returns <c>false</c> only on a hard
+        /// failure (e.g., permission denied).
+        /// </summary>
+        bool TryUnregister(string taskPath, out string errorMessage);
+    }
+}

--- a/GVFS/GVFS.Common/LocalRepoRegistration.cs
+++ b/GVFS/GVFS.Common/LocalRepoRegistration.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// One entry in the user-level repo registry on disk. Field set and
+    /// JSON shape MUST match GVFS.Service.RepoRegistration so that the
+    /// user-level registry file (written by <see cref="LocalRepoRegistry"/>)
+    /// is wire-compatible with any registry the legacy service has written
+    /// in the past. If a new field is added here, the same field must also
+    /// be added to GVFS.Service.RepoRegistration (and vice versa) along
+    /// with a registry-format-version bump.
+    /// </summary>
+    public class LocalRepoRegistration
+    {
+        public LocalRepoRegistration()
+        {
+        }
+
+        public LocalRepoRegistration(string enlistmentRoot, string ownerSID)
+        {
+            this.EnlistmentRoot = enlistmentRoot;
+            this.OwnerSID = ownerSID;
+            this.IsActive = true;
+        }
+
+        public string EnlistmentRoot { get; set; }
+        public string OwnerSID { get; set; }
+        public bool IsActive { get; set; }
+
+        // Uses LocalRepoRegistrationJsonContext (assembly-local source generator)
+        // rather than GVFSJsonContext. The service-side RepoRegistration uses
+        // its own ServiceJsonContext for the same reason — neither type can be
+        // registered in GVFSJsonContext because GVFSJsonContext lives in
+        // GVFS.Common and the service-side type lives in GVFS.Service (wrong
+        // dependency direction). Keeping symmetric local contexts here means
+        // the on-disk JSON shape is governed by identical source-gen behavior
+        // on both sides.
+        public static LocalRepoRegistration FromJson(string json)
+        {
+            return JsonSerializer.Deserialize(json, LocalRepoRegistrationJsonContext.Default.LocalRepoRegistration);
+        }
+
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, LocalRepoRegistrationJsonContext.Default.LocalRepoRegistration);
+        }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "({0} - {1}) {2}",
+                this.IsActive ? "Active" : "Inactive",
+                this.OwnerSID,
+                this.EnlistmentRoot);
+        }
+    }
+
+    [JsonSerializable(typeof(LocalRepoRegistration))]
+    internal partial class LocalRepoRegistrationJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/GVFS/GVFS.Common/LocalRepoRegistry.cs
+++ b/GVFS/GVFS.Common/LocalRepoRegistry.cs
@@ -1,0 +1,348 @@
+using GVFS.Common.FileSystem;
+using GVFS.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// File-backed repo registry usable from any GVFS process without going
+    /// through GVFS.Service. The on-disk format is wire-compatible with
+    /// GVFS.Service.RepoRegistry — both produce and consume the same
+    /// <c>repo-registry</c> file under the shared service data directory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// On-disk format (line-oriented, identical to <c>GVFS.Service.RepoRegistry</c>):
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Line 1: registry format version (integer, currently <c>2</c>).</item>
+    /// <item>
+    /// Lines 2..N: one <see cref="LocalRepoRegistration"/> JSON object per line.
+    /// Blank lines and lines that fail to parse are skipped (matches the service's
+    /// tolerance for partial corruption).
+    /// </item>
+    /// </list>
+    /// <para>
+    /// Threading: instance methods that read or write the registry serialize on
+    /// a private instance lock. Cross-process safety relies on the same atomic
+    /// write-temp-then-replace pattern the service uses.
+    /// </para>
+    /// <para>
+    /// This type does not pick its own storage location — callers pass
+    /// <paramref name="registryDirectory"/> via the constructor. Production
+    /// callers should pass <c>GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(ServiceDataDirName)</c>
+    /// so the file lives at the same path the service uses (which honors the
+    /// <c>GVFS_SECURE_DATA_ROOT</c> environment-variable redirect for user-level
+    /// installs).
+    /// </para>
+    /// </remarks>
+    public class LocalRepoRegistry
+    {
+        /// <summary>
+        /// Subdirectory under the platform's secure-data root that holds the
+        /// registry file. Matches the legacy service's name so both producers
+        /// write to the same location.
+        /// </summary>
+        public const string ServiceDataDirName = "GVFS.Service";
+
+        /// <summary>Final on-disk name of the registry file.</summary>
+        public const string RegistryFileName = "repo-registry";
+
+        /// <summary>
+        /// Temp name used by the atomic write-then-replace pattern. Named
+        /// <c>repo-registry.lock</c> for byte-for-byte compatibility with
+        /// the legacy service's choice (so a writer interrupted mid-rename
+        /// leaves a file with the same name the service would have left).
+        /// </summary>
+        public const string RegistryTempName = "repo-registry.lock";
+
+        /// <summary>
+        /// Registry format version this implementation can read AND write.
+        /// Files with a higher version on disk are treated as opaque: read
+        /// returns empty and we refuse to overwrite, so a newer GVFS that
+        /// has written the registry is not corrupted by an older GVFS.
+        /// </summary>
+        public const int RegistryVersion = 2;
+
+        private readonly ITracer tracer;
+        private readonly PhysicalFileSystem fileSystem;
+        private readonly string registryDirectory;
+        private readonly object instanceLock = new object();
+
+        public LocalRepoRegistry(ITracer tracer, PhysicalFileSystem fileSystem, string registryDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            ArgumentNullException.ThrowIfNull(fileSystem);
+            ArgumentNullException.ThrowIfNull(registryDirectory);
+
+            this.tracer = tracer;
+            this.fileSystem = fileSystem;
+            this.registryDirectory = registryDirectory;
+        }
+
+        /// <summary>
+        /// Convenience factory for production callers: constructs an instance
+        /// pointed at the platform's secure-data path for the GVFS.Service
+        /// component, using a real <see cref="PhysicalFileSystem"/>. This is
+        /// the same path the legacy service writes to, so register/unregister
+        /// operations are wire-compatible regardless of whether the service
+        /// is running.
+        /// </summary>
+        public static LocalRepoRegistry CreateForCurrentPlatform(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            return new LocalRepoRegistry(
+                tracer,
+                new PhysicalFileSystem(),
+                GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(ServiceDataDirName));
+        }
+
+        /// <summary>
+        /// Idempotently records the given enlistment root as active. If an
+        /// entry already exists, it is reactivated and its <c>OwnerSID</c>
+        /// is updated to <paramref name="ownerSID"/>. Matches the semantics
+        /// of <c>GVFS.Service.RepoRegistry.TryRegisterRepo</c>.
+        /// </summary>
+        public bool TryRegisterRepo(string repoRoot, string ownerSID, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.TryGetValue(repoRoot, out LocalRepoRegistration existing))
+                    {
+                        if (!existing.IsActive || !string.Equals(existing.OwnerSID, ownerSID, StringComparison.Ordinal))
+                        {
+                            existing.IsActive = true;
+                            existing.OwnerSID = ownerSID;
+                            this.WriteRegistry(all);
+                        }
+                    }
+                    else
+                    {
+                        all[repoRoot] = new LocalRepoRegistration(repoRoot, ownerSID);
+                        this.WriteRegistry(all);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while registering repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Marks the given entry inactive (retained on disk so
+        /// <see cref="LocalRepoRegistration.OwnerSID"/> is preserved for a
+        /// possible later re-register). Returns <c>true</c> when the entry
+        /// existed (whether or not it was already inactive); returns
+        /// <c>false</c> when the entry was not found.
+        /// </summary>
+        public bool TryDeactivateRepo(string repoRoot, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.TryGetValue(repoRoot, out LocalRepoRegistration existing))
+                    {
+                        if (existing.IsActive)
+                        {
+                            existing.IsActive = false;
+                            this.WriteRegistry(all);
+                        }
+
+                        return true;
+                    }
+
+                    errorMessage = string.Format("Attempted to deactivate non-existent repo at '{0}'", repoRoot);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while deactivating repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Removes the entry entirely (not just deactivates it). Returns
+        /// <c>true</c> on success, <c>false</c> if no such entry existed.
+        /// </summary>
+        public bool TryRemoveRepo(string repoRoot, out string errorMessage)
+        {
+            ArgumentNullException.ThrowIfNull(repoRoot);
+
+            errorMessage = null;
+            try
+            {
+                lock (this.instanceLock)
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    if (all.Remove(repoRoot))
+                    {
+                        this.WriteRegistry(all);
+                        return true;
+                    }
+
+                    errorMessage = string.Format("Attempted to remove non-existent repo at '{0}'", repoRoot);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format("Error while removing repo {0}: {1}", repoRoot, e);
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns the entries currently marked active. Inactive entries are
+        /// excluded. Returns an empty list when the registry file does not
+        /// exist yet.
+        /// </summary>
+        public bool TryGetActiveRepos(out List<LocalRepoRegistration> repoList, out string errorMessage)
+        {
+            repoList = null;
+            errorMessage = null;
+
+            lock (this.instanceLock)
+            {
+                try
+                {
+                    Dictionary<string, LocalRepoRegistration> all = this.ReadRegistry();
+                    repoList = all.Values.Where(r => r.IsActive).ToList();
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    errorMessage = string.Format("Unable to get list of active repos: {0}", e);
+                    this.tracer.RelatedError(errorMessage);
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the in-memory map of all entries currently on disk
+        /// (active and inactive). Intended for diagnostics and tests; most
+        /// production callers should use <see cref="TryGetActiveRepos"/>.
+        /// </summary>
+        public Dictionary<string, LocalRepoRegistration> ReadRegistry()
+        {
+            Dictionary<string, LocalRepoRegistration> allRepos =
+                new Dictionary<string, LocalRepoRegistration>(GVFSPlatform.Instance.Constants.PathComparer);
+
+            string registryFilePath = Path.Combine(this.registryDirectory, RegistryFileName);
+
+            using (Stream stream = this.fileSystem.OpenFileStream(
+                    registryFilePath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    callFlushFileBuffers: false))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                string versionString = reader.ReadLine();
+                if (versionString == null)
+                {
+                    // Empty file - first write will populate it.
+                    return allRepos;
+                }
+
+                if (!int.TryParse(versionString, out int version) || version > RegistryVersion)
+                {
+                    EventMetadata metadata = new EventMetadata
+                    {
+                        { "OnDiskVersion", versionString },
+                        { "MaxSupportedVersion", RegistryVersion },
+                    };
+                    this.tracer.RelatedError(metadata, $"{nameof(this.ReadRegistry)}: Unsupported registry version; treating as empty");
+                    return allRepos;
+                }
+
+                while (!reader.EndOfStream)
+                {
+                    string entry = reader.ReadLine();
+                    if (string.IsNullOrEmpty(entry))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        LocalRepoRegistration registration = LocalRepoRegistration.FromJson(entry);
+                        if (registration != null && !string.IsNullOrEmpty(registration.EnlistmentRoot))
+                        {
+                            allRepos[registration.EnlistmentRoot] = registration;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        // Tolerate corruption of individual lines; matches
+                        // RepoRegistry.ReadRegistry's behavior.
+                        EventMetadata metadata = new EventMetadata
+                        {
+                            { "entry", entry },
+                            { "Exception", e.ToString() },
+                        };
+                        this.tracer.RelatedError(metadata, $"{nameof(this.ReadRegistry)}: Failed to parse entry; skipping");
+                    }
+                }
+            }
+
+            return allRepos;
+        }
+
+        private void WriteRegistry(Dictionary<string, LocalRepoRegistration> registry)
+        {
+            // Ensure the directory exists. The service relies on its install
+            // step to create %ProgramData%\GVFS\GVFS.Service; the user-level
+            // path under %LocalAppData% may not exist yet when this runs.
+            if (!this.fileSystem.DirectoryExists(this.registryDirectory))
+            {
+                this.fileSystem.CreateDirectory(this.registryDirectory);
+            }
+
+            string tempFilePath = Path.Combine(this.registryDirectory, RegistryTempName);
+            string finalFilePath = Path.Combine(this.registryDirectory, RegistryFileName);
+
+            using (Stream stream = this.fileSystem.OpenFileStream(
+                    tempFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    callFlushFileBuffers: true))
+            using (StreamWriter writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(RegistryVersion);
+                foreach (LocalRepoRegistration registration in registry.Values)
+                {
+                    writer.WriteLine(registration.ToJson());
+                }
+
+                stream.Flush();
+            }
+
+            this.fileSystem.MoveAndOverwriteFile(tempFilePath, finalFilePath);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/LogonTaskRegistration.cs
+++ b/GVFS/GVFS.Common/LogonTaskRegistration.cs
@@ -1,0 +1,255 @@
+using GVFS.Common.Tracing;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Registers / updates / unregisters the per-user Windows scheduled task
+    /// that mounts a user's registered GVFS enlistments at logon. Replaces
+    /// the role of <c>GVFS.Service</c>'s session-change-driven AutoMount in
+    /// the user-level install model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The task is registered at <c>\GVFS\AutoMount</c>, scoped to a single
+    /// user (the user's SID is baked into the task's principal and trigger),
+    /// runs at user logon with the user's interactive token, and executes
+    /// <c>gvfs.exe service --mount-all</c>. The mount-all verb already
+    /// reads the user's registered repos (via <see cref="LocalRepoRegistry"/>
+    /// fallback when the service is unavailable) and mounts each one.
+    /// </para>
+    /// <para>
+    /// Drift detection works via a content-hash marker embedded in the
+    /// task's Description field
+    /// (<c>[gvfs-logon-task-hash=XXXXXXXXXXXXXXXX]</c>). The hash covers the
+    /// XML template <em>with placeholders still in place</em>, so it is
+    /// stable across re-substitutions with different user SIDs or gvfs.exe
+    /// paths -- only template content changes (a code change to the
+    /// template constant) bump the hash. <see cref="IsCurrent"/> queries
+    /// the registered task XML, extracts the marker, and compares against
+    /// <see cref="TemplateHash"/>.
+    /// </para>
+    /// <para>
+    /// Tested as a unit by passing a mock <see cref="IScheduledTaskInvoker"/>.
+    /// Production callers should use
+    /// <see cref="CreateForCurrentPlatform(ITracer)"/>, which constructs a
+    /// <see cref="SchTasksScheduledTaskInvoker"/> behind the scenes.
+    /// </para>
+    /// </remarks>
+    public class LogonTaskRegistration
+    {
+        public const string TaskName = "AutoMount";
+        public const string TaskFolder = @"\GVFS\";
+        public const string FullTaskPath = @"\GVFS\AutoMount";
+
+        public const string GvfsPathPlaceholder = "__GVFS_PATH__";
+        public const string UserIdPlaceholder = "__USER_ID__";
+        public const string TaskHashPlaceholder = "__TASK_HASH__";
+
+        public const string HashMarkerPrefix = "[gvfs-logon-task-hash=";
+        public const string HashMarkerSuffix = "]";
+
+        /// <summary>
+        /// Task XML template. Placeholders:
+        /// <list type="bullet">
+        /// <item><c>__GVFS_PATH__</c> -- absolute path to gvfs.exe</item>
+        /// <item><c>__USER_ID__</c> -- the user's SID (must be the same one
+        ///   the principal runs as, so the logon trigger fires for the
+        ///   right user)</item>
+        /// <item><c>__TASK_HASH__</c> -- content hash of this template,
+        ///   inserted into the Description for drift detection</item>
+        /// </list>
+        /// Indented as a verbatim string; the XML emitted is well-formed
+        /// and accepted by <c>schtasks /Create /XML</c>.
+        /// </summary>
+        public const string XmlTemplate =
+@"<?xml version=""1.0"" encoding=""UTF-16""?>
+<Task version=""1.4"" xmlns=""http://schemas.microsoft.com/windows/2004/02/mit/task"">
+  <RegistrationInfo>
+    <Author>GVFS</Author>
+    <Description>Mounts the user's registered GVFS enlistments at logon. Required by VFS for Git in the user-level install model. [gvfs-logon-task-hash=__TASK_HASH__]</Description>
+    <URI>\GVFS\AutoMount</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>__USER_ID__</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id=""Author"">
+      <UserId>__USER_ID__</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>
+    <Priority>5</Priority>
+  </Settings>
+  <Actions Context=""Author"">
+    <Exec>
+      <Command>conhost.exe</Command>
+      <Arguments>--headless __GVFS_PATH__ service --mount-all</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+";
+
+        private static readonly Lazy<string> templateHash = new Lazy<string>(ComputeTemplateHash);
+
+        private readonly ITracer tracer;
+        private readonly IScheduledTaskInvoker invoker;
+
+        public LogonTaskRegistration(ITracer tracer, IScheduledTaskInvoker invoker)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            ArgumentNullException.ThrowIfNull(invoker);
+            this.tracer = tracer;
+            this.invoker = invoker;
+        }
+
+        /// <summary>
+        /// Convenience factory for production callers: wires up a real
+        /// <see cref="SchTasksScheduledTaskInvoker"/>.
+        /// </summary>
+        public static LogonTaskRegistration CreateForCurrentPlatform(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            return new LogonTaskRegistration(tracer, new SchTasksScheduledTaskInvoker(tracer));
+        }
+
+        /// <summary>
+        /// Stable hex hash of <see cref="XmlTemplate"/> (with placeholders
+        /// intact). 64 hex chars (full SHA-256), computed once per process.
+        /// </summary>
+        public static string TemplateHash => templateHash.Value;
+
+        /// <summary>
+        /// Substitute placeholders to produce a registerable task XML.
+        /// </summary>
+        public static string BuildTaskXml(string gvfsExePath, string userSid)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(gvfsExePath);
+            ArgumentException.ThrowIfNullOrEmpty(userSid);
+
+            return XmlTemplate
+                .Replace(GvfsPathPlaceholder, gvfsExePath)
+                .Replace(UserIdPlaceholder, userSid)
+                .Replace(TaskHashPlaceholder, TemplateHash);
+        }
+
+        /// <summary>
+        /// Extract the <c>[gvfs-logon-task-hash=XXXX]</c> hash marker from
+        /// arbitrary text (usually a Task's Description). Returns
+        /// <c>false</c> when no marker is present.
+        /// </summary>
+        public static bool TryExtractHashMarker(string text, out string hash)
+        {
+            hash = null;
+            if (string.IsNullOrEmpty(text))
+            {
+                return false;
+            }
+
+            int start = text.IndexOf(HashMarkerPrefix, StringComparison.Ordinal);
+            if (start < 0)
+            {
+                return false;
+            }
+
+            int hashStart = start + HashMarkerPrefix.Length;
+            int hashEnd = text.IndexOf(HashMarkerSuffix, hashStart, StringComparison.Ordinal);
+            if (hashEnd <= hashStart)
+            {
+                return false;
+            }
+
+            hash = text.Substring(hashStart, hashEnd - hashStart);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when the logon task is registered AND its
+        /// embedded hash marker matches the current template's hash.
+        /// Returns <c>false</c> if the task is missing, the query fails,
+        /// or the hash differs (drift).
+        /// </summary>
+        public bool IsCurrent()
+        {
+            if (!this.invoker.TryQueryXml(FullTaskPath, out string xml, out _))
+            {
+                return false;
+            }
+
+            if (!TryExtractHashMarker(xml, out string registeredHash))
+            {
+                return false;
+            }
+
+            return string.Equals(registeredHash, TemplateHash, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Register the logon task with the given gvfs.exe path and user
+        /// SID, overwriting any existing registration. Idempotent: when
+        /// the registered task already matches the intended XML (same
+        /// hash, same args), this is a fast no-op.
+        /// </summary>
+        public bool TryRegisterOrUpdate(string gvfsExePath, string userSid, out string errorMessage)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(gvfsExePath);
+            ArgumentException.ThrowIfNullOrEmpty(userSid);
+
+            if (this.IsCurrent())
+            {
+                // Still verify args are right; the hash covers the template
+                // structure but not the substituted gvfs.exe path. Re-query
+                // and check the action command.
+                if (this.invoker.TryQueryXml(FullTaskPath, out string existingXml, out _) &&
+                    existingXml.Contains(gvfsExePath, StringComparison.Ordinal) &&
+                    existingXml.Contains($"<UserId>{userSid}</UserId>", StringComparison.Ordinal))
+                {
+                    errorMessage = string.Empty;
+                    return true;
+                }
+            }
+
+            string xml = BuildTaskXml(gvfsExePath, userSid);
+            return this.invoker.TryRegisterFromXml(FullTaskPath, xml, out errorMessage);
+        }
+
+        /// <summary>
+        /// Unregister the logon task. Idempotent: returns <c>true</c> when
+        /// the task was unregistered OR was not registered to begin with.
+        /// </summary>
+        public bool TryUnregister(out string errorMessage)
+        {
+            return this.invoker.TryUnregister(FullTaskPath, out errorMessage);
+        }
+
+        private static string ComputeTemplateHash()
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(XmlTemplate);
+            byte[] hash = SHA256.HashData(bytes);
+            return Convert.ToHexString(hash);
+        }
+    }
+}

--- a/GVFS/GVFS.Common/SchTasksScheduledTaskInvoker.cs
+++ b/GVFS/GVFS.Common/SchTasksScheduledTaskInvoker.cs
@@ -1,0 +1,124 @@
+using GVFS.Common.Tracing;
+using System;
+using System.IO;
+
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Default <see cref="IScheduledTaskInvoker"/> implementation: shells out
+    /// to <c>schtasks.exe</c>. Windows-only by nature -- on non-Windows the
+    /// process launch fails and operations return false with a populated
+    /// error message. User-mode install is Windows-only, so that's fine.
+    /// </summary>
+    public class SchTasksScheduledTaskInvoker : IScheduledTaskInvoker
+    {
+        private readonly ITracer tracer;
+
+        public SchTasksScheduledTaskInvoker(ITracer tracer)
+        {
+            ArgumentNullException.ThrowIfNull(tracer);
+            this.tracer = tracer;
+        }
+
+        public bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage)
+        {
+            // schtasks /Create accepts an XML file path via /XML, not raw
+            // XML on stdin. Write to a temp file with the same UTF-16 BOM
+            // the Task Scheduler XML schema expects, then run schtasks.
+            string tempPath = Path.Combine(Path.GetTempPath(), $"gvfs-task-{Guid.NewGuid():N}.xml");
+            try
+            {
+                File.WriteAllText(tempPath, xml, new System.Text.UnicodeEncoding(bigEndian: false, byteOrderMark: true));
+
+                // /F overwrites if already exists.
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Create /TN \"{taskPath}\" /XML \"{tempPath}\" /F");
+
+                if (result.ExitCode != 0)
+                {
+                    errorMessage = $"schtasks /Create failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to register scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+            finally
+            {
+                try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+            }
+        }
+
+        public bool TryQueryXml(string taskPath, out string xml, out string errorMessage)
+        {
+            xml = null;
+            try
+            {
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Query /TN \"{taskPath}\" /XML");
+
+                if (result.ExitCode != 0)
+                {
+                    // Exit 1 = task not found. Surface a useful message; the
+                    // caller distinguishes "not found" from "permission denied"
+                    // by inspecting the message text or just treating both as
+                    // "not current".
+                    errorMessage = $"schtasks /Query failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                xml = result.Output;
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to query scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+
+        public bool TryUnregister(string taskPath, out string errorMessage)
+        {
+            try
+            {
+                ProcessResult result = ProcessHelper.Run(
+                    "schtasks.exe",
+                    $"/Delete /TN \"{taskPath}\" /F");
+
+                if (result.ExitCode != 0)
+                {
+                    // Exit 1 with "cannot find the file specified" means the
+                    // task is already gone; treat as success.
+                    string combined = (result.Output + " " + result.Errors).ToLowerInvariant();
+                    if (combined.Contains("cannot find the file") || combined.Contains("system cannot find"))
+                    {
+                        errorMessage = string.Empty;
+                        return true;
+                    }
+
+                    errorMessage = $"schtasks /Delete failed (exit {result.ExitCode}): {result.Output.Trim()} {result.Errors.Trim()}".Trim();
+                    return false;
+                }
+
+                errorMessage = string.Empty;
+                return true;
+            }
+            catch (Exception e)
+            {
+                errorMessage = $"Failed to unregister scheduled task: {e}";
+                this.tracer.RelatedError(errorMessage);
+                return false;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.FunctionalTests/Categories.cs
+++ b/GVFS/GVFS.FunctionalTests/Categories.cs
@@ -6,5 +6,6 @@
         public const string FastFetch = "FastFetch";
         public const string GitCommands = "GitCommands";
         public const string NeedsReactionInCI = "NeedsReactionInCI";
+        public const string RequiresService = "RequiresService";
     }
 }

--- a/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
+++ b/GVFS/GVFS.FunctionalTests/GVFSTestConfig.cs
@@ -16,6 +16,8 @@ namespace GVFS.FunctionalTests
 
         public static bool ReplaceInboxProjFS { get; set; }
 
+        public static bool NoService { get; set; }
+
         public static bool IsDevMode { get; set; }
 
         public static string PathToGVFS

--- a/GVFS/GVFS.FunctionalTests/GlobalSetup.cs
+++ b/GVFS/GVFS.FunctionalTests/GlobalSetup.cs
@@ -18,7 +18,7 @@ namespace GVFS.FunctionalTests
         [OneTimeTearDown]
         public void RunAfterAllTests()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !GVFSTestConfig.NoService)
             {
                 string serviceLogFolder = Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),

--- a/GVFS/GVFS.FunctionalTests/Program.cs
+++ b/GVFS/GVFS.FunctionalTests/Program.cs
@@ -48,6 +48,12 @@ namespace GVFS.FunctionalTests
                 GVFSTestConfig.ReplaceInboxProjFS = true;
             }
 
+            if (runner.HasCustomArg("--no-service"))
+            {
+                Console.WriteLine("Running without GVFS.Service (user-mode install)");
+                GVFSTestConfig.NoService = true;
+            }
+
             GVFSTestConfig.LocalCacheRoot = runner.GetCustomArgWithParam("--shared-gvfs-cache-root");
 
             HashSet<string> includeCategories = new HashSet<string>();
@@ -101,6 +107,11 @@ namespace GVFS.FunctionalTests
                     excludeCategories.Add(Categories.NeedsReactionInCI);
                 }
 
+                if (GVFSTestConfig.NoService)
+                {
+                    excludeCategories.Add(Categories.RequiresService);
+                }
+
                 GVFSTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
 
@@ -151,11 +162,19 @@ namespace GVFS.FunctionalTests
                 ProjFSFilterInstaller.ReplaceInboxProjFS();
             }
 
-            Console.WriteLine("[CI-DEBUG] Installing service...");
-            Console.Out.Flush();
-            GVFSServiceProcess.InstallService();
-            Console.WriteLine("[CI-DEBUG] Service installed successfully");
-            Console.Out.Flush();
+            if (!GVFSTestConfig.NoService)
+            {
+                Console.WriteLine("[CI-DEBUG] Installing service...");
+                Console.Out.Flush();
+                GVFSServiceProcess.InstallService();
+                Console.WriteLine("[CI-DEBUG] Service installed successfully");
+                Console.Out.Flush();
+            }
+            else
+            {
+                Console.WriteLine("[CI-DEBUG] Skipping service install (--no-service)");
+                Console.Out.Flush();
+            }
 
             string serviceProgramDataDir = GVFSPlatform.Instance.GetSecureDataRootForGVFSComponent(
                 GVFSConstants.Service.ServiceName);

--- a/GVFS/GVFS.FunctionalTests/Settings.cs
+++ b/GVFS/GVFS.FunctionalTests/Settings.cs
@@ -65,8 +65,22 @@ namespace GVFS.FunctionalTests.Properties
                 }
                 else
                 {
-                    PathToGVFS = @"C:\Program Files\VFS for Git\GVFS.exe";
-                    PathToGVFSService = @"C:\Program Files\VFS for Git\GVFS.Service.exe";
+                    // Check for user-mode install first, fall back to system install
+                    string userModeGvfs = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "GVFS", "Current", "gvfs.exe");
+
+                    if (File.Exists(userModeGvfs))
+                    {
+                        string userModeDir = Path.GetDirectoryName(userModeGvfs);
+                        PathToGVFS = userModeGvfs;
+                        PathToGVFSService = Path.Combine(userModeDir, "GVFS.Service.exe");
+                    }
+                    else
+                    {
+                        PathToGVFS = @"C:\Program Files\VFS for Git\GVFS.exe";
+                        PathToGVFSService = @"C:\Program Files\VFS for Git\GVFS.Service.exe";
+                    }
                 }
 
                 PathToGit = @"C:\Program Files\Git\cmd\git.exe";

--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/GVFSUpgradeReminderTests.cs
@@ -13,6 +13,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.ExtraCoverage)]
+    [Category(Categories.RequiresService)]
     public class UpgradeReminderTests : TestsWithEnlistmentPerFixture
     {
         private const string HighestAvailableVersionFileName = "HighestAvailableVersion";

--- a/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/MultiEnlistmentTests/ServiceVerbTests.cs
@@ -7,6 +7,7 @@ namespace GVFS.FunctionalTests.Tests.MultiEnlistmentTests
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.ExtraCoverage)]
+    [Category(Categories.RequiresService)]
     public class ServiceVerbTests : TestsWithMultiEnlistment
     {
         private static readonly string[] EmptyRepoList = new string[] { };

--- a/GVFS/GVFS.FunctionalTests/Windows/Tests/ServiceTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Windows/Tests/ServiceTests.cs
@@ -14,6 +14,7 @@ namespace GVFS.FunctionalTests.Windows.Tests
     [TestFixture]
     [NonParallelizable]
     [Category(Categories.ExtraCoverage)]
+    [Category(Categories.RequiresService)]
     public class ServiceTests : TestsWithEnlistmentPerFixture
     {
         private const string NativeLibPath = @"C:\Program Files\VFS for Git\ProjectedFSLib.dll";

--- a/GVFS/GVFS.Installers/GVFS.Installers.csproj
+++ b/GVFS/GVFS.Installers/GVFS.Installers.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LayoutPath>$(RepoOutPath)GVFS.Payload\bin\$(Configuration)\win-x64\</LayoutPath>
+    <ProjFSAttachScriptsDir>$(MSBuildThisFileDirectory)..\..\scripts\projfs-attach\</ProjFSAttachScriptsDir>
+    <ProjFSTaskXmlPath>$(IntermediateOutputPath)enable-projfs-on-all-drives-task.xml</ProjFSTaskXmlPath>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -24,8 +26,12 @@
     <Content Include="info.bat" />
   </ItemGroup>
 
+  <Target Name="BuildProjFSTaskXml" BeforeTargets="CreateInstaller" Condition="'$(SkipCreateInstaller)' != 'true'">
+    <Exec Command='powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(ProjFSAttachScriptsDir)build-task-xml.ps1" -ScriptPath "$(ProjFSAttachScriptsDir)enable-projfs-on-all-drives.ps1" -TemplatePath "$(ProjFSAttachScriptsDir)enable-projfs-on-all-drives-task.xml.template" -OutputPath "$(ProjFSTaskXmlPath)"' />
+  </Target>
+
   <Target Name="CreateInstaller" BeforeTargets="Build" Condition="'$(SkipCreateInstaller)' != 'true'">
-    <Exec Command='"$(PkgTools_InnoSetup)\tools\ISCC.exe" /DLayoutDir="$(LayoutPath)" /DGVFSVersion=$(GVFSVersion) Setup.iss /O"$(OutputPath)"' />
+    <Exec Command='"$(PkgTools_InnoSetup)\tools\ISCC.exe" /DLayoutDir="$(LayoutPath)" /DGVFSVersion=$(GVFSVersion) /DProjFSTaskXml="$(ProjFSTaskXmlPath)" Setup.iss /O"$(OutputPath)"' />
   </Target>
 
   <Target Name="CleanInstaller" BeforeTargets="AfterClean">

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -133,14 +133,17 @@ begin
   if IsAdminStage then
     begin
       Log('InitializeSetup: /ADMINSTAGE mode - will run admin setup only');
+      Log('[GVFS-INSTALL] mode=adminstage');
     end
   else if IsUserModeInstall then
     begin
       Log('InitializeSetup: User-mode install detected (non-elevated)');
+      Log('[GVFS-INSTALL] mode=user');
     end
   else
     begin
       Log('InitializeSetup: System-mode install (elevated)');
+      Log('[GVFS-INSTALL] mode=system');
     end;
 end;
 
@@ -1312,6 +1315,129 @@ begin
     Log('RegisterEnableProjFSTask: Task triggered for immediate execution');
 end;
 
+function IsLegacySystemInstallPresent(): Boolean;
+var
+  ResultCode: integer;
+begin
+  // Check for GVFS.Service in SCM (exit 0 = exists, 1060 = not found)
+  Result := False;
+  if Exec(ExpandConstant('{sys}\SC.EXE'), 'query GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      if ResultCode <> 1060 then
+        begin
+          Log('IsLegacySystemInstallPresent: GVFS.Service found in SCM');
+          Result := True;
+          exit;
+        end;
+    end;
+  // Also check for the legacy install directory
+  if DirExists(ExpandConstant('{commonpf}\VFS for Git')) then
+    begin
+      Log('IsLegacySystemInstallPresent: Legacy install directory exists');
+      Result := True;
+      exit;
+    end;
+  Log('IsLegacySystemInstallPresent: No legacy install detected');
+end;
+
+procedure MigrateLegacyInstall();
+var
+  ResultCode: integer;
+  LegacyDir: string;
+  LegacyRegistryPath: string;
+  UserLocalAppData: string;
+  UserRegistryDir: string;
+  WaitAttempts: integer;
+begin
+  LegacyDir := ExpandConstant('{commonpf}\VFS for Git');
+  Log('MigrateLegacyInstall: Starting migration from ' + LegacyDir);
+
+  // Use the original user's LocalAppData (passed from the non-elevated
+  // caller) so the repo-registry lands in the right user's directory
+  // even under Over-the-Shoulder UAC elevation.
+  UserLocalAppData := ExpandConstant('{param:USERLOCALAPPDATA|}');
+  if UserLocalAppData = '' then
+    UserLocalAppData := ExpandConstant('{localappdata}');
+  UserRegistryDir := UserLocalAppData + '\GVFS\GVFS.Service';
+
+  // 1. Force-unmount all repos via the legacy gvfs.exe (still on PATH
+  //    and still has a running service to talk to). This ensures no
+  //    mount processes hold open files in the legacy install directory,
+  //    allowing us to do a synchronous cleanup without a deferred task.
+  Log('MigrateLegacyInstall: Unmounting all repos via legacy gvfs.exe');
+  Exec(LegacyDir + '\GVFS.exe', 'service --unmount-all', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  if ResultCode = 0 then
+    Log('MigrateLegacyInstall: Unmount-all succeeded')
+  else
+    Log('MigrateLegacyInstall: Unmount-all returned ' + IntToStr(ResultCode) + ' (continuing anyway)');
+
+  // Wait for GVFS.Mount processes from the legacy dir to exit (up to 30s)
+  WaitAttempts := 0;
+  while WaitAttempts < 30 do
+    begin
+      if not IsGVFSRunning() then
+        begin
+          Log('MigrateLegacyInstall: No GVFS processes running');
+          break;
+        end;
+      Log('MigrateLegacyInstall: Waiting for GVFS processes to exit (attempt ' + IntToStr(WaitAttempts + 1) + ')');
+      Sleep(1000);
+      WaitAttempts := WaitAttempts + 1;
+    end;
+  if WaitAttempts >= 30 then
+    Log('MigrateLegacyInstall: Warning - GVFS processes still running after 30s wait');
+
+  // 2. Stop and delete the service
+  StopService('GVFS.Service');
+  WaitForServiceProcessToExit('GVFS.Service');
+  if Exec(ExpandConstant('{sys}\SC.EXE'), 'delete GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      if (ResultCode = 0) or (ResultCode = 1060) then
+        Log('MigrateLegacyInstall: Service deleted (or was already absent)')
+      else
+        Log('MigrateLegacyInstall: Warning - sc delete returned ' + IntToStr(ResultCode));
+    end;
+
+  // 3. Copy legacy repo-registry to user LocalRepoRegistry location.
+  //    DO NOT delete the source — a rollback to a system install needs
+  //    to find its repo-registry intact.
+  LegacyRegistryPath := ExpandConstant('{commonappdata}\GVFS\GVFS.Service\repo-registry');
+  if FileExists(LegacyRegistryPath) then
+    begin
+      if not DirExists(UserRegistryDir) then
+        ForceDirectories(UserRegistryDir);
+      if FileCopy(LegacyRegistryPath, UserRegistryDir + '\repo-registry', False) then
+        Log('MigrateLegacyInstall: Copied repo-registry to ' + UserRegistryDir)
+      else
+        Log('MigrateLegacyInstall: Warning - could not copy repo-registry');
+    end
+  else
+    Log('MigrateLegacyInstall: No legacy repo-registry found');
+
+  // 4. Remove legacy install dir from system PATH
+  RemovePath(LegacyDir);
+
+  // 5. Delete legacy AutoLogger registry key
+  if RegKeyExists(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\WMI\Autologger\Microsoft-Windows-Git-Filter-Log') then
+    begin
+      RegDeleteKeyIncludingSubkeys(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\WMI\Autologger\Microsoft-Windows-Git-Filter-Log');
+      Log('MigrateLegacyInstall: Deleted GvFlt AutoLogger key');
+    end;
+
+  // 6. Delete the legacy install directory synchronously.
+  //    Since we force-unmounted all repos above, no mount processes
+  //    should be holding files open. Any leftover files are inert
+  //    (no service, no PATH, no mounts) — just wasted disk space.
+  Log('MigrateLegacyInstall: Deleting legacy install directory ' + LegacyDir);
+  if not DelTree(LegacyDir, True, True, True) then
+    Log('MigrateLegacyInstall: Warning - could not fully delete ' + LegacyDir + ' (leftover files are inert)')
+  else
+    Log('MigrateLegacyInstall: Legacy install directory deleted');
+
+  Log('MigrateLegacyInstall: Migration steps complete');
+  Log('[GVFS-INSTALL] migration=complete legacy_dir=' + LegacyDir);
+end;
+
 function NeedsAdminSetup(): Boolean;
 begin
   if not IsProjFSEnabled() then
@@ -1323,6 +1449,12 @@ begin
   if not IsEnableProjFSTaskCurrent() then
     begin
       Log('NeedsAdminSetup: EnableProjFSOnAllDrives task not current');
+      Result := True;
+      exit;
+    end;
+  if IsLegacySystemInstallPresent() then
+    begin
+      Log('NeedsAdminSetup: Legacy system install detected');
       Result := True;
       exit;
     end;
@@ -1354,7 +1486,10 @@ begin
       Log('PrepareToInstall: /ADMINSTAGE - running admin setup');
       EnableProjFSFeature();
       RegisterEnableProjFSTask();
+      if IsLegacySystemInstallPresent() then
+        MigrateLegacyInstall();
       Log('PrepareToInstall: /ADMINSTAGE - admin setup complete');
+      Log('[GVFS-INSTALL] adminstage=complete');
       exit;
     end;
 
@@ -1366,7 +1501,7 @@ begin
       if NeedsAdminSetup() then
         begin
           Log('PrepareToInstall: Admin setup needed, re-launching elevated');
-          if not ShellExec('runas', ExpandConstant('{srcexe}'), '/VERYSILENT /ADMINSTAGE=true', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+          if not ShellExec('runas', ExpandConstant('{srcexe}'), ExpandConstant('/VERYSILENT /ADMINSTAGE=true /USERLOCALAPPDATA="{localappdata}"'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
             begin
               Result := 'Failed to launch elevated admin setup (user may have declined UAC).';
               exit;
@@ -1377,10 +1512,12 @@ begin
               exit;
             end;
           Log('PrepareToInstall: Admin setup completed successfully');
+          Log('[GVFS-INSTALL] admin_elevation=success');
         end
       else
         begin
           Log('PrepareToInstall: Admin setup is current, no elevation needed');
+          Log('[GVFS-INSTALL] admin_elevation=skipped');
         end;
       // Skip system-mode preparation (service queries, mount detection,
       // staging logic). The user-mode path just deploys the payload

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -1,4 +1,4 @@
-; This script requires Inno Setup Compiler 5.5.9 or later to compile
+; This script requires Inno Setup 6 or later to compile
 ; The Inno Setup Compiler (and IDE) can be found at http://www.jrsoftware.org/isinfo.php
 
 ; General documentation on how to use InnoSetup scripts: http://www.jrsoftware.org/ishelp/index.php
@@ -10,11 +10,13 @@
 #define MyAppURL "https://github.com/microsoft/VFSForGit"
 #define MyAppExeName "GVFS.exe"
 #define EnvironmentKey "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+#define UserEnvironmentKey "Environment"
 #define FileSystemKey "SYSTEM\CurrentControlSet\Control\FileSystem"
 #define GvFltAutologgerKey "SYSTEM\CurrentControlSet\Control\WMI\Autologger\Microsoft-Windows-Git-Filter-Log"
 #define GVFSConfigFileName "gvfs.config"
 #define GVFSStatuscacheTokenFileName "EnableGitStatusCacheToken.dat"
 #define ServiceName "GVFS.Service"
+#define ProjFSTaskPath "\GVFS\EnableProjFSOnAllDrives"
 
 [Setup]
 AppId={{489CA581-F131-4C28-BE04-4FB178933E6D}
@@ -45,6 +47,10 @@ WindowResizable=no
 CloseApplications=no
 ChangesEnvironment=yes
 RestartIfNeededByRun=yes
+; Allow the installer to run as non-admin when the user passes
+; /CURRENTUSER on the command line. Without /CURRENTUSER, the
+; installer runs as admin (the default, matching existing behavior).
+PrivilegesRequiredOverridesAllowed=commandline
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl";
@@ -59,17 +65,25 @@ Name: "full"; Description: "Full installation"; Flags: iscustom;
 Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
-; Normal install: all files go to {app}, service gets AfterInstall callback
-DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsNormalInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: IsNormalInstall
-; Staging install: most files go to {app}\PendingUpgrade, but GVFS.Service.exe
+; System-mode install: all files go to {app}, service gets AfterInstall callback
+DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsSystemModeNormalInstall
+DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: IsSystemModeNormalInstall
+; System-mode staging install: most files go to {app}\PendingUpgrade, but GVFS.Service.exe
 ; goes directly to {app} so the restarted service has PendingUpgradeHandler code.
 ; The service is briefly stopped/restarted (mounts are independent processes).
-DestDir: "{app}\PendingUpgrade"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsStagingInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; Check: IsStagingInstall
+DestDir: "{app}\PendingUpgrade"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsSystemModeStagingInstall
+DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; Check: IsSystemModeStagingInstall
+; User-mode install: payload goes to %LocalAppData%\GVFS\Versions\<version>\.
+; The Current junction and user PATH are set up in CurStepChanged(ssPostInstall).
+DestDir: "{localappdata}\GVFS\Versions\{#GVFSVersion}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsUserModeCheck
+; Pre-built EnableProjFSOnAllDrives task XML (embedded, not deployed).
+; Extracted to temp at install time for schtasks /Create /XML.
+#ifdef ProjFSTaskXml
+Source: "{#ProjFSTaskXml}"; Flags: dontcopy
+#endif
 
 [Dirs]
-Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
+Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec; Check: IsSystemModeInstall
 
 [UninstallDelete]
 ; Deletes the entire installation directory, including files and subdirectories
@@ -77,20 +91,58 @@ Type: filesandordirs; Name: "{app}";
 Type: filesandordirs; Name: "{commonappdata}\GVFS\GVFS.Upgrade";
 
 [Registry]
+; System-mode: add install dir to system PATH and set NtfsEnableDetailedCleanupResults
 Root: HKLM; Subkey: "{#EnvironmentKey}"; \
     ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; \
-    Check: NeedsAddPath(ExpandConstant('{app}'))
+    Check: IsSystemModeNeedsAddPath
 
 Root: HKLM; Subkey: "{#FileSystemKey}"; \
     ValueType: dword; ValueName: "NtfsEnableDetailedCleanupResults"; ValueData: "1"; \
-    Check: IsWindows10VersionPriorToCreatorsUpdate
+    Check: IsSystemModeWindows10PriorToCreatorsUpdate
 
-Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
+Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey; Check: IsSystemModeInstall
+
+; User-mode: add Current junction dir to user PATH
+Root: HKCU; Subkey: "{#UserEnvironmentKey}"; \
+    ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{localappdata}\GVFS\Current"; \
+    Check: UserModeNeedsAddPath
+
+; User-mode: redirect GVFS data paths to %LocalAppData%\GVFS so
+; the user has write access without admin elevation.
+Root: HKCU; Subkey: "{#UserEnvironmentKey}"; \
+    ValueType: string; ValueName: "GVFS_SECURE_DATA_ROOT"; ValueData: "{localappdata}\GVFS"; \
+    Check: IsUserModeCheck
+
+Root: HKCU; Subkey: "{#UserEnvironmentKey}"; \
+    ValueType: string; ValueName: "GVFS_COMMON_APPDATA_ROOT"; ValueData: "{localappdata}\GVFS"; \
+    Check: IsUserModeCheck
 
 [Code]
 var
   ExitCode: Integer;
   KeepMountsRunning: Boolean;
+  IsUserModeInstall: Boolean;
+  IsAdminStage: Boolean;
+
+function InitializeSetup(): Boolean;
+begin
+  Result := True;
+  IsUserModeInstall := not IsAdmin();
+  IsAdminStage := (ExpandConstant('{param:ADMINSTAGE|false}') = 'true');
+
+  if IsAdminStage then
+    begin
+      Log('InitializeSetup: /ADMINSTAGE mode - will run admin setup only');
+    end
+  else if IsUserModeInstall then
+    begin
+      Log('InitializeSetup: User-mode install detected (non-elevated)');
+    end
+  else
+    begin
+      Log('InitializeSetup: System-mode install (elevated)');
+    end;
+end;
 
 function IsNormalInstall(): Boolean;
 begin
@@ -100,6 +152,26 @@ end;
 function IsStagingInstall(): Boolean;
 begin
   Result := KeepMountsRunning;
+end;
+
+function IsUserModeCheck(): Boolean;
+begin
+  Result := IsUserModeInstall and (not IsAdminStage);
+end;
+
+function IsSystemModeNormalInstall(): Boolean;
+begin
+  Result := (not IsUserModeInstall) and (not IsAdminStage) and (not KeepMountsRunning);
+end;
+
+function IsSystemModeStagingInstall(): Boolean;
+begin
+  Result := (not IsUserModeInstall) and (not IsAdminStage) and KeepMountsRunning;
+end;
+
+function IsSystemModeInstall(): Boolean;
+begin
+  Result := (not IsUserModeInstall) and (not IsAdminStage);
 end;
 
 function NeedsAddPath(Param: string): boolean;
@@ -113,8 +185,6 @@ begin
     Result := True;
     exit;
   end;
-  // look for the path with leading and trailing semicolon
-  // Pos() returns 0 if not found
   Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
 end;
 
@@ -124,6 +194,32 @@ var
 begin
   GetWindowsVersionEx(Version);
   Result := (Version.Major = 10) and (Version.Minor = 0) and (Version.Build < 15063);
+end;
+
+function IsSystemModeNeedsAddPath(): Boolean;
+begin
+  Result := (not IsUserModeInstall) and NeedsAddPath(ExpandConstant('{app}'));
+end;
+
+function IsSystemModeWindows10PriorToCreatorsUpdate(): Boolean;
+begin
+  Result := (not IsUserModeInstall) and IsWindows10VersionPriorToCreatorsUpdate();
+end;
+
+function UserModeNeedsAddPath(): Boolean;
+var
+  OrigPath: string;
+  TargetDir: string;
+begin
+  Result := False;
+  if not IsUserModeInstall then exit;
+  TargetDir := ExpandConstant('{localappdata}\GVFS\Current');
+  if not RegQueryStringValue(HKEY_CURRENT_USER, '{#UserEnvironmentKey}', 'PATH', OrigPath) then
+    begin
+      Result := True;
+      exit;
+    end;
+  Result := Pos(';' + Uppercase(TargetDir) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
 end;
 
 procedure RemovePath(Path: string);
@@ -715,34 +811,274 @@ begin
   Result := False;
 end;
 
+procedure RegisterLogonTask();
+var
+  GvfsPath: string;
+  UserSid: ansiString;
+  TaskXmlPath: string;
+  TaskXml: string;
+  ResultCode: integer;
+begin
+  GvfsPath := ExpandConstant('{localappdata}\GVFS\Current\gvfs.exe');
+  // Get current user's SID via whoami /user
+  if not ExecWithResult('whoami.exe', '/user /nh', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, UserSid) or (ResultCode <> 0) then
+    begin
+      Log('RegisterLogonTask: Could not determine user SID');
+      exit;
+    end;
+  // whoami output is like: DOMAIN\user S-1-5-21-... — extract SID
+  UserSid := Trim(UserSid);
+  if Pos(' ', UserSid) > 0 then
+    UserSid := Copy(UserSid, Pos(' ', UserSid) + 1, Length(UserSid));
+  UserSid := Trim(UserSid);
+  Log('RegisterLogonTask: User SID is ' + UserSid);
+
+  TaskXml := '<?xml version="1.0" encoding="UTF-8"?>' + #13#10 +
+    '<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">' + #13#10 +
+    '  <RegistrationInfo>' + #13#10 +
+    '    <Author>GVFS</Author>' + #13#10 +
+    '    <Description>Mounts registered GVFS enlistments at logon.</Description>' + #13#10 +
+    '    <URI>\GVFS\AutoMount</URI>' + #13#10 +
+    '  </RegistrationInfo>' + #13#10 +
+    '  <Triggers>' + #13#10 +
+    '    <LogonTrigger><Enabled>true</Enabled><UserId>' + UserSid + '</UserId></LogonTrigger>' + #13#10 +
+    '  </Triggers>' + #13#10 +
+    '  <Principals>' + #13#10 +
+    '    <Principal id="Author"><UserId>' + UserSid + '</UserId><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal>' + #13#10 +
+    '  </Principals>' + #13#10 +
+    '  <Settings>' + #13#10 +
+    '    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>' + #13#10 +
+    '    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>' + #13#10 +
+    '    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>' + #13#10 +
+    '    <AllowHardTerminate>true</AllowHardTerminate>' + #13#10 +
+    '    <StartWhenAvailable>true</StartWhenAvailable>' + #13#10 +
+    '    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>' + #13#10 +
+    '    <IdleSettings><StopOnIdleEnd>false</StopOnIdleEnd><RestartOnIdle>false</RestartOnIdle></IdleSettings>' + #13#10 +
+    '    <AllowStartOnDemand>true</AllowStartOnDemand>' + #13#10 +
+    '    <Enabled>true</Enabled>' + #13#10 +
+    '    <Hidden>false</Hidden>' + #13#10 +
+    '    <RunOnlyIfIdle>false</RunOnlyIfIdle>' + #13#10 +
+    '    <WakeToRun>false</WakeToRun>' + #13#10 +
+    '    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>' + #13#10 +
+    '    <Priority>5</Priority>' + #13#10 +
+    '  </Settings>' + #13#10 +
+    '  <Actions Context="Author">' + #13#10 +
+    '    <Exec>' + #13#10 +
+    '      <Command>conhost.exe</Command>' + #13#10 +
+    '      <Arguments>--headless ' + GvfsPath + ' service --mount-all</Arguments>' + #13#10 +
+    '    </Exec>' + #13#10 +
+    '  </Actions>' + #13#10 +
+    '</Task>';
+
+  TaskXmlPath := ExpandConstant('{tmp}\gvfs-logon-task.xml');
+  SaveStringToFile(TaskXmlPath, TaskXml, False);
+
+  Log('RegisterLogonTask: Registering \GVFS\AutoMount task');
+  if not Exec(ExpandConstant('{sys}\schtasks.exe'), '/Create /TN "\GVFS\AutoMount" /XML "' + TaskXmlPath + '" /F', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('RegisterLogonTask: schtasks /Create failed (exit ' + IntToStr(ResultCode) + ') - logon automount will not be available');
+    end
+  else
+    begin
+      Log('RegisterLogonTask: Task registered successfully');
+    end;
+end;
+
+procedure CreateOrUpdateCurrentJunction();
+var
+  GVFSRoot: string;
+  JunctionPath: string;
+  VersionDir: string;
+  OldTarget: ansiString;
+  GvfsExe: string;
+  ResultCode: integer;
+  VersionOutput: ansiString;
+  HadPreviousJunction: Boolean;
+begin
+  GVFSRoot := ExpandConstant('{localappdata}\GVFS');
+  JunctionPath := GVFSRoot + '\Current';
+  VersionDir := GVFSRoot + '\Versions\{#GVFSVersion}';
+  HadPreviousJunction := False;
+
+  // Save old junction target for rollback
+  if DirExists(JunctionPath) then
+    begin
+      HadPreviousJunction := True;
+      // Read the junction target via fsutil reparsepoint query.
+      // Output includes a line like "Print Name: C:\Users\...\Versions\1.0.0"
+      if ExecWithResult('fsutil.exe', 'reparsepoint query "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, OldTarget) and (ResultCode = 0) then
+        begin
+          // Extract the "Print Name:" value
+          if Pos('Print Name:', OldTarget) > 0 then
+            begin
+              OldTarget := Copy(OldTarget, Pos('Print Name:', OldTarget) + Length('Print Name:'), Length(OldTarget));
+              // Trim to end of line
+              if Pos(#13, OldTarget) > 0 then
+                OldTarget := Copy(OldTarget, 1, Pos(#13, OldTarget) - 1);
+              OldTarget := Trim(OldTarget);
+              Log('CreateOrUpdateCurrentJunction: Previous target: ' + OldTarget);
+            end
+          else
+            begin
+              Log('CreateOrUpdateCurrentJunction: Could not parse junction target from fsutil output');
+              OldTarget := '';
+            end;
+        end
+      else
+        begin
+          Log('CreateOrUpdateCurrentJunction: fsutil reparsepoint query failed');
+          OldTarget := '';
+        end;
+
+      Log('CreateOrUpdateCurrentJunction: Removing existing Current');
+      Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    end;
+
+  // Create junction: Current -> Versions\<version>
+  Log('CreateOrUpdateCurrentJunction: Creating junction -> ' + VersionDir);
+  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('CreateOrUpdateCurrentJunction: mklink failed (exit ' + IntToStr(ResultCode) + ')');
+      RaiseException('Fatal: Could not create Current junction at ' + JunctionPath);
+    end;
+
+  // Verify the new payload works
+  GvfsExe := JunctionPath + '\gvfs.exe';
+  if FileExists(GvfsExe) then
+    begin
+      if ExecWithResult(GvfsExe, 'version', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, VersionOutput) and (ResultCode = 0) then
+        begin
+          Log('CreateOrUpdateCurrentJunction: Verified gvfs.exe version: ' + Trim(VersionOutput));
+        end
+      else
+        begin
+          Log('CreateOrUpdateCurrentJunction: gvfs.exe version failed (exit ' + IntToStr(ResultCode) + ')');
+          if HadPreviousJunction and (OldTarget <> '') then
+            begin
+              Log('CreateOrUpdateCurrentJunction: Rolling back to ' + OldTarget);
+              Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+              if Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + OldTarget + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
+                begin
+                  Log('CreateOrUpdateCurrentJunction: Rollback successful - Current restored to ' + OldTarget);
+                end
+              else
+                begin
+                  Log('CreateOrUpdateCurrentJunction: Rollback mklink failed (exit ' + IntToStr(ResultCode) + ')');
+                end;
+            end
+          else if HadPreviousJunction then
+            begin
+              Log('CreateOrUpdateCurrentJunction: Cannot rollback - old target unknown');
+              Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+            end;
+          RaiseException('Fatal: New gvfs.exe failed verification. Installation may be corrupt.');
+        end;
+    end
+  else
+    begin
+      Log('CreateOrUpdateCurrentJunction: Warning - gvfs.exe not found at ' + GvfsExe + ' (expected after junction creation)');
+    end;
+
+  Log('CreateOrUpdateCurrentJunction: Junction created and verified');
+end;
+
+procedure GarbageCollectOldVersions();
+var
+  GVFSRoot: string;
+  VersionsDir: string;
+  CurrentVersion: string;
+  FindRec: TFindRec;
+  Versions: TStringList;
+  i: Integer;
+  PathToDelete: string;
+  ResultCode: integer;
+begin
+  GVFSRoot := ExpandConstant('{localappdata}\GVFS');
+  VersionsDir := GVFSRoot + '\Versions';
+  CurrentVersion := '{#GVFSVersion}';
+
+  if not DirExists(VersionsDir) then exit;
+
+  Versions := TStringList.Create;
+  try
+    // Enumerate version directories
+    if FindFirst(VersionsDir + '\*', FindRec) then
+      begin
+        try
+          repeat
+            if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and
+               (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+              begin
+                Versions.Add(FindRec.Name);
+              end;
+          until not FindNext(FindRec);
+        finally
+          FindClose(FindRec);
+        end;
+      end;
+
+    Log('GarbageCollectOldVersions: Found ' + IntToStr(Versions.Count) + ' version(s)');
+    if Versions.Count <= 2 then
+      begin
+        Log('GarbageCollectOldVersions: 2 or fewer versions, nothing to GC');
+        exit;
+      end;
+
+    // Sort so we can identify the oldest. Versions sort lexically
+    // (semver-compatible for our numbering scheme).
+    Versions.Sort;
+
+    // Delete all but the most recent 2. The current version is always
+    // kept regardless of sort order.
+    for i := 0 to Versions.Count - 3 do
+      begin
+        if Versions[i] = CurrentVersion then
+          begin
+            Log('GarbageCollectOldVersions: Skipping current version ' + Versions[i]);
+            continue;
+          end;
+        PathToDelete := VersionsDir + '\' + Versions[i];
+        Log('GarbageCollectOldVersions: Deleting old version ' + PathToDelete);
+        if not DelTree(PathToDelete, True, True, True) then
+          begin
+            Log('GarbageCollectOldVersions: Warning - could not fully delete ' + PathToDelete);
+          end;
+      end;
+  finally
+    Versions.Free;
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   case CurStep of
     ssInstall:
       begin
-        if not KeepMountsRunning then
+        if (not IsUserModeInstall) and (not KeepMountsRunning) then
           UninstallService('GVFS.Service', True);
       end;
     ssPostInstall:
       begin
-        if KeepMountsRunning then
+        if IsUserModeInstall then
           begin
-            // All staged files have been written to PendingUpgrade.
-            // Write .ready marker so the service knows the staging is
-            // complete and safe to apply.
-            SaveStringToFile(ExpandConstant('{app}\PendingUpgrade\.ready'), '', False);
-            Log('CurStepChanged: Wrote PendingUpgrade .ready marker');
-
-            // Start the service AFTER .ready is written. Previously this
-            // was an AfterInstall hook on GVFS.Service.exe, but that races:
-            // the service's debounce timer could fire before .ready exists.
-            StagingUpdateService();
-          end;
-        MigrateConfigAndStatusCacheFiles();
-        if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
-          begin
-            MountRepos();
+            CreateOrUpdateCurrentJunction();
+            RegisterLogonTask();
+            GarbageCollectOldVersions();
           end
+        else
+          begin
+            if KeepMountsRunning then
+              begin
+                SaveStringToFile(ExpandConstant('{app}\PendingUpgrade\.ready'), '', False);
+                Log('CurStepChanged: Wrote PendingUpgrade .ready marker');
+                StagingUpdateService();
+              end;
+            MigrateConfigAndStatusCacheFiles();
+            if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
+              begin
+                MountRepos();
+              end
+          end;
       end;
     end;
 end;
@@ -884,8 +1220,119 @@ begin
   end;
 end;
 
+function IsProjFSEnabled(): Boolean;
+var
+  ResultCode: integer;
+begin
+  Result := False;
+  // exit 3 = enabled, exit 4 = disabled, exit 2 = not an optional feature
+  if Exec('powershell.exe', '-NoProfile "$f=Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -ErrorAction SilentlyContinue; if($f -and $f.State -eq ''Enabled''){exit 0}else{exit 1}"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      Result := (ResultCode = 0);
+    end;
+end;
+
+function IsEnableProjFSTaskCurrent(): Boolean;
+var
+  ResultCode: integer;
+  TaskXml: ansiString;
+  HashPos: Integer;
+  ExpectedHash: string;
+begin
+  Result := False;
+  // Query the registered task XML via schtasks
+  if not ExecWithResult(ExpandConstant('{sys}\schtasks.exe'), '/Query /TN "{#ProjFSTaskPath}" /XML', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, TaskXml) then
+    exit;
+  if ResultCode <> 0 then
+    exit;
+  // Look for the hash marker in the task description
+  HashPos := Pos('[gvfs-task-hash=', TaskXml);
+  if HashPos = 0 then
+    exit;
+  // The expected hash is passed as a preprocessor define at build time
+  // (set by the build step that runs build-task-xml.ps1). For now, if
+  // any valid hash marker is present, we consider the task registered.
+  // B4 will add the exact hash comparison when it wires up the build step.
+  Result := True;
+  Log('IsEnableProjFSTaskCurrent: Task found with hash marker');
+end;
+
+procedure EnableProjFSFeature();
+var
+  ResultCode: integer;
+begin
+  if IsProjFSEnabled() then
+    begin
+      Log('EnableProjFSFeature: Already enabled, skipping');
+      exit;
+    end;
+  Log('EnableProjFSFeature: Enabling Client-ProjFS optional feature');
+  if Exec('powershell.exe', '-NoProfile "Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      if ResultCode <> 0 then
+        Log('EnableProjFSFeature: PowerShell returned ' + IntToStr(ResultCode) + ' (may require reboot)')
+      else
+        Log('EnableProjFSFeature: Enabled successfully');
+    end
+  else
+    begin
+      Log('EnableProjFSFeature: Failed to launch PowerShell');
+      RaiseException('Fatal: Could not enable ProjFS.');
+    end;
+end;
+
+procedure RegisterEnableProjFSTask();
+var
+  ResultCode: integer;
+  TaskXmlPath: string;
+begin
+  if IsEnableProjFSTaskCurrent() then
+    begin
+      Log('RegisterEnableProjFSTask: Task is already current, skipping');
+      exit;
+    end;
+
+  Log('RegisterEnableProjFSTask: Registering EnableProjFSOnAllDrives task');
+  // Extract the pre-built task XML from the installer's embedded files
+  ExtractTemporaryFile('enable-projfs-on-all-drives-task.xml');
+  TaskXmlPath := ExpandConstant('{tmp}\enable-projfs-on-all-drives-task.xml');
+
+  if not Exec(ExpandConstant('{sys}\schtasks.exe'), '/Create /TN "{#ProjFSTaskPath}" /XML "' + TaskXmlPath + '" /F', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('RegisterEnableProjFSTask: schtasks /Create failed with exit code ' + IntToStr(ResultCode));
+      RaiseException('Fatal: Could not register EnableProjFSOnAllDrives scheduled task.');
+    end;
+  Log('RegisterEnableProjFSTask: Task registered successfully');
+
+  // Run the task immediately so PrjFlt is attached before we return
+  Exec(ExpandConstant('{sys}\schtasks.exe'), '/Run /TN "{#ProjFSTaskPath}"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  if ResultCode <> 0 then
+    Log('RegisterEnableProjFSTask: Warning - immediate task run returned ' + IntToStr(ResultCode))
+  else
+    Log('RegisterEnableProjFSTask: Task triggered for immediate execution');
+end;
+
+function NeedsAdminSetup(): Boolean;
+begin
+  if not IsProjFSEnabled() then
+    begin
+      Log('NeedsAdminSetup: ProjFS not enabled');
+      Result := True;
+      exit;
+    end;
+  if not IsEnableProjFSTaskCurrent() then
+    begin
+      Log('NeedsAdminSetup: EnableProjFSOnAllDrives task not current');
+      Result := True;
+      exit;
+    end;
+  Log('NeedsAdminSetup: Admin setup is current, no elevation needed');
+  Result := False;
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
+  MsgBoxResult: integer;
   Repos: ansiString;
   ResultCode: integer;
   HasMounts: Boolean;
@@ -893,6 +1340,54 @@ begin
   NeedsRestart := False;
   KeepMountsRunning := False;
   Result := '';
+
+  if IsAdminStage then
+    begin
+      // Elevated re-launch from the user-mode installer. Do only
+      // the per-machine admin setup, then exit cleanly. The user-mode
+      // installer is waiting for our exit code (0 = success).
+      //
+      // We let Inno Setup proceed through the install phase, but all
+      // [Files] entries are gated behind Check functions that return
+      // false in admin-stage mode, so nothing is deployed. This gives
+      // us a clean exit code without fighting the Inno Setup lifecycle.
+      Log('PrepareToInstall: /ADMINSTAGE - running admin setup');
+      EnableProjFSFeature();
+      RegisterEnableProjFSTask();
+      Log('PrepareToInstall: /ADMINSTAGE - admin setup complete');
+      exit;
+    end;
+
+  if IsUserModeInstall then
+    begin
+      // User-mode install: check whether per-machine admin setup
+      // (ProjFS feature + EnableProjFSOnAllDrives task) is current.
+      // If not, re-launch ourselves elevated to do the admin portion.
+      if NeedsAdminSetup() then
+        begin
+          Log('PrepareToInstall: Admin setup needed, re-launching elevated');
+          if not ShellExec('runas', ExpandConstant('{srcexe}'), '/VERYSILENT /ADMINSTAGE=true', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+            begin
+              Result := 'Failed to launch elevated admin setup (user may have declined UAC).';
+              exit;
+            end;
+          if ResultCode <> 0 then
+            begin
+              Result := 'Admin setup failed (exit code ' + IntToStr(ResultCode) + ').';
+              exit;
+            end;
+          Log('PrepareToInstall: Admin setup completed successfully');
+        end
+      else
+        begin
+          Log('PrepareToInstall: Admin setup is current, no elevation needed');
+        end;
+      // Skip system-mode preparation (service queries, mount detection,
+      // staging logic). The user-mode path just deploys the payload
+      // and sets up the junction + PATH.
+      exit;
+    end;
+
   SetNuGetFeedIfNecessary();
 
   // Check for mounted repos by querying the service, and also check for
@@ -925,10 +1420,19 @@ begin
         end
       else
         begin
-          // Interactive mode: show a radio-button modal so the user can pick
-          // between remounting (immediate but brief unavailability) and
-          // staging the upgrade (deferred until repos are unmounted).
-          if not ShowMountChoiceDialog(Repos, KeepMountsRunning) then
+          // Interactive mode: let user choose
+          MsgBoxResult := SuppressibleMsgBox(
+            'The following repos are currently mounted:' + #13#10 + Repos + #13#10#13#10 +
+            'Click Yes to keep repos mounted during the upgrade.' + #13#10 +
+            'The upgrade will complete automatically when all repos are unmounted.' + #13#10#13#10 +
+            'Click No to unmount all repos now and upgrade without restart.' + #13#10 +
+            'Repos will be temporarily unavailable during the upgrade.',
+            mbConfirmation, MB_YESNOCANCEL, IDYES);
+          if MsgBoxResult = IDYES then
+            KeepMountsRunning := True
+          else if MsgBoxResult = IDNO then
+            KeepMountsRunning := False
+          else
             begin
               Result := 'Installation cancelled.';
               exit;

--- a/GVFS/GVFS.UnitTests/Common/LocalRepoRegistryTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LocalRepoRegistryTests.cs
@@ -1,0 +1,281 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LocalRepoRegistryTests
+    {
+        private const string DataLocation = @"mock:\registryDataFolder";
+        private const string Repo1 = @"mock:\code\repo1";
+        private const string Repo2 = @"mock:\code\repo2";
+        private const string Repo3 = @"mock:\code\repo3";
+
+        [TestCase]
+        public void TryRegisterRepo_EmptyRegistry_RoundTripsThroughDisk()
+        {
+            (LocalRepoRegistry registry, MockFileSystem _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out string error).ShouldBeTrue(error);
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(1);
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerSID, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_DuplicateActiveSameOwner_DoesNotRewrite()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+
+            string contentBefore = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            string contentAfter = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+
+            // No semantic change → no rewrite. Important for caller patterns
+            // that re-register on every mount; we don't want a writer storm.
+            contentAfter.ShouldEqual(contentBefore);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_ReactivatesAfterDeactivate()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerSID, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryRegisterRepo_NewOwnerSidIsPersisted()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerA = Guid.NewGuid().ToString();
+            string ownerB = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerA, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo1, ownerB, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            VerifyEntry(all[Repo1], expectedOwnerSID: ownerB, expectedIsActive: true);
+        }
+
+        [TestCase]
+        public void TryDeactivateRepo_NonExistent_ReturnsFalseWithError()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+
+            registry.TryDeactivateRepo(Repo1, out string error).ShouldBeFalse();
+            string.IsNullOrEmpty(error).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryDeactivateRepo_AlreadyInactive_StillReturnsTrue()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+            // Second deactivate on an already-inactive entry is a no-op success
+            registry.TryDeactivateRepo(Repo1, out _).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void TryRemoveRepo_RemovesEntryEntirely()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryRemoveRepo(Repo1, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void TryRemoveRepo_NonExistent_ReturnsFalse()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            registry.TryRemoveRepo(Repo1, out string error).ShouldBeFalse();
+            string.IsNullOrEmpty(error).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryGetActiveRepos_FiltersInactive()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            string ownerSID = Guid.NewGuid().ToString();
+
+            registry.TryRegisterRepo(Repo1, ownerSID, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo2, ownerSID, out _).ShouldBeTrue();
+            registry.TryRegisterRepo(Repo3, ownerSID, out _).ShouldBeTrue();
+            registry.TryDeactivateRepo(Repo2, out _).ShouldBeTrue();
+
+            registry.TryGetActiveRepos(out List<LocalRepoRegistration> active, out _).ShouldBeTrue();
+            active.Count.ShouldEqual(2);
+            active.Any(r => r.EnlistmentRoot.Equals(Repo1)).ShouldBeTrue();
+            active.Any(r => r.EnlistmentRoot.Equals(Repo3)).ShouldBeTrue();
+            active.Any(r => r.EnlistmentRoot.Equals(Repo2)).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryGetActiveRepos_EmptyRegistry_ReturnsEmptyList()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+
+            registry.TryGetActiveRepos(out List<LocalRepoRegistration> active, out string error).ShouldBeTrue(error);
+            active.Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_NoRegistryFile_ReturnsEmpty()
+        {
+            (LocalRepoRegistry registry, _) = this.CreateRegistry();
+            registry.ReadRegistry().Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_HigherVersionOnDisk_ReturnsEmptyAndDoesNotOverwrite()
+        {
+            // Simulate a newer GVFS having written the registry.
+            // We must read as empty AND must NOT overwrite when a subsequent
+            // write happens, so the newer GVFS's data is preserved.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string futureContent = "99\n{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"future\",\"IsActive\":true}\n";
+            fs.WriteAllText(registryPath, futureContent);
+
+            registry.ReadRegistry().Count.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void ReadRegistry_MalformedLine_SkippedNotFatal()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string contents =
+                "2\n" +
+                "{ this is not valid json }\n" +
+                "{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"sid\",\"IsActive\":true}\n";
+            fs.WriteAllText(registryPath, contents);
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(1);
+            all[Repo1].OwnerSID.ShouldEqual("sid");
+        }
+
+        [TestCase]
+        public void ReadRegistry_BlankLinesIgnored()
+        {
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string registryPath = Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName);
+            string contents =
+                "2\n" +
+                "\n" +
+                "{\"EnlistmentRoot\":\"" + Repo1.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"sid\",\"IsActive\":true}\n" +
+                "\n";
+            fs.WriteAllText(registryPath, contents);
+
+            registry.ReadRegistry().Count.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void ReadRegistry_OnDiskFormatMatchesServiceRegistry()
+        {
+            // The on-disk format MUST be wire-compatible with
+            // GVFS.Service.RepoRegistry: first line is the version
+            // (a bare integer); subsequent lines are JSON objects with
+            // EnlistmentRoot / OwnerSID / IsActive fields.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string sid = Guid.NewGuid().ToString();
+            registry.TryRegisterRepo(Repo1, sid, out _).ShouldBeTrue();
+
+            string raw = fs.ReadAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName));
+            string[] lines = raw.Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+
+            // Version line
+            lines[0].ShouldEqual(LocalRepoRegistry.RegistryVersion.ToString());
+
+            // Entry line is JSON with the three required fields
+            lines.Length.ShouldEqual(2);
+            lines[1].Contains("\"EnlistmentRoot\"").ShouldBeTrue();
+            lines[1].Contains("\"OwnerSID\"").ShouldBeTrue();
+            lines[1].Contains("\"IsActive\"").ShouldBeTrue();
+            lines[1].Contains(sid).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void RegisterAfterRead_PreservesOtherEntriesWrittenByAnotherProcess()
+        {
+            // Simulate another process having written an entry between
+            // construction and our register call: we read fresh on each
+            // operation, so the other entry must survive.
+            (LocalRepoRegistry registry, MockFileSystem fs) = this.CreateRegistry();
+            string sid = Guid.NewGuid().ToString();
+
+            string contents =
+                "2\n" +
+                "{\"EnlistmentRoot\":\"" + Repo2.Replace("\\", "\\\\") + "\",\"OwnerSID\":\"" + sid + "\",\"IsActive\":true}\n";
+            fs.WriteAllText(Path.Combine(DataLocation, LocalRepoRegistry.RegistryFileName), contents);
+
+            registry.TryRegisterRepo(Repo1, sid, out _).ShouldBeTrue();
+
+            Dictionary<string, LocalRepoRegistration> all = registry.ReadRegistry();
+            all.Count.ShouldEqual(2);
+            all.ContainsKey(Repo1).ShouldBeTrue();
+            all.ContainsKey(Repo2).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void Constructor_NullArgs_Throws()
+        {
+            MockFileSystem fs = new MockFileSystem(new MockDirectory(DataLocation, null, null));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(null, fs, DataLocation));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(new MockTracer(), null, DataLocation));
+            Assert.Throws<ArgumentNullException>(() => new LocalRepoRegistry(new MockTracer(), fs, null));
+        }
+
+        [TestCase]
+        public void LocalRepoRegistration_JsonRoundTrip()
+        {
+            LocalRepoRegistration original = new LocalRepoRegistration("path", "sid") { IsActive = false };
+            string json = original.ToJson();
+            LocalRepoRegistration roundTripped = LocalRepoRegistration.FromJson(json);
+
+            roundTripped.EnlistmentRoot.ShouldEqual(original.EnlistmentRoot);
+            roundTripped.OwnerSID.ShouldEqual(original.OwnerSID);
+            roundTripped.IsActive.ShouldEqual(original.IsActive);
+        }
+
+        private (LocalRepoRegistry registry, MockFileSystem fs) CreateRegistry()
+        {
+            MockFileSystem fs = new MockFileSystem(new MockDirectory(DataLocation, null, null));
+            LocalRepoRegistry registry = new LocalRepoRegistry(new MockTracer(), fs, DataLocation);
+            return (registry, fs);
+        }
+
+        private static void VerifyEntry(LocalRepoRegistration entry, string expectedOwnerSID, bool expectedIsActive)
+        {
+            entry.ShouldNotBeNull();
+            entry.OwnerSID.ShouldEqual(expectedOwnerSID);
+            entry.IsActive.ShouldEqual(expectedIsActive);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/LogonTaskRegistrationTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/LogonTaskRegistrationTests.cs
@@ -1,0 +1,288 @@
+using GVFS.Common;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class LogonTaskRegistrationTests
+    {
+        private const string TestGvfsPath = @"C:\Users\test\AppData\Local\Programs\GVFS\Current\gvfs.exe";
+        private const string TestUserSid = "S-1-5-21-1111-2222-3333-1001";
+        private const string OtherUserSid = "S-1-5-21-1111-2222-3333-1002";
+
+        [TestCase]
+        public void TemplateHash_IsStableAcrossCalls()
+        {
+            // Same template content => same hash, every time.
+            LogonTaskRegistration.TemplateHash.ShouldEqual(LogonTaskRegistration.TemplateHash);
+            // Full SHA-256 hex = 64 chars
+            LogonTaskRegistration.TemplateHash.Length.ShouldEqual(64);
+        }
+
+        [TestCase]
+        public void BuildTaskXml_SubstitutesAllPlaceholders()
+        {
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+
+            xml.Contains(LogonTaskRegistration.GvfsPathPlaceholder).ShouldBeFalse("no GVFS_PATH placeholder should remain");
+            xml.Contains(LogonTaskRegistration.UserIdPlaceholder).ShouldBeFalse("no USER_ID placeholder should remain");
+            xml.Contains(LogonTaskRegistration.TaskHashPlaceholder).ShouldBeFalse("no TASK_HASH placeholder should remain");
+
+            xml.Contains(TestGvfsPath).ShouldBeTrue("gvfs.exe path should appear in the XML");
+            xml.Contains(TestUserSid).ShouldBeTrue("user SID should appear in the XML");
+            xml.Contains(LogonTaskRegistration.TemplateHash).ShouldBeTrue("template hash should appear in the XML");
+        }
+
+        [TestCase]
+        public void BuildTaskXml_ProducesMountAllArguments()
+        {
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+            // The task action runs `gvfs.exe service --mount-all`.
+            xml.Contains("service --mount-all").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void BuildTaskXml_NullOrEmptyArgsThrow()
+        {
+            // Assert.Catch accepts derived types (ArgumentNullException is
+            // also raised by ThrowIfNullOrEmpty for null inputs).
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml(null, TestUserSid));
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml("", TestUserSid));
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml(TestGvfsPath, null));
+            Assert.Catch<ArgumentException>(() => LogonTaskRegistration.BuildTaskXml(TestGvfsPath, ""));
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_FindsMarkerInDescription()
+        {
+            string description = "Mounts the user's enlistments at logon. [gvfs-logon-task-hash=DEADBEEF12345678ABCDEF0123456789FEDCBA9876543210CAFEBABE12345678]";
+            LogonTaskRegistration.TryExtractHashMarker(description, out string hash).ShouldBeTrue();
+            hash.ShouldEqual("DEADBEEF12345678ABCDEF0123456789FEDCBA9876543210CAFEBABE12345678");
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_NoMarker_ReturnsFalse()
+        {
+            LogonTaskRegistration.TryExtractHashMarker("Just a plain description.", out string hash).ShouldBeFalse();
+            hash.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_EmptyOrNull_ReturnsFalse()
+        {
+            LogonTaskRegistration.TryExtractHashMarker(null, out _).ShouldBeFalse();
+            LogonTaskRegistration.TryExtractHashMarker("", out _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_MalformedMarker_ReturnsFalse()
+        {
+            // Opening prefix but no closing bracket
+            LogonTaskRegistration.TryExtractHashMarker("foo [gvfs-logon-task-hash=ABCD no close", out _).ShouldBeFalse();
+            // Closing bracket before any content
+            LogonTaskRegistration.TryExtractHashMarker("foo [gvfs-logon-task-hash=]", out _).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryExtractHashMarker_FindsMarkerInGeneratedXml()
+        {
+            // Round-trip: the XML produced by BuildTaskXml must contain the
+            // template hash, and TryExtractHashMarker must recover it.
+            string xml = LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+            LogonTaskRegistration.TryExtractHashMarker(xml, out string hash).ShouldBeTrue();
+            hash.ShouldEqual(LogonTaskRegistration.TemplateHash);
+        }
+
+        [TestCase]
+        public void IsCurrent_NoRegisteredTask_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            // Default mock has no registered tasks => TryQueryXml fails.
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void IsCurrent_MatchingHash_ReturnsTrue()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void IsCurrent_DifferentHash_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            // Simulate a task registered by a previous template version
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                "<Task><RegistrationInfo><Description>Old. [gvfs-logon-task-hash=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA]</Description></RegistrationInfo></Task>";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void IsCurrent_TaskExistsButNoMarker_ReturnsFalse()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                "<Task><RegistrationInfo><Description>Manually edited, no marker.</Description></RegistrationInfo></Task>";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+            reg.IsCurrent().ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_CreatesNewTask()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, TestUserSid, out string error).ShouldBeTrue(error);
+
+            invoker.RegisteredTasks.ContainsKey(LogonTaskRegistration.FullTaskPath).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(1);
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_AlreadyCurrentSameArgs_NoRewrite()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, TestUserSid, out _).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_CurrentHashButDifferentUser_Reregisters()
+        {
+            // Same template hash, but task is bound to a different user SID
+            // (e.g. someone else's per-user task left behind). We must
+            // re-register with the requesting user's SID.
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath, OtherUserSid);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, TestUserSid, out _).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(1);
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath].Contains(TestUserSid).ShouldBeTrue();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath].Contains(OtherUserSid).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_CurrentHashButDifferentGvfsPath_Reregisters()
+        {
+            // GVFS install moved (junction swap). Template hash unchanged
+            // but the Command path in the task points at the old location.
+            // We must rewrite.
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            string oldPath = @"C:\Users\test\AppData\Local\Programs\GVFS\Versions\0.1.0\gvfs.exe";
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(oldPath, TestUserSid);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, TestUserSid, out _).ShouldBeTrue();
+            invoker.RegisterCallCount.ShouldEqual(1);
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath].Contains(TestGvfsPath).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void TryRegisterOrUpdate_InvokerFails_SurfacesError()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.NextRegisterError = "Permission denied";
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryRegisterOrUpdate(TestGvfsPath, TestUserSid, out string error).ShouldBeFalse();
+            error.ShouldEqual("Permission denied");
+        }
+
+        [TestCase]
+        public void TryUnregister_DelegatesToInvoker()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            invoker.RegisteredTasks[LogonTaskRegistration.FullTaskPath] =
+                LogonTaskRegistration.BuildTaskXml(TestGvfsPath, TestUserSid);
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryUnregister(out string error).ShouldBeTrue(error);
+            invoker.RegisteredTasks.ContainsKey(LogonTaskRegistration.FullTaskPath).ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void TryUnregister_TaskNotRegistered_StillReturnsTrue()
+        {
+            // Idempotent: unregister of nothing is a success.
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            LogonTaskRegistration reg = new LogonTaskRegistration(new MockTracer(), invoker);
+
+            reg.TryUnregister(out _).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void Constructor_NullArgs_Throws()
+        {
+            MockScheduledTaskInvoker invoker = new MockScheduledTaskInvoker();
+            Assert.Throws<ArgumentNullException>(() => new LogonTaskRegistration(null, invoker));
+            Assert.Throws<ArgumentNullException>(() => new LogonTaskRegistration(new MockTracer(), null));
+        }
+
+        private sealed class MockScheduledTaskInvoker : IScheduledTaskInvoker
+        {
+            public Dictionary<string, string> RegisteredTasks { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public string NextRegisterError { get; set; }
+            public string NextUnregisterError { get; set; }
+            public int RegisterCallCount { get; private set; }
+
+            public bool TryRegisterFromXml(string taskPath, string xml, out string errorMessage)
+            {
+                this.RegisterCallCount++;
+
+                if (!string.IsNullOrEmpty(this.NextRegisterError))
+                {
+                    errorMessage = this.NextRegisterError;
+                    return false;
+                }
+
+                this.RegisteredTasks[taskPath] = xml;
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            public bool TryQueryXml(string taskPath, out string xml, out string errorMessage)
+            {
+                if (this.RegisteredTasks.TryGetValue(taskPath, out xml))
+                {
+                    errorMessage = string.Empty;
+                    return true;
+                }
+
+                xml = null;
+                errorMessage = "Task not found";
+                return false;
+            }
+
+            public bool TryUnregister(string taskPath, out string errorMessage)
+            {
+                if (!string.IsNullOrEmpty(this.NextUnregisterError))
+                {
+                    errorMessage = this.NextUnregisterError;
+                    return false;
+                }
+
+                this.RegisteredTasks.Remove(taskPath);
+                errorMessage = string.Empty;
+                return true;
+            }
+        }
+    }
+}

--- a/GVFS/GVFS/CommandLine/GVFSVerb.cs
+++ b/GVFS/GVFS/CommandLine/GVFSVerb.cs
@@ -16,8 +16,6 @@ namespace GVFS.CommandLine
 {
     public abstract class GVFSVerb
     {
-        protected const string StartServiceInstructions = "Run 'sc start GVFS.Service' from an elevated command prompt to ensure it is running.";
-
         private readonly bool validateOriginURL;
 
         public GVFSVerb(bool validateOrigin = true)
@@ -570,8 +568,23 @@ You can specify a URL, a name of a configured cache server, or the special names
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "GVFS.Service is not responding. " + GVFSVerb.StartServiceInstructions;
-                    return false;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). In that model, the boot-time
+                    // EnableProjFSOnAllDrives scheduled task is responsible
+                    // for ensuring PrjFlt is enabled and attached to every
+                    // NTFS/ReFS volume - and re-attaching on volume-mount
+                    // events for newly-attached drives. So when the service
+                    // pipe is unavailable, the right answer is to return
+                    // success silently and let the caller proceed; if PrjFlt
+                    // is actually missing at mount time, the mount-process
+                    // filter check will surface a clearer "filter not
+                    // attached" error downstream.
+                    //
+                    // We deliberately do NOT fall back on BrokenPipeException
+                    // below: that indicates the service IS present but
+                    // crashed mid-request, and silently succeeding would
+                    // mask a real bug.
+                    return true;
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -235,7 +235,7 @@ namespace GVFS.CommandLine
                     tracer.RelatedInfo($"{nameof(this.Execute)}: Registering for automount");
 
                     if (this.ShowStatusWhileRunning(
-                        () => { return this.RegisterMount(enlistment, out errorMessage); },
+                        () => { return this.RegisterMount(enlistment, tracer, out errorMessage); },
                         "Registering for automount"))
                     {
                         tracer.RelatedInfo($"{nameof(this.Execute)}: Registered for automount");
@@ -280,26 +280,39 @@ namespace GVFS.CommandLine
             return GVFSEnlistment.WaitUntilMounted(tracer, enlistment.NamedPipeName, enlistment.WorkingDirectoryRoot, this.Unattended, out errorMessage);
         }
 
-        private bool RegisterMount(GVFSEnlistment enlistment, out string errorMessage)
+        private bool RegisterMount(GVFSEnlistment enlistment, ITracer tracer, out string errorMessage)
         {
             errorMessage = string.Empty;
 
-            NamedPipeMessages.RegisterRepoRequest request = new NamedPipeMessages.RegisterRepoRequest();
-
             // Worktree mounts register with their worktree path so they can be
             // listed and unregistered independently of the primary enlistment.
-            request.EnlistmentRoot = enlistment.IsWorktree
+            string enlistmentRoot = enlistment.IsWorktree
                 ? enlistment.WorkingDirectoryRoot
                 : enlistment.PrimaryEnlistmentRoot;
+            string ownerSID = GVFSPlatform.Instance.GetCurrentUser();
 
-            request.OwnerSID = GVFSPlatform.Instance.GetCurrentUser();
+            NamedPipeMessages.RegisterRepoRequest request = new NamedPipeMessages.RegisterRepoRequest();
+            request.EnlistmentRoot = enlistmentRoot;
+            request.OwnerSID = ownerSID;
 
             using (NamedPipeClient client = new NamedPipeClient(this.ServicePipeName))
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "Unable to register repo because GVFS.Service is not responding.";
-                    return false;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to writing the
+                    // registry file directly. The service writes to the same
+                    // file at the same path when it IS running, so the two
+                    // models can co-exist or be migrated between without any
+                    // data being lost. We only reach this fallback when the
+                    // pipe doesn't exist at all - if the service is present
+                    // but mid-request crashes, that surfaces as
+                    // BrokenPipeException below and we deliberately do NOT
+                    // fall back (the service remains the authoritative
+                    // writer in that case).
+                    tracer.RelatedInfo($"{nameof(this.RegisterMount)}: GVFS.Service pipe unavailable; falling back to LocalRepoRegistry");
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(tracer);
+                    return localRegistry.TryRegisterRepo(enlistmentRoot, ownerSID, out errorMessage);
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -1,6 +1,7 @@
 using GVFS.Common;
 using GVFS.Common.FileSystem;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -156,8 +157,18 @@ namespace GVFS.CommandLine
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "GVFS.Service is not responding.";
-                    return false;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to reading the
+                    // registry file directly. See the matching comment in
+                    // MountVerb.RegisterMount for the design rationale.
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(NullTracer.Instance);
+                    if (!localRegistry.TryGetActiveRepos(out List<LocalRepoRegistration> activeRepos, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    repoList = activeRepos.Select(r => r.EnlistmentRoot).ToList();
+                    return true;
                 }
 
                 try

--- a/GVFS/GVFS/CommandLine/UnmountVerb.cs
+++ b/GVFS/GVFS/CommandLine/UnmountVerb.cs
@@ -1,5 +1,6 @@
 using GVFS.Common;
 using GVFS.Common.NamedPipes;
+using GVFS.Common.Tracing;
 using System;
 using System.Diagnostics;
 
@@ -204,7 +205,30 @@ namespace GVFS.CommandLine
             {
                 if (!client.Connect())
                 {
-                    errorMessage = "Unable to unregister repo because GVFS.Service is not responding. " + GVFSVerb.StartServiceInstructions;
+                    // Service not installed or not running (typical for the
+                    // user-level install model). Fall back to writing the
+                    // registry file directly. See the matching comment in
+                    // MountVerb.RegisterMount for the design rationale and
+                    // the deliberate decision NOT to fall back on
+                    // BrokenPipeException (the service-broken-mid-request
+                    // case).
+                    LocalRepoRegistry localRegistry = LocalRepoRegistry.CreateForCurrentPlatform(NullTracer.Instance);
+                    if (localRegistry.TryDeactivateRepo(rootPath, out errorMessage))
+                    {
+                        return true;
+                    }
+
+                    // TryDeactivateRepo returns false for two reasons:
+                    //   1. Entry not found — benign, nothing to unregister.
+                    //   2. I/O error — real failure, propagate to caller.
+                    // Distinguish by checking for the "non-existent" message
+                    // that TryDeactivateRepo produces for case 1.
+                    if (errorMessage != null && errorMessage.Contains("non-existent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        errorMessage = string.Empty;
+                        return true;
+                    }
+
                     return false;
                 }
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,40 @@ winget install --id Microsoft.VFSforGit
 You will need to continue using the `microsoft/git` version of Git, and it
 will notify you when new versions are available.
 
+### User-mode installation (opt-in)
+
+VFS for Git can be installed per-user (no admin required for routine
+operations) by passing `/CURRENTUSER` to the installer:
+
+```
+SetupGVFS.<version>.exe /CURRENTUSER
+```
+
+Or in silent mode:
+
+```
+SetupGVFS.<version>.exe /VERYSILENT /CURRENTUSER
+```
+
+This installs to `%LocalAppData%\GVFS\` instead of `C:\Program Files\`.
+A one-time admin elevation is required on first install to enable the
+ProjFS Windows feature and register a boot-time scheduled task — subsequent
+installs and upgrades require no elevation.
+
+### Migrating from a system install
+
+If you previously had VFS for Git installed system-wide and switch to a
+user-mode install via `/CURRENTUSER`, the installer automatically:
+
+1. Stops and removes the GVFS.Service Windows service
+2. Migrates your registered repo list to the user-mode location
+3. Removes the legacy install directory from the system PATH
+4. Registers a cleanup task that deletes the old `C:\Program Files\VFS for Git\`
+   files once any running legacy mounts have exited
+
+Running mounts are **not disrupted** — they continue to work until you
+unmount or reboot. After that, mounts use the user-mode install.
+
 
 ## Building VFS for Git
 

--- a/scripts/projfs-attach/build-task-xml.ps1
+++ b/scripts/projfs-attach/build-task-xml.ps1
@@ -1,0 +1,103 @@
+# build-task-xml.ps1
+#
+# Produces the final EnableProjFSOnAllDrives scheduled task XML by
+# base64-encoding enable-projfs-on-all-drives.ps1 and substituting it
+# (along with a content hash) into enable-projfs-on-all-drives-task.xml.template.
+#
+# Inputs and output are passed by parameter so this script is callable
+# from layout.bat, MSBuild, or directly during development.
+#
+# The hash embedded in the task Description (via __TASK_HASH__) is
+# SHA-256 over the un-encoded inputs (template + script body, in that
+# order, separated by a NUL byte). Stable across re-runs with
+# unchanged inputs; changes the moment either input's content
+# changes. This is what the installer's drift detection compares
+# against the registered task's Description marker to decide whether
+# re-registration is needed.
+#
+# Output XML is UTF-16 LE with BOM (required by Task Scheduler's
+# /XML import).
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TemplatePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ScriptPath)) { throw "Script not found: $ScriptPath" }
+if (-not (Test-Path $TemplatePath)) { throw "Template not found: $TemplatePath" }
+
+# Read raw bytes so the hash and the base64 are computed over exactly
+# what's on disk, regardless of line-ending or BOM conventions.
+$scriptBytes = [System.IO.File]::ReadAllBytes($ScriptPath)
+
+# Read the template as text (UTF-8 or UTF-16 with BOM both work for
+# Get-Content; the template is checked in as UTF-16 to match the XML
+# encoding declaration but we re-emit as UTF-16 with BOM either way).
+$templateText = [System.IO.File]::ReadAllText($TemplatePath)
+$templateBytes = [System.Text.Encoding]::UTF8.GetBytes($templateText)
+
+# PowerShell -EncodedCommand expects UTF-16 LE bytes, base64 encoded.
+$scriptUtf16 = [System.Text.Encoding]::Unicode.GetString($scriptBytes)
+# If the source script was UTF-8 (typical for files checked into git),
+# the line above produces garbage. Detect by checking for a UTF-8 BOM
+# or by attempting a UTF-8 decode and re-encoding to UTF-16.
+$scriptText =
+    if ($scriptBytes.Length -ge 3 -and $scriptBytes[0] -eq 0xEF -and $scriptBytes[1] -eq 0xBB -and $scriptBytes[2] -eq 0xBF) {
+        [System.Text.Encoding]::UTF8.GetString($scriptBytes, 3, $scriptBytes.Length - 3)
+    }
+    elseif ($scriptBytes.Length -ge 2 -and $scriptBytes[0] -eq 0xFF -and $scriptBytes[1] -eq 0xFE) {
+        [System.Text.Encoding]::Unicode.GetString($scriptBytes, 2, $scriptBytes.Length - 2)
+    }
+    else {
+        # Assume UTF-8 without BOM (git's default for text)
+        [System.Text.Encoding]::UTF8.GetString($scriptBytes)
+    }
+
+$scriptUtf16Bytes = [System.Text.Encoding]::Unicode.GetBytes($scriptText)
+$encodedCommand = [System.Convert]::ToBase64String($scriptUtf16Bytes)
+
+# Hash inputs: template bytes + NUL + script bytes (the raw bytes,
+# not re-encoded, so the hash is reproducible even if the encoding
+# detection logic is changed in a future revision of this script).
+$hasher = [System.Security.Cryptography.SHA256]::Create()
+try {
+    $combined = New-Object byte[] ($templateBytes.Length + 1 + $scriptBytes.Length)
+    [System.Buffer]::BlockCopy($templateBytes, 0, $combined, 0, $templateBytes.Length)
+    $combined[$templateBytes.Length] = 0
+    [System.Buffer]::BlockCopy($scriptBytes, 0, $combined, $templateBytes.Length + 1, $scriptBytes.Length)
+    $hashBytes = $hasher.ComputeHash($combined)
+    $hashHex = ([System.BitConverter]::ToString($hashBytes)).Replace('-', '')
+}
+finally {
+    $hasher.Dispose()
+}
+
+# Substitute placeholders. Order matters only because __SCRIPT_BASE64__
+# could in theory contain the __TASK_HASH__ literal -- highly unlikely
+# but trivially defended by substituting hash first.
+$finalXml = $templateText.
+    Replace('__TASK_HASH__', $hashHex).
+    Replace('__SCRIPT_BASE64__', $encodedCommand)
+
+# Ensure output directory exists.
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir -and -not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+# Write UTF-16 LE with BOM (required by schtasks /Create /XML).
+[System.IO.File]::WriteAllText(
+    $OutputPath,
+    $finalXml,
+    (New-Object System.Text.UnicodeEncoding $false, $true))
+
+Write-Host "Wrote $OutputPath ($([System.IO.File]::ReadAllBytes($OutputPath).Length) bytes, hash=$hashHex)"

--- a/scripts/projfs-attach/enable-projfs-on-all-drives-task.xml.template
+++ b/scripts/projfs-attach/enable-projfs-on-all-drives-task.xml.template
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<!--
+enable-projfs-on-all-drives-task.xml.template
+
+Scheduled task definition for the user-level GVFS install model.
+
+This is a TEMPLATE: build-task-xml.ps1 reads it, substitutes
+__SCRIPT_BASE64__ with the base64-encoded contents of
+enable-projfs-on-all-drives.ps1 and __TASK_HASH__ with the SHA-256
+of the un-substituted template + script combined (so the hash is
+stable across re-substitutions but changes when either input
+content changes).
+
+Registered once per machine at install time (admin elevation
+required). Once registered, runs as LocalSystem with no further
+UAC. No on-disk script file is deployed -- the body of the
+PowerShell script is embedded in the <Exec><Arguments> as
+-EncodedCommand <base64>.
+
+Two triggers:
+  1. BootTrigger - fires at OS startup. Re-attaches prjflt to every
+     NTFS/ReFS volume after reboot (FilterAttach is not persistent).
+  2. EventTrigger - subscribes to the Microsoft-Windows-Partition
+     Diagnostic event log, Event ID 1006 (partition online). This
+     event fires when a new partition becomes available, including
+     USB plug-in, VHD mount, and new partition creation.
+
+The Microsoft-Windows-Partition channel is enabled by default on
+Windows 10+ and fires reliably for both fixed and removable media.
+
+The Description contains the marker [gvfs-task-hash=__TASK_HASH__]
+which the installer's drift-detect uses to decide whether the
+registered task still matches the intended one (no rewrite needed)
+or has drifted (re-register required). Re-registration is the only
+operation that requires UAC; per-user GVFS upgrades that don't
+change this task body never need elevation.
+-->
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Author>Microsoft\GVFS</Author>
+    <Description>Re-attaches the ProjFS filter (prjflt) to NTFS/ReFS volumes after reboot or volume mount. Required by VFS for Git in the user-level install model. [gvfs-task-hash=__TASK_HASH__]</Description>
+    <URI>\GVFS\EnableProjFSOnAllDrives</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+    <EventTrigger>
+      <Enabled>true</Enabled>
+      <Subscription>&lt;QueryList&gt;&lt;Query Id="0" Path="Microsoft-Windows-Partition/Diagnostic"&gt;&lt;Select Path="Microsoft-Windows-Partition/Diagnostic"&gt;*[System[Provider[@Name='Microsoft-Windows-Partition'] and (EventID=1006)]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;</Subscription>
+    </EventTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>S-1-5-18</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Queue</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>
+    <Priority>5</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand __SCRIPT_BASE64__</Arguments>
+    </Exec>
+  </Actions>
+</Task>

--- a/scripts/projfs-attach/enable-projfs-on-all-drives.ps1
+++ b/scripts/projfs-attach/enable-projfs-on-all-drives.ps1
@@ -1,0 +1,135 @@
+# enable-projfs-on-all-drives.ps1
+#
+# Source of truth for the EnableProjFSOnAllDrives scheduled task body.
+# This script is NOT deployed to disk in the user-mode install model;
+# instead, build-task-xml.ps1 base64-encodes the contents and embeds
+# them in the task XML's <Exec><Arguments> as -EncodedCommand. The
+# task then runs as: powershell.exe -EncodedCommand <base64-of-this>.
+#
+# Runs as LocalSystem (configured by the scheduled task) so it has
+# SE_LOAD_DRIVER_PRIVILEGE for FilterAttach and HKLM write access
+# for the Dev Drive allowed-filters registry.
+#
+# Two invocation modes (selected by the task's triggers):
+#   1. AT_SYSTEM_START - no DriveLetter argument. Reconciles the Dev
+#      Drive allow-list (machine-wide) and attaches prjflt to every
+#      eligible NTFS/ReFS volume. FilterAttach is not persistent
+#      across reboots, so this is required every boot.
+#   2. Event 1006 from Microsoft-Windows-Partition/Diagnostic -
+#      DriveLetter argument is the drive of the newly-mounted volume.
+#      Attaches prjflt to just that one drive. Avoids work on every
+#      USB plug-in / VHD mount.
+#
+# Logs to %ProgramData%\GVFS\enable-projfs-on-all-drives.log
+# (HKLM-writable from SYSTEM, persistent across reboots).
+#
+# Idempotent everywhere: fltmc NameCollision is treated as success,
+# fsutil devdrv setFiltersAllowed is a no-op if already set. Safe to
+# run repeatedly.
+
+[CmdletBinding()]
+param(
+    # If provided, only attempt to attach to this single drive letter.
+    # Used by the volume-mount trigger to scope work narrowly. When
+    # absent, all NTFS/ReFS volumes are processed (boot trigger path),
+    # and the Dev Drive allow-list is also reconciled.
+    [string]$DriveLetter
+)
+
+$ErrorActionPreference = 'Stop'
+
+$logDir = Join-Path $env:ProgramData 'GVFS'
+$logPath = Join-Path $logDir 'enable-projfs-on-all-drives.log'
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+function Write-Log([string]$msg) {
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $msg"
+    Add-Content -Path $logPath -Value $line -Encoding UTF8
+}
+
+function Set-PrjFltDevDriveAllowed {
+    # Dev Drives consult a machine-wide allow-list at mount time to
+    # decide which minifilters may attach. Without PrjFlt in the list,
+    # GVFS cannot work on Dev Drives even if we call FilterAttach.
+    # Set unconditionally; fsutil is a no-op if already set.
+    try {
+        $out = (& fsutil.exe devdrv setFiltersAllowed PrjFlt 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -eq 0) {
+            Write-Log "DevDrive allow-list: PrjFlt allowed (output: $out)"
+        }
+        else {
+            # Non-fatal: on older Windows builds without Dev Drive
+            # support, fsutil devdrv may fail. Log and continue.
+            Write-Log "DevDrive allow-list: fsutil exit=$LASTEXITCODE (likely no Dev Drive support on this OS) output=$out"
+        }
+    }
+    catch {
+        Write-Log "DevDrive allow-list: exception (likely no Dev Drive support): $_"
+    }
+}
+
+function Add-PrjFltToVolume([string]$drive) {
+    $output = (& fltmc.exe attach PrjFlt "${drive}:" 2>&1 | Out-String).Trim()
+    $exit = $LASTEXITCODE
+    # NameCollision is success-equivalent: filter is already attached.
+    # Check the output BEFORE the exit code because fltmc returns exit
+    # 1 for NameCollision (despite it being benign).
+    if ($output -match 'instance already exists' -or
+        $output -match 'instance name collision' -or
+        $output -match '0x801f0012') {
+        Write-Log "OK   ${drive}: already attached (NameCollision)"
+        return $true
+    }
+    if ($exit -ne 0) {
+        Write-Log "FAIL ${drive}: exit=$exit output=$output"
+        return $false
+    }
+    Write-Log "OK   ${drive}: attached (output: $output)"
+    return $true
+}
+
+try {
+    Write-Log "===== enable-projfs-on-all-drives.ps1 starting (DriveLetter='$DriveLetter') ====="
+
+    if ($DriveLetter) {
+        # Single-volume mode (volume-mount trigger)
+        $drive = $DriveLetter.TrimEnd(':').TrimEnd('\').ToUpperInvariant()
+        if ($drive.Length -ne 1) {
+            Write-Log "ERROR: invalid DriveLetter '$DriveLetter' (parsed='$drive')"
+            exit 2
+        }
+        $vol = Get-Volume -DriveLetter $drive -ErrorAction SilentlyContinue
+        if (-not $vol) {
+            Write-Log "SKIP ${drive}: volume not found"
+            exit 0
+        }
+        if ($vol.FileSystemType -notin @('NTFS', 'ReFS')) {
+            Write-Log "SKIP ${drive}: filesystem=$($vol.FileSystemType) (not NTFS/ReFS)"
+            exit 0
+        }
+        Add-PrjFltToVolume $drive | Out-Null
+    }
+    else {
+        # All-volumes mode (boot trigger). Reconcile both the Dev Drive
+        # allow-list AND per-volume attachments. Cheap; idempotent.
+        Set-PrjFltDevDriveAllowed
+        $volumes = Get-Volume |
+            Where-Object {
+                $_.DriveLetter -and
+                $_.FileSystemType -in @('NTFS', 'ReFS')
+            }
+        Write-Log "Found $(@($volumes).Count) eligible volume(s)"
+        foreach ($v in $volumes) {
+            Add-PrjFltToVolume ([string]$v.DriveLetter) | Out-Null
+        }
+    }
+
+    Write-Log "===== enable-projfs-on-all-drives.ps1 done ====="
+}
+catch {
+    Write-Log "EXCEPTION: $_"
+    Write-Log $_.ScriptStackTrace
+    exit 3
+}


### PR DESCRIPTION
## PR-C: Install-time migration + SYSTEM cleanup task

Stacked on PR #2022 (PR-B: user-mode install via /CURRENTUSER).

When the user-mode installer detects a legacy system install, migration is transparent -- no CLI verbs, no user prompts.

### Install-time (elevated /ADMINSTAGE)
- Stop + sc delete GVFS.Service
- Copy legacy repo-registry to user LocalRepoRegistry location (then delete source to prevent cleanup-task rollback false positive)
- Remove legacy dir from system PATH
- Delete legacy AutoLogger registry key
- Register MigrationCleanup scheduled task
- Trigger immediate cleanup

Passes /USERLOCALAPPDATA to the elevated process so repo-registry lands in the correct user dir even under Over-the-Shoulder UAC.

### Cleanup task (SYSTEM context, self-unregistering)
Fires at boot, logon, and every 30 minutes. Four guards:
1. GVFS.Service in SCM = rollback detected, skip
2. Legacy repo-registry exists = rollback detected, skip
3. Legacy GVFS.Mount processes running from Program Files = wait
4. Legacy dir gone = already done, unregister self

When all guards pass: deletes legacy files + dirs, unregisters self.

### Build changes
GVFS.Installers.csproj: BuildCleanupTaskXml target (reuses build-task-xml.ps1 from A5). Cleanup task XML embedded via [Files] dontcopy.

### Review fixes incorporated
- Delete source repo-registry after FileCopy (prevents cleanup task permanent block)
- Pass USERLOCALAPPDATA from non-elevated caller (fixes OTS UAC wrong-user)