### PR TITLE
ci: drop Debug configuration from build and test matrices

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,7 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [ Debug, Release ]
+        configuration: [ Release ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [ Debug, Release ]
+        configuration: [ Release ]
         architecture: [ x86_64, arm64 ]
         nr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] # 10 parallel jobs to speed up the tests
       fail-fast: false # most failures are flaky tests, no need to stop the other jobs from succeeding

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [ Debug ]
+        configuration: [ Release ]
         scenario:
           - staging-upgrade
           - clean-upgrade

--- a/GVFS/GVFS.Common/GitStatusCache.cs
+++ b/GVFS/GVFS.Common/GitStatusCache.cs
@@ -3,7 +3,7 @@ using GVFS.Common.NamedPipes;
 using GVFS.Common.Tracing;
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
+
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -597,7 +597,10 @@ namespace GVFS.Common
 
         private bool TryDeleteStatusCacheFile()
         {
-            Debug.Assert(this.cacheFileLock.IsHeldByCurrentThread, "Attempting to delete the git status cache file without the cacheFileLock");
+            if (!this.cacheFileLock.IsHeldByCurrentThread)
+            {
+                throw new InvalidOperationException("Attempting to delete the git status cache file without the cacheFileLock");
+            }
 
             try
             {
@@ -635,7 +638,10 @@ namespace GVFS.Common
         /// <returns>True on success, False on failure</returns>
         private bool MoveCacheFileToFinalLocation(string tmpStatusFilePath)
         {
-            Debug.Assert(this.cacheFileLock.IsHeldByCurrentThread, "Attempting to update the git status cache file without the cacheFileLock");
+            if (!this.cacheFileLock.IsHeldByCurrentThread)
+            {
+                throw new InvalidOperationException("Attempting to update the git status cache file without the cacheFileLock");
+            }
 
             try
             {

--- a/GVFS/GVFS.Common/Tracing/QueuedPipeStringWriter.cs
+++ b/GVFS/GVFS.Common/Tracing/QueuedPipeStringWriter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
+
 using System.IO.Pipes;
 using System.Text;
 using System.Threading;
@@ -86,7 +86,10 @@ namespace GVFS.Common.Tracing
             this.queue.CompleteAdding();
             this.writerThread.Join();
 
-            Debug.Assert(this.queue.IsCompleted, "Message queue should be empty after being stopped");
+            if (!this.queue.IsCompleted)
+            {
+                throw new InvalidOperationException("Message queue should be empty after being stopped");
+            }
         }
 
         public void Dispose()

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
@@ -3,7 +3,8 @@ using GVFS.Common.FileSystem;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
 using GVFS.Common.Tracing;
-using System.Diagnostics;
+
+using System;
 using System.IO;
 
 namespace GVFS.UnitTests.Mock.Common
@@ -26,7 +27,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public override string WriteTempPackFile(Stream stream)
         {
-            Debug.Assert(stream != null, "WriteTempPackFile should not receive a null stream");
+            ArgumentNullException.ThrowIfNull(stream);
 
             using (stream)
             using (StreamReader reader = new StreamReader(stream))


### PR DESCRIPTION
## Motivation

The CI test matrix is about to get more complex: user-level install testing and arm64-native builds will each add new matrix dimensions. Before that expansion, simplify by removing the Debug configuration — which currently doubles every build and test job for minimal benefit.

## What this does

**Removes Debug from CI matrices** in all three workflows:
- `build.yaml` — build + unit test matrix: `[Debug, Release]` → `[Release]`
- `functional-tests.yaml` — functional test matrix: `[Debug, Release]` → `[Release]`
- `upgrade-tests.yaml` — upgrade test matrix: `[Debug]` → `[Release]`

**Promotes Debug.Assert to runtime checks** so coverage is strictly *better* than before:
- `GitStatusCache.cs` — two lock-discipline assertions → `InvalidOperationException`
- `QueuedPipeStringWriter.cs` — queue-drained assertion → `InvalidOperationException`
- `MockPhysicalGitObjects.cs` — null-stream assertion → `ArgumentNullException.ThrowIfNull`

## Why Debug CI had little value here

- **Zero `#if DEBUG` blocks** in the codebase — no Debug-only code paths exist
- **Only 3 `Debug.Assert` calls** total in production code (now promoted)
- **No custom `DefineConstants` or `CheckForOverflowUnderflow`** in build props
- The practical difference was: JIT/AOT optimizations on/off, and 3 assertions that are now always-on

## Impact

- ~50% reduction in CI runner usage per PR (1 fewer build, 20 fewer FT shards, 6 fewer upgrade-test jobs)
- Debug configuration remains fully buildable locally for dev inner-loop