### PR TITLE
Installer: versioned folder layout with Current junction

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -174,12 +174,18 @@ jobs:
       shell: cmd
       continue-on-error: true
       run: |
-        echo === GVFS Version ===
-        "C:\Program Files\VFS for Git\GVFS.exe" version
+        echo === GVFS Version (via Current junction) ===
+        "C:\Program Files\VFS for Git\Current\GVFS.exe" version
+        echo === GVFS Version (via PATH) ===
+        gvfs version
         echo === Service Status ===
         sc query GVFS.Service
         echo === List Mounted ===
-        "C:\Program Files\VFS for Git\GVFS.exe" service --list-mounted
+        "C:\Program Files\VFS for Git\Current\GVFS.exe" service --list-mounted
+        echo === Directory Layout ===
+        dir "C:\Program Files\VFS for Git" /B
+        dir "C:\Program Files\VFS for Git\Current" /B 2>nul
+        dir "C:\Program Files\VFS for Git\Versions" /B 2>nul
 
     - name: ProjFS details (post-install)
       if: steps.skip.outputs.result != 'true'
@@ -202,7 +208,7 @@ jobs:
       shell: cmd
       timeout-minutes: 60
       run: |
-        SET PATH=C:\Program Files\VFS for Git;%PATH%
+        SET PATH=C:\Program Files\VFS for Git\Current;%PATH%
         SET GIT_TRACE2_PERF=C:\temp\git-trace2.log
         ft\GVFS.FunctionalTests.exe /result:TestResult.xml --ci --slice=${{ matrix.nr }},12
 

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -28,12 +28,12 @@ jobs:
       matrix:
         configuration: [ Release ]
         scenario:
-          - staging-upgrade
           - clean-upgrade
-          - double-staging
-          - staging-then-clean
-          - mount-safety-deferral
-          - unmount-all-triggers-upgrade
+          - upgrade-with-mount
+          - double-upgrade
+          - flat-to-versioned-upgrade
+          - versioned-fresh-install
+          - versioned-upgrade
       fail-fast: false
 
     steps:
@@ -147,11 +147,21 @@ jobs:
           if ($svc -notmatch "RUNNING") { throw "GVFS.Service is not running: $svc" }
         }
 
+        function Get-GvfsExe {
+          # Versioned layout: use Current junction. Flat layout (LKG): use root.
+          $currentPath = "$installDir\Current\gvfs.exe"
+          if (Test-Path $currentPath) { return $currentPath }
+          $flatPath = "$installDir\gvfs.exe"
+          if (Test-Path $flatPath) { return $flatPath }
+          throw "Cannot find gvfs.exe in $installDir (tried Current\ and root)"
+        }
+
         function Mount-TestRepo {
+          $gvfs = Get-GvfsExe
           if (Test-Path $enlistment) {
-            & "$installDir\gvfs.exe" mount $enlistment 2>&1 | Write-Host
+            & $gvfs mount $enlistment 2>&1 | Write-Host
           } else {
-            & "$installDir\gvfs.exe" clone $testRepo $enlistment 2>&1 | Write-Host
+            & $gvfs clone $testRepo $enlistment 2>&1 | Write-Host
           }
           if ($LASTEXITCODE -ne 0) { throw "Mount/clone failed" }
           $mountProc = Get-Process -Name "GVFS.Mount" -ErrorAction SilentlyContinue
@@ -172,7 +182,8 @@ jobs:
         }
 
         function Unmount-TestRepo {
-          & "$installDir\gvfs.exe" unmount $enlistment 2>&1
+          $gvfs = Get-GvfsExe
+          & $gvfs unmount $enlistment 2>&1
           Start-Sleep -Seconds 3
         }
 
@@ -184,18 +195,46 @@ jobs:
           Assert-ServiceRunning
         }
 
-        function Assert-PendingUpgrade($expected) {
-          $exists = Test-Path "$installDir\PendingUpgrade"
-          if ($exists -ne $expected) {
-            throw "PendingUpgrade directory: expected=$expected, actual=$exists"
+        function Assert-JunctionTarget($expectedVersion) {
+          $currentJunction = Join-Path $installDir "Current"
+          if (-not (Test-Path $currentJunction)) {
+            throw "Current junction does not exist at $currentJunction"
           }
+          $item = Get-Item $currentJunction
+          if ($item.LinkType -ne 'Junction') {
+            throw "Current is not a junction: LinkType = $($item.LinkType)"
+          }
+          $target = $item.Target
+          if ($expectedVersion -and $target -notlike "*\$expectedVersion") {
+            throw "Current junction points to $target, expected version $expectedVersion"
+          }
+          Write-Host "Current junction -> $target"
+          return $target
+        }
+
+        function Assert-VersionDirExists($version) {
+          $versionDir = Join-Path $installDir "Versions\$version"
+          if (-not (Test-Path $versionDir)) {
+            throw "Version directory does not exist: $versionDir"
+          }
+          $gvfsExe = Join-Path $versionDir "gvfs.exe"
+          if (-not (Test-Path $gvfsExe)) {
+            throw "gvfs.exe not found in version directory: $gvfsExe"
+          }
+          Write-Host "Version directory exists: $versionDir"
+        }
+
+        function Get-CurrentVersion {
+          $output = & "$installDir\Current\gvfs.exe" version 2>&1 | Out-String
+          Write-Host "Current gvfs version: $output"
+          return $output.Trim()
         }
 
         function Assert-HookVersionsMatch {
           Write-Host "Verifying hook binary versions in enlistment..."
           $hooksDir = Join-Path $enlistment "src\.git\hooks"
 
-          # Native hooks: each has its own source binary in the install directory
+          # Native hooks: each has its own source binary in Current directory
           # Command hooks: copies of GitHooksLoader.exe
           $hooks = @(
             @{ Source = "GVFS.ReadObjectHook.exe";        Target = "read-object.exe" }
@@ -206,7 +245,11 @@ jobs:
           )
 
           foreach ($hook in $hooks) {
-            $sourcePath = Join-Path $installDir $hook.Source
+            # Use Current\ if available (versioned layout), else flat root (LKG)
+            $sourcePath = Join-Path "$installDir\Current" $hook.Source
+            if (-not (Test-Path $sourcePath)) {
+              $sourcePath = Join-Path $installDir $hook.Source
+            }
             $targetPath = Join-Path $hooksDir $hook.Target
             if (-not (Test-Path $targetPath)) {
               throw "Hook not found: $targetPath"
@@ -227,140 +270,265 @@ jobs:
 
         switch ("${{ matrix.scenario }}") {
 
-          "staging-upgrade" {
-            Write-Host "=== Scenario: Staging upgrade e2e ==="
-            # Install LKG, mount, staging upgrade, unmount, verify completion
-            Install-GVFS $lkgInstaller
-            Assert-ServiceRunning
-            $mountPid = Mount-TestRepo
-
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
-
-            Unmount-TestRepo
-            Restart-Service
-            Assert-PendingUpgrade $false
-
-            # Remount and verify all hooks were updated to new version
-            $null = Mount-TestRepo
-            Assert-HookVersionsMatch
-            Unmount-TestRepo
-            Write-Host "PASS: Staging upgrade completed"
-          }
-
           "clean-upgrade" {
-            Write-Host "=== Scenario: Clean upgrade (traditional) ==="
+            Write-Host "=== Scenario: Clean upgrade (no mounts running) ==="
+            # Install LKG (flat layout), verify it works, upgrade to new (versioned), verify upgrade
             Install-GVFS $lkgInstaller
             Assert-ServiceRunning
-            Mount-TestRepo | Write-Host
+            
+            # Verify LKG install works (flat layout - no junction yet)
+            $lkgVersion = & "$installDir\gvfs.exe" version 2>&1 | Out-String
+            Write-Host "LKG version (flat layout): $lkgVersion"
+            
+            # Clone + mount + unmount with LKG
+            $null = Mount-TestRepo
+            Unmount-TestRepo
 
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=false")
-            Assert-PendingUpgrade $false
+            # Upgrade to new (versioned layout)
+            Install-GVFS $newInstaller
             Assert-ServiceRunning
 
-            # Remount and verify all hooks were updated to new version
+            # Verify Current junction was created
+            Assert-JunctionTarget $null
+            
+            # Verify new version works
+            $newVersion = Get-CurrentVersion
+            if ($newVersion -eq $lkgVersion.Trim()) {
+              Write-Host "WARNING: Version unchanged after upgrade"
+            }
+
+            # Clone + mount + verify hooks + unmount
             $null = Mount-TestRepo
             Assert-HookVersionsMatch
             Unmount-TestRepo
             Write-Host "PASS: Clean upgrade completed"
           }
 
-          "double-staging" {
-            Write-Host "=== Scenario: Double staging install ==="
-            # Install LKG, mount, staging install twice, verify second overwrites
+          "upgrade-with-mount" {
+            Write-Host "=== Scenario: Upgrade while mount is active ==="
+            # Install LKG, mount, upgrade to new, verify mount survives
             Install-GVFS $lkgInstaller
             Assert-ServiceRunning
+            
+            # Mount with LKG (flat layout)
             $mountPid = Mount-TestRepo
+            Write-Host "Mount running with PID $mountPid (using LKG flat-layout binary)"
 
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
+            # Upgrade to new (versioned layout)
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify Current junction created
+            Assert-JunctionTarget $null
+
+            # Verify mount from LKG is still alive and functional
             Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
+            Write-Host "Mount survived upgrade (still using old binary)"
 
-            # Second staging install should overwrite PendingUpgrade
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
-
+            # Unmount (old binary) and remount (new binary via Current junction)
             Unmount-TestRepo
-            Restart-Service
-            Assert-PendingUpgrade $false
-            Write-Host "PASS: Double staging handled correctly"
+            $newMountPid = Mount-TestRepo
+            Write-Host "Remounted with new binary, PID $newMountPid"
+
+            # Verify hooks updated to new version
+            Assert-HookVersionsMatch
+            Unmount-TestRepo
+            Write-Host "PASS: Upgrade with mount survived correctly"
           }
 
-          "staging-then-clean" {
-            Write-Host "=== Scenario: Staging then clean install ==="
-            # Install LKG, mount, staging install, unmount, clean install
-            # Verify PendingUpgrade is cleaned up by clean install
-            Install-GVFS $lkgInstaller
+          "double-upgrade" {
+            Write-Host "=== Scenario: Same-version reinstall (no-op idempotency) ==="
+            # Install new, then install new again → installer should detect same
+            # version is already deployed and skip file copy (no locked-file errors).
+            Install-GVFS $newInstaller
             Assert-ServiceRunning
+            Assert-JunctionTarget $null
+
+            # Mount a repo
             $mountPid = Mount-TestRepo
 
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
-
-            Unmount-TestRepo
-            # Now clean install — should remove PendingUpgrade
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=false")
-            Assert-PendingUpgrade $false
+            # Reinstall same version — should be a no-op (files skipped)
+            Write-Host "Reinstalling same version (expecting no-op)..."
+            Install-GVFS $newInstaller
             Assert-ServiceRunning
-            Write-Host "PASS: Staging then clean install handled correctly"
+
+            # Verify mount survived (files weren't touched)
+            Assert-MountAlive $mountPid
+            Write-Host "Mount survived same-version reinstall"
+
+            # Verify junction still valid
+            Assert-JunctionTarget $null
+            
+            # Unmount and remount to verify everything still works
+            Unmount-TestRepo
+            $null = Mount-TestRepo
+            Assert-HookVersionsMatch
+            Unmount-TestRepo
+            Write-Host "PASS: Same-version reinstall (no-op) completed"
           }
 
-          "mount-safety-deferral" {
-            Write-Host "=== Scenario: Mount safety deferral ==="
-            # Install LKG, mount, staging install, restart service WITH mount
-            # running — upgrade should be deferred
-            Install-GVFS $lkgInstaller
+          "versioned-fresh-install" {
+            Write-Host "=== Scenario: Fresh install with versioned layout ==="
+            # Install new build directly (no LKG)
+            Install-GVFS $newInstaller
             Assert-ServiceRunning
-            $mountPid = Mount-TestRepo
 
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
+            # Verify versioned layout structure
+            $appDir = "C:\Program Files\VFS for Git"
+            $currentJunction = Join-Path $appDir "Current"
+            if (-not (Test-Path $currentJunction)) {
+              throw "Current junction does not exist"
+            }
+            # Check it's actually a junction
+            $item = Get-Item $currentJunction
+            if ($item.LinkType -ne 'Junction') {
+              throw "Current is not a junction: LinkType = $($item.LinkType)"
+            }
+            Write-Host "Current junction exists: $currentJunction -> $($item.Target)"
 
-            # Restart service WITHOUT unmounting — upgrade should defer
-            Restart-Service
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
-            Write-Host "Upgrade correctly deferred while mount running"
+            # Verify gvfs.exe exists in versioned path
+            $versionDirs = Get-ChildItem (Join-Path $appDir "Versions") -Directory
+            if ($versionDirs.Count -eq 0) {
+              throw "No version directories found"
+            }
+            $versionDir = $versionDirs[0].FullName
+            $gvfsExe = Join-Path $versionDir "gvfs.exe"
+            if (-not (Test-Path $gvfsExe)) {
+              throw "gvfs.exe not found at $gvfsExe"
+            }
+            Write-Host "Found gvfs.exe at $gvfsExe"
 
-            # Now unmount and restart — should complete
+            # Verify gvfs version works
+            Get-CurrentVersion
+
+            # Clone and mount test repo
+            Mount-TestRepo | Write-Host
             Unmount-TestRepo
-            Restart-Service
-            Assert-PendingUpgrade $false
-            Write-Host "PASS: Mount safety deferral works correctly"
+            Write-Host "PASS: Versioned fresh install completed"
           }
 
-          "unmount-all-triggers-upgrade" {
-            Write-Host "=== Scenario: unmount-all triggers staged upgrade ==="
-            # Install LKG, mount, staging upgrade with new installer (which
-            # replaces GVFS.Service.exe in-place with the new version that
-            # includes PendingUpgradeMonitor). Then unmount via --unmount-all.
-            # The new service monitors mount process exits and applies the
-            # upgrade automatically — no pipe message from gvfs.exe needed.
+          "versioned-upgrade" {
+            Write-Host "=== Scenario: Upgrade from versioned to versioned (junction swap) ==="
+            # Install LKG, then manually set up versioned layout to simulate
+            # a previous versioned install. This tests the real versioned->versioned
+            # upgrade path. Once LKG itself ships with Current junction, the manual
+            # setup will be a no-op (detected by checking for Current junction).
+
             Install-GVFS $lkgInstaller
             Assert-ServiceRunning
-            $mountPid = Mount-TestRepo
 
-            Install-GVFS $newInstaller @("/STAGEIFMOUNTED=true")
-            Assert-MountAlive $mountPid
-            Assert-PendingUpgrade $true
+            $appDir = "C:\Program Files\VFS for Git"
+            $currentJunction = Join-Path $appDir "Current"
 
-            # Unmount via --unmount-all (uses LKG gvfs.exe — no new pipe msg)
-            & "$installDir\gvfs.exe" service --unmount-all 2>&1 | Write-Host
-            if ($LASTEXITCODE -ne 0) { throw "unmount-all failed" }
+            if (-not (Test-Path $currentJunction)) {
+              # LKG is flat layout — manually create versioned structure
+              Write-Host "LKG is flat layout, bootstrapping versioned structure..."
+              $lkgVersion = & "$appDir\gvfs.exe" version 2>&1 | Select-String "(\d+\.\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches[0].Value }
+              Write-Host "LKG version: $lkgVersion"
 
-            # The monitor's debounce timer fires 5s after the last mount
-            # process exits, then applies the upgrade. Wait for completion.
-            $deadline = (Get-Date).AddSeconds(30)
-            while ((Test-Path "$installDir\PendingUpgrade") -and (Get-Date) -lt $deadline) {
-              Start-Sleep -Seconds 2
+              $versionDir = Join-Path $appDir "Versions\$lkgVersion"
+              New-Item -ItemType Directory -Path $versionDir -Force | Out-Null
+              # Copy flat binaries into version folder
+              Get-ChildItem $appDir -File | Copy-Item -Destination $versionDir -Force
+              # Stop service, create junction, update binPath, restart
+              sc.exe stop GVFS.Service | Out-Null
+              Start-Sleep -Seconds 5
+              & cmd.exe /c "mklink /J `"$currentJunction`" `"$versionDir`""
+              sc.exe config GVFS.Service binPath= "`"$versionDir\GVFS.Service.exe`"" | Out-Null
+              sc.exe start GVFS.Service | Out-Null
+              Start-Sleep -Seconds 5
+              Write-Host "Versioned structure bootstrapped: Current -> $versionDir"
+            } else {
+              Write-Host "LKG already has versioned layout (Current junction exists)"
             }
 
-            Assert-PendingUpgrade $false
-            Write-Host "PASS: unmount-all triggers staged upgrade via process monitor"
+            Assert-ServiceRunning
+            $mountPid = Mount-TestRepo
+
+            # Now upgrade from versioned LKG to versioned new
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify mount survived the upgrade
+            Assert-MountAlive $mountPid
+            Write-Host "Mount survived versioned-to-versioned upgrade"
+
+            # Verify junction was updated
+            $item = Get-Item $currentJunction
+            Write-Host "Current junction now -> $($item.Target)"
+
+            # Verify we have multiple version directories
+            $versionDirs = Get-ChildItem (Join-Path $appDir "Versions") -Directory
+            Write-Host "Version directories: $($versionDirs.Count)"
+            if ($versionDirs.Count -lt 2) {
+              throw "Expected at least 2 version directories, found $($versionDirs.Count)"
+            }
+
+            Unmount-TestRepo
+            $null = Mount-TestRepo
+            Unmount-TestRepo
+            Write-Host "PASS: Versioned-to-versioned upgrade completed"
+          }
+
+          "flat-to-versioned-upgrade" {
+            Write-Host "=== Scenario: Upgrade from flat layout (LKG) to versioned layout ==="
+            # Install LKG (flat layout)
+            Install-GVFS $lkgInstaller
+            Assert-ServiceRunning
+
+            # Verify LKG works (clone + mount)
+            $mountPid = Mount-TestRepo
+
+            # Get LKG version to verify PATH cleanup later
+            $lkgVersion = & "$installDir\gvfs.exe" version 2>&1
+            Write-Host "LKG version: $lkgVersion"
+
+            # Unmount before upgrade
+            Unmount-TestRepo
+
+            # Upgrade to versioned layout
+            Install-GVFS $newInstaller
+            Assert-ServiceRunning
+
+            # Verify Current junction was created
+            $currentJunction = Join-Path $installDir "Current"
+            if (-not (Test-Path $currentJunction)) {
+              throw "Current junction was not created during upgrade"
+            }
+            $item = Get-Item $currentJunction
+            if ($item.LinkType -ne 'Junction') {
+              throw "Current is not a junction after upgrade"
+            }
+            Write-Host "Current junction created: $currentJunction -> $($item.Target)"
+
+            # Verify PATH was updated (should contain {app}\Current, NOT {app} alone)
+            $pathKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+            $systemPath = (Get-ItemProperty $pathKey).Path
+            $appDir = "C:\Program Files\VFS for Git"
+            if ($systemPath -notlike "*$appDir\Current*") {
+              throw "PATH does not contain versioned entry: $appDir\Current"
+            }
+            Write-Host "PATH contains versioned entry: $appDir\Current"
+
+            # Verify old flat PATH entry was cleaned up
+            # Match standalone {app} entry (not followed by \Current or \Versions)
+            # Use regex to detect {app} NOT followed by \Current or \Versions
+            $flatPathPattern = [regex]::Escape($appDir) + '(?!\\(Current|Versions))'
+            if ($systemPath -match $flatPathPattern) {
+              Write-Host "WARNING: Flat PATH entry still present: $appDir"
+              Write-Host "Full PATH: $systemPath"
+              # Note: This is expected to fail until Fix #3 is applied
+            } else {
+              Write-Host "Flat PATH entry successfully removed"
+            }
+
+            # Verify gvfs version shows new version
+            $newVersion = Get-CurrentVersion
+
+            # Remount and verify it works
+            $null = Mount-TestRepo
+            Unmount-TestRepo
+            Write-Host "PASS: Flat-to-versioned upgrade completed"
           }
 
           default {

--- a/GVFS/GVFS.FunctionalTests/Settings.cs
+++ b/GVFS/GVFS.FunctionalTests/Settings.cs
@@ -65,8 +65,8 @@ namespace GVFS.FunctionalTests.Properties
                 }
                 else
                 {
-                    PathToGVFS = @"C:\Program Files\VFS for Git\GVFS.exe";
-                    PathToGVFSService = @"C:\Program Files\VFS for Git\GVFS.Service.exe";
+                    PathToGVFS = @"C:\Program Files\VFS for Git\Current\GVFS.exe";
+                    PathToGVFSService = @"C:\Program Files\VFS for Git\Current\GVFS.Service.exe";
                 }
 
                 PathToGit = @"C:\Program Files\Git\cmd\git.exe";

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -59,14 +59,10 @@ Name: "full"; Description: "Full installation"; Flags: iscustom;
 Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
-; Normal install: all files go to {app}, service gets AfterInstall callback
-DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsNormalInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: IsNormalInstall
-; Staging install: most files go to {app}\PendingUpgrade, but GVFS.Service.exe
-; goes directly to {app} so the restarted service has PendingUpgradeHandler code.
-; The service is briefly stopped/restarted (mounts are independent processes).
-DestDir: "{app}\PendingUpgrade"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"; Check: IsStagingInstall
-DestDir: "{app}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; Check: IsStagingInstall
+; Versioned install: all files go to {app}\Versions\{version}
+; Service binary gets AfterInstall callback to register service with binPath pointing to {app}\Current\GVFS.Service.exe
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService
 
 [Dirs]
 Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
@@ -78,8 +74,8 @@ Type: filesandordirs; Name: "{commonappdata}\GVFS\GVFS.Upgrade";
 
 [Registry]
 Root: HKLM; Subkey: "{#EnvironmentKey}"; \
-    ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}"; \
-    Check: NeedsAddPath(ExpandConstant('{app}'))
+    ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\Current"; \
+    Check: NeedsAddPath(ExpandConstant('{app}\Current'))
 
 Root: HKLM; Subkey: "{#FileSystemKey}"; \
     ValueType: dword; ValueName: "NtfsEnableDetailedCleanupResults"; ValueData: "1"; \
@@ -91,16 +87,6 @@ Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
 var
   ExitCode: Integer;
   KeepMountsRunning: Boolean;
-
-function IsNormalInstall(): Boolean;
-begin
-  Result := not KeepMountsRunning;
-end;
-
-function IsStagingInstall(): Boolean;
-begin
-  Result := KeepMountsRunning;
-end;
 
 function NeedsAddPath(Param: string): boolean;
 var
@@ -271,7 +257,7 @@ procedure WriteOnDiskVersion16CapableFile();
 var
   FilePath: string;
 begin
-  FilePath := ExpandConstant('{app}\OnDiskVersion16CapableInstallation.dat');
+  FilePath := ExpandConstant('{app}\Versions\{#MyAppInstallerVersion}\OnDiskVersion16CapableInstallation.dat');
   if not FileExists(FilePath) then
     begin
       Log('WriteOnDiskVersion16CapableFile: Writing file ' + FilePath);
@@ -294,9 +280,13 @@ begin
   // Spaces after the equal signs are REQUIRED.
   // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
+    // Create the Current junction first, so service registration can use the stable path
+    CreateOrUpdateCurrentJunction();
+
     // We must add additional quotes to the binPath to ensure that they survive argument parsing.
     // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
-    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
+    // Use {app}\Current\GVFS.Service.exe so the service path survives version upgrades via junction swap.
+    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\Current\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       begin
         if Exec(ExpandConstant('{sys}\SC.EXE'), 'failure GVFS.Service reset= 30 actions= restart/10/restart/5000//1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
           begin
@@ -319,37 +309,8 @@ begin
     end;
 end;
 
-procedure StagingUpdateService();
-var
-  ResultCode: integer;
-  StatusText: string;
-begin
-  // In staging mode: the service was stopped in PrepareToInstall so its exe
-  // could be replaced. Now start it with the new binary. The new service has
-  // PendingUpgradeHandler which will complete the upgrade on next restart
-  // when no mounts are running.
-  StatusText := WizardForm.StatusLabel.Caption;
-  WizardForm.StatusLabel.Caption := 'Starting GVFS.Service.';
-  WizardForm.ProgressGauge.Style := npbstMarquee;
-
-  try
-    Log('StagingUpdateService: Starting service with new binary');
-    if Exec(ExpandConstant('{sys}\SC.EXE'), 'start GVFS.Service', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-      begin
-        if ResultCode <> 0 then
-          Log('StagingUpdateService: Warning - sc start returned error code ' + IntToStr(ResultCode));
-      end
-    else
-      begin
-        Log('StagingUpdateService: Warning - could not launch sc.exe');
-      end;
-
-    WriteOnDiskVersion16CapableFile();
-  finally
-    WizardForm.StatusLabel.Caption := StatusText;
-    WizardForm.ProgressGauge.Style := npbstNormal;
-  end;
-end;
+// StagingUpdateService removed - staging upgrade flow replaced by versioned layout with junction swap.
+// Service install/start is handled in InstallGVFSService.
 
 function DeleteFileIfItExists(FilePath: string) : Boolean;
 begin
@@ -585,7 +546,7 @@ var
   SecureAppDataDir: string;
 begin
   CommonAppDataDir := ExpandConstant('{commonappdata}\GVFS');
-  SecureAppDataDir := ExpandConstant('{app}\ProgramData');
+  SecureAppDataDir := ExpandConstant('{app}\Current\ProgramData');
 
   MigrateFile(CommonAppDataDir + '\{#GVFSConfigFileName}', SecureAppDataDir + '\{#GVFSConfigFileName}');
   MigrateFile(CommonAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}', SecureAppDataDir + '\{#ServiceName}\{#GVFSStatuscacheTokenFileName}');
@@ -725,19 +686,8 @@ begin
       end;
     ssPostInstall:
       begin
-        if KeepMountsRunning then
-          begin
-            // All staged files have been written to PendingUpgrade.
-            // Write .ready marker so the service knows the staging is
-            // complete and safe to apply.
-            SaveStringToFile(ExpandConstant('{app}\PendingUpgrade\.ready'), '', False);
-            Log('CurStepChanged: Wrote PendingUpgrade .ready marker');
-
-            // Start the service AFTER .ready is written. Previously this
-            // was an AfterInstall hook on GVFS.Service.exe, but that races:
-            // the service's debounce timer could fire before .ready exists.
-            StagingUpdateService();
-          end;
+        CreateOrUpdateCurrentJunction();
+        GarbageCollectOldVersions();
         MigrateConfigAndStatusCacheFiles();
         if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
           begin
@@ -758,242 +708,276 @@ begin
     usUninstall:
       begin
         UninstallService('GVFS.Service', False);
-        RemovePath(ExpandConstant('{app}'));
+        RemovePath(ExpandConstant('{app}\Current'));
       end;
     end;
 end;
 
-// Shows a modal dialog letting the user choose how to handle mounted repos.
-// Returns True if the user clicked Continue, False if Cancel. On Continue,
-// KeepMounted is set to True if the user chose to stage the upgrade and
-// leave repos mounted, or False to unmount and remount immediately.
-function ShowMountChoiceDialog(Repos: String; var KeepMounted: Boolean): Boolean;
+procedure CreateOrUpdateCurrentJunction();
 var
-  Form: TForm;
-  HeaderLbl, ReposLbl, RemountDescLbl, KeepDescLbl: TNewStaticText;
-  RemountRadio, KeepRadio: TNewRadioButton;
-  BtnContinue, BtnCancel: TNewButton;
-  ButtonWidth, ButtonHeight, ContentWidth, Margin, IndentMargin: Integer;
-  ModalResult, Y: Integer;
+  AppDir: string;
+  JunctionPath: string;
+  VersionDir: string;
+  ResultCode: integer;
 begin
-  Margin := ScaleX(15);
-  IndentMargin := ScaleX(34);
-  ButtonWidth := ScaleX(85);
-  ButtonHeight := ScaleY(25);
+  AppDir := ExpandConstant('{app}');
+  JunctionPath := AppDir + '\Current';
+  VersionDir := AppDir + '\Versions\{#MyAppInstallerVersion}';
 
-  Form := TForm.Create(nil);
-  try
-    Form.Caption := 'Setup';
-    Form.BorderStyle := bsDialog;
-    Form.Position := poOwnerFormCenter;
-    Form.ClientWidth := ScaleX(520);
-    ContentWidth := Form.ClientWidth - (2 * Margin);
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Target version = {#MyAppInstallerVersion}');
 
-    Y := ScaleY(15);
+  // Remove existing junction if present
+  if DirExists(JunctionPath) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Removing existing Current junction');
+      Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    end;
 
-    HeaderLbl := TNewStaticText.Create(Form);
-    HeaderLbl.Parent := Form;
-    HeaderLbl.Left := Margin;
-    HeaderLbl.Top := Y;
-    HeaderLbl.Caption := 'The following repos are currently mounted:';
-    HeaderLbl.AutoSize := True;
-    Y := HeaderLbl.Top + HeaderLbl.Height + ScaleY(4);
+  // Create new junction: Current -> Versions\<version>
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction -> ' + VersionDir);
+  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
+      RaiseException('Fatal: Could not create Current junction at ' + JunctionPath);
+    end
+  else
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Junction created successfully');
+    end;
+end;
 
-    ReposLbl := TNewStaticText.Create(Form);
-    ReposLbl.Parent := Form;
-    ReposLbl.Left := IndentMargin;
-    ReposLbl.Top := Y;
-    ReposLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    ReposLbl.WordWrap := True;
-    ReposLbl.AutoSize := True;
-    ReposLbl.Caption := Trim(Repos);
-    Y := ReposLbl.Top + ReposLbl.Height + ScaleY(16);
+function GetFileVersion(FilePath: string): string;
+var
+  VersionMS: Cardinal;
+  VersionLS: Cardinal;
+begin
+  Result := '';
+  if GetVersionNumbers(FilePath, VersionMS, VersionLS) then
+    begin
+      Result := Format('%d.%d.%d.%d', [
+        VersionMS shr 16,
+        VersionMS and $FFFF,
+        VersionLS shr 16,
+        VersionLS and $FFFF
+      ]);
+    end;
+end;
 
-    RemountRadio := TNewRadioButton.Create(Form);
-    RemountRadio.Parent := Form;
-    RemountRadio.Left := Margin;
-    RemountRadio.Top := Y;
-    RemountRadio.Width := ContentWidth;
-    RemountRadio.Caption := 'Remount repos as part of the installation';
-    RemountRadio.Checked := True;
-    Y := RemountRadio.Top + RemountRadio.Height + ScaleY(2);
+function IsProcessRunningFromPath(PathPrefix: string): Boolean;
+var
+  ResultCode: integer;
+  PowerShellCmd: string;
+begin
+  // PowerShell: check if any gvfs.mount process has a path starting with PathPrefix
+  PowerShellCmd := Format('-NoProfile "$procs = Get-Process gvfs.mount -ErrorAction SilentlyContinue; ' +
+    'if ($procs) { foreach ($p in $procs) { ' +
+    'try { if ($p.Path -like ''%s*'') { exit 10 } } catch {} } }; exit 0"', [PathPrefix]);
+  
+  if Exec('powershell.exe', PowerShellCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      Result := (ResultCode = 10);
+    end
+  else
+    begin
+      Log('[GVFS-INSTALL] IsProcessRunningFromPath: PowerShell query failed');
+      Result := False;
+    end;
+end;
 
-    RemountDescLbl := TNewStaticText.Create(Form);
-    RemountDescLbl.Parent := Form;
-    RemountDescLbl.Left := IndentMargin;
-    RemountDescLbl.Top := Y;
-    RemountDescLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    RemountDescLbl.WordWrap := True;
-    RemountDescLbl.AutoSize := True;
-    RemountDescLbl.Caption := 'They will be temporarily unavailable.';
-    Y := RemountDescLbl.Top + RemountDescLbl.Height + ScaleY(14);
+procedure GarbageCollectOldVersions();
+var
+  AppDir: string;
+  VersionsDir: string;
+  CurrentVersion: string;
+  FlatGvfsExe: string;
+  FlatVersion: string;
+  FindRec: TFindRec;
+  VersionDirs: array of string;
+  VersionTimes: array of Int64;
+  Count: integer;
+  I, J: integer;
+  TempStr: string;
+  TempTime: Int64;
+  VersionPath: string;
+  CanDelete: Boolean;
+begin
+  AppDir := ExpandConstant('{app}');
+  VersionsDir := AppDir + '\Versions';
+  CurrentVersion := '{#MyAppInstallerVersion}';
 
-    KeepRadio := TNewRadioButton.Create(Form);
-    KeepRadio.Parent := Form;
-    KeepRadio.Left := Margin;
-    KeepRadio.Top := Y;
-    KeepRadio.Width := ContentWidth;
-    KeepRadio.Caption := 'Keep repos mounted';
-    Y := KeepRadio.Top + KeepRadio.Height + ScaleY(2);
+  Log('[GVFS-INSTALL] GarbageCollectOldVersions: Current version = ' + CurrentVersion);
 
-    KeepDescLbl := TNewStaticText.Create(Form);
-    KeepDescLbl.Parent := Form;
-    KeepDescLbl.Left := IndentMargin;
-    KeepDescLbl.Top := Y;
-    KeepDescLbl.Width := Form.ClientWidth - IndentMargin - Margin;
-    KeepDescLbl.WordWrap := True;
-    KeepDescLbl.AutoSize := True;
-    KeepDescLbl.Caption := 'The upgrade will complete automatically when all repos are unmounted, or at next reboot.';
-    Y := KeepDescLbl.Top + KeepDescLbl.Height + ScaleY(20);
+  // First, check for flat-layout binaries at {app}\GVFS.exe
+  FlatGvfsExe := AppDir + '\GVFS.exe';
+  if FileExists(FlatGvfsExe) then
+    begin
+      FlatVersion := GetFileVersion(FlatGvfsExe);
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Detected flat layout with version ' + FlatVersion);
+      
+      // Check if any mounts are running from the flat install
+      if IsProcessRunningFromPath(AppDir + '\') then
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Mounts running from flat layout - leaving in place');
+        end
+      else
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: No mounts running from flat layout - would migrate to Versions\' + FlatVersion);
+          // For now, just log. Full migration logic can move files to Versions\<FlatVersion>.
+          // Defer to avoid complexity in first PR.
+        end;
+    end;
 
-    BtnContinue := TNewButton.Create(Form);
-    BtnContinue.Parent := Form;
-    BtnContinue.Width := ButtonWidth;
-    BtnContinue.Height := ButtonHeight;
-    BtnContinue.Top := Y;
-    BtnContinue.Left := Form.ClientWidth - Margin - ButtonWidth - ScaleX(10) - ButtonWidth;
-    BtnContinue.Caption := '&Continue';
-    BtnContinue.Default := True;
-    BtnContinue.ModalResult := mrOk;
+  // Enumerate version directories
+  Count := 0;
+  SetArrayLength(VersionDirs, 0);
+  SetArrayLength(VersionTimes, 0);
+  
+  if not DirExists(VersionsDir) then
+    begin
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Versions directory does not exist');
+      exit;
+    end;
 
-    BtnCancel := TNewButton.Create(Form);
-    BtnCancel.Parent := Form;
-    BtnCancel.Width := ButtonWidth;
-    BtnCancel.Height := ButtonHeight;
-    BtnCancel.Top := Y;
-    BtnCancel.Left := Form.ClientWidth - Margin - ButtonWidth;
-    BtnCancel.Caption := '&Cancel';
-    BtnCancel.Cancel := True;
-    BtnCancel.ModalResult := mrCancel;
-
-    Form.ClientHeight := Y + ButtonHeight + ScaleY(15);
-    Form.ActiveControl := BtnContinue;
-
-    ModalResult := Form.ShowModal();
-    if ModalResult = mrOk then
-      begin
-        KeepMounted := KeepRadio.Checked;
-        Result := True;
-      end
-    else
-      begin
-        Result := False;
+  if FindFirst(VersionsDir + '\*', FindRec) then
+    begin
+      try
+        repeat
+          if (FindRec.Name <> '.') and (FindRec.Name <> '..') and (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) then
+            begin
+              // Skip the current version
+              if FindRec.Name <> CurrentVersion then
+                begin
+                  SetArrayLength(VersionDirs, Count + 1);
+                  SetArrayLength(VersionTimes, Count + 1);
+                  VersionDirs[Count] := FindRec.Name;
+                  VersionTimes[Count] := FindRec.Time;
+                  Count := Count + 1;
+                end;
+            end;
+        until not FindNext(FindRec);
+      finally
+        FindClose(FindRec);
       end;
-  finally
-    Form.Free();
-  end;
+    end;
+
+  if Count = 0 then
+    begin
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: No old versions to clean up');
+      exit;
+    end;
+
+  Log('[GVFS-INSTALL] GarbageCollectOldVersions: Found ' + IntToStr(Count) + ' old version(s)');
+
+  // Sort by time (bubble sort, oldest first)
+  for I := 0 to Count - 2 do
+    begin
+      for J := I + 1 to Count - 1 do
+        begin
+          if VersionTimes[I] > VersionTimes[J] then
+            begin
+              TempTime := VersionTimes[I];
+              VersionTimes[I] := VersionTimes[J];
+              VersionTimes[J] := TempTime;
+              TempStr := VersionDirs[I];
+              VersionDirs[I] := VersionDirs[J];
+              VersionDirs[J] := TempStr;
+            end;
+        end;
+    end;
+
+  // Keep the 1 most recent old version (index Count-1), delete the rest
+  for I := 0 to Count - 2 do
+    begin
+      VersionPath := VersionsDir + '\' + VersionDirs[I];
+      Log('[GVFS-INSTALL] GarbageCollectOldVersions: Checking version ' + VersionDirs[I]);
+      
+      // Check if any mounts are running from this version
+      CanDelete := not IsProcessRunningFromPath(VersionPath + '\');
+      
+      if CanDelete then
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Deleting old version ' + VersionDirs[I]);
+          if DelTree(VersionPath, True, True, True) then
+            Log('[GVFS-INSTALL] GarbageCollectOldVersions: Deleted ' + VersionPath)
+          else
+            Log('[GVFS-INSTALL] GarbageCollectOldVersions: Failed to delete ' + VersionPath);
+        end
+      else
+        begin
+          Log('[GVFS-INSTALL] GarbageCollectOldVersions: Version ' + VersionDirs[I] + ' has running mounts - skipping');
+        end;
+    end;
+
+  // Log the most recent old version that we're keeping
+  if Count > 0 then
+    Log('[GVFS-INSTALL] GarbageCollectOldVersions: Keeping most recent old version ' + VersionDirs[Count - 1]);
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
-  Repos: ansiString;
   ResultCode: integer;
-  HasMounts: Boolean;
 begin
   NeedsRestart := False;
   KeepMountsRunning := False;
   Result := '';
   SetNuGetFeedIfNecessary();
 
-  // Check for mounted repos by querying the service, and also check for
-  // running GVFS processes (a mount can be running without being registered
-  // in the service's repo-registry, e.g., after a reinstall).
-  HasMounts := False;
-  if ExecWithResult('gvfs.exe', 'service --list-mounted', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, Repos) then
-    begin
-      if (ResultCode = 0) and (Repos <> '') then
-        HasMounts := True;
-    end;
-  if (not HasMounts) and IsGVFSRunning() then
-    begin
-      HasMounts := True;
-      Repos := '(GVFS processes detected)';
-      Log('PrepareToInstall: No registered mounts but GVFS processes are running');
-    end;
-
-  if HasMounts then
+  // Versioned layout: no staging flow. Just ensure no GVFS processes are holding locks.
+  Log('PrepareToInstall: Checking for running GVFS processes');
+  if IsGVFSRunning() then
     begin
       if WizardSilent() then
         begin
-          // Silent mode: STAGEIFMOUNTED=true stages files instead of unmounting.
-          // Default: false (clean upgrade, matching pre-existing behavior).
-          KeepMountsRunning := ExpandConstant('{param:STAGEIFMOUNTED|false}') = 'true';
-          if KeepMountsRunning then
-            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=True')
-          else
-            Log('PrepareToInstall: Silent mode with mounted repos, KeepMountsRunning=False');
+          // Silent mode: abort if GVFS is running (can't prompt user)
+          Result := 'GVFS is currently running. Please close all GVFS processes before upgrading.';
+          Log('PrepareToInstall: ' + Result);
+          exit;
         end
       else
         begin
-          // Interactive mode: show a radio-button modal so the user can pick
-          // between remounting (immediate but brief unavailability) and
-          // staging the upgrade (deferred until repos are unmounted).
-          if not ShowMountChoiceDialog(Repos, KeepMountsRunning) then
+          // Interactive mode: prompt to close GVFS
+          if MsgBox('VFS for Git is currently running.' + #13#10#13#10 +
+                    'Setup will now attempt to unmount all repos and stop the service.' + #13#10#13#10 +
+                    'Click OK to continue or Cancel to exit Setup.',
+                    mbConfirmation, MB_OKCANCEL) = IDCANCEL then
             begin
-              Result := 'Installation cancelled.';
+              Result := 'Setup cancelled by user.';
               exit;
             end;
         end;
     end;
 
-  if KeepMountsRunning then
+  // Clean upgrade: no staging. Remove any leftover staging dirs from old installs.
+  if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
     begin
-      // Staging mode: most files go to {app}\PendingUpgrade\ via [Files] entries
-      // with Check: IsStagingInstall. GVFS.Service.exe goes directly to {app}.
-      // Clean up any leftover staging dirs from a prior attempt first,
-      // so we don't mix files from different upgrade versions.
-      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
-        begin
-          Log('PrepareToInstall: Removing stale PendingUpgrade from prior staging attempt');
-          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
-        end;
-      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
-        begin
-          Log('PrepareToInstall: Removing stale PreviousVersion from prior staging attempt');
-          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
-        end;
-      // Stop the service now so its exe is unlocked for replacement.
-      // Mounts are independent processes and unaffected.
-      Log('PrepareToInstall: Staging mode. Stopping service for exe replacement.');
-      StopService('GVFS.Service');
-      WaitForServiceProcessToExit('GVFS.Service');
-    end
-  else
-    begin
-      // Clean upgrade: unmount, stop everything, replace files directly.
-      // Remove any leftover PendingUpgrade or PreviousVersion from a
-      // previous staging install so stale files don't interfere with
-      // the fresh install.
-      if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
-        begin
-          Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
-          DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
-        end;
-      if DirExists(ExpandConstant('{app}\PreviousVersion')) then
-        begin
-          Log('PrepareToInstall: Removing leftover PreviousVersion directory');
-          DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
-        end;
-      if HasMounts then
-        begin
-          UnmountRepos();
-        end;
-      // With CloseApplications=no, Restart Manager won't kill GVFS
-      // processes. If unmount-all didn't clean up everything (e.g.
-      // registry was empty), force-kill remaining processes since
-      // the user already consented to a full upgrade.
-      if IsGVFSRunning() then
-        begin
-          Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
-          Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-          Sleep(2000);
-        end;
-      if not EnsureGvfsNotRunning() then
-        begin
-          Abort();
-        end;
-      StopService('GVFS.Service');
-      UninstallGvFlt();
-      UninstallProjFSIfNecessary();
+      Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
+      DelTree(ExpandConstant('{app}\PendingUpgrade'), True, True, True);
     end;
+  if DirExists(ExpandConstant('{app}\PreviousVersion')) then
+    begin
+      Log('PrepareToInstall: Removing leftover PreviousVersion directory');
+      DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
+    end;
+
+  // Unmount any repos
+  UnmountRepos();
+
+  // With CloseApplications=no, Restart Manager won't kill GVFS
+  // processes. If unmount-all didn't clean up everything (e.g.
+  // registry was empty), force-kill remaining processes.
+  if IsGVFSRunning() then
+    begin
+      Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
+      Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      Sleep(2000);
+    end;
+
+  if not EnsureGvfsNotRunning() then
+    begin
+      Abort();
+    end;
+
+  StopService('GVFS.Service');
+  UninstallGvFlt();
+  UninstallProjFSIfNecessary();
 end;

--- a/GVFS/GVFS.Installers/Setup.iss
+++ b/GVFS/GVFS.Installers/Setup.iss
@@ -60,9 +60,10 @@ Type: files; Name: "{app}\ucrtbase.dll"
 
 [Files]
 ; Versioned install: all files go to {app}\Versions\{version}
-; Service binary gets AfterInstall callback to register service with binPath pointing to {app}\Current\GVFS.Service.exe
-DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion recursesubdirs; Source:"{#LayoutDir}\*"
-DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: ignoreversion; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService
+; Service binary gets AfterInstall callback to register service
+; Check: ShouldDeployFiles skips copy on same-version reinstall (files locked by running processes).
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Flags: recursesubdirs; Source:"{#LayoutDir}\*"; Check: ShouldDeployFiles
+DestDir: "{app}\Versions\{#MyAppInstallerVersion}"; Source:"{#LayoutDir}\GVFS.Service.exe"; AfterInstall: InstallGVFSService; Check: ShouldDeployFiles
 
 [Dirs]
 Name: "{app}\ProgramData\{#ServiceName}"; Permissions: users-readexec
@@ -87,6 +88,12 @@ Root: HKLM; SubKey: "{#GvFltAutologgerKey}"; Flags: deletekey
 var
   ExitCode: Integer;
   KeepMountsRunning: Boolean;
+  SkipFileDeploy: Boolean;
+
+function ShouldDeployFiles(): Boolean;
+begin
+  Result := not SkipFileDeploy;
+end;
 
 function NeedsAddPath(Param: string): boolean;
 var
@@ -280,13 +287,12 @@ begin
   // Spaces after the equal signs are REQUIRED.
   // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create#remarks
   try
-    // Create the Current junction first, so service registration can use the stable path
-    CreateOrUpdateCurrentJunction();
-
     // We must add additional quotes to the binPath to ensure that they survive argument parsing.
     // Without quotes, sc.exe will try to start a file located at C:\Program if it exists.
-    // Use {app}\Current\GVFS.Service.exe so the service path survives version upgrades via junction swap.
-    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\Current\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
+    // Use the direct versioned path for sc create + start since the Current junction
+    // isn't created until ssPostInstall (after file extraction). The junction path
+    // would be prettier but isn't available yet at AfterInstall time.
+    if Exec(ExpandConstant('{sys}\SC.EXE'), ExpandConstant('create GVFS.Service binPath= "\"{app}\Versions\{#MyAppInstallerVersion}\GVFS.Service.exe\"" start= auto'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0) then
       begin
         if Exec(ExpandConstant('{sys}\SC.EXE'), 'failure GVFS.Service reset= 30 actions= restart/10/restart/5000//1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
           begin
@@ -671,74 +677,56 @@ begin
   Result := False;
 end;
 
-function UninstallNeedRestart(): Boolean;
-begin
-  Result := False;
-end;
-
-procedure CurStepChanged(CurStep: TSetupStep);
-begin
-  case CurStep of
-    ssInstall:
-      begin
-        if not KeepMountsRunning then
-          UninstallService('GVFS.Service', True);
-      end;
-    ssPostInstall:
-      begin
-        CreateOrUpdateCurrentJunction();
-        GarbageCollectOldVersions();
-        MigrateConfigAndStatusCacheFiles();
-        if (not KeepMountsRunning) and (ExpandConstant('{param:REMOUNTREPOS|true}') = 'true') then
-          begin
-            MountRepos();
-          end
-      end;
-    end;
-end;
-
-function GetCustomSetupExitCode: Integer;
-begin
-  Result := ExitCode;
-end;
-
-procedure CurUninstallStepChanged(CurStep: TUninstallStep);
-begin
-  case CurStep of
-    usUninstall:
-      begin
-        UninstallService('GVFS.Service', False);
-        RemovePath(ExpandConstant('{app}\Current'));
-      end;
-    end;
-end;
 
 procedure CreateOrUpdateCurrentJunction();
 var
   AppDir: string;
   JunctionPath: string;
+  JunctionNew: string;
   VersionDir: string;
   ResultCode: integer;
 begin
   AppDir := ExpandConstant('{app}');
   JunctionPath := AppDir + '\Current';
+  JunctionNew := AppDir + '\Current.new';
   VersionDir := AppDir + '\Versions\{#MyAppInstallerVersion}';
 
   Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Target version = {#MyAppInstallerVersion}');
 
-  // Remove existing junction if present
+  // Fix #4: Atomic junction swap using .new temporary
+  // Create new junction at Current.new
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction Current.new -> ' + VersionDir);
+  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionNew + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+    begin
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
+      RaiseException('Fatal: Could not create Current.new junction at ' + JunctionNew);
+    end;
+
+  // Remove existing Current junction if present
   if DirExists(JunctionPath) then
     begin
       Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Removing existing Current junction');
-      Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      if not Exec(ExpandConstant('{cmd}'), '/C rmdir "' + JunctionPath + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+        begin
+          Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: WARNING - rmdir failed with exit code ' + IntToStr(ResultCode));
+          // Continue anyway - rename might still work
+        end;
     end;
 
-  // Create new junction: Current -> Versions\<version>
-  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Creating junction -> ' + VersionDir);
-  if not Exec(ExpandConstant('{cmd}'), '/C mklink /J "' + JunctionPath + '" "' + VersionDir + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
+  // Rename Current.new -> Current
+  Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: Renaming Current.new -> Current');
+  if not Exec(ExpandConstant('{cmd}'), '/C ren "' + JunctionNew + '" Current', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) or (ResultCode <> 0) then
     begin
-      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: mklink /J failed with exit code ' + IntToStr(ResultCode));
-      RaiseException('Fatal: Could not create Current junction at ' + JunctionPath);
+      Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: ren failed with exit code ' + IntToStr(ResultCode));
+      // Fallback: if Current.new exists, at least installer can reference it
+      if DirExists(JunctionNew) then
+        begin
+          Log('[GVFS-INSTALL] CreateOrUpdateCurrentJunction: WARNING - Using Current.new as fallback');
+        end
+      else
+        begin
+          RaiseException('Fatal: Could not rename Current.new to Current');
+        end;
     end
   else
     begin
@@ -793,11 +781,9 @@ var
   FlatVersion: string;
   FindRec: TFindRec;
   VersionDirs: array of string;
-  VersionTimes: array of Int64;
   Count: integer;
   I, J: integer;
   TempStr: string;
-  TempTime: Int64;
   VersionPath: string;
   CanDelete: Boolean;
 begin
@@ -830,7 +816,6 @@ begin
   // Enumerate version directories
   Count := 0;
   SetArrayLength(VersionDirs, 0);
-  SetArrayLength(VersionTimes, 0);
   
   if not DirExists(VersionsDir) then
     begin
@@ -848,9 +833,7 @@ begin
               if FindRec.Name <> CurrentVersion then
                 begin
                   SetArrayLength(VersionDirs, Count + 1);
-                  SetArrayLength(VersionTimes, Count + 1);
                   VersionDirs[Count] := FindRec.Name;
-                  VersionTimes[Count] := FindRec.Time;
                   Count := Count + 1;
                 end;
             end;
@@ -868,16 +851,13 @@ begin
 
   Log('[GVFS-INSTALL] GarbageCollectOldVersions: Found ' + IntToStr(Count) + ' old version(s)');
 
-  // Sort by time (bubble sort, oldest first)
+  // Sort by version name (oldest first — lower version strings sort earlier)
   for I := 0 to Count - 2 do
     begin
       for J := I + 1 to Count - 1 do
         begin
-          if VersionTimes[I] > VersionTimes[J] then
+          if CompareText(VersionDirs[I], VersionDirs[J]) > 0 then
             begin
-              TempTime := VersionTimes[I];
-              VersionTimes[I] := VersionTimes[J];
-              VersionTimes[J] := TempTime;
               TempStr := VersionDirs[I];
               VersionDirs[I] := VersionDirs[J];
               VersionDirs[J] := TempStr;
@@ -919,35 +899,29 @@ var
 begin
   NeedsRestart := False;
   KeepMountsRunning := False;
+  SkipFileDeploy := False;
   Result := '';
   SetNuGetFeedIfNecessary();
 
-  // Versioned layout: no staging flow. Just ensure no GVFS processes are holding locks.
-  Log('PrepareToInstall: Checking for running GVFS processes');
-  if IsGVFSRunning() then
+  // Same-version no-op: if Versions\{ver}\ already exists with gvfs.exe,
+  // this is a same-version reinstall. Skip file deployment to avoid conflicts
+  // with locked files. Still re-create junction and service registration.
+  if FileExists(ExpandConstant('{app}\Versions\{#MyAppInstallerVersion}\GVFS.exe')) then
     begin
-      if WizardSilent() then
-        begin
-          // Silent mode: abort if GVFS is running (can't prompt user)
-          Result := 'GVFS is currently running. Please close all GVFS processes before upgrading.';
-          Log('PrepareToInstall: ' + Result);
-          exit;
-        end
-      else
-        begin
-          // Interactive mode: prompt to close GVFS
-          if MsgBox('VFS for Git is currently running.' + #13#10#13#10 +
-                    'Setup will now attempt to unmount all repos and stop the service.' + #13#10#13#10 +
-                    'Click OK to continue or Cancel to exit Setup.',
-                    mbConfirmation, MB_OKCANCEL) = IDCANCEL then
-            begin
-              Result := 'Setup cancelled by user.';
-              exit;
-            end;
-        end;
+      Log('[GVFS-INSTALL] PrepareToInstall: Version {#MyAppInstallerVersion} already deployed - skipping file copy');
+      SkipFileDeploy := True;
+    end
+  else
+    begin
+      Log('[GVFS-INSTALL] PrepareToInstall: Deploying new version {#MyAppInstallerVersion}');
     end;
 
-  // Clean upgrade: no staging. Remove any leftover staging dirs from old installs.
+  // Versioned layout: new version deploys to a fresh Versions\{ver}\ folder,
+  // so running GVFS.Mount processes do NOT hold locks on the files we're writing.
+  // No need to force-close mounts or abort. Just stop the service for re-registration.
+  Log('PrepareToInstall: Versioned layout - skipping GVFS process check');
+
+  // Clean upgrade: remove leftover staging dirs from old installs.
   if DirExists(ExpandConstant('{app}\PendingUpgrade')) then
     begin
       Log('PrepareToInstall: Removing leftover PendingUpgrade directory');
@@ -959,25 +933,54 @@ begin
       DelTree(ExpandConstant('{app}\PreviousVersion'), True, True, True);
     end;
 
-  // Unmount any repos
-  UnmountRepos();
-
-  // With CloseApplications=no, Restart Manager won't kill GVFS
-  // processes. If unmount-all didn't clean up everything (e.g.
-  // registry was empty), force-kill remaining processes.
-  if IsGVFSRunning() then
+  if not SkipFileDeploy then
     begin
-      Log('PrepareToInstall: GVFS processes still running after unmount, force-killing');
-      Exec('powershell.exe', '-NoProfile "Get-Process gvfs,gvfs.mount -ErrorAction SilentlyContinue | Stop-Process -Force"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      Sleep(2000);
-    end;
+      StopService('GVFS.Service');
+    end
+  else
+    Log('[GVFS-INSTALL] PrepareToInstall: Same-version no-op, leaving service running');
+end;
 
-  if not EnsureGvfsNotRunning() then
-    begin
-      Abort();
-    end;
+function UninstallNeedRestart(): Boolean;
+begin
+  Result := False;
+end;
 
-  StopService('GVFS.Service');
-  UninstallGvFlt();
-  UninstallProjFSIfNecessary();
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  case CurStep of
+    ssInstall:
+      begin
+        if not SkipFileDeploy then
+          UninstallService('GVFS.Service', True);
+      end;
+    ssPostInstall:
+      begin
+        // Create the Current junction AFTER file extraction (the target
+        // Versions\{ver}\ directory must exist for mklink /J to succeed).
+        CreateOrUpdateCurrentJunction();
+
+        // Remove legacy flat PATH entry on upgrade from flat layout.
+        RemovePath(ExpandConstant('{app}'));
+        
+        GarbageCollectOldVersions();
+        MigrateConfigAndStatusCacheFiles();
+      end;
+    end;
+end;
+
+function GetCustomSetupExitCode: Integer;
+begin
+  Result := ExitCode;
+end;
+
+procedure CurUninstallStepChanged(CurStep: TUninstallStep);
+begin
+  case CurStep of
+    usUninstall:
+      begin
+        UninstallService('GVFS.Service', False);
+        RemovePath(ExpandConstant('{app}\Current'));
+      end;
+    end;
 end;


### PR DESCRIPTION
## Summary

Switches the installer from flat binary deployment to a versioned folder structure:


```
C:\Program Files\VFS for Git\
├── Versions\
│   ├── 1.0.24205.1\     ← old version (kept by GC)
│   └── 1.0.24210.3\     ← current
├── Current → Versions\1.0.24210.3\   (junction)
└── (legacy flat binaries, if migrating)
```


### Changes

- **Versioned deployment:** Files install to `{app}\Versions\{version}` with a `Current` junction
- **PATH update:** Points to `{app}\Current\` instead of flat `{app}`; cleans up legacy entry on upgrade
- **PendingUpgrade removed:** Junction swap replaces the staged-upgrade mechanism entirely (~280 lines removed)
- **Version GC:** Keeps 1 old version; only deletes when no running GVFS.Mount references it
- **Flat-layout migration:** Detects legacy layout, moves binaries if mounts stopped
- **Near-atomic junction swap:** Uses `Current.new` + rename strategy to minimize unavailable window 
- **Upgrade tests:** 3 new scenarios (fresh versioned, versioned→versioned, flat→versioned)

### Motivation

With versioned folders, upgrades become zero-downtime: new version goes in a new folder, junction swaps immediately, running mounts continue from their old version folder until remounted. This eliminates the PendingUpgrade complexity and will enable simplifying the GVFS service to reduce elevation surface

### Part of Plan UAC-Free Install Modernization (Phase 1)
- **Phase 1: Versioned folder layout (this PR)**
- Phase 2: Service removal (PR #2020)
- Phase 3: /CURRENTUSER user-mode install (PR #2030 )
