### PR TITLE
Set WorkingDirectory for background mount process to avoid holding caller's CWD handle

### DIFF
--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -153,6 +153,12 @@ namespace GVFS.Platform.Windows
                 processInfo.UseShellExecute = true;
                 processInfo.WindowStyle = ProcessWindowStyle.Hidden;
 
+                // Set the working directory to the program's own directory so the
+                // background process does not hold a handle on the caller's CWD.
+                // This allows callers (e.g. bootstrapping tools) to clean up or
+                // delete their own directory after launching gvfs clone/mount.
+                processInfo.WorkingDirectory = Path.GetDirectoryName(programName);
+
                 Process executingProcess = new Process();
                 executingProcess.StartInfo = processInfo;
                 executingProcess.Start();


### PR DESCRIPTION
## Problem

When running `gvfs clone` or `gvfs mount`, the background `GVFS.Mount.exe` process inherits the caller's current working directory. This holds a handle on that directory, preventing the caller from cleaning up or deleting it afterward.

This is a problem for bootstrapping tools that launch gvfs and then need to remove themselves.

## Fix

Set `ProcessStartInfo.WorkingDirectory` to the directory containing the mount executable (`programName`). Since the mount process only uses its command-line arguments (which are already absolute paths) to locate the enlistment, it has no dependency on the inherited CWD.

## Validation

- `GVFS.Platform.Windows` builds cleanly
- `GVFS.UnitTests` builds cleanly
- All paths passed to the background process are already absolute (`mountExecutableLocation` is built from `ProcessHelper.GetCurrentProcessLocation()`, and `mountPath` comes from `enlistment.EnlistmentRoot` / `enlistment.WorkingDirectoryRoot`)