### PR TITLE
Fix heartbeat telemetry serialization of nested objects

### DIFF
--- a/GVFS/GVFS.Common/Tracing/EventMetadataConverter.cs
+++ b/GVFS/GVFS.Common/Tracing/EventMetadataConverter.cs
@@ -119,6 +119,33 @@ namespace GVFS.Common.Tracing
                 case Enum e:
                     writer.WriteStringValue(e.ToString());
                     break;
+                case EventMetadata nested:
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<string, object> kvp in nested)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        WriteValue(writer, kvp.Value);
+                    }
+
+                    writer.WriteEndObject();
+                    break;
+                case IDictionary<string, string> dict:
+                    writer.WriteStartObject();
+                    foreach (KeyValuePair<string, string> kvp in dict)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        if (kvp.Value is null)
+                        {
+                            writer.WriteNullValue();
+                        }
+                        else
+                        {
+                            writer.WriteStringValue(kvp.Value);
+                        }
+                    }
+
+                    writer.WriteEndObject();
+                    break;
                 default:
                     writer.WriteStringValue(value.ToString());
                     break;

--- a/GVFS/GVFS.UnitTests/Common/EventMetadataConverterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/EventMetadataConverterTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class EventMetadataConverterTests
+    {
+        [TestCase]
+        public void NestedEventMetadataSerializesAsObject()
+        {
+            EventMetadata inner = new EventMetadata();
+            inner.Add("ProcessName1", "git.exe");
+            inner.Add("ProcessCount1", 42);
+
+            EventMetadata outer = new EventMetadata();
+            outer.Add("FilePlaceholderCreation", inner);
+
+            string json = EventMetadataConverter.SerializeToString(outer);
+
+            json.ShouldContain("\"FilePlaceholderCreation\":{");
+            json.ShouldContain("\"ProcessName1\":\"git.exe\"");
+            json.ShouldContain("\"ProcessCount1\":42");
+            json.ShouldNotContain(false, "GVFS.Common.Tracing.EventMetadata");
+        }
+
+        [TestCase]
+        public void DictionaryStringStringSerializesAsObject()
+        {
+            Dictionary<string, string> diskInfo = new Dictionary<string, string>
+            {
+                ["DriveLetter"] = "D",
+                ["VolumeDriveType"] = "Fixed",
+                ["VolumeFileSystem"] = "ReFS",
+            };
+
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("PhysicalDiskInfo", diskInfo);
+
+            string json = EventMetadataConverter.SerializeToString(metadata);
+
+            json.ShouldContain("\"PhysicalDiskInfo\":{");
+            json.ShouldContain("\"DriveLetter\":\"D\"");
+            json.ShouldContain("\"VolumeDriveType\":\"Fixed\"");
+            json.ShouldContain("\"VolumeFileSystem\":\"ReFS\"");
+            json.ShouldNotContain(false, "System.Collections.Generic.Dictionary");
+        }
+
+        [TestCase]
+        public void EmptyNestedEventMetadataSerializesAsEmptyObject()
+        {
+            EventMetadata inner = new EventMetadata();
+            EventMetadata outer = new EventMetadata();
+            outer.Add("FilePlaceholderCreation", inner);
+
+            string json = EventMetadataConverter.SerializeToString(outer);
+
+            json.ShouldContain("\"FilePlaceholderCreation\":{}");
+        }
+
+        [TestCase]
+        public void PrimitiveValuesStillSerializeCorrectly()
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("StringVal", "hello");
+            metadata.Add("IntVal", 123);
+            metadata.Add("LongVal", 999999999999L);
+            metadata.Add("BoolVal", true);
+
+            string json = EventMetadataConverter.SerializeToString(metadata);
+
+            json.ShouldContain("\"StringVal\":\"hello\"");
+            json.ShouldContain("\"IntVal\":123");
+            json.ShouldContain("\"LongVal\":999999999999");
+            json.ShouldContain("\"BoolVal\":true");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

In GVFS 2.0.26162.1, the VFS.Heartbeat event's payload has a serialization regression. Fields that should contain structured data (`FilePlaceholderCreation`, `FolderPlaceholderCreation`, `FilePlaceholdersHydrated`, `PhysicalDiskInfo`) are serialized as .NET type names instead of their key-value contents:

```json
{
  "FilePlaceholderCreation": "GVFS.Common.Tracing.EventMetadata",
  "PhysicalDiskInfo": "System.Collections.Generic.Dictionary\2[System.String,System.String]"
}
```

## Root Cause

`EventMetadataConverter.WriteValue()` had no pattern-match cases for nested `EventMetadata` or `Dictionary<string, string>` values. Both fell through to `default: writer.WriteStringValue(value.ToString())`, which produces the type name.

## Fix

Added two case arms before the `default` fall-through:
- `EventMetadata nested` — recursively serializes as a JSON object
- `IDictionary<string, string> dict` — serializes as a flat string-to-string JSON object

## Testing

Added `EventMetadataConverterTests` with 4 test cases covering nested EventMetadata, Dictionary<string, string>, empty nested objects, and primitive value passthrough. All pass.