### PR TITLE
Add telemetry events to mount initialization phases

### DIFF
--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -128,8 +128,19 @@ namespace GVFS.Mount
             // TryInitializeAndQueryGVFSConfig combines the anonymous probe, credential fetch,
             // and config query into at most 2 HTTP requests (1 for anonymous repos), reusing
             // the same HttpClient/TCP connection.
+            Stopwatch mountPhaseTimer = Stopwatch.StartNew();
             Stopwatch parallelTimer = Stopwatch.StartNew();
             bool hasCacheServer = this.cacheServer != null && !string.IsNullOrWhiteSpace(this.cacheServer.Url);
+
+            this.tracer.RelatedEvent(
+                EventLevel.Informational,
+                "MountPhase",
+                new EventMetadata
+                {
+                    { "Phase", "ParallelMountStarted" },
+                    { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                },
+                Keywords.Telemetry);
 
             // When a cache server is configured locally, auth/config is best-effort:
             // mount can proceed without it. We still attempt it so GCM can pop up a
@@ -168,6 +179,19 @@ namespace GVFS.Mount
                 }
 
                 this.ValidateGVFSVersion(config, failOnError: !hasCacheServer);
+
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "NetworkValidationComplete" },
+                        { "DurationMs", sw.ElapsedMilliseconds },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
+
+
                 this.tracer.RelatedInfo("ParallelMount: Auth + config completed in {0}ms", sw.ElapsedMilliseconds);
                 return config;
             });
@@ -250,6 +274,18 @@ namespace GVFS.Mount
                     }
 
                     this.LogEnlistmentInfoAndSetConfigValues();
+
+                    this.tracer.RelatedEvent(
+                        EventLevel.Informational,
+                        "MountPhase",
+                        new EventMetadata
+                        {
+                            { "Phase", "LocalValidationComplete" },
+                            { "DurationMs", sw.ElapsedMilliseconds },
+                            { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                        },
+                        Keywords.Telemetry);
+
                     this.tracer.RelatedInfo("ParallelMount: Local validations + git config completed in {0}ms", sw.ElapsedMilliseconds);
                 });
 
@@ -280,16 +316,58 @@ namespace GVFS.Mount
                 parallelTimer.Stop();
                 this.tracer.RelatedInfo("ParallelMount: All parallel tasks completed in {0}ms", parallelTimer.ElapsedMilliseconds);
 
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "ParallelMountComplete" },
+                        { "DurationMs", parallelTimer.ElapsedMilliseconds },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
+
                 ServerGVFSConfig serverGVFSConfig = hasCacheServer ? null : networkTask.Result;
 
                 this.mountProgressMessage = "Resolving cache server";
                 CacheServerResolver cacheServerResolver = new CacheServerResolver(this.tracer, this.enlistment);
                 this.cacheServer = cacheServerResolver.ResolveNameFromRemote(this.cacheServer.Url, serverGVFSConfig);
 
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "CacheServerResolved" },
+                        { "CacheServerUrl", this.cacheServer.Url ?? string.Empty },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
+
                 this.EnsureLocalCacheIsHealthy(serverGVFSConfig);
+
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "LocalCacheHealthy" },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
 
                 this.mountProgressMessage = "Preparing mount";
                 this.context = this.CreateContext();
+
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "ContextCreated" },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
 
                 if (this.context.Unattended)
                 {
@@ -307,10 +385,42 @@ namespace GVFS.Mount
                     this.FailMountAndExit(errorMessage);
                 }
 
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "HooksUpdated" },
+                        { "Skipped", this.enlistment.IsWorktree },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
+
                 GVFSPlatform.Instance.ConfigureVisualStudio(this.enlistment.GitBinPath, this.tracer);
 
                 this.mountProgressMessage = "Starting virtualization";
+
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "VirtualizationStarting" },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
+
                 this.MountAndStartWorkingDirectoryCallbacks(this.cacheServer);
+
+                this.tracer.RelatedEvent(
+                    EventLevel.Informational,
+                    "MountPhase",
+                    new EventMetadata
+                    {
+                        { "Phase", "VirtualizationComplete" },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
+                    },
+                    Keywords.Telemetry);
 
                 try
                 {
@@ -329,6 +439,7 @@ namespace GVFS.Mount
                         // Use TracingConstants.MessageKey.InfoMessage rather than TracingConstants.MessageKey.CriticalMessage
                         // as this message should not appear as an error
                         { TracingConstants.MessageKey.InfoMessage, "Virtual repo is ready" },
+                        { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
                     },
                     Keywords.Telemetry);
 


### PR DESCRIPTION
## Problem

When the GVFS mount process hangs during initialization, there is NO telemetry in Application Insights between the `VFS.EnlistmentInfo` event and `VFS.Mount 'Virtual repo is ready'`. This makes it impossible to diagnose which phase is stuck from server-side telemetry.

A user experienced a mount that took 136 seconds to initialize (normally <1s), and we could only see a 60-second gap in telemetry with no events. The mount was stuck in the auth/network validation phase.

## Solution

Add `Keywords.Telemetry` events at each phase transition during `MountWithLockAcquired`. Each event uses a consistent `MountPhase` event name with a `Phase` field and an `ElapsedMs` field measuring time since mount start.

### New MountPhase events

| Phase | When |
|-------|------|
| `ParallelMountStarted` | Parallel auth + local validation begins |
| `NetworkValidationComplete` | Auth + /gvfs/config query done |
| `LocalValidationComplete` | Git/hooks/fs validation + config done |
| `ParallelMountComplete` | Both parallel tasks finished |
| `CacheServerResolved` | Cache server URL resolved |
| `LocalCacheHealthy` | Local object cache validated |
| `ContextCreated` | GVFSContext initialized |
| `HooksUpdated` | Hook binaries installed (or skipped for worktrees) |
| `VirtualizationStarting` | About to start ProjFS callbacks |

The existing `VFS.Mount 'Virtual repo is ready'` event serves as the final phase.

## Analysis: Network timeout budget

`RetryConfig` defaults: 6 retries x 30s timeout = **210s worst case** for `TryInitializeAndQueryGVFSConfig`. When auth is expired or network is unreachable, the mount can block for up to 210s in the network task with no telemetry — these new events make that gap visible and pinpoint exactly which phase is stuck.

## Testing

- Builds successfully (`dotnet build GVFS.Mount.csproj`)
- Events are informational-level with `Keywords.Telemetry` so they flow to Application Insights
- No behavioral changes — purely additive observability