### PR TITLE
Mount: don't block startup on auth when cache server is configured

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -13,8 +13,11 @@ namespace GVFS.Common.Git
     public class GitAuthentication
     {
         private const double MaxBackoffSeconds = 30;
+        public const int DefaultCredentialTimeoutMs = 30_000;
+        public const int BackgroundCredentialTimeoutMs = 120_000;
 
         private readonly Lock gitAuthLock = new Lock();
+        private readonly SemaphoreSlim credentialGate = new SemaphoreSlim(1, 1);
         private readonly ICredentialStore credentialStore;
         private readonly string repoUrl;
 
@@ -219,7 +222,8 @@ namespace GVFS.Common.Git
             RetryConfig retryConfig,
             out ServerGVFSConfig serverGVFSConfig,
             out string errorMessage,
-            out bool isAuthFailure)
+            out bool isAuthFailure,
+            int credentialTimeoutMs = DefaultCredentialTimeoutMs)
         {
             if (this.isInitialized)
             {
@@ -246,6 +250,7 @@ namespace GVFS.Common.Git
 
                 if (httpStatus != HttpStatusCode.Unauthorized)
                 {
+                    this.isInitialized = true;
                     errorMessage = "Unable to query /gvfs/config";
                     tracer.RelatedWarning("{0}: Config query failed with status {1}", nameof(this.TryInitializeAndQueryGVFSConfig), httpStatus?.ToString() ?? "None");
                     return false;
@@ -254,9 +259,13 @@ namespace GVFS.Common.Git
                 // Server requires authentication — fetch credentials
                 this.IsAnonymous = false;
 
-                if (!this.TryCallGitCredential(tracer, out errorMessage))
+                if (!this.TryCallGitCredential(tracer, out errorMessage, credentialTimeoutMs))
                 {
                     isAuthFailure = true;
+                    // Mark initialized even on failure so TryGetCredentials can
+                    // retry later (e.g., when mount proceeds with a cache server
+                    // and object downloads need auth).
+                    this.isInitialized = true;
                     tracer.RelatedWarning("{0}: Credential fetch failed: {1}", nameof(this.TryInitializeAndQueryGVFSConfig), errorMessage);
                     return false;
                 }
@@ -376,28 +385,45 @@ namespace GVFS.Common.Git
             this.numberOfAttempts++;
         }
 
-        private bool TryCallGitCredential(ITracer tracer, out string errorMessage)
+        private bool TryCallGitCredential(ITracer tracer, out string errorMessage, int timeoutMs = -1)
         {
-            string gitUsername;
-            string gitPassword;
-            if (!this.credentialStore.TryGetCredential(tracer, this.repoUrl, out gitUsername, out gitPassword, out errorMessage))
+            // Serialize credential fetches so only one git-credential-fill
+            // process runs at a time. Without this, a background auth task
+            // and a foreground object download could both spawn GCM prompts.
+            // Wait up to 60s for an in-flight fetch; if the gate is still
+            // held (e.g., background GCM prompt), fall through and let this
+            // caller spawn its own credential fetch.
+            bool acquired = this.credentialGate.Wait(60_000);
+            try
             {
-                this.UpdateBackoff();
-                return false;
-            }
+                string gitUsername;
+                string gitPassword;
+                if (!this.credentialStore.TryGetCredential(tracer, this.repoUrl, out gitUsername, out gitPassword, out errorMessage, timeoutMs))
+                {
+                    this.UpdateBackoff();
+                    return false;
+                }
 
-            if (!string.IsNullOrEmpty(gitUsername) && !string.IsNullOrEmpty(gitPassword))
-            {
-                this.cachedCredentialString = Convert.ToBase64String(Encoding.ASCII.GetBytes(gitUsername + ":" + gitPassword));
-                this.isCachedCredentialStringApproved = false;
-            }
-            else
-            {
-                errorMessage = "Got back empty credentials from git";
-                return false;
-            }
+                if (!string.IsNullOrEmpty(gitUsername) && !string.IsNullOrEmpty(gitPassword))
+                {
+                    this.cachedCredentialString = Convert.ToBase64String(Encoding.ASCII.GetBytes(gitUsername + ":" + gitPassword));
+                    this.isCachedCredentialStringApproved = false;
+                }
+                else
+                {
+                    errorMessage = "Got back empty credentials from git";
+                    return false;
+                }
 
-            return true;
+                return true;
+            }
+            finally
+            {
+                if (acquired)
+                {
+                    this.credentialGate.Release();
+                }
+            }
         }
     }
 }

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -297,7 +297,8 @@ namespace GVFS.Common.Git
             string repoUrl,
             out string username,
             out string password,
-            out string errorMessage)
+            out string errorMessage,
+            int timeoutMs = -1)
         {
             username = null;
             password = null;
@@ -311,16 +312,29 @@ namespace GVFS.Common.Git
                     GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
                     parseStdOutLine: null,
-                    usePreCommandHook: false);
+                    usePreCommandHook: false,
+                    timeoutMs: timeoutMs);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
                 {
                     EventMetadata errorData = new EventMetadata();
-                    tracer.RelatedWarning(
-                        errorData,
-                        "Git could not get credentials: " + gitCredentialOutput.Errors,
-                        Keywords.Network | Keywords.Telemetry);
-                    errorMessage = gitCredentialOutput.Errors;
+
+                    if (gitCredentialOutput.Errors.StartsWith("Operation timed out"))
+                    {
+                        errorMessage = "Credential manager did not respond within " + (timeoutMs / 1000) + " seconds";
+                        tracer.RelatedWarning(
+                            errorData,
+                            "Git credential fill timed out after " + timeoutMs + "ms",
+                            Keywords.Network | Keywords.Telemetry);
+                    }
+                    else
+                    {
+                        errorMessage = gitCredentialOutput.Errors;
+                        tracer.RelatedWarning(
+                            errorData,
+                            "Git could not get credentials: " + gitCredentialOutput.Errors,
+                            Keywords.Network | Keywords.Telemetry);
+                    }
 
                     return false;
                 }
@@ -1113,7 +1127,8 @@ namespace GVFS.Common.Git
             Action<StreamWriter> writeStdIn,
             Action<string> parseStdOutLine,
             bool usePreCommandHook = true,
-            string gitObjectsDirectory = null)
+            string gitObjectsDirectory = null,
+            int timeoutMs = -1)
         {
             // This git command should not need/use the working directory of the repo.
             // Run git.exe in Environment.SystemDirectory to ensure the git.exe process
@@ -1125,7 +1140,7 @@ namespace GVFS.Common.Git
                 useReadObjectHook: false,
                 writeStdIn: writeStdIn,
                 parseStdOutLine: parseStdOutLine,
-                timeoutMs: -1,
+                timeoutMs: timeoutMs,
                 gitObjectsDirectory: gitObjectsDirectory,
                 usePreCommandHook: usePreCommandHook);
         }

--- a/GVFS/GVFS.Common/Git/ICredentialStore.cs
+++ b/GVFS/GVFS.Common/Git/ICredentialStore.cs
@@ -4,7 +4,7 @@ namespace GVFS.Common.Git
 {
     public interface ICredentialStore
     {
-        bool TryGetCredential(ITracer tracer, string url, out string username, out string password, out string error);
+        bool TryGetCredential(ITracer tracer, string url, out string username, out string password, out string error, int timeoutMs = -1);
 
         bool TryStoreCredential(ITracer tracer, string url, string username, string password, out string error);
 

--- a/GVFS/GVFS.Common/ReturnCode.cs
+++ b/GVFS/GVFS.Common/ReturnCode.cs
@@ -12,5 +12,7 @@
         DehydrateFolderFailures = 7,
         MountAlreadyRunning = 8,
         AuthenticationError = 9,
+        CredentialTimeout = 10,
+        RemoteGvfsConfigError = 11,
     }
 }

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -129,7 +129,11 @@ namespace GVFS.Mount
             // and config query into at most 2 HTTP requests (1 for anonymous repos), reusing
             // the same HttpClient/TCP connection.
             Stopwatch parallelTimer = Stopwatch.StartNew();
+            bool hasCacheServer = this.cacheServer != null && !string.IsNullOrWhiteSpace(this.cacheServer.Url);
 
+            // When a cache server is configured locally, auth/config is best-effort:
+            // mount can proceed without it. We still attempt it so GCM can pop up a
+            // renewal prompt for stale tokens, but we don't block mount on the result.
             var networkTask = Task.Run(() =>
             {
                 Stopwatch sw = Stopwatch.StartNew();
@@ -139,22 +143,31 @@ namespace GVFS.Mount
 
                 if (!this.enlistment.Authentication.TryInitializeAndQueryGVFSConfig(
                     this.tracer, this.enlistment, this.retryConfig,
-                    out config, out authConfigError, out isAuthFailure))
+                    out config, out authConfigError, out isAuthFailure,
+                    credentialTimeoutMs: hasCacheServer ? GitAuthentication.BackgroundCredentialTimeoutMs : GitAuthentication.DefaultCredentialTimeoutMs))
                 {
-                    if (this.cacheServer != null && !string.IsNullOrWhiteSpace(this.cacheServer.Url))
+                    if (hasCacheServer)
                     {
                         this.tracer.RelatedWarning("Mount will proceed with fallback cache server: " + authConfigError);
                         config = null;
                     }
                     else
                     {
+                        ReturnCode exitCode = ReturnCode.RemoteGvfsConfigError;
+                        if (isAuthFailure)
+                        {
+                            exitCode = authConfigError != null && authConfigError.Contains("Credential manager did not respond")
+                                ? ReturnCode.CredentialTimeout
+                                : ReturnCode.AuthenticationError;
+                        }
+
                         this.FailMountAndExit(
-                            isAuthFailure ? ReturnCode.AuthenticationError : ReturnCode.GenericError,
+                            exitCode,
                             "Unable to query /gvfs/config" + Environment.NewLine + authConfigError);
                     }
                 }
 
-                this.ValidateGVFSVersion(config);
+                this.ValidateGVFSVersion(config, failOnError: !hasCacheServer);
                 this.tracer.RelatedInfo("ParallelMount: Auth + config completed in {0}ms", sw.ElapsedMilliseconds);
                 return config;
             });
@@ -242,7 +255,22 @@ namespace GVFS.Mount
 
                 try
                 {
-                    Task.WaitAll(networkTask, localTask);
+                    if (hasCacheServer)
+                    {
+                        // With a cache server, don't block mount on the network task.
+                        // Auth runs in the background to warm credentials / pop GCM,
+                        // but mount proceeds immediately using the local cache server URL.
+                        localTask.Wait();
+
+                        // Observe background task exceptions so they don't go unhandled.
+                        networkTask.ContinueWith(
+                            t => this.tracer.RelatedWarning("Background auth task failed: " + t.Exception.Flatten().InnerExceptions[0].Message),
+                            TaskContinuationOptions.OnlyOnFaulted);
+                    }
+                    else
+                    {
+                        Task.WaitAll(networkTask, localTask);
+                    }
                 }
                 catch (AggregateException ae)
                 {
@@ -252,7 +280,7 @@ namespace GVFS.Mount
                 parallelTimer.Stop();
                 this.tracer.RelatedInfo("ParallelMount: All parallel tasks completed in {0}ms", parallelTimer.ElapsedMilliseconds);
 
-                ServerGVFSConfig serverGVFSConfig = networkTask.Result;
+                ServerGVFSConfig serverGVFSConfig = hasCacheServer ? null : networkTask.Result;
 
                 this.mountProgressMessage = "Resolving cache server";
                 CacheServerResolver cacheServerResolver = new CacheServerResolver(this.tracer, this.enlistment);
@@ -1467,7 +1495,7 @@ namespace GVFS.Mount
             return serverGVFSConfig;
         }
 
-        private void ValidateGVFSVersion(ServerGVFSConfig config)
+        private void ValidateGVFSVersion(ServerGVFSConfig config, bool failOnError = true)
         {
             using (ITracer activity = this.tracer.StartActivity("ValidateGVFSVersion", EventLevel.Informational))
             {
@@ -1519,7 +1547,10 @@ namespace GVFS.Mount
                 }
 
                 activity.RelatedError("GVFS version {0} is not supported", currentVersion);
-                this.FailMountAndExit("ERROR: Your GVFS version is no longer supported. Install the latest and try again.");
+                if (failOnError)
+                {
+                    this.FailMountAndExit("ERROR: Your GVFS version is no longer supported. Install the latest and try again.");
+                }
             }
         }
 

--- a/GVFS/GVFS/CommandLine/MountVerb.cs
+++ b/GVFS/GVFS/CommandLine/MountVerb.cs
@@ -280,11 +280,31 @@ namespace GVFS.CommandLine
 
             tracer.RelatedInfo($"{nameof(this.TryMount)}: Waiting for repo to be mounted");
 
+            Process process = this.mountProcess;
+            Func<GVFSEnlistment.MountProcessSnapshot> snapshot = () =>
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        return new GVFSEnlistment.MountProcessSnapshot(process.Id, hasExited: false, exitCode: 0);
+                    }
+
+                    return new GVFSEnlistment.MountProcessSnapshot(process.Id, hasExited: true, exitCode: process.ExitCode);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process object disposed or not started — treat as exited.
+                    return new GVFSEnlistment.MountProcessSnapshot(processId: 0, hasExited: true, exitCode: -1);
+                }
+            };
+
             return GVFSEnlistment.WaitUntilMounted(
                 tracer,
                 enlistment.NamedPipeName,
                 enlistment.WorkingDirectoryRoot,
                 this.Unattended,
+                snapshot,
                 out errorMessage,
                 onProgress: progress => this.currentMountProgress = progress);
         }


### PR DESCRIPTION
## Problem

A user reported *'Unable to mount because the GVFS.Mount process is not responding'* when GCM was blocked waiting for interactive auth on a headless server. The mount process was alive but stuck in `git credential fill`, and MountVerb's 60-second pipe connect expired with a misleading error.

More broadly: when a cache server URL is already in local git config, there's no reason for mount to block on authentication. The enlistment can serve objects from the local cache immediately, and knows the cache server to use when not available locally. If a cache server has not been configured already though (or explicitly set to not use cache server) then the mount should try to configure one upon startup.

## Fix

**Background auth with cache server** — When a cache server URL is configured locally, the auth + config query runs as a fire-and-forget background task. Mount proceeds immediately after local validations complete. GCM still gets a chance to pop up a renewal prompt so the token is fresh for subsequent object downloads, but it cannot delay mount.

**Without a cache server** — auth remains synchronous and blocking (as before), but with better diagnostics:

| Exit code | Name | Meaning |
|-----------|------|---------|
| 9 | `AuthenticationError` | Credentials rejected by server |
| 10 | `CredentialTimeout` | `git credential fill` hung for 30s (GCM waiting for interactive auth nobody is answering) |
| 11 | `RemoteGvfsConfigError` | `/gvfs/config` query failed for non-auth reasons (DNS, timeout, 5xx) |

**Process tracking in MountVerb** — `WaitUntilMounted` now uses short-interval (500ms) connect retries with process liveness checks instead of a single blocking 60s connect. If GVFS.Mount exits early, MountVerb detects it within 500ms.

## Implementation details

- **Credential gate** — `SemaphoreSlim(1,1)` in `GitAuthentication` serializes all `git-credential-fill` calls. Prevents duplicate GCM prompts when the background auth task and foreground object downloads race to fetch credentials.
- **30s credential timeout (no-cache-server only)** — `git credential fill` is killed after 30 seconds so mount fails fast with exit code 10 instead of hanging indefinitely. The timeout is added to `ICredentialStore.TryGetCredential` (default infinite, preserving existing behavior for all other callers).
- **Version check is log-only in background** — `ValidateGVFSVersion` logs but doesn't `FailMountAndExit` when running as the background auth task, avoiding a race where the process could terminate after mount already reported success.
- **isInitialized on credential failure** — `GitAuthentication` marks itself initialized even when credential fetch fails, so `TryGetCredentials` can retry during later object downloads rather than throwing `InvalidOperationException`.