### PR TITLE
fix: tighten FT slicer grouping regex to class-level

### DIFF
--- a/GVFS/GVFS.Tests/NUnitRunner.cs
+++ b/GVFS/GVFS.Tests/NUnitRunner.cs
@@ -98,16 +98,29 @@ namespace GVFS.Tests
             }
 
             // Now distribute the tests into the buckets.
-            // Tests from the same fixture class must stay in the same bucket
-            // when the fixture shares a single enlistment across tests (both
-            // EnlistmentPerFixture classes, MultiEnlistmentTests with [Order],
-            // and GitCommands fixture classes like GitCommandsTests, CheckoutTests,
-            // etc. use a shared enlistment).
-            // The regex captures "everything up to and including the class name"
-            // so that SomeClass.TestA and SomeClass.TestB share a prefix.
+            //
+            // Some test classes share state across test methods and must land in the
+            // same slice.  The regex captures a per-class prefix so that all methods of
+            // those classes are grouped together.
+            //
+            // Classes that MUST stay together:
+            //   EnlistmentPerFixture.*  — share a single mounted enlistment for the
+            //                             whole fixture; tests may be order-dependent.
+            //   MultiEnlistmentTests.ConfigVerbTests — uses [Order(1..8)]; each test
+            //                             reads/writes GVFS config set by the previous.
+            //
+            // Classes that are safe to split (do NOT add to this regex):
+            //   GitCommands.*      — each test resets state via git-checkout in [SetUp]
+            //                        or gets a fresh per-test enlistment.
+            //   SharedCacheTests   — [SetUp] generates a new Guid-based cache path per
+            //                        test; no shared state across test methods.
+            //   ServiceVerbTests   — [NonParallelizable] prevents within-process
+            //                        concurrency; different slices run on different
+            //                        machines so cross-slice isolation is guaranteed.
             Regex fixtureRegex = new Regex(
-                @"^.*\.(?:EnlistmentPerFixture|MultiEnlistmentTests|GitCommands)\..+\.",
+                @"^.*\.(?:EnlistmentPerFixture\..+|MultiEnlistmentTests\.ConfigVerbTests)\.",
                 RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
             for (uint i = 0; i < list.Length; i++)
             {
                 var test = list[i].Trim();


### PR DESCRIPTION
## Problem

Functional test CI slices had a large runtime imbalance driven by overly broad grouping in the slicer. Analysis of PR #2028 (run 28466413742):

| Slice | Duration | Bottleneck |
|-------|----------|------------|
| 9 (x64) | **18.9 min** | `CheckoutTests(Full)`: 38 tests, ~16.4 min |
| 2 (x64) | 17.0 min | `CreatePlaceholderTests` + `SharedCacheTests` |
| 6 (x64) | 1.3 min  | Fast tests only |

Gap: **14.5x** between fastest and slowest. Ideal per-slice = ~9 min.

## Root Cause

The grouping regex kept all tests from the `GitCommands` and `MultiEnlistmentTests` namespaces together in the same slice. Since the slicer groups *consecutive* explore-output entries sharing a class prefix, this caused:

1. **`GitCommands` namespace**: All 38 `CheckoutTests(Full)` methods (~16 min) in one slice.
2. **`MultiEnlistmentTests` namespace**: All 10 `SharedCacheTests` methods (~7 min) in one slice — the whole namespace was grouped, not just the one class that actually needs ordering.

## Fix

Tighten the regex from namespace-level to class-level:

```
OLD: ^.*\.(?:EnlistmentPerFixture|MultiEnlistmentTests)\..+\.
NEW: ^.*\.(?:EnlistmentPerFixture\..+|MultiEnlistmentTests\.ConfigVerbTests)\.
```

**What must stay grouped:**
- `EnlistmentPerFixture.*` — share a single mounted enlistment per fixture class; tests may be order-dependent.
- `MultiEnlistmentTests.ConfigVerbTests` — uses `[Order(1..8)]`; each test reads config written by the previous.

**What is safe to split:**
- `GitCommands.*` — each test resets via `git checkout` in `[SetUp]` or gets a fresh per-test enlistment.
- `SharedCacheTests` — `[SetUp]` generates a new `Guid`-based cache path per test; no shared state across methods.
- `ServiceVerbTests` — `[NonParallelizable]` only blocks within-process concurrency; different slices run on different machines.

## Results (run 28547872842)

All 24 slices passed.

| | Before (PR #2028) | After |
|-|------------------|-------|
| Critical path (x64) | **18.9 min** | **9.5 min** (−50%) |
| Critical path (arm64) | ~18+ min | **9.8 min** |
| Fastest slice | 1.3 min | 3.6 min |
| Worst/best ratio | **14.5x** | **2.6x** |
