### PR TITLE
Include executable extension in core.virtualfilesystem path

### DIFF
--- a/GVFS/GVFS.Common/Git/RequiredGitConfig.cs
+++ b/GVFS/GVFS.Common/Git/RequiredGitConfig.cs
@@ -24,8 +24,14 @@ namespace GVFS.Common.Git
             // path would split the command.  Git's config parser strips double quotes
             // but preserves single quotes, and bash treats single-quoted strings as
             // a single token.
+            //
+            // Include the platform's executable extension (matching the file actually
+            // written to disk by HooksInstaller) so the shell can exec it directly
+            // instead of probing PATHEXT candidates (.COM, .EXE, ...) on every hook
+            // invocation.
             string virtualFileSystemPath = "'" + Paths.ConvertPathToGitFormat(
-                Path.Combine(enlistment.DotGitRoot, GVFSConstants.DotGit.Hooks.RootName, GVFSConstants.DotGit.Hooks.VirtualFileSystemName)) + "'";
+                Path.Combine(enlistment.DotGitRoot, GVFSConstants.DotGit.Hooks.RootName, GVFSConstants.DotGit.Hooks.VirtualFileSystemName) +
+                GVFSPlatform.Instance.Constants.ExecutableExtension) + "'";
 
             string gitStatusCachePath = null;
             if (!GVFSEnlistment.IsUnattended(tracer: null) && GVFSPlatform.Instance.IsGitStatusCacheSupported())


### PR DESCRIPTION
## Summary

`core.virtualfilesystem` is set to an absolute path *without* a file extension, even though VFSForGit is the one that writes the corresponding hook executable (with the platform-specific extension) to `.git/hooks/`.

Because git invokes `core.virtualfilesystem` via the shell (`use_shell=1` in `virtualfilesystem.c`), on Windows this means `cmd.exe` has to probe `PATHEXT` candidates (`.COM`, `.EXE`, ...) to resolve the bare `virtual-filesystem` path to the actual `virtual-filesystem.exe` file on every hook invocation.

Since VFSForGit controls both the config value and the file it points to, this change appends `GVFSPlatform.Instance.Constants.ExecutableExtension` to the path — matching what `HooksInstaller` already does when writing the file — so the shell can exec the file directly without probing. This is a no-op on macOS/Linux, where `ExecutableExtension` is empty.

## Testing

- `dotnet build src\GVFS\GVFS.UnitTests\GVFS.UnitTests.csproj -c Debug`
- Ran `GVFS.UnitTests.exe`: 876 passed, 0 failed (11 skipped tests are unrelated native-hook-exe checks that require a full native build).
