### PR TITLE
Fix clone ownership under Windows Administrator Protection

### DIFF
--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystem.cs
@@ -327,6 +327,10 @@ namespace GVFS.Platform.Windows
         /// Also, even if the fix were in place, automount would still fail because it runs under SYSTEM account.
         ///
         /// This method ensures that the directory is owned by the current user (which is verified to work for SYSTEM account for automount).
+        ///
+        /// Exception: under Windows "Administrator protection" (AP), an elevated process runs as a profile-separated shadow admin
+        /// account (MACHINE\admin_&lt;user&gt;) whose SID differs from the real (non-elevated) user's. In that case the directory owner is
+        /// left as the Administrators group rather than being reassigned to the shadow admin (see the AP note inline).
         /// </summary>
         public void EnsureDirectoryIsOwnedByCurrentUser(string directoryPath)
         {
@@ -339,6 +343,25 @@ namespace GVFS.Platform.Windows
             SecurityIdentifier administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
             if (directoryOwner == administratorsSid)
             {
+                // Under Windows "Administrator protection" (AP), an elevated process runs as a profile-separated shadow
+                // admin account (MACHINE\admin_<user>) whose SID differs from the real (non-elevated) user's. Reassigning
+                // ownership to the current user here would set the owner to that shadow admin, causing the real user to hit
+                // "fatal: detected dubious ownership" — git's Administrators-membership grace does not cover another specific
+                // user's SID. The shadow admin also cannot SetOwner to the real user's SID. Leaving the owner as the
+                // Administrators group is accepted by modern git and the libgit2 non-elevated-admin-owner overlay for any
+                // Administrators member (real user, shadow admin, and SYSTEM for automount alike), so skip the reassignment.
+                //
+                // Note: a libgit2 consumer that lacks the non-elevated-admin-owner patch (i.e. stock libgit2 without the
+                // Administrators-membership fix) will not be able to open an Administrators-owned repo. Addressing that would
+                // require setting git's safe.directory for the real user, but safe.directory is only honored from global/system
+                // config (never repo-local), and an elevated clone runs as the shadow admin — so covering the real user would
+                // mean mutating the real user's global gitconfig or machine-wide system config from the shadow admin. After
+                // consideration, GVFS is not the right place to do that; unpatched third-party libgit2 consumers are out of scope.
+                if (WindowsPlatform.IsCurrentUserAdminProtectionShadowAccount())
+                {
+                    return;
+                }
+
                 WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
                 directorySecurity.SetOwner(currentUser.User);
                 directoryInfo.SetAccessControl(directorySecurity);

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -24,6 +24,10 @@ namespace GVFS.Platform.Windows
         private const string BuildLabRegistryValue = "BuildLab";
         private const string BuildLabExRegistryValue = "BuildLabEx";
 
+        private const string ProfileListRegistryKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList";
+        private const string ProfileImagePathRegistryValue = "ProfileImagePath";
+        private const string AdminProtectionProfilePrefix = "ADMIN_";
+
         public WindowsPlatform() : base(underConstruction: new UnderConstructionFlags())
         {
         }
@@ -74,6 +78,46 @@ namespace GVFS.Platform.Windows
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// Detects whether the current process token belongs to a Windows "Administrator protection" (AP)
+        /// shadow admin account.
+        ///
+        /// Under AP, elevating produces a token whose user is a hidden, system-managed local account
+        /// (MACHINE\admin_&lt;user&gt;, SID S-1-5-21-...) with its own user profile named ADMIN_&lt;user&gt;. That
+        /// account's SID differs from the real (interactive) user's SID, so treating it as "the current user"
+        /// for file-ownership purposes is wrong.
+        ///
+        /// This inspects the running process's own token (its effective elevation identity) rather than the
+        /// TypeOfAdminApprovalMode policy value, so it is correct even across an AP policy change that has not
+        /// yet been rebooted (where the policy value is pending but elevation still yields a shadow admin).
+        /// </summary>
+        public static bool IsCurrentUserAdminProtectionShadowAccount()
+        {
+            using (WindowsIdentity currentUser = WindowsIdentity.GetCurrent())
+            {
+                SecurityIdentifier userSid = currentUser.User;
+
+                // AP shadow accounts are local machine accounts (S-1-5-21-...); the real interactive user is a
+                // domain or Entra ID account (e.g. S-1-12-1-...), which is not an "account SID" in this sense.
+                if (userSid == null || !userSid.IsAccountSid())
+                {
+                    return false;
+                }
+
+                string profilePath = GetStringFromRegistry(
+                    $"{ProfileListRegistryKey}\\{userSid.Value}",
+                    ProfileImagePathRegistryValue);
+                if (string.IsNullOrEmpty(profilePath))
+                {
+                    return false;
+                }
+
+                string profileFolderName = Path.GetFileName(
+                    profilePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                return profileFolderName.StartsWith(AdminProtectionProfilePrefix, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         public static bool TrySetDWordInRegistry(RegistryHive registryHive, string key, string valueName, uint value)


### PR DESCRIPTION
## Problem

Under Windows **Administrator protection** (AP), an elevated process runs as a hidden, profile-separated *shadow admin* account (`MACHINE\admin_<user>`) whose SID is a local account (`S-1-5-21-…`) that differs from the real, non-elevated user's SID.

When `gvfs clone` runs elevated, the enlistment's `src` and `.git` directories are created owned by the **Administrators** group. `EnsureDirectoryIsOwnedByCurrentUser` then reassigned ownership to the *current* user to satisfy git's dubious-ownership check. Under AP the "current user" is the shadow admin, so ownership was set to `admin_<user>`.

The real (non-elevated) user then hits:

```
fatal: detected dubious ownership in repository
```

because git's Administrators-group-membership grace does **not** cover another specific user's SID, and the shadow admin cannot `SetOwner` to the real user's SID either.

## Fix

Detect the AP shadow admin from the **running process's own token** (its effective elevation identity) and, when present, **leave the directory owner as the Administrators group** instead of reassigning it to the shadow admin.

An `Administrators`-owned directory is accepted by modern git and the libgit2 `non-elevated-admin-owner` overlay for any Administrators member — the real user, the shadow admin, and `SYSTEM` (for automount) alike. So skipping the reassignment for a shadow admin is correct for every consumer. When the current user is **not** a shadow admin, behavior is unchanged (owner reassigned to the current user, as before).

### Why token-based, not `TypeOfAdminApprovalMode`

An earlier revision read the `TypeOfAdminApprovalMode` policy value. That reflects the **pending** policy, not the **effective** state: across an AP enable/disable that hasn't been rebooted, the policy value and the actual elevation behavior disagree, so the guard would misfire (e.g. policy reads `1` but elevation still yields a shadow admin → bug persists). Inspecting the process token is reboot-independent and targets the actual failure condition.

A shadow admin is identified as a local account SID (`S-1-5-21-…`, `IsAccountSid()`) whose `ProfileList` profile directory is `ADMIN_`-prefixed. The real interactive user (a domain / Entra ID account, e.g. `S-1-12-1-…`) is excluded.

### Why not also set `safe.directory`

Considered and deliberately rejected. `safe.directory` would let *stock* libgit2 consumers (those lacking the `non-elevated-admin-owner` overlay) open an Administrators-owned repo regardless of owner. But:

- git ignores `safe.directory` in **repo-local** config (security), so it only works from **global/user** or **system** config — there is no clean repo-scoped place to write it.
- `--global` under an elevated clone lands in the **shadow admin's** profile (`ADMIN_<user>\.gitconfig`), which does the real user no good.
- Covering the real user would require the elevated shadow-admin process to **mutate the real user's global gitconfig** (invasive) or write **machine-wide system config** (per-repo pollution affecting all users).
- The GVFS-supported toolchain already works with Administrators ownership: `microsoft/git` has the Administrators-membership fix, and GVFS's bundled libgit2 carries the overlay. Only non-GVFS third-party stock-libgit2 tools are unaffected by the fix, and the non-AP elevated-clone path likewise relies purely on ownership (no `safe.directory`).

Leaving `safe.directory` untouched keeps the AP and non-AP paths symmetric and avoids cross-user config mutation.

### Changes
- `GVFS.Platform.Windows/WindowsPlatform.cs` — add `IsCurrentUserAdminProtectionShadowAccount()` (inspects the current token + ProfileList).
- `GVFS.Platform.Windows/WindowsFileSystem.cs` — in `EnsureDirectoryIsOwnedByCurrentUser`, skip the Administrators→current-user reassignment when the current user is an AP shadow admin.

## Testing

Builds clean (`GVFS.Platform.Windows`, 0 warnings / 0 errors).

**Detection logic** validated on a real AP machine against the live SIDs:
- real user `S-1-12-1-…` → `IsAccountSid=False` → not shadow (reassignment proceeds).
- shadow admin `S-1-5-21-…-1001` → profile `ADMIN_<user>` → shadow (reassignment skipped).

**End-to-end**, on a real AP machine in the effective-AP state, using an installed build of this branch:

| Check | Result |
| --- | --- |
| Elevated `gvfs clone` (runs as shadow admin) | Succeeded, mounted |
| Owner of `src` | `BUILTIN\Administrators` (not `admin_<user>`) |
| Owner of `src\.git` | `BUILTIN\Administrators` |
| Non-elevated real user `git status` / `git rev-parse` | Exit 0 — no `dubious ownership` error |

Pre-fix, those directories would have been owned by the shadow admin, and the real user would have hit `fatal: detected dubious ownership`.

## Related
- Original elevated-clone ownership fix: #1829 (`4e23d28a`).
