### PR TITLE
Harden GVFS.Mount against native ProjFS failures under memory pressure (0xC000CE01)

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -1,4 +1,4 @@
-﻿using GVFS.Common;
+using GVFS.Common;
 using GVFS.Virtualization.Projection;
 using Microsoft.Windows.ProjFS;
 using System.Collections.Generic;

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -119,14 +119,21 @@ namespace GVFS.Platform.Windows
 
         public override FileSystemResult ClearNegativePathCache(out uint totalEntryCount)
         {
-            HResult result = this.virtualizationInstance.ClearNegativePathCache(out totalEntryCount);
+            uint entryCount = 0;
+            HResult result = this.TryInvokeProjFS(
+                () => this.virtualizationInstance.ClearNegativePathCache(out entryCount),
+                nameof(this.ClearNegativePathCache));
+            totalEntryCount = entryCount;
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
 
         public override FileSystemResult DeleteFile(string relativePath, UpdatePlaceholderType updateFlags, out UpdateFailureReason failureReason)
         {
             UpdateFailureCause failureCause = UpdateFailureCause.NoFailure;
-            HResult result = this.virtualizationInstance.DeleteFile(relativePath, (UpdateType)updateFlags, out failureCause);
+            HResult result = this.TryInvokeProjFS(
+                () => this.virtualizationInstance.DeleteFile(relativePath, (UpdateType)updateFlags, out failureCause),
+                nameof(this.DeleteFile),
+                relativePath);
             failureReason = (UpdateFailureReason)failureCause;
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
@@ -137,17 +144,20 @@ namespace GVFS.Platform.Windows
             string sha)
         {
             FileProperties properties = this.FileSystemCallbacks.GetLogsHeadFileProperties();
-            HResult result = this.virtualizationInstance.WritePlaceholderInfo(
-                relativePath,
-                properties.CreationTimeUTC,
-                properties.LastAccessTimeUTC,
-                properties.LastWriteTimeUTC,
-                changeTime: properties.LastWriteTimeUTC,
-                fileAttributes: FileAttributes.Archive,
-                endOfFile: endOfFile,
-                isDirectory: false,
-                contentId: FileSystemVirtualizer.ConvertShaToContentId(sha),
-                providerId: PlaceholderVersionId);
+            HResult result = this.TryInvokeProjFS(
+                () => this.virtualizationInstance.WritePlaceholderInfo(
+                    relativePath,
+                    properties.CreationTimeUTC,
+                    properties.LastAccessTimeUTC,
+                    properties.LastWriteTimeUTC,
+                    changeTime: properties.LastWriteTimeUTC,
+                    fileAttributes: FileAttributes.Archive,
+                    endOfFile: endOfFile,
+                    isDirectory: false,
+                    contentId: FileSystemVirtualizer.ConvertShaToContentId(sha),
+                    providerId: PlaceholderVersionId),
+                nameof(this.WritePlaceholderFile),
+                relativePath);
 
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
@@ -155,17 +165,20 @@ namespace GVFS.Platform.Windows
         public override FileSystemResult WritePlaceholderDirectory(string relativePath)
         {
             FileProperties properties = this.FileSystemCallbacks.GetLogsHeadFileProperties();
-            HResult result = this.virtualizationInstance.WritePlaceholderInfo(
-                relativePath,
-                properties.CreationTimeUTC,
-                properties.LastAccessTimeUTC,
-                properties.LastWriteTimeUTC,
-                changeTime: properties.LastWriteTimeUTC,
-                fileAttributes: FileAttributes.Directory,
-                endOfFile: 0,
-                isDirectory: true,
-                contentId: FolderContentId,
-                providerId: PlaceholderVersionId);
+            HResult result = this.TryInvokeProjFS(
+                () => this.virtualizationInstance.WritePlaceholderInfo(
+                    relativePath,
+                    properties.CreationTimeUTC,
+                    properties.LastAccessTimeUTC,
+                    properties.LastWriteTimeUTC,
+                    changeTime: properties.LastWriteTimeUTC,
+                    fileAttributes: FileAttributes.Directory,
+                    endOfFile: 0,
+                    isDirectory: true,
+                    contentId: FolderContentId,
+                    providerId: PlaceholderVersionId),
+                nameof(this.WritePlaceholderDirectory),
+                relativePath);
 
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
@@ -183,18 +196,21 @@ namespace GVFS.Platform.Windows
             out UpdateFailureReason failureReason)
         {
             UpdateFailureCause failureCause = UpdateFailureCause.NoFailure;
-            HResult result = this.virtualizationInstance.UpdateFileIfNeeded(
-                relativePath,
-                creationTime,
-                lastAccessTime,
-                lastWriteTime,
-                changeTime,
-                fileAttributes,
-                endOfFile,
-                ConvertShaToContentId(shaContentId),
-                PlaceholderVersionId,
-                (UpdateType)updateFlags,
-                out failureCause);
+            HResult result = this.TryInvokeProjFS(
+                () => this.virtualizationInstance.UpdateFileIfNeeded(
+                    relativePath,
+                    creationTime,
+                    lastAccessTime,
+                    lastWriteTime,
+                    changeTime,
+                    fileAttributes,
+                    endOfFile,
+                    ConvertShaToContentId(shaContentId),
+                    PlaceholderVersionId,
+                    (UpdateType)updateFlags,
+                    out failureCause),
+                nameof(this.UpdatePlaceholderIfNeeded),
+                relativePath);
             failureReason = (UpdateFailureReason)failureCause;
             return new FileSystemResult(HResultToFSResult(result), unchecked((int)result));
         }
@@ -652,11 +668,99 @@ namespace GVFS.Platform.Windows
             CancellationTokenSource cancellationSource;
             if (this.activeCommands.TryRemove(commandId, out cancellationSource))
             {
-                this.virtualizationInstance.CompleteCommand(commandId, result);
-                return true;
+                // Track whether the native completion actually ran. If CompleteCommand faults under
+                // memory pressure, TryInvokeProjFS swallows the exception so the mount survives, but
+                // ProjFS never accepted the completion and so will not drive the matching
+                // EndDirectoryEnumeration callback. In that case we must report the command as not
+                // completed so callers clean up any state they registered (for example the active
+                // enumeration) instead of leaking it.
+                bool completionHandedOffToProjFS = false;
+                this.TryInvokeProjFS(
+                    () =>
+                    {
+                        HResult completionResult = this.virtualizationInstance.CompleteCommand(commandId, result);
+                        completionHandedOffToProjFS = true;
+                        return completionResult;
+                    },
+                    nameof(this.TryCompleteCommand),
+                    addDetails: metadata =>
+                    {
+                        metadata.Add("commandId", commandId);
+                        metadata.Add("completionResult", result.ToString("X") + "(" + result.ToString("G") + ")");
+                    });
+
+                return completionHandedOffToProjFS;
             }
 
             return false;
+        }
+
+        private void AddMemoryPressureData(EventMetadata metadata)
+        {
+            metadata.Add("activeEnumerations", this.activeEnumerations.Count);
+            metadata.Add("activeCommands", this.activeCommands.Count);
+            metadata.Add("gcTotalMemoryBytes", GC.GetTotalMemory(forceFullCollection: false));
+        }
+
+        /// <summary>
+        /// Invokes a GVFS-initiated native ProjFS operation, converting a native failure into a
+        /// failed <see cref="HResult"/> instead of a process crash.
+        /// </summary>
+        /// <remarks>
+        /// A native ProjFS call can fault under memory pressure (for example a NullReferenceException
+        /// surfaced from projectedfslib.dll). If that exception escaped, it would tear down
+        /// GVFS.Mount, orphaning the virtualization root and causing every subsequent placeholder
+        /// access to fail with STATUS_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE (0xC000CE01). Callers
+        /// map the returned non-Ok HResult to a failure result and continue serving the mount.
+        ///
+        /// This is used for outbound operations that are safe to fail individually. Operations that
+        /// mutate projection state use <see cref="InvokeProjFSOrThrow"/> instead, which logs the same
+        /// telemetry but rethrows. Callback completions funnel through <see cref="TryCompleteCommand"/>
+        /// (which uses this guard); the file-stream handler already fails a single hydration on any
+        /// exception.
+        /// </remarks>
+        private HResult TryInvokeProjFS(Func<HResult> nativeCall, string operationName, string relativePath = null, Action<EventMetadata> addDetails = null)
+        {
+            try
+            {
+                return nativeCall();
+            }
+            catch (Exception e)
+            {
+                this.LogProjFSNativeFailure(operationName, e, relativePath, addDetails);
+                return HResult.InternalError;
+            }
+        }
+
+        /// <summary>
+        /// Invokes a GVFS-initiated native ProjFS operation for which swallowing a failure is unsafe
+        /// (for example because it mutates projection state). Emits the same high-signal
+        /// <c>*_NativeFailure</c> telemetry as <see cref="TryInvokeProjFS"/> for the memory-pressure
+        /// diagnostics, then rethrows so the mount fails fast rather than continuing in an
+        /// inconsistent state.
+        /// </summary>
+        private HResult InvokeProjFSOrThrow(Func<HResult> nativeCall, string operationName, string relativePath = null, Action<EventMetadata> addDetails = null)
+        {
+            try
+            {
+                return nativeCall();
+            }
+            catch (Exception e)
+            {
+                this.LogProjFSNativeFailure(operationName, e, relativePath, addDetails);
+                throw;
+            }
+        }
+
+        private void LogProjFSNativeFailure(string operationName, Exception e, string relativePath, Action<EventMetadata> addDetails)
+        {
+            EventMetadata metadata = this.CreateEventMetadata(relativePath, e);
+            addDetails?.Invoke(metadata);
+            this.AddMemoryPressureData(metadata);
+            metadata.Add(
+                TracingConstants.MessageKey.ErrorMessage,
+                operationName + ": native ProjFS call threw under suspected memory pressure");
+            this.Context.Tracer.RelatedError(metadata, operationName + "_NativeFailure", Keywords.Telemetry);
         }
 
         private void StartDirectoryEnumerationAsyncHandler(
@@ -720,10 +824,12 @@ namespace GVFS.Platform.Windows
 
             if (!this.TryCompleteCommand(commandId, result))
             {
-                // Command has already been canceled, and no EndDirectoryEnumeration callback will be received
+                // Either the command was already canceled or the native completion failed under
+                // memory pressure; in both cases no EndDirectoryEnumeration callback will arrive, so
+                // remove the enumeration we just registered rather than leaking it.
 
                 EventMetadata metadata = this.CreateEventMetadata(virtualPath);
-                metadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}: TryCompleteCommand returned false, command already canceled");
+                metadata.Add(TracingConstants.MessageKey.InfoMessage, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}: TryCompleteCommand returned false; command canceled or native completion failed");
                 metadata.Add("commandId", commandId);
                 metadata.Add("enumerationId", enumerationId);
                 metadata.Add(nameof(result), result.ToString("X") + "(" + result.ToString("G") + ")");
@@ -731,7 +837,7 @@ namespace GVFS.Platform.Windows
                 ActiveEnumeration activeEnumeration;
                 bool activeEnumerationsUpdated = this.activeEnumerations.TryRemove(enumerationId, out activeEnumeration);
                 metadata.Add("activeEnumerationsUpdated", activeEnumerationsUpdated);
-                this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}_CommandAlreadyCanceled", metadata);
+                this.Context.Tracer.RelatedEvent(EventLevel.Informational, $"{nameof(this.StartDirectoryEnumerationAsyncHandler)}_CommandNotCompleted", metadata);
             }
         }
 
@@ -1070,10 +1176,13 @@ namespace GVFS.Platform.Windows
             string triggeringProcessImageFileName)
         {
             string directoryPath = Path.Combine(this.Context.Enlistment.WorkingDirectoryRoot, virtualPath);
-            HResult hr = this.virtualizationInstance.MarkDirectoryAsPlaceholder(
-                directoryPath,
-                FolderContentId,
-                PlaceholderVersionId);
+            HResult hr = this.InvokeProjFSOrThrow(
+                () => this.virtualizationInstance.MarkDirectoryAsPlaceholder(
+                    directoryPath,
+                    FolderContentId,
+                    PlaceholderVersionId),
+                nameof(this.MarkDirectoryAsPlaceholder),
+                virtualPath);
 
             if (hr == HResult.Ok)
             {

--- a/GVFS/GVFS.UnitTests/Windows/Mock/MockVirtualizationInstance.cs
+++ b/GVFS/GVFS.UnitTests/Windows/Mock/MockVirtualizationInstance.cs
@@ -62,6 +62,18 @@ namespace GVFS.UnitTests.Windows.Mock
         public HResult DeleteFileResult { get; set; }
         public UpdateFailureCause DeleteFileUpdateFailureCause { get; set; }
 
+        // When set, DeleteFile throws this to simulate a native ProjFS failure (e.g. a
+        // NullReferenceException surfaced from projectedfslib.dll under memory pressure).
+        public Exception DeleteFileException { get; set; }
+
+        // When set, the other GVFS-initiated native operations (ClearNegativePathCache,
+        // WritePlaceholderInfo, UpdateFileIfNeeded) throw this to simulate a native ProjFS failure.
+        public Exception NativeCallException { get; set; }
+
+        // When set, CompleteCommand throws this to simulate the native ProjFS completion faulting
+        // under memory pressure (e.g. a NullReferenceException surfaced from projectedfslib.dll).
+        public Exception CompleteCommandException { get; set; }
+
         public HResult UpdateFileIfNeededResult { get; set; }
         public UpdateFailureCause UpdateFileIfNeededFailureCase { get; set; }
 
@@ -82,6 +94,11 @@ namespace GVFS.UnitTests.Windows.Mock
 
         public HResult ClearNegativePathCache(out uint totalEntryNumber)
         {
+            if (this.NativeCallException != null)
+            {
+                throw this.NativeCallException;
+            }
+
             totalEntryNumber = this.NegativePathCacheCount;
             this.NegativePathCacheCount = 0;
             return HResult.Ok;
@@ -89,12 +106,22 @@ namespace GVFS.UnitTests.Windows.Mock
 
         public HResult DeleteFile(string relativePath, UpdateType updateFlags, out UpdateFailureCause failureReason)
         {
+            if (this.DeleteFileException != null)
+            {
+                throw this.DeleteFileException;
+            }
+
             failureReason = this.DeleteFileUpdateFailureCause;
             return this.DeleteFileResult;
         }
 
         public HResult UpdateFileIfNeeded(string relativePath, DateTime creationTime, DateTime lastAccessTime, DateTime lastWriteTime, DateTime changeTime, FileAttributes fileAttributes, long endOfFile, byte[] contentId, byte[] providerId, UpdateType updateFlags, out UpdateFailureCause failureReason)
         {
+            if (this.NativeCallException != null)
+            {
+                throw this.NativeCallException;
+            }
+
             failureReason = this.UpdateFileIfNeededFailureCase;
             return this.UpdateFileIfNeededResult;
         }
@@ -121,6 +148,11 @@ namespace GVFS.UnitTests.Windows.Mock
             byte[] contentId,
             byte[] epochId)
         {
+            if (this.NativeCallException != null)
+            {
+                throw this.NativeCallException;
+            }
+
             this.CreatedPlaceholders.Add(relativePath);
             this.placeholderCreated.Set();
             return HResult.Ok;
@@ -169,6 +201,11 @@ namespace GVFS.UnitTests.Windows.Mock
 
         public HResult CompleteCommand(int commandId, HResult completionResult)
         {
+            if (this.CompleteCommandException != null)
+            {
+                throw this.CompleteCommandException;
+            }
+
             this.completionResult = completionResult;
             this.commandCompleted.Set();
             return HResult.Ok;

--- a/GVFS/GVFS.UnitTests/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
@@ -96,6 +96,75 @@ namespace GVFS.UnitTests.Windows.Virtualization
         }
 
         [TestCase]
+        public void DeleteFileReturnsIOErrorWhenVirtualizationInstanceThrows()
+        {
+            using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
+            using (WindowsFileSystemVirtualizer virtualizer = new WindowsFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects, mockVirtualization, numWorkThreads))
+            {
+                // A native ProjFS failure (for example a NullReferenceException surfaced from
+                // projectedfslib.dll under memory pressure) must fail this single delete rather than
+                // propagate out and crash the mount.
+                mockVirtualization.DeleteFileException = new NullReferenceException("simulated native ProjFS failure");
+
+                UpdateFailureReason failureReason = UpdateFailureReason.DirtyData;
+                virtualizer
+                    .DeleteFile("test.txt", UpdatePlaceholderType.AllowReadOnly, out failureReason)
+                    .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)HResult.InternalError));
+                failureReason.ShouldEqual(UpdateFailureReason.NoFailure);
+            }
+        }
+
+        [TestCase]
+        public void OutboundProjFSOperationsReturnFailureWhenVirtualizationInstanceThrows()
+        {
+            using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
+            using (WindowsFileSystemVirtualizer virtualizer = new WindowsFileSystemVirtualizer(this.Repo.Context, this.Repo.GitObjects, mockVirtualization, numWorkThreads))
+            {
+                // Every GVFS-initiated native ProjFS operation must fail the single call rather than
+                // propagate a native exception (e.g. a NullReferenceException from projectedfslib.dll
+                // under memory pressure) and crash the mount.
+                mockVirtualization.NativeCallException = new NullReferenceException("simulated native ProjFS failure");
+
+                virtualizer
+                    .ClearNegativePathCache(out uint _)
+                    .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)HResult.InternalError));
+
+                UpdateFailureReason failureReason = UpdateFailureReason.DirtyData;
+                virtualizer
+                    .UpdatePlaceholderIfNeeded(
+                        "test.txt",
+                        DateTime.Now,
+                        DateTime.Now,
+                        DateTime.Now,
+                        DateTime.Now,
+                        0,
+                        15,
+                        string.Empty,
+                        UpdatePlaceholderType.AllowReadOnly,
+                        out failureReason)
+                    .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)HResult.InternalError));
+                failureReason.ShouldEqual(UpdateFailureReason.NoFailure);
+            }
+        }
+
+        [TestCase]
+        public void WritePlaceholderOperationsReturnFailureWhenVirtualizationInstanceThrows()
+        {
+            using (WindowsFileSystemVirtualizerTester tester = new WindowsFileSystemVirtualizerTester(this.Repo))
+            {
+                tester.MockVirtualization.NativeCallException = new NullReferenceException("simulated native ProjFS failure");
+
+                tester.WindowsVirtualizer
+                    .WritePlaceholderFile("test.txt", endOfFile: 15, sha: new string('0', 40))
+                    .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)HResult.InternalError));
+
+                tester.WindowsVirtualizer
+                    .WritePlaceholderDirectory("testDir")
+                    .ShouldEqual(new FileSystemResult(FSResult.IOError, (int)HResult.InternalError));
+            }
+        }
+
+        [TestCase]
         public void UpdatePlaceholderIfNeeded()
         {
             using (MockVirtualizationInstance mockVirtualization = new MockVirtualizationInstance())
@@ -471,6 +540,34 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 result.ShouldEqual(tester.MockVirtualization.WriteFileReturnResult);
                 MockTracer mockTracker = this.Repo.Context.Tracer as MockTracer;
                 mockTracker.RelatedErrorEvents.ShouldBeEmpty();
+            }
+        }
+
+        [TestCase]
+        public void OnStartDirectoryEnumerationCleansUpEnumerationWhenNativeCompletionFails()
+        {
+            using (WindowsFileSystemVirtualizerTester tester = new WindowsFileSystemVirtualizerTester(this.Repo))
+            {
+                MockTracer mockTracker = this.Repo.Context.Tracer as MockTracer;
+                mockTracker.WaitRelatedEventName = "StartDirectoryEnumerationAsyncHandler_CommandNotCompleted";
+
+                // Simulate the native ProjFS completion faulting under memory pressure. TryInvokeProjFS
+                // must swallow the exception so the mount survives, and because ProjFS never accepted the
+                // completion no EndDirectoryEnumeration callback will arrive. The enumeration registered by
+                // the async handler must therefore be removed here rather than leaked.
+                tester.MockVirtualization.CompleteCommandException = new NullReferenceException("simulated native ProjFS failure");
+
+                Guid enumerationGuid = Guid.NewGuid();
+                tester.GitIndexProjection.EnumerationInMemory = false;
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(1, enumerationGuid, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Pending);
+
+                // Deterministically wait for the async handler to reach its cleanup path (the enumeration is
+                // removed immediately before this event is emitted). If the native failure were reported as a
+                // successful completion, this event would never fire.
+                mockTracker.WaitForRelatedEvent();
+
+                // The enumeration must already have been removed, so End cannot find it.
+                tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(enumerationGuid).ShouldEqual(HResult.InternalError);
             }
         }
     }


### PR DESCRIPTION
## Problem

`GVFS.Mount` crashes are being reported that surface downstream as other tools exiting with `-1073689087` = `0xC000CE01` = `STATUS_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE`. The chain is: **GVFS.Mount crashes → the ProjFS virtualization root is orphaned → every subsequent placeholder access on that enlistment returns `0xC000CE01`** until remount.

Watson attributes the crashes to `radar_high_memory projectedfslib.dll!prjcompletecommand`, alongside `System.OutOfMemoryException` buckets and GC access violations. The dominant managed signatures are `NullReferenceException` surfaced from the **native** ProjFS command-completion (`PrjCompleteCommand`, via `StartDirectoryEnumerationAsyncHandler`) and delete (`PrjDeleteFile`) paths — the native code faults under memory exhaustion and the CLR raises a (catchable) `NullReferenceException` on the worker thread, which today reaches `ExecuteFileOrNetworkRequest` and calls `Environment.Exit`.

VFS for Git is already on the latest `Microsoft.Windows.ProjFS` (2.1.0), so the native `projectedfslib.dll` fault cannot be fixed from here. The only managed-side lever this PR pulls is: **stop converting a single failed native ProjFS call into a whole-mount crash.** It does **not** claim to eliminate the native OOM fault itself.

> Not a v2.0 regression: the crash-prone call sites date to 2018 (`785ccb4a`, .NET Framework era). The v2.0 pure-C# ProjFS rewrite (`66334474`) made the same latent native fault *legible* as a managed NRE in GVFS telemetry — so the recent spike in reports is largely improved visibility, which this PR's telemetry is designed to quantify.

## Scope of this PR — the stabilization-safe core

This is the **narrow, hot-path-neutral** half of the investigation, intended for the 2.0 stabilization prerelease. A second, *speculative* half — bounding the leaked `activeEnumerations` collection — has been **split out into a separate draft PR, #2053**, because it alters the directory-enumeration hot path and its premise is not yet proven (see Repro below). #2053 keeps that change behind an off-by-default config flag and adds always-on Heartbeat telemetry to measure the leak first. This PR does not touch the enumeration hot path.

## Don't crash the mount on a native ProjFS failure

A single boundary helper, `TryInvokeProjFS(Func<HResult>, operationName, …)`, wraps each **GVFS-initiated** native ProjFS call: it catches the exception, emits high-signal telemetry (`*_NativeFailure`, with `activeEnumerations`/`activeCommands` counts and `GC.GetTotalMemory`), and returns `HResult.InternalError` so the caller maps it to a failure result and keeps serving.

Routed through the swallow-and-continue helper: `CompleteCommand` (via `TryCompleteCommand` — covers the completion leg of **all** async callbacks: enumeration, placeholder-info, file-data), `DeleteFile`, `WritePlaceholderFile`, `WritePlaceholderDirectory`, `UpdatePlaceholderIfNeeded`, `ClearNegativePathCache`.

**`MarkDirectoryAsPlaceholder`** mutates projection state, so swallowing is unsafe. It uses a sibling helper `InvokeProjFSOrThrow` that emits the **same** `*_NativeFailure` telemetry (so the memory diagnostics are captured) and then **rethrows** — the exception still reaches `LogUnhandledExceptionAndExit`, preserving fail-fast. Both helpers share one `LogProjFSNativeFailure`.

**Left as-is (already non-fatal):** `GetFileStreamHandlerAsyncHandler` already fails a single hydration on any exception (completes the command with `FileNotAvailable`, no exit), so `CreateWriteBuffer`/`WriteFileData` are already non-fatal.

> The exception is demonstrably catchable — it already reaches GVFS's `LogUnhandledExceptionAndExit` today (the source of the existing `VFS.Error "exiting process"` events). This change intercepts it one frame earlier and either declines to exit or (for state-mutating ops) enriches the crash with memory telemetry first.

## Local repro attempt (empirical) — why the enumeration-leak fix was split out

I built a variant of this change and, on top of it, tried to reproduce an enumeration leak → OOM → native crash: installed it, cloned a large enlistment, and hammered it with cancelled directory enumerations (`FindFirstFileExW` + `CancelSynchronousIo` mid-flight).

Controlled A/B, each touching 15k **cold** directories exactly once:

| Run | Aborted enums | Mount ΔWorkingSet |
|---|---|---|
| Control (no cancel) | 0 | **+10 MB** |
| Test (cancel) | 10,034 | **+7 MB** |

The cancel run grew *less* than the no-cancel control. A sustained 180 s / 869k-enumeration / 110k-abort run added only ~37 MB of slow creep dominated by legitimate cold→warm projection cache, stayed flat on idle, and produced **zero** `*_NativeFailure` / OOM / crash. Telemetry showed **883** async-path cancellations, **all** with `activeEnumerationsUpdated:true` — i.e. the existing async-cancel cleanup (`StartDirectoryEnumerationAsyncHandler` → `TryCompleteCommand` returns false → `TryRemove`) already removes every cancelled enumeration.

**Takeaways:**
- The simplest, most-suspected leak vector — enumeration cancellation — **does not** produce runaway growth in the current code; it self-heals. That is exactly why the `activeEnumerations` eviction was pulled out of this PR into **#2053** and gated off-by-default: it is unproven insurance, not the demonstrated driver, and it should not perturb the enumeration hot path in a stabilization build.
- The real-world OOM therefore comes from a different source (sync-path `Start`-without-`End`, abnormal process termination, or genuine kernel-memory exhaustion). That is exactly what **this PR's `*_NativeFailure` + `activeEnumerations`/memory telemetry is there to identify** once rolled out.

## Tests

- `DeleteFileReturnsIOErrorWhenVirtualizationInstanceThrows`, `OutboundProjFSOperationsReturnFailureWhenVirtualizationInstanceThrows` (ClearNegativePathCache, UpdatePlaceholderIfNeeded), `WritePlaceholderOperationsReturnFailureWhenVirtualizationInstanceThrows` (tester-based) — a throwing native call yields `IOError`, not a propagated exception.
- (`InvokeProjFSOrThrow`'s rethrow path ends in `Environment.Exit`, so it isn't safely unit-testable in-process; it's symmetric with the tested `TryInvokeProjFS`.)
- Full unit suite: **879 passed, 0 failed** (11 skipped); clean build.

## Open question for review

One design question remains genuinely open; I'd appreciate reviewer input.

**Swallow-and-continue vs. controlled remount.** When a native ProjFS call faults, this change logs `*_NativeFailure` and fails just that one operation, keeping the mount alive. That is strictly better than today's behavior (crash → orphaned root → `0xC000CE01` for everything). But if the native virtualization context is *genuinely* dead — not merely a transient allocation failure — then every subsequent operation will also fault, and the mount is effectively limping while still reporting itself as up. In that case a **deliberate, clean unmount + remount** on repeated `*_NativeFailure` (e.g. N failures within a window) might be better recovery than indefinitely serving errors. Open points:
- Is limping-but-alive the right default, or should repeated native failures escalate to a controlled remount / self-restart of the mount process?
- If we do escalate, what signal distinguishes "transient" from "context is dead"? A simple failure-rate threshold, or something more specific?
- I could **not settle this locally**: the native OOM fault was not reproducible via cancelled enumerations (see Repro — cancellation is self-healed), so I have no local scenario that reaches the dead-context state to test remount-vs-limp against. This needs either a heavier memory-pressure harness or production data.

## Summary / conclusion

The core value of this PR is **turning an opaque, fatal crash into a survivable, observable event.** Today the native ProjFS fault kills GVFS.Mount and all we get is a `radar_high_memory` Watson bucket with no GVFS-side context. After this change the mount stays alive, and every native failure emits high-signal telemetry (`activeEnumerations` / `activeCommands` counts and `GC.GetTotalMemory` at the exact failure point).

That telemetry is precisely what will let us **answer the open question above with real data instead of guesses**, and — together with the Heartbeat `ActiveEnumerationCount` added in **#2053** — tell us whether the enumeration-leak eviction is ever even needed in the field. The local repro already narrowed the search: enumeration cancellation is self-healed and is *not* the OOM driver, so the real memory source lies elsewhere. Land this to stop the bleeding and start collecting the data needed to fix the root cause.

---

*Assisted-by: Claude Opus 4.8*
