### PR TITLE
ci: run build workflow on release/** branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ run-name: ${{ inputs.run_name || 'VFS for Git' }}
 
 on:
   pull_request:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, 'release/**' ]
   push:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, 'release/**' ]
   workflow_dispatch:
     inputs:
       git_version:


### PR DESCRIPTION
## Summary

Adds `release/**` to the `pull_request` and `push` branch filters in
`.github/workflows/build.yaml` so the CI build/test workflow runs on long-lived
**release-train branches** (e.g. `release/2.0`).

## Why

We're moving off the legacy `milestones/M<N>` → `releases/shipped` snapshot model
toward long-lived `release/<major>.<minor>` branches that separate
release-candidate stabilization from feature work on `master`.

`build.yaml` currently triggers only on `[ master, releases/shipped ]`. A release
branch such as `release/2.0` would therefore get **no** workflow run on push or
PR — which means the aggregate `Build, Unit and Functional Tests Successful`
check is never produced. If a branch-protection/ruleset requires that check,
PRs into the release branch become **permanently un-mergeable**. This change is a
prerequisite for gating release branches on CI.

## Change

```diff
 on:
   pull_request:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, 'release/**' ]
   push:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, 'release/**' ]
```

Single-file change. The reusable workflows `functional-tests.yaml` and
`upgrade-tests.yaml` are `on: workflow_call` only (invoked by `build.yaml`), so
they need no branch-filter change.

## Notes

- Because `release/2.0` will be branched from an older tag (v2.0.26162.1) whose
  `build.yaml` predates this change, this commit also needs to be **present on
  the release branch itself** (it will be cherry-picked there) — for both `push`
  and `pull_request` events the branch-filter that matters is the workflow file
  on the base branch.
- Future release branches forked from `master` inherit this automatically.
