### PR TITLE
Bound git stdout/stderr capture to prevent GVFS.Mount OOM

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -15,6 +15,28 @@ namespace GVFS.Common.Git
     {
         private const int HResultEHANDLE = -2147024890; // 0x80070006 E_HANDLE
 
+        /// <summary>
+        /// Upper bound on the number of characters buffered from a git process's stderr. Bounding
+        /// stderr prevents a pathologically noisy git command (e.g. 'multi-pack-index write' repeatedly
+        /// reporting "could not load pack N" against a corrupt packfile) from growing the capture buffer
+        /// until GVFS.Mount hits an OutOfMemoryException. stderr is a diagnostic stream, so truncating it
+        /// is safe: callers can observe it via <see cref="Result.ErrorsTruncated"/> and should log it,
+        /// but must not fail solely because of it.
+        /// </summary>
+        private const int MaxCapturedStdErrChars = 10 * 1024 * 1024; // ~20 MB of UTF-16
+
+        /// <summary>
+        /// Upper bound on the number of characters buffered from a git process's stdout when the caller
+        /// buffers the whole result (i.e. does not stream it line-by-line). Sized to hold the
+        /// machine-readable (-z) output of the largest real repositories - on the order of 2.8M
+        /// status/diff records on the biggest os.2020 branches - with headroom, while staying far below
+        /// the .NET maximum array/string size so the buffer itself cannot OOM. stdout can carry
+        /// correctness-critical data (e.g. the full staged-file list), so truncation here is surfaced via
+        /// <see cref="Result.OutputTruncated"/> and those callers fail safe rather than act on a partial
+        /// result.
+        /// </summary>
+        private const int MaxCapturedStdOutChars = 128 * 1024 * 1024; // ~256 MB of UTF-16
+
         private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false);
         private static bool failedToSetEncoding = false;
         private static string expireTimeDateString;
@@ -967,14 +989,19 @@ namespace GVFS.Common.Git
                 // Do not perform a synchronous read to the end of both redirected streams.
                 using (this.executingProcess = this.GetGitProcess(command, workingDirectory, dotGitDirectory, useReadObjectHook, gitObjectsDirectory: gitObjectsDirectory, usePreCommandHook: usePreCommandHook))
                 {
-                    StringBuilder output = new StringBuilder();
-                    StringBuilder errors = new StringBuilder();
+                    // Bound how much stdout/stderr we buffer so a pathologically noisy git command
+                    // cannot grow these buffers without limit until GVFS.Mount hits an
+                    // OutOfMemoryException. stderr gets a tight cap (it is diagnostic); stdout gets a
+                    // large cap sized for the biggest real repositories. Truncation is surfaced on the
+                    // Result so callers of correctness-critical commands can fail safe.
+                    BoundedGitOutputBuffer output = new BoundedGitOutputBuffer(MaxCapturedStdOutChars);
+                    BoundedGitOutputBuffer errors = new BoundedGitOutputBuffer(MaxCapturedStdErrChars);
 
                     this.executingProcess.ErrorDataReceived += (sender, args) =>
                     {
                         if (args.Data != null)
                         {
-                            errors.Append(args.Data + "\n");
+                            errors.AppendLine(args.Data);
                         }
                     };
                     this.executingProcess.OutputDataReceived += (sender, args) =>
@@ -987,7 +1014,7 @@ namespace GVFS.Common.Git
                             }
                             else
                             {
-                                output.Append(args.Data + "\n");
+                                output.AppendLine(args.Data);
                             }
                         }
                     };
@@ -1026,11 +1053,11 @@ namespace GVFS.Common.Git
                         {
                             this.executingProcess.Kill();
 
-                            return new Result(output.ToString(), "Operation timed out: " + errors.ToString(), Result.GenericFailureCode);
+                            return new Result(output.ToString(), "Operation timed out: " + errors.ToString(), Result.GenericFailureCode, output.Truncated, errors.Truncated);
                         }
                     }
 
-                    return new Result(output.ToString(), errors.ToString(), this.executingProcess.ExitCode);
+                    return new Result(output.ToString(), errors.ToString(), this.executingProcess.ExitCode, output.Truncated, errors.Truncated);
                 }
             }
             catch (Win32Exception e)
@@ -1151,15 +1178,37 @@ namespace GVFS.Common.Git
             public const int GenericFailureCode = 1;
 
             public Result(string stdout, string stderr, int exitCode)
+                : this(stdout, stderr, exitCode, outputTruncated: false, errorsTruncated: false)
+            {
+            }
+
+            public Result(string stdout, string stderr, int exitCode, bool outputTruncated, bool errorsTruncated)
             {
                 this.Output = stdout;
                 this.Errors = stderr;
                 this.ExitCode = exitCode;
+                this.OutputTruncated = outputTruncated;
+                this.ErrorsTruncated = errorsTruncated;
             }
 
             public string Output { get; }
             public string Errors { get; }
             public int ExitCode { get; }
+
+            /// <summary>
+            /// True if the git process produced more stdout than the capture buffer allowed, so
+            /// <see cref="Output"/> is incomplete. Callers whose correctness depends on the full output
+            /// (e.g. the complete list of staged files) must treat this as a failure rather than acting
+            /// on a partial result.
+            /// </summary>
+            public bool OutputTruncated { get; }
+
+            /// <summary>
+            /// True if the git process produced more stderr than the capture buffer allowed, so
+            /// <see cref="Errors"/> is incomplete. This is expected for pathologically noisy commands and
+            /// is safe: callers should log it for diagnostics but should not fail solely because of it.
+            /// </summary>
+            public bool ErrorsTruncated { get; }
 
             public bool ExitCodeIsSuccess
             {
@@ -1181,6 +1230,65 @@ namespace GVFS.Common.Git
                 }
 
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Accumulates lines from a git process's redirected stdout or stderr while enforcing a hard
+        /// upper bound on the number of characters buffered. Once the cap is reached, further input is
+        /// dropped and a single truncation marker is appended. This prevents a noisy git command from
+        /// growing an unbounded StringBuilder until GVFS.Mount hits an OutOfMemoryException. Whether
+        /// truncation occurred is exposed via <see cref="Truncated"/>.
+        /// </summary>
+        public class BoundedGitOutputBuffer
+        {
+            private readonly StringBuilder builder = new StringBuilder();
+            private readonly int maxChars;
+            private bool truncated;
+
+            public BoundedGitOutputBuffer(int maxChars)
+            {
+                this.maxChars = maxChars;
+            }
+
+            /// <summary>
+            /// True once output has exceeded the cap and been truncated.
+            /// </summary>
+            public bool Truncated => this.truncated;
+
+            /// <summary>
+            /// Appends a single line (followed by a newline) unless doing so would exceed the cap. The
+            /// first time the cap is reached, as much of the line as fits is kept and a truncation marker
+            /// is appended; all subsequent lines are dropped.
+            /// </summary>
+            public void AppendLine(string line)
+            {
+                if (this.truncated)
+                {
+                    return;
+                }
+
+                // +1 accounts for the trailing newline we append after each line.
+                if (this.builder.Length + line.Length + 1 > this.maxChars)
+                {
+                    int remaining = this.maxChars - this.builder.Length;
+                    if (remaining > 0)
+                    {
+                        this.builder.Append(line, 0, Math.Min(remaining, line.Length));
+                    }
+
+                    this.builder.Append("\n[... GVFS truncated git output after " + this.maxChars + " characters to avoid OutOfMemoryException ...]\n");
+                    this.truncated = true;
+                    return;
+                }
+
+                this.builder.Append(line);
+                this.builder.Append('\n');
+            }
+
+            public override string ToString()
+            {
+                return this.builder.ToString();
             }
         }
 

--- a/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
+++ b/GVFS/GVFS.Common/Maintenance/GitMaintenanceStep.cs
@@ -193,6 +193,17 @@ namespace GVFS.Common.Maintenance
                     throw new StoppingException();
                 }
 
+                if (result?.ErrorsTruncated == true)
+                {
+                    // stderr was too large to buffer fully and was truncated to avoid an
+                    // OutOfMemoryException (e.g. a corrupt packfile producing a flood of errors). This is
+                    // safe and non-fatal - record it for diagnostics but do not fail the command for it.
+                    this.Context.Tracer.RelatedWarning(
+                        metadata: null,
+                        message: $"{this.Area}: Git process {gitCommand} stderr was truncated to bound memory use",
+                        keywords: Keywords.Telemetry);
+                }
+
                 if (result?.ExitCodeIsFailure == true)
                 {
                     string errorMessage = result?.Errors == null ? string.Empty : result.Errors;

--- a/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitProcessTests.cs
@@ -10,6 +10,88 @@ namespace GVFS.UnitTests.Git
     public class GitProcessTests
     {
         [TestCase]
+        public void BoundedGitOutputBuffer_KeepsShortOutput()
+        {
+            GitProcess.BoundedGitOutputBuffer buffer = new GitProcess.BoundedGitOutputBuffer(1000);
+            buffer.AppendLine("line one");
+            buffer.AppendLine("line two");
+
+            buffer.Truncated.ShouldBeFalse();
+            buffer.ToString().ShouldEqual("line one\nline two\n");
+        }
+
+        [TestCase]
+        public void BoundedGitOutputBuffer_TruncatesBeyondCapWithoutUnboundedGrowth()
+        {
+            // Simulate a flood of output (e.g. 'multi-pack-index write' spewing "could not load pack"
+            // against a corrupt packfile). Before the cap this grew an unbounded StringBuilder until
+            // GVFS.Mount hit OutOfMemoryException.
+            const int Cap = 4096;
+            GitProcess.BoundedGitOutputBuffer buffer = new GitProcess.BoundedGitOutputBuffer(Cap);
+
+            const string NoisyLine = "error: could not load pack 2";
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                buffer.AppendLine(NoisyLine);
+            }
+
+            buffer.Truncated.ShouldBeTrue();
+
+            string result = buffer.ToString();
+
+            // We appended ~28 million characters; the buffer must stay bounded near the cap
+            // (cap + a single one-time truncation marker), nowhere near the raw input size.
+            (result.Length < Cap + 200).ShouldBeTrue("Buffer grew beyond its cap: " + result.Length);
+            result.Contains("truncated").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void BoundedGitOutputBuffer_KeepsPartialLineThatCrossesCap()
+        {
+            GitProcess.BoundedGitOutputBuffer buffer = new GitProcess.BoundedGitOutputBuffer(10);
+            buffer.AppendLine("123456789012345");
+
+            buffer.Truncated.ShouldBeTrue();
+            string result = buffer.ToString();
+
+            // The portion of the line that fit under the cap is retained, then the marker.
+            result.StartsWith("1234567890").ShouldBeTrue();
+            result.Contains("truncated").ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void BoundedGitOutputBuffer_ExactlyAtCapIsNotTruncated()
+        {
+            // "abcd" + "\n" == 5 chars == cap; must fit without tripping truncation.
+            GitProcess.BoundedGitOutputBuffer buffer = new GitProcess.BoundedGitOutputBuffer(5);
+            buffer.AppendLine("abcd");
+
+            buffer.Truncated.ShouldBeFalse();
+            buffer.ToString().ShouldEqual("abcd\n");
+        }
+
+        [TestCase]
+        public void Result_TruncationFlagsDefaultToFalse()
+        {
+            GitProcess.Result result = new GitProcess.Result("out", "err", 0);
+
+            result.OutputTruncated.ShouldBeFalse();
+            result.ErrorsTruncated.ShouldBeFalse();
+        }
+
+        [TestCase]
+        public void Result_TruncationFlagsRoundTripThroughConstructor()
+        {
+            GitProcess.Result outputTruncated = new GitProcess.Result("out", "err", 0, outputTruncated: true, errorsTruncated: false);
+            outputTruncated.OutputTruncated.ShouldBeTrue();
+            outputTruncated.ErrorsTruncated.ShouldBeFalse();
+
+            GitProcess.Result errorsTruncated = new GitProcess.Result("out", "err", 0, outputTruncated: false, errorsTruncated: true);
+            errorsTruncated.OutputTruncated.ShouldBeFalse();
+            errorsTruncated.ErrorsTruncated.ShouldBeTrue();
+        }
+
+        [TestCase]
         public void TryKillRunningProcess_NeverRan()
         {
             GitProcess process = new GitProcess(new MockGVFSEnlistment());

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -436,6 +436,20 @@ namespace GVFS.Virtualization
             // Query all staged files in one call using --name-status -z.
             // Output format: "A\0path1\0M\0path2\0D\0path3\0"
             GitProcess.Result result = gitProcess.DiffCachedNameStatus(pathspecs, pathspecFromFile, pathspecFileNul);
+
+            if (result.OutputTruncated)
+            {
+                // The staged-file list exceeded the capture buffer. Acting on a partial list would leave
+                // some staged files out of ModifiedPaths (skip-worktree not cleared, stale placeholders),
+                // which is worse than failing. Fail safe and let the caller retry.
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("ExitCode", result.ExitCode);
+                this.context.Tracer.RelatedError(
+                    metadata,
+                    nameof(this.AddStagedFilesToModifiedPaths) + ": git diff --cached output was truncated; refusing to update ModifiedPaths from a partial staged-file list");
+                return false;
+            }
+
             if (result.ExitCodeIsSuccess && !string.IsNullOrEmpty(result.Output))
             {
                 string[] parts = result.Output.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);

--- a/GVFS/GVFS/CommandLine/SparseVerb.cs
+++ b/GVFS/GVFS/CommandLine/SparseVerb.cs
@@ -639,6 +639,17 @@ namespace GVFS.CommandLine
                         return false;
                     }
 
+                    if (statusResult.OutputTruncated)
+                    {
+                        // git status output exceeded the capture buffer. A partial status could omit
+                        // dirty paths and let sparse proceed over uncommitted changes (data loss), so
+                        // treat truncation as "cannot verify clean" and abort.
+                        tracer.RelatedError(
+                            new EventMetadata(),
+                            "git status output was truncated; aborting sparse to avoid acting on an incomplete status");
+                        return false;
+                    }
+
                     dirtyPathsNotInSparseSet = this.GetPathsNotCoveredBySparseFolders(statusResult.Output, sparseFolders);
                     return dirtyPathsNotInSparseSet.Count == 0;
                 },
@@ -650,6 +661,10 @@ namespace GVFS.CommandLine
                 if (statusResult.ExitCodeIsFailure)
                 {
                     this.WriteMessage(tracer, "Failed to run git status: " + statusResult.Errors);
+                }
+                else if (statusResult.OutputTruncated)
+                {
+                    this.WriteMessage(tracer, "git status reported too many changes to process safely. Aborting to avoid acting on an incomplete status; reduce the number of pending changes and retry.");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

GVFS.Mount could crash with `System.OutOfMemoryException`. `GitProcess.InvokeGitImpl` buffered **all** of a git process's stdout and stderr into unbounded `StringBuilder`s via the `DataReceived` handlers. A corrupt/truncated packfile in the shared object cache makes `git multi-pack-index` stream a large volume of `could not load pack` errors to stderr, growing the buffer until the mount OOM-crashes.

This is the **first of a series** that splits a larger fix into independently-reviewable, lower-risk pieces:
- **This PR** — bound the captured output (the crash-stopper).
- Follow-up — convert the two `-z` commands below to stream their output (removes the truncation exposure entirely).
- Separate PR — packfile-corruption auto-recovery.

## Change

Bound each captured stream with its **own** cap:
- **stderr: ~20 MB** (10M chars). stderr is diagnostic, so truncating it is safe — this is the cap that actually stops the corrupt-packfile crash.
- **stdout: ~256 MB** (128M chars) when the caller buffers the whole result. Sized to hold the machine-readable (`-z`) output of the largest real repositories — on the order of **2.8M status/diff records** on the biggest os.2020 branches — with headroom, while staying far below the .NET max array/string size so the buffer itself cannot OOM. Line-streamed commands are unaffected.

Truncation is surfaced on `GitProcess.Result` (`OutputTruncated`, `ErrorsTruncated`) so callers can react:
- **stdout is correctness-critical** for two commands, which now **fail safe** on truncation + emit telemetry rather than act on a partial result:
  - `AddStagedFilesToModifiedPaths` (`diff --cached --name-status -z`) — refuses to update `ModifiedPaths` from a partial staged-file list (which would leave staged files with skip-worktree set and stale placeholders).
  - `SparseVerb` git status check (`status --porcelain -z`) — aborts sparse rather than proceed over uncommitted changes it failed to see.
- **stderr truncation is expected and non-fatal**; `GitMaintenanceStep.RunGitCommand` logs it for diagnostics but does not fail the command for it.

## Tests

`GitProcessTests`: `BoundedGitOutputBuffer` keeps short output, truncates a flood without unbounded growth (with a marker + `Truncated` flag), keeps the partial line that crosses the cap, and does not trip exactly at the cap; `Result` truncation flags default to false and round-trip through the constructor. Full unit suite: **882 passed, 0 failed** (11 pre-existing native-hook skips).

## Note on follow-up

The two `-z` callers keep their buffered form here; the fail-safe valves are the interim guard. The follow-up PR converts them to NUL-delimited streaming (no buffering, no truncation possible) and removes the valves. A functional test for the large-unstage path is tracked for that PR.
