### PR TITLE
Narrow IsTransientError to BUSY+LOCKED only; exclude IOERR

### DIFF
--- a/GVFS/GVFS.Common/Database/SqliteErrorCodes.cs
+++ b/GVFS/GVFS.Common/Database/SqliteErrorCodes.cs
@@ -22,13 +22,21 @@ namespace GVFS.Common.Database
         public const int NotADatabase = 26;
 
         /// <summary>
-        /// Returns true if the error code represents a transient condition
-        /// that may resolve on retry (I/O errors, locking contention).
+        /// Returns true if the error code represents a transient locking condition
+        /// that is safe to retry. Only BUSY and LOCKED qualify: both mean the operation
+        /// was blocked before executing and was never committed, so retrying is idempotent.
+        ///
+        /// SQLITE_IOERR is intentionally excluded. An I/O error can fire during connection
+        /// disposal AFTER a write has already committed (e.g. WAL flush on close). Retrying
+        /// in that case would re-execute the read phase on an already-empty table and return
+        /// stale results — a risk that exists in ExecuteReadThenWrite (RemoveAllEntriesForFolder).
+        /// IOERR on a genuinely failed write will have been rolled back by SQLite atomically,
+        /// but we cannot distinguish that case at the catch site without inspecting whether
+        /// the write had already committed. The safe choice is to surface IOERR immediately.
         /// </summary>
         public static bool IsTransientError(int sqliteErrorCode)
         {
-            return sqliteErrorCode == DiskIOError
-                || sqliteErrorCode == Busy
+            return sqliteErrorCode == Busy
                 || sqliteErrorCode == Locked;
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #2031 (GVFSTable transient SQLite resilience).

`SQLITE_IOERR` is removed from the retry-eligible set in `IsTransientError`.

## Why

`ExecuteReadThenWrite` (used by `PlaceholderTable.RemoveAllEntriesForFolder`) performs a SELECT then DELETE on the same command/connection inside the retry loop. If `SQLITE_IOERR` fires during **connection disposal** — after the DELETE has already committed to the WAL — `ExecuteWithRetry` catches it and retries. The retry re-runs the SELECT, finds zero rows (DELETE already committed), and returns an empty `RemovedPlaceholders` list.

The caller (`TryDehydrateFolder` in `FileSystemCallbacks`) uses this list to roll back the dehydrate if the filesystem operation subsequently fails. An empty list means the rollback is a no-op and the placeholder entries are silently lost.

`BUSY` and `LOCKED` don't have this risk: both mean the operation was blocked **before executing** and was never committed — retry is always safe and idempotent.

## What changed

`SqliteErrorCodes.IsTransientError` now returns `true` only for `BUSY` (5) and `LOCKED` (6). `SQLITE_IOERR` (10) is surfaced immediately.

The `DiskIOError` constant is retained in `SqliteErrorCodes` for use in future diagnostic/logging code.

## Context

The root cause of the production LOCKED errors that motivated #2031 was `Cache=Shared` (already removed in that PR). IOERR tolerance was speculative. Removing it eliminates a real correctness hazard with no practical loss.

Flagged during GVFS 2.0 stabilization review.