### PR TITLE
Mount: remove broad HandleRequest exception catch

### DIFF
--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -707,6 +707,7 @@ namespace GVFS.Mount
                 metadata.Add("Header", message.Header);
                 metadata.Add("Exception", e.ToString());
                 this.tracer.RelatedError(metadata, "HandleRequest: Unhandled exception in request handler");
+                throw;
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2021 (merged). Changes the outer try-catch in `HandleRequest` from **swallowing** exceptions to **catch-log-rethrow**, so fail-fast via `Environment.Exit` is preserved while adding diagnostic context.

## Problem

The original broad catch suppressed all exceptions (except `OutOfMemoryException`) from every pipe request handler. This could silently mask corruption in state-mutating handlers:
- **PostIndexChanged** — projection update mid-flight → stale/wrong projection
- **DehydrateFolders** — folder moves + reset → half-dehydrated state
- **ReleaseLock** — lock bookkeeping corruption

Instead of crashing (which surfaces the problem immediately), the mount would continue serving in an inconsistent state.

## Fix

The catch now logs the message **header** and exception details (context that `OnNewConnection`'s generic `LogErrorAndExit` in `NamedPipeServer` does not capture), then **rethrows** so the exception propagates to `OnNewConnection` → `Environment.Exit` as before.

## What stays unchanged

The **inner** try-catch in `HandleDownloadObjectRequest` remains — it covers the specific crash scenario #2021 addressed. The download path is safe to catch and suppress:
- Loose object writes are atomic (temp file → rename)
- `missingTreeTracker` is advisory (re-populated on next request)
- No critical mount state (projection, lock, placeholder DB) is mutated
- Returns proper `DownloadFailed` response instead of broken pipe

## Testing

- Unit tests: 876 passed, 0 failed
- The inner DownloadObject catch continues to prevent the flaky rebase test crash