### PR TITLE
ProjFS: only tolerate FilterAttach ACCESS_DENIED for unelevated callers

### DIFF
--- a/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
+++ b/GVFS/GVFS.Platform.Windows/ProjFSFilter.cs
@@ -87,7 +87,7 @@ namespace GVFS.Platform.Windows
 
         /// <summary>
         /// Attempts to attach the ProjFS filter driver to the volume containing the enlistment.
-        /// If FilterAttach returns ACCESS_DENIED but the ProjFS service is already running,
+        /// If an unelevated caller gets ACCESS_DENIED but the ProjFS service is already running,
         /// the filter is presumed to already be attached and the call succeeds.
         /// </summary>
         public static bool TryAttachToVolume(string enlistmentRoot, ITracer tracer, out string errorMessage)
@@ -98,14 +98,22 @@ namespace GVFS.Platform.Windows
             }
 
             // FilterAttach requires SE_LOAD_DRIVER_PRIVILEGE, which is typically only
-            // granted to administrators. When the caller lacks this privilege but the
-            // ProjFS service is confirmed running, the filter is probably already
-            // attached to the volume — treat ACCESS_DENIED as success in that case.
+            // granted to administrators. An UNELEVATED caller therefore always gets
+            // ACCESS_DENIED regardless of whether the filter is actually attached, so
+            // when the ProjFS service is confirmed running we presume the (already
+            // elevated) service attached the filter and treat this as success.
+            //
+            // We intentionally do NOT tolerate ACCESS_DENIED for an ELEVATED caller
+            // (e.g. GVFS.Service, which runs as LocalSystem): an elevated caller holds
+            // the privilege, so ACCESS_DENIED there is a genuine failure (AV/EDR lock,
+            // Group Policy, or driver corruption) that must surface rather than be
+            // silently swallowed and leave the mount in a broken state.
             if (errorMessage != null
                 && errorMessage.Contains(AccessDeniedResult.ToString())
+                && !WindowsPlatform.IsElevatedImplementation()
                 && IsServiceRunning(tracer))
             {
-                tracer.RelatedInfo($"{nameof(TryAttachToVolume)}: FilterAttach returned ACCESS_DENIED, but ProjFS service is running. Proceeding.");
+                tracer.RelatedInfo($"{nameof(TryAttachToVolume)}: FilterAttach returned ACCESS_DENIED to an unelevated caller, but ProjFS service is running. Proceeding.");
                 errorMessage = null;
                 return true;
             }


### PR DESCRIPTION
## Summary

Narrows the ACCESS_DENIED tolerance added in #1980 so it only applies to **unelevated** callers of `ProjFSFilter.TryAttachToVolume`. This keeps the unelevated `gvfs mount` fix intact while ensuring the **elevated** `GVFS.Service` no longer silently swallows a genuine attach failure.

## Background

#1980 made `TryAttachToVolume` treat `ACCESS_DENIED` from `FilterAttach` as success whenever the ProjFS service is running. Both callers share this method:

- `ProjFSFilter.IsReady()` — runs in the (usually **unelevated**) `gvfs mount` process.
- `EnableAndAttachProjFSHandler.Run()` — runs in `GVFS.Service`, which is **elevated** (LocalSystem).

## The problem (error-swallowing risk)

`FilterAttach` requires `SE_LOAD_DRIVER_PRIVILEGE`, checked as a privilege gate at the API entry point:

- An **unelevated** caller *always* gets `ACCESS_DENIED`, regardless of whether the filter is actually attached. When the service is running, the (elevated) service already attached the filter, so tolerating this is the correct fix — and is the whole point of #1980.
- An **elevated** caller (the service) holds the privilege, so `ACCESS_DENIED` is **never** the benign case there. It signals a real problem — AV/EDR lock, Group Policy restriction, or driver corruption — and swallowing it lets the mount proceed in a broken state with no actionable error.

Before #1980, the service called raw `TryAttach` and reported that failure. After #1980 it swallows it. This PR restores that safety for the elevated path.

## The fix

Add a `!WindowsPlatform.IsElevatedImplementation()` guard to the tolerance condition. `ACCESS_DENIED` is a deterministic privilege gate, not a transient contention error, so distinguishing purely on elevation is precise:

- Unelevated `gvfs mount`: still tolerated → #1980 fix preserved.
- Elevated `GVFS.Service`: `ACCESS_DENIED` surfaces again → genuine failures are reported, not masked.

This also aligns the code with the existing comment's stated intent ("when the caller lacks this privilege"), which the merged code never actually checked.

## Explicitly out of scope

A bounded retry loop for "transient AV-scan contention" is **not** included: `FilterAttach`'s `ACCESS_DENIED` is a deterministic privilege gate, not a sharing/contention error (which would surface as a different HRESULT). Retrying would add latency and still mask real failures.

## Tests

- `GVFS.Platform.Windows`, `GVFS.Service`, and `GVFS.UnitTests` build clean (0 warnings, 0 errors).
- `ProjFSFilterTests` — 3/3 passed.
