### PR TITLE
Bound leaked ActiveEnumeration collection behind an off-by-default flag + Heartbeat observation telemetry

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -29,6 +29,7 @@ namespace GVFS.Common
             public const string MaxRetriesConfig = GVFSPrefix + "max-retries";
             public const string TimeoutSecondsConfig = GVFSPrefix + "timeout-seconds";
             public const string GitStatusCacheBackoffConfig = GVFSPrefix + "status-cache-backoff-seconds";
+            public const string MaxActiveEnumerationsConfig = GVFSPrefix + "max-active-enumerations";
             public const string MountId = GVFSPrefix + "mount-id";
             public const string EnlistmentId = GVFSPrefix + "enlistment-id";
             public const string CacheServer = GVFSPrefix + "cache-server";

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -180,6 +180,28 @@ namespace GVFS.Common.Git
             return succeeded;
         }
 
+        /// <summary>
+        /// Reads a git config value through the in-process libgit2 repo (no git.exe spawn).
+        /// </summary>
+        /// <param name="name">Config setting name (e.g. "gvfs.max-active-enumerations").</param>
+        /// <param name="value">
+        /// The config value, or null if the setting is unset. Only meaningful when this returns true.
+        /// </param>
+        /// <returns>
+        /// true if the libgit2 repo was available and the lookup ran (the setting may still be unset,
+        /// in which case <paramref name="value"/> is null); false if no libgit2 repo is available.
+        /// </returns>
+        public virtual bool TryGetConfigValue(string name, out string value)
+        {
+            value = null;
+            if (this.libgit2RepoInvoker == null)
+            {
+                return false;
+            }
+
+            return this.libgit2RepoInvoker.TryInvoke(repo => repo.GetConfigString(name), out value);
+        }
+
         public void Dispose()
         {
             if (this.libgit2RepoInvoker != null)

--- a/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
+++ b/GVFS/GVFS.Platform.Windows/ActiveEnumeration.cs
@@ -1,6 +1,7 @@
 ﻿using GVFS.Common;
 using GVFS.Virtualization.Projection;
 using Microsoft.Windows.ProjFS;
+using System;
 using System.Collections.Generic;
 
 namespace GVFS.Platform.Windows
@@ -20,9 +21,27 @@ namespace GVFS.Platform.Windows
             this.fileInfoEnumerator = new ProjectedFileInfoEnumerator(fileInfos);
             this.ResetEnumerator();
             this.MoveNext();
+            this.RecordActivity();
         }
 
         public delegate bool FileNamePatternMatcher(string name, string pattern);
+
+        /// <summary>
+        /// Monotonic tick count (<see cref="Environment.TickCount64"/>, milliseconds) of the most
+        /// recent activity (creation or enumeration read) on this enumeration. Used to identify
+        /// enumerations that ProjFS never ended, so their memory can be reclaimed. A monotonic
+        /// source is used (rather than wall-clock time) so that NTP/clock adjustments cannot cause a
+        /// live-but-idle enumeration to be misjudged as stale.
+        /// </summary>
+        public long LastActivityTickCount { get; private set; }
+
+        /// <summary>
+        /// Records that this enumeration was just touched, so it is not treated as abandoned.
+        /// </summary>
+        public void RecordActivity()
+        {
+            this.LastActivityTickCount = Environment.TickCount64;
+        }
 
         /// <summary>
         /// true if Current refers to an element in the enumeration, false if Current is past the end of the collection

--- a/GVFS/GVFS.Platform.Windows/InternalsVisibleTo.cs
+++ b/GVFS/GVFS.Platform.Windows/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GVFS.UnitTests")]

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -33,12 +33,39 @@ namespace GVFS.Platform.Windows
         private ConcurrentDictionary<Guid, ActiveEnumeration> activeEnumerations;
         private ConcurrentDictionary<int, CancellationTokenSource> activeCommands;
 
+        // ProjFS does not always deliver EndDirectoryEnumeration for a StartDirectoryEnumeration
+        // (for example when an enumeration is cancelled), which leaks the corresponding
+        // ActiveEnumeration - and the projected item list it pins - in this.activeEnumerations. Over
+        // long-lived mounts this unbounded growth is a suspected contributor to the memory pressure
+        // that ultimately crashes GVFS.Mount in the native ProjFS command-completion path.
+        //
+        // Eviction of stale (never-ended) enumerations is OFF by default and enabled only when the
+        // gvfs.max-active-enumerations git config is set to a positive value: once activeEnumerations
+        // grows past that threshold, a throttled sweep evicts entries idle longer than a timeout.
+        // The count telemetry below is always emitted on the Heartbeat event so the leak can be
+        // observed in the field before eviction is turned on anywhere.
+        private static readonly TimeSpan ActiveEnumerationStaleTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan ActiveEnumerationEvictionSweepInterval = TimeSpan.FromMinutes(1);
+
+        // Effective staleness cutoff for a never-ended enumeration. Defaults to the constant above;
+        // overridable by tests via ActiveEnumerationStaleTimeoutForTest.
+        private TimeSpan activeEnumerationStaleTimeout = ActiveEnumerationStaleTimeout;
+
+        // 0 disables eviction (the default). When > 0, it is the count of live enumerations above
+        // which a sweep evicts stale ones. Read from git config (gvfs.max-active-enumerations).
+        private int maxActiveEnumerations;
+
+        // Monotonic (Environment.TickCount64, milliseconds) timestamp of the last eviction sweep, so
+        // the throttle cannot be disturbed by wall-clock adjustments.
+        private long lastEnumerationEvictionSweepTickCount = Environment.TickCount64;
+
         public WindowsFileSystemVirtualizer(GVFSContext context, GVFSGitObjects gitObjects)
             : this(
                   context,
                   gitObjects,
                   virtualizationInstance: null,
-                  numWorkerThreads: FileSystemVirtualizer.DefaultNumWorkerThreads)
+                  numWorkerThreads: FileSystemVirtualizer.DefaultNumWorkerThreads,
+                  maxActiveEnumerations: ReadMaxActiveEnumerationsFromConfig(context))
         {
         }
 
@@ -46,7 +73,8 @@ namespace GVFS.Platform.Windows
             GVFSContext context,
             GVFSGitObjects gitObjects,
             IVirtualizationInstance virtualizationInstance,
-            int numWorkerThreads)
+            int numWorkerThreads,
+            int maxActiveEnumerations = 0)
             : base(context, gitObjects, numWorkerThreads)
         {
             List<NotificationMapping> notificationMappings = new List<NotificationMapping>()
@@ -72,9 +100,145 @@ namespace GVFS.Platform.Windows
 
             this.activeEnumerations = new ConcurrentDictionary<Guid, ActiveEnumeration>();
             this.activeCommands = new ConcurrentDictionary<int, CancellationTokenSource>();
+
+            this.maxActiveEnumerations = maxActiveEnumerations;
         }
 
         protected override string EtwArea => ClassName;
+
+        public override void AddHeartbeatMetadata(EventMetadata metadata)
+        {
+            // Always emitted, even when eviction is disabled, so the size of the activeEnumerations
+            // collection (and thus whether the never-ended-enumeration leak is a real memory driver)
+            // can be observed in the field before enabling eviction anywhere.
+            metadata.Add("ActiveEnumerationCount", this.activeEnumerations.Count);
+            metadata.Add("ActiveCommandCount", this.activeCommands.Count);
+        }
+
+        /// <summary>
+        /// Reads the gvfs.max-active-enumerations git config value (0 = eviction disabled, the
+        /// default). Uses the in-process libgit2 repo (no git.exe spawn). Never throws: any failure
+        /// reading git config leaves eviction disabled.
+        /// </summary>
+        private static int ReadMaxActiveEnumerationsFromConfig(GVFSContext context)
+        {
+            try
+            {
+                if (context?.Repository != null &&
+                    context.Repository.TryGetConfigValue(GVFSConstants.GitConfig.MaxActiveEnumerationsConfig, out string rawValue))
+                {
+                    if (string.IsNullOrWhiteSpace(rawValue))
+                    {
+                        // Setting is unset: eviction disabled.
+                        return 0;
+                    }
+
+                    if (int.TryParse(rawValue.Trim(), out int value) && value > 0)
+                    {
+                        return value;
+                    }
+
+                    if (context.Tracer != null)
+                    {
+                        EventMetadata metadata = new EventMetadata();
+                        metadata.Add("Area", ClassName);
+                        metadata.Add("configValue", rawValue);
+                        context.Tracer.RelatedWarning(metadata, nameof(ReadMaxActiveEnumerationsFromConfig) + ": could not parse " + GVFSConstants.GitConfig.MaxActiveEnumerationsConfig + " as a positive int, leaving enumeration eviction disabled");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                if (context?.Tracer != null)
+                {
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add("Area", ClassName);
+                    metadata.Add("Exception", e.ToString());
+                    context.Tracer.RelatedWarning(metadata, nameof(ReadMaxActiveEnumerationsFromConfig) + ": exception reading git config, leaving enumeration eviction disabled");
+                }
+            }
+
+            return 0;
+        }
+
+        private void MaybeEvictStaleEnumerations()
+        {
+            if (this.maxActiveEnumerations <= 0)
+            {
+                // Eviction disabled (gvfs.max-active-enumerations unset or non-positive).
+                return;
+            }
+
+            long now = Environment.TickCount64;
+            long last = Interlocked.Read(ref this.lastEnumerationEvictionSweepTickCount);
+            if (now - last < (long)ActiveEnumerationEvictionSweepInterval.TotalMilliseconds)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref this.lastEnumerationEvictionSweepTickCount, now, last) != last)
+            {
+                // Another thread just claimed this sweep interval.
+                return;
+            }
+
+            this.EvictStaleEnumerations();
+        }
+
+        private void EvictStaleEnumerations()
+        {
+            if (this.activeEnumerations.Count <= this.maxActiveEnumerations)
+            {
+                return;
+            }
+
+            long cutoff = Environment.TickCount64 - (long)this.activeEnumerationStaleTimeout.TotalMilliseconds;
+            int evictedCount = 0;
+            foreach (KeyValuePair<Guid, ActiveEnumeration> entry in this.activeEnumerations)
+            {
+                if (entry.Value.LastActivityTickCount < cutoff &&
+                    this.activeEnumerations.TryRemove(entry.Key, out _))
+                {
+                    evictedCount++;
+                }
+            }
+
+            if (evictedCount > 0)
+            {
+                EventMetadata metadata = this.CreateEventMetadata();
+                metadata.Add("evictedCount", evictedCount);
+                metadata.Add("remainingCount", this.activeEnumerations.Count);
+                metadata.Add("maxActiveEnumerations", this.maxActiveEnumerations);
+                metadata.Add("staleTimeoutMinutes", this.activeEnumerationStaleTimeout.TotalMinutes);
+                metadata.Add("gcTotalMemoryBytes", GC.GetTotalMemory(forceFullCollection: false));
+                metadata.Add(
+                    TracingConstants.MessageKey.WarningMessage,
+                    nameof(this.EvictStaleEnumerations) + ": evicted stale directory enumerations that ProjFS never ended, to bound memory usage");
+                this.Context.Tracer.RelatedEvent(EventLevel.Warning, nameof(this.EvictStaleEnumerations), metadata, Keywords.Telemetry);
+            }
+        }
+
+        internal TimeSpan ActiveEnumerationStaleTimeoutForTest
+        {
+            set { this.activeEnumerationStaleTimeout = value; }
+        }
+
+        internal int MaxActiveEnumerationsForTest
+        {
+            set { this.maxActiveEnumerations = value; }
+        }
+
+        /// <summary>
+        /// Test-only: resets the sweep throttle and runs the same eviction path the enumeration hot
+        /// callback runs, so eviction behavior can be exercised deterministically.
+        /// </summary>
+        internal void ForceEnumerationEvictionSweepForTest()
+        {
+            Interlocked.Exchange(
+                ref this.lastEnumerationEvictionSweepTickCount,
+                Environment.TickCount64 - (long)ActiveEnumerationEvictionSweepInterval.TotalMilliseconds - 1);
+            this.MaybeEvictStaleEnumerations();
+        }
 
         /// <remarks>
         /// Public for unit testing
@@ -211,6 +375,8 @@ namespace GVFS.Platform.Windows
         {
             try
             {
+                this.MaybeEvictStaleEnumerations();
+
                 List<ProjectedFileInfo> projectedItems;
                 if (this.FileSystemCallbacks.GitIndexProjection.TryGetProjectedItemsFromMemory(virtualPath, out projectedItems))
                 {
@@ -286,6 +452,8 @@ namespace GVFS.Platform.Windows
 
                     return HResult.InternalError;
                 }
+
+                activeEnumeration.RecordActivity();
 
                 if (restartScan)
                 {

--- a/GVFS/GVFS.UnitTests/Windows/Virtualization/ActiveEnumerationTests.cs
+++ b/GVFS/GVFS.UnitTests/Windows/Virtualization/ActiveEnumerationTests.cs
@@ -46,6 +46,20 @@ namespace GVFS.UnitTests.Windows.Virtualization
         }
 
         [TestCase]
+        public void RecordActivityUpdatesLastActivityTime()
+        {
+            long beforeCreate = Environment.TickCount64;
+            ActiveEnumeration activeEnumeration = CreateActiveEnumeration(new List<ProjectedFileInfo>());
+
+            // The constructor records initial activity.
+            (activeEnumeration.LastActivityTickCount >= beforeCreate).ShouldBeTrue();
+
+            long beforeRecord = Environment.TickCount64;
+            activeEnumeration.RecordActivity();
+            (activeEnumeration.LastActivityTickCount >= beforeRecord).ShouldBeTrue();
+        }
+
+        [TestCase]
         public void EnumerateSingleEntryList()
         {
             List<ProjectedFileInfo> entries = new List<ProjectedFileInfo>()

--- a/GVFS/GVFS.UnitTests/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
+++ b/GVFS/GVFS.UnitTests/Windows/Virtualization/WindowsFileSystemVirtualizerTests.cs
@@ -11,7 +11,9 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using GVFS.Common.Tracing;
 
 namespace GVFS.UnitTests.Windows.Virtualization
 {
@@ -178,6 +180,80 @@ namespace GVFS.UnitTests.Windows.Virtualization
                 tester.GitIndexProjection.EnumerationInMemory = true;
                 tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(1, enumerationGuid, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
                 tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(enumerationGuid).ShouldEqual(HResult.Ok);
+            }
+        }
+
+        [TestCase]
+        public void HeartbeatMetadataReportsActiveEnumerationCount()
+        {
+            using (WindowsFileSystemVirtualizerTester tester = new WindowsFileSystemVirtualizerTester(this.Repo, new[] { "test" }))
+            {
+                tester.GitIndexProjection.EnumerationInMemory = true;
+
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(1, Guid.NewGuid(), "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(2, Guid.NewGuid(), "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+
+                EventMetadata metadata = new EventMetadata();
+                tester.WindowsVirtualizer.AddHeartbeatMetadata(metadata);
+
+                metadata.ContainsKey("ActiveEnumerationCount").ShouldBeTrue();
+                ((int)metadata["ActiveEnumerationCount"]).ShouldEqual(2);
+                metadata.ContainsKey("ActiveCommandCount").ShouldBeTrue();
+            }
+        }
+
+        [TestCase]
+        public void StaleEnumerationsAreNotEvictedWhenDisabled()
+        {
+            using (WindowsFileSystemVirtualizerTester tester = new WindowsFileSystemVirtualizerTester(this.Repo, new[] { "test" }))
+            {
+                tester.GitIndexProjection.EnumerationInMemory = true;
+
+                // Eviction is disabled by default (gvfs.max-active-enumerations unset => 0). Even with
+                // a zero stale timeout - which would make every enumeration eligible - nothing is evicted.
+                tester.WindowsVirtualizer.MaxActiveEnumerationsForTest = 0;
+                tester.WindowsVirtualizer.ActiveEnumerationStaleTimeoutForTest = TimeSpan.Zero;
+
+                Guid firstId = Guid.NewGuid();
+                Guid secondId = Guid.NewGuid();
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(1, firstId, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+                Thread.Sleep(20);
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(2, secondId, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+
+                tester.WindowsVirtualizer.ForceEnumerationEvictionSweepForTest();
+
+                // Both enumerations are still present (a missing id would return InternalError).
+                tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(firstId).ShouldEqual(HResult.Ok);
+                tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(secondId).ShouldEqual(HResult.Ok);
+            }
+        }
+
+        [TestCase]
+        public void StaleEnumerationsAreEvictedWhenEnabledButLiveOnesAreKept()
+        {
+            using (WindowsFileSystemVirtualizerTester tester = new WindowsFileSystemVirtualizerTester(this.Repo, new[] { "test" }))
+            {
+                tester.GitIndexProjection.EnumerationInMemory = true;
+
+                // Enable eviction above 1 live enumeration, treating anything idle longer than 20ms as stale.
+                tester.WindowsVirtualizer.MaxActiveEnumerationsForTest = 1;
+                tester.WindowsVirtualizer.ActiveEnumerationStaleTimeoutForTest = TimeSpan.FromMilliseconds(20);
+
+                Guid staleId = Guid.NewGuid();
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(1, staleId, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+
+                // Let the first enumeration age well past the stale timeout before adding a fresh one.
+                Thread.Sleep(200);
+
+                Guid freshId = Guid.NewGuid();
+                tester.MockVirtualization.RequiredCallbacks.StartDirectoryEnumerationCallback(2, freshId, "test", TriggeringProcessId, TriggeringProcessImageFileName).ShouldEqual(HResult.Ok);
+
+                tester.WindowsVirtualizer.ForceEnumerationEvictionSweepForTest();
+
+                // The stale enumeration was evicted: its End now fails to find it (fails loudly, does
+                // not silently return partial results). The fresh enumeration is retained.
+                tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(staleId).ShouldEqual(HResult.InternalError);
+                tester.MockVirtualization.RequiredCallbacks.EndDirectoryEnumerationCallback(freshId).ShouldEqual(HResult.Ok);
             }
         }
 

--- a/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Virtualization/FileSystem/FileSystemVirtualizer.cs
@@ -111,6 +111,14 @@ namespace GVFS.Virtualization.FileSystem
 
         public abstract FileSystemResult DehydrateFolder(string relativePath);
 
+        /// <summary>
+        /// Adds platform-specific virtualization diagnostics (for example live directory-enumeration
+        /// counts) to the periodic Heartbeat telemetry event. The default implementation adds nothing.
+        /// </summary>
+        public virtual void AddHeartbeatMetadata(EventMetadata metadata)
+        {
+        }
+
         public void Dispose()
         {
             if (this.fileAndNetworkRequests != null)

--- a/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
+++ b/GVFS/GVFS.Virtualization/FileSystemCallbacks.cs
@@ -278,6 +278,8 @@ namespace GVFS.Virtualization
             metadata.Add("FilePlaceholderCount", this.placeholderDatabase.GetFilePlaceholdersCount());
             metadata.Add("FolderPlaceholderCount", this.placeholderDatabase.GetFolderPlaceholdersCount());
 
+            this.fileSystemVirtualizer?.AddHeartbeatMetadata(metadata);
+
             if (this.gitStatusCache.WriteTelemetryandReset(metadata))
             {
                 logToFile = true;


### PR DESCRIPTION
## Background

GVFS.Mount crashes surface downstream as `STATUS_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE` (0xC000CE01): once the mount dies, the ProjFS virtualization root is orphaned and every subsequent placeholder access fails. Watson attributes the crashes to `radar_high_memory projectedfslib.dll!prjcompletecommand` — GVFS.Mount is crashing under **memory pressure** in the native ProjFS command-completion path.

One suspected managed-side contributor: ProjFS does not always deliver `EndDirectoryEnumeration` for a `StartDirectoryEnumeration` (e.g. cancelled enumerations), leaking the `ActiveEnumeration` — and the projected item list it pins — in `activeEnumerations`. Over a long-lived mount this grows without bound.

**We do not yet have direct evidence** that this leak is a dominant driver of the memory pressure. So this PR is deliberately structured to *measure first, act second*:

## What this PR does

**1. Observation telemetry — always on.**
- `ActiveEnumeration` tracks a monotonic `LastActivityTickCount`.
- New `FileSystemVirtualizer.AddHeartbeatMetadata` hook; the Windows virtualizer reports `ActiveEnumerationCount` / `ActiveCommandCount` on the periodic **Heartbeat** event, regardless of the flag below.
- This ships the signal needed to confirm/refute the leak on real machines.

**2. Eviction — off by default, behind `gvfs.max-active-enumerations`.**
- Unset or `<= 0` → **eviction disabled, enumeration hot path unchanged** (the default).
- `> 0` → a throttled sweep (≤ once/min, only once the collection exceeds the configured count) evicts enumerations idle longer than 5 minutes.
- Monotonic clocks for both the throttle and the staleness cutoff; the throttle claim uses `Interlocked.CompareExchange` keyed on the previously-read tick so two threads in the same interval can't both sweep.

Evicting a live-but-idle enumeration is **safe and loud**: the next `GetDirectoryEnumeration` for that id misses the collection and returns `HResult.InternalError` (fails that one listing rather than returning truncated results as if complete), and every eviction is traced.

## Relationship to #2042 (independent — either order)

#2042 addresses a *different* lever on the same crash: it stops a single failed native ProjFS call from taking down the whole mount (survive-and-report instead of crash). This PR instead targets the *memory pressure* that triggers those faults, and gates the behavior change off until telemetry justifies it.

The two are **independent**: this branch does not contain #2042's commit and references none of its code (and vice-versa). They can be reviewed and merged in **either order** with no rebase — verified with `git merge-tree` (clean, no conflicts). #2042's own investigation (a local repro that showed enumeration *cancellation* self-heals and is not the OOM driver) is part of why the eviction here is unproven and therefore gated off by default.

## Open questions this is meant to answer
1. Does `activeEnumerations` actually grow without bound in the field? (Heartbeat `ActiveEnumerationCount`.)
2. If so, does bounding it measurably reduce the native-ProjFS-under-memory-pressure crash rate? (Enable the flag on a ring and compare.)

## Testing
- `ActiveEnumeration` records activity time.
- Heartbeat metadata reports the live enumeration count.
- Eviction disabled → stale enumerations retained.
- Eviction enabled → stale enumerations evicted (subsequent `End` → `InternalError`), freshly-active ones kept.
- Full unit suite passes (881 passed, 0 failed, 11 skipped).
