### PR TITLE
Gate CLI mount-progress display behind gvfs.mount-progress config

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -47,6 +47,14 @@ namespace GVFS.Common
             public const string ShowHydrationStatus = GVFSPrefix + "show-hydration-status";
             public const bool ShowHydrationStatusDefault = false;
 
+            /* Gates the CLI mount-progress display layer (progress phase strings surfaced
+             * over the named pipe during `gvfs mount`). Disabled by default so stabilization
+             * builds keep the reliability-relevant early-pipe infrastructure without shipping
+             * the newer progress-display behavior. The early pipe, HandleRequest Mounting
+             * guard, volatile currentState, and null-safe GetStatus are always on regardless. */
+            public const string MountProgress = GVFSPrefix + "mount-progress";
+            public const bool MountProgressDefault = false;
+
             public const string MaxHttpConnectionsConfig = GVFSPrefix + "max-http-connections";
 
             public const string PrefetchUseIdx = GVFSPrefix + "prefetch-use-idx";

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -58,6 +58,12 @@ namespace GVFS.Mount
 
         private volatile MountState currentState;
         private volatile string mountProgressMessage;
+
+        // When false (default), the mount process does not surface progress phase
+        // strings over the named pipe, so the CLI falls back to its static spinner.
+        // This gates only the display layer; the early-pipe reliability infrastructure
+        // (early pipe start, HandleRequest Mounting guard, null-safe GetStatus) is unaffected.
+        private bool reportMountProgress;
         private HeartbeatThread heartbeat;
         private ManualResetEvent unmountEvent;
 
@@ -232,6 +238,11 @@ namespace GVFS.Mount
                 });
 
             this.enlistment.InitializeCachePaths(localCacheRoot, gitObjectsRoot, blobSizesRoot);
+
+            // Read the display-layer flag once before the pipe opens so the very first
+            // GetStatus request is served consistently. Only gates the progress strings;
+            // the pipe still starts early regardless (reliability infrastructure).
+            this.reportMountProgress = this.ShouldReportMountProgress();
 
             // Start the pipe server early so MountVerb can connect and poll progress
             // during the parallel validation phase. Only GetStatus requests are
@@ -578,6 +589,27 @@ namespace GVFS.Mount
             {
                 this.FailMountAndExit("Failed to create mount point. Mount path exceeds the maximum number of allowed characters");
                 return null;
+            }
+        }
+
+        private bool ShouldReportMountProgress()
+        {
+            // Read via a transient LibGit2Repo rather than the context's shared
+            // LibGit2RepoInvoker: the invoker isn't created until CreateContext (after the
+            // pipe starts), and its constructor force-loads the object store, which we must
+            // not do on the pre-pipe critical path. A raw LibGit2Repo opens only the repo
+            // handle + config (no object store) and gives native git-bool parsing.
+            try
+            {
+                using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot))
+                {
+                    return repo.GetConfigBool(GVFSConstants.GitConfig.MountProgress) ?? GVFSConstants.GitConfig.MountProgressDefault;
+                }
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedWarning($"Failed to read {GVFSConstants.GitConfig.MountProgress} config, using default: {e.Message}");
+                return GVFSConstants.GitConfig.MountProgressDefault;
             }
         }
 
@@ -1377,7 +1409,11 @@ namespace GVFS.Mount
             {
                 case MountState.Mounting:
                     response.MountStatus = NamedPipeMessages.GetStatus.Mounting;
-                    response.MountProgress = this.mountProgressMessage;
+                    if (this.reportMountProgress)
+                    {
+                        response.MountProgress = this.mountProgressMessage;
+                    }
+
                     break;
 
                 case MountState.Ready:


### PR DESCRIPTION
## Summary

PR #2005 ("Show mount progress phases in CLI during gvfs mount") did two separable things:

1. **Reliability infrastructure (must keep):** moved the named-pipe server start *before* the parallel auth+validation wait in `InProcessMount.MountWithLockAcquired`, plus a `HandleRequest` `Mounting`-state guard, `volatile currentState`, and a null-safe `HandleGetStatusRequest`. Opening the pipe early widens the `WaitUntilMounted` connect window: the `"Unable to mount because the GVFS.Mount process is not responding"` error only fires from the *connect* phase (60s interactive / 300s unattended); once connected, the `GetStatus` poll loop is untimed. So an early pipe converts a possible connect-timeout into an indefinite-but-progressing wait. This benefits the SYSTEM-service **automount** path (`GVFSMountProcess` uses the same `WaitUntilMounted`).

2. **Display layer (cosmetic):** the `MountProgress` phase strings + CLI dynamic spinner.

## Change

Adds a **disabled-by-default** `gvfs.mount-progress` config flag that gates **only the display layer**:

- When off (default), `HandleGetStatusRequest` no longer populates `response.MountProgress`. `WaitUntilMounted` fires its `onProgress` callback only on non-empty progress, and `ConsoleHelper` renders just the base message when progress is empty — so the CLI falls back to its existing static spinner. **No client-side changes needed.**
- The reliability infrastructure (early pipe start, `Mounting` guard, `volatile currentState`, null-safe `GetStatus`) is **always on**, independent of the flag.

Net effect for a stabilization prerelease: keep the automount robustness from #2005, hold back the newer progress-display behavior behind an opt-in (`git config gvfs.mount-progress true`).

## Testing

- `dotnet build GVFS.Mount` — clean (0 warnings, 0 errors)
- Unit tests: **887 total, 876 passed, 0 failed, 11 expected skips**

## Notes

- The `MountProcessSnapshot` / `TryConnectWithProcessTracking` early-exit connect tracking is a **separate** change (commit `d98a2bb9`) and is intentionally untouched.
