### PR TITLE
Split ServiceVerb repo-state check into intent-specific predicates

### DIFF
--- a/GVFS/GVFS/CommandLine/ServiceVerb.cs
+++ b/GVFS/GVFS/CommandLine/ServiceVerb.cs
@@ -73,7 +73,7 @@ namespace GVFS.CommandLine
             {
                 foreach (string repoRoot in repoList)
                 {
-                    if (this.IsRepoMounted(repoRoot))
+                    if (this.IsRepoReady(repoRoot))
                     {
                         this.Output.WriteLine(repoRoot);
                     }
@@ -93,7 +93,7 @@ namespace GVFS.CommandLine
 
                 foreach (string repoRoot in repoList)
                 {
-                    if (!this.IsRepoMounted(repoRoot))
+                    if (this.IsRepoAvailableToMount(repoRoot))
                     {
                         this.Output.WriteLine("\r\nMounting repo at " + repoRoot);
                         ReturnCode result = this.Execute<MountVerb>(repoRoot);
@@ -118,7 +118,7 @@ namespace GVFS.CommandLine
 
                 foreach (string repoRoot in repoList)
                 {
-                    if (this.IsRepoMounted(repoRoot))
+                    if (this.IsRepoAvailableToUnmount(repoRoot))
                     {
                         this.Output.WriteLine("\r\nUnmounting repo at " + repoRoot);
                         ReturnCode result = this.Execute<UnmountVerb>(
@@ -199,8 +199,35 @@ namespace GVFS.CommandLine
             }
         }
 
-        private bool IsRepoMounted(string repoRoot)
+        private bool IsRepoReady(string repoRoot)
         {
+            // For --list-mounted: only a repo whose mount is fully Ready is reported as mounted.
+            return this.TryGetRepoMountStatus(repoRoot, out string mountStatus)
+                && mountStatus.Equals(NamedPipeMessages.GetStatus.Ready, StringComparison.Ordinal);
+        }
+
+        private bool IsRepoAvailableToMount(string repoRoot)
+        {
+            // For --mount-all: a repo can be mounted only when no live mount process is
+            // answering for it (i.e. it is not already Mounting, Ready, Unmounting, or MountFailed).
+            return !this.TryGetRepoMountStatus(repoRoot, out _);
+        }
+
+        private bool IsRepoAvailableToUnmount(string repoRoot)
+        {
+            // For --unmount-all: only unmount a repo whose mount is in a state that accepts an
+            // unmount request. A repo already Unmounting is reaching the desired state on its own,
+            // and one still Mounting rejects the request, so both are skipped to avoid spurious
+            // "Already unmounting" / "not mounted" failures during concurrent teardown.
+            return this.TryGetRepoMountStatus(repoRoot, out string mountStatus)
+                && (mountStatus.Equals(NamedPipeMessages.GetStatus.Ready, StringComparison.Ordinal)
+                    || mountStatus.Equals(NamedPipeMessages.GetStatus.MountFailed, StringComparison.Ordinal));
+        }
+
+        private bool TryGetRepoMountStatus(string repoRoot, out string mountStatus)
+        {
+            mountStatus = null;
+
             // Hide the output of status
             StringWriter statusOutput = new StringWriter();
             ReturnCode result = this.Execute<StatusVerb>(
@@ -210,9 +237,20 @@ namespace GVFS.CommandLine
                     verb.Output = statusOutput;
                 });
 
-            if (result == ReturnCode.Success)
+            if (result != ReturnCode.Success)
             {
-                return true;
+                // No live mount process is answering for this repo.
+                return false;
+            }
+
+            foreach (string line in statusOutput.ToString().Split('\n'))
+            {
+                string trimmedLine = line.Trim();
+                if (trimmedLine.StartsWith(StatusVerb.MountStatusOutputPrefix, StringComparison.Ordinal))
+                {
+                    mountStatus = trimmedLine.Substring(StatusVerb.MountStatusOutputPrefix.Length).Trim();
+                    return true;
+                }
             }
 
             return false;

--- a/GVFS/GVFS/CommandLine/StatusVerb.cs
+++ b/GVFS/GVFS/CommandLine/StatusVerb.cs
@@ -23,6 +23,10 @@ namespace GVFS.CommandLine
 
         private const string StatusVerbName = "status";
 
+        // Prefix used when writing the mount status line to output. ServiceVerb parses
+        // this to recover a repo's MountState without re-implementing the pipe protocol.
+        public const string MountStatusOutputPrefix = "Mount status: ";
+
         protected override string VerbName
         {
             get { return StatusVerbName; }
@@ -47,7 +51,7 @@ namespace GVFS.CommandLine
                     this.Output.WriteLine("Repo URL: " + getStatusResponse.RepoUrl);
                     this.Output.WriteLine("Cache Server: " + getStatusResponse.CacheServer);
                     this.Output.WriteLine("Local Cache: " + getStatusResponse.LocalCacheRoot);
-                    this.Output.WriteLine("Mount status: " + getStatusResponse.MountStatus);
+                    this.Output.WriteLine(MountStatusOutputPrefix + getStatusResponse.MountStatus);
                     this.Output.WriteLine("GVFS Lock: " + getStatusResponse.LockStatus);
                     this.Output.WriteLine("Background operations: " + getStatusResponse.BackgroundOperationCount);
                     this.Output.WriteLine("Disk layout version: " + getStatusResponse.DiskLayoutVersion);


### PR DESCRIPTION
## Problem

`gvfs service --unmount-all` intermittently fails with exit code 3 and `Already unmounting, please wait`, surfacing as the flaky functional test `GVFS.FunctionalTests.Tests.MultiEnlistmentTests.ServiceVerbTests.ServiceCommandsWithNoRepos`.

## Root cause

The service verbs (`--list-mounted`, `--mount-all`, `--unmount-all`) iterate the service's global repo registry and used a single `IsRepoMounted(repoRoot)` helper. That helper returned `true` whenever the mount named pipe merely **answered** a `GetStatus` request — regardless of the actual `MountState`. `StatusVerb` reports success as long as it can connect, so a `GVFS.Mount` process in the transient `Unmounting` state (a concurrent or prior unmount still shutting it down) counts as "mounted."

`--unmount-all` therefore attempts to unmount a repo that is already on its way out, gets the transient `Already unmounting` response from the mount process, and treats it as a hard failure — even though the desired end state (repo unmounted) is already being reached.

## Fix

Replace `IsRepoMounted` with three intent-specific predicates, all built on a `TryGetRepoMountStatus` primitive that reads the actual `MountState`:

| Predicate | Meaning | Caller |
|---|---|---|
| `IsRepoReady` | `MountState == Ready` | `--list-mounted` |
| `IsRepoAvailableToMount` | no live mount process answering | `--mount-all` |
| `IsRepoAvailableToUnmount` | `MountState ∈ {Ready, MountFailed}` | `--unmount-all` |

`--unmount-all` now skips repos that are `Unmounting` (already reaching the desired state) or `Mounting` (an unmount request would be rejected anyway), eliminating the spurious failure.

`StatusVerb` exposes the `"Mount status: "` output prefix as a shared constant so `ServiceVerb` recovers the `MountState` without re-implementing the pipe protocol (and without changing `StatusVerb`'s worktree/enlistment resolution, so there's no behavior regression for worktree mounts).

## Behavior changes

- **`--unmount-all`**: skips repos in `Unmounting`/`Mounting` instead of failing on them. (The fix.)
- **`--list-mounted`**: now reports only fully-`Ready` repos (previously also listed `Mounting`/`Unmounting`/`MountFailed` processes that happened to answer the pipe).
- **`--mount-all`**: unchanged — still mounts only when no live mount process is answering.

## Testing

- Builds clean (`dotnet build GVFS\GVFS\GVFS.csproj -c Debug`, 0 warnings).
- Covered by the existing `ServiceVerbTests` functional suite (`ServiceCommandsWithNoRepos`, `ServiceCommandsWithMultipleRepos`, `ServiceCommandsWithMountAndUnmount`), whose expectations remain consistent with the new state-aware behavior. There is no unit-test seam for the service verbs (they require a live service pipe).

## Related

This is the first of a set of fixes for the same flaky test. Two follow-ups are tracked separately: closing the mount-process lifecycle gap (a repo committed to unmounting still presents as a normal mounted repo to concurrent callers), and scoping the functional-test service registry so the global `--mount-all`/`--unmount-all` verbs can't reach across parallel fixtures.
