### PR TITLE
Harden orphan-lock detection against false-release on transient failures

### DIFF
--- a/GVFS/GVFS.Common/GVFSLock.cs
+++ b/GVFS/GVFS.Common/GVFSLock.cs
@@ -47,7 +47,8 @@ namespace GVFS.Common
             // failure on OpenProcess for a different-integrity caller) we still accept the
             // lock and fall back to the legacy PID-only orphan check; record the fallback in
             // telemetry so we can spot if it becomes common.
-            long? requestorStartTime = GVFSPlatform.Instance.TryGetActiveProcessStartTime(requestor.PID, out long startTime)
+            long? requestorStartTime =
+                GVFSPlatform.Instance.TryGetActiveProcessStartTime(requestor.PID, out long startTime) == ProcessStartTimeResult.Success
                 ? startTime
                 : (long?)null;
             if (requestorStartTime == null)
@@ -214,6 +215,17 @@ namespace GVFS.Common
                     this.ReleaseLockForTerminatedProcess(existingExternalHolder.PID, terminationReason);
                     this.tracer.SetGitCommandSessionId(string.Empty);
                     existingExternalHolder = null;
+                }
+                else if (terminationReason == "StartTimeIndeterminate" && existingExternalHolder != null)
+                {
+                    // We could not determine whether the holder is still alive, so we deliberately
+                    // kept the lock rather than risk releasing one that is still held. Record it so
+                    // we can see whether these transient failures ever happen in the field (and,
+                    // if a holder ever gets stuck this way, why the lock was not released).
+                    EventMetadata metadata = new EventMetadata();
+                    metadata.Add("CurrentLockHolder", existingExternalHolder.ToString());
+                    metadata.Add("Reason", terminationReason);
+                    this.tracer.RelatedEvent(EventLevel.Verbose, "ExternalHolderLivenessIndeterminate", metadata);
                 }
 
                 return existingExternalHolder == null;
@@ -460,17 +472,43 @@ namespace GVFS.Common
                     {
                         // Identity check: confirm the same process still owns this PID by comparing
                         // the OS-supplied process start time we captured at acquisition with the
-                        // current one. A mismatch means the original holder exited and Windows
-                        // recycled the PID to a different process (the bug this code fixes).
-                        if (!GVFSPlatform.Instance.TryGetActiveProcessStartTime(pid, out long currentStartTime))
+                        // current one. We only conclude the holder is gone (and release its lock)
+                        // when we have positive evidence, so that a transient failure to read the
+                        // start time can never release a lock that is still legitimately held.
+                        ProcessStartTimeResult result = GVFSPlatform.Instance.TryGetActiveProcessStartTime(pid, out long currentStartTime);
+                        switch (result)
                         {
-                            externalHolderTerminatedWithoutReleasingLock = true;
-                            terminationReason = "ProcessNotActive";
-                        }
-                        else if (currentStartTime != capturedStartTime)
-                        {
-                            externalHolderTerminatedWithoutReleasingLock = true;
-                            terminationReason = "PidRecycled";
+                            case ProcessStartTimeResult.Success when currentStartTime == capturedStartTime:
+                                // Same process, still alive. Keep the lock.
+                                break;
+
+                            case ProcessStartTimeResult.Success:
+                                // A different, still-running process now owns this PID: the original
+                                // holder exited and Windows recycled the PID (the bug this fixes).
+                                externalHolderTerminatedWithoutReleasingLock = true;
+                                terminationReason = "PidRecycled";
+                                break;
+
+                            case ProcessStartTimeResult.ProcessNotFound:
+                                // Positive evidence the holder is gone (no such PID, or it exited).
+                                externalHolderTerminatedWithoutReleasingLock = true;
+                                terminationReason = "ProcessExited";
+                                break;
+
+                            case ProcessStartTimeResult.Inaccessible:
+                                // We could open the holder at acquire time, and that access is stable
+                                // for the process's lifetime, so an access-denied result now means the
+                                // PID refers to a different process: the original holder is gone.
+                                externalHolderTerminatedWithoutReleasingLock = true;
+                                terminationReason = "HolderInaccessible";
+                                break;
+
+                            case ProcessStartTimeResult.Indeterminate:
+                            default:
+                                // We could not determine liveness (e.g. transient resource error).
+                                // Do NOT release: keep the lock and let the next poll re-evaluate.
+                                terminationReason = "StartTimeIndeterminate";
+                                break;
                         }
                     }
                     else

--- a/GVFS/GVFS.Common/GVFSPlatform.cs
+++ b/GVFS/GVFS.Common/GVFSPlatform.cs
@@ -68,16 +68,21 @@ namespace GVFS.Common
         public abstract bool IsProcessActive(int processId);
 
         /// <summary>
-        /// Returns true and writes an opaque, OS-supplied process-identity token (e.g. process
-        /// creation time on Windows) when the process with the given PID is currently active.
-        /// The token has no meaning beyond identity comparison: two calls for the same underlying
-        /// process yield equal tokens, and a call after the OS has recycled the PID to a different
-        /// process yields a different token. Returns false (and startTime = 0) if the process
-        /// is no longer running, or if it could not be identified for any reason (e.g. permission
-        /// failure). Callers must treat a false return as "no identity information available" and
-        /// fall back to <see cref="IsProcessActive(int)"/> if they still need a liveness check.
+        /// Attempts to read an opaque, OS-supplied process-identity token (e.g. process creation
+        /// time on Windows) for the process with the given PID. The token has no meaning beyond
+        /// identity comparison: two calls for the same underlying process yield equal tokens, and
+        /// a call after the OS has recycled the PID to a different process yields a different token.
         /// </summary>
-        public abstract bool TryGetActiveProcessStartTime(int processId, out long startTime);
+        /// <param name="processId">The PID to inspect.</param>
+        /// <param name="startTime">The identity token, valid only when the result is <see cref="ProcessStartTimeResult.Success"/>.</param>
+        /// <returns>
+        /// A <see cref="ProcessStartTimeResult"/> describing the outcome. Callers making a
+        /// release-versus-hold decision about a lock holder must only treat
+        /// <see cref="ProcessStartTimeResult.ProcessNotFound"/> and
+        /// <see cref="ProcessStartTimeResult.Inaccessible"/> as evidence the original holder is gone;
+        /// <see cref="ProcessStartTimeResult.Indeterminate"/> means "unknown" and must not trigger a release.
+        /// </returns>
+        public abstract ProcessStartTimeResult TryGetActiveProcessStartTime(int processId, out long startTime);
 
         public abstract void IsServiceInstalledAndRunning(string name, out bool installed, out bool running);
         public abstract string GetNamedPipeName(string enlistmentRoot);

--- a/GVFS/GVFS.Common/ProcessStartTimeResult.cs
+++ b/GVFS/GVFS.Common/ProcessStartTimeResult.cs
@@ -1,0 +1,38 @@
+namespace GVFS.Common
+{
+    /// <summary>
+    /// Outcome of attempting to read a process's start time for lock-holder identity checks.
+    /// The distinction between the failure values matters: the orphan-lock detector must only
+    /// release a lock when it has positive evidence that the original holder is gone, so it
+    /// treats "we could not determine anything" (<see cref="Indeterminate"/>) differently from
+    /// evidence that the holder has exited or been replaced.
+    /// </summary>
+    public enum ProcessStartTimeResult
+    {
+        /// <summary>
+        /// The process is active and its start time was read successfully. The out start time is valid.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// Positive evidence that no live process with the requested identity exists: either there is
+        /// no process at that PID, or a process was opened but has already exited. Safe to treat the
+        /// original holder as gone.
+        /// </summary>
+        ProcessNotFound,
+
+        /// <summary>
+        /// A process exists at the PID but we could not open it (access denied). Because we only
+        /// identity-track holders we successfully opened at acquire time (and that access relationship
+        /// is stable for a given process's lifetime), an access-denied result here means the PID now
+        /// refers to a different process than the original holder.
+        /// </summary>
+        Inaccessible,
+
+        /// <summary>
+        /// A transient or unclassified failure (e.g. resource exhaustion). We genuinely do not know
+        /// whether the original holder is alive, so callers must NOT treat this as evidence of exit.
+        /// </summary>
+        Indeterminate,
+    }
+}

--- a/GVFS/GVFS.Hooks/GVFS.Hooks.csproj
+++ b/GVFS/GVFS.Hooks/GVFS.Hooks.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\GVFS.Common\ProcessResult.cs">
       <Link>Common\ProcessResult.cs</Link>
     </Compile>
+    <Compile Include="..\GVFS.Common\ProcessStartTimeResult.cs">
+      <Link>Common\ProcessStartTimeResult.cs</Link>
+    </Compile>
     <Compile Include="..\GVFS.Common\WorktreeCommandParser.cs">
       <Link>Common\WorktreeCommandParser.cs</Link>
     </Compile>

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.Shared.cs
@@ -3,6 +3,7 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 
 namespace GVFS.Platform.Windows
@@ -13,6 +14,9 @@ namespace GVFS.Platform.Windows
         public const string UpgradeConfirmMessage = "`gvfs upgrade --confirm`";
 
         private const int StillActive = 259; /* from Win32 STILL_ACTIVE */
+
+        private const int ErrorAccessDenied = 5;         /* ERROR_ACCESS_DENIED */
+        private const int ErrorInvalidParameter = 87;    /* ERROR_INVALID_PARAMETER */
 
         public static bool IsElevatedImplementation()
         {
@@ -54,15 +58,14 @@ namespace GVFS.Platform.Windows
         }
 
         /// <summary>
-        /// Returns true if a process with the given PID is currently active AND writes its
-        /// creation timestamp (raw FILETIME, 100-ns ticks since 1601) to <paramref name="startTime"/>.
-        /// The returned value is intended for identity comparison only -- two calls for the
-        /// same underlying process (no PID reuse) always yield equal values; if the OS recycles
-        /// a PID to a new process the value will differ. Returns false (and startTime = 0)
-        /// if the process is gone, has terminated (but its kernel object lingers due to an
-        /// outstanding handle elsewhere), or cannot be opened for QueryLimitedInformation.
+        /// Attempts to read a process's creation timestamp (raw FILETIME, 100-ns ticks since 1601)
+        /// for identity comparison. The value written to <paramref name="startTime"/> is only valid
+        /// when the return value is <see cref="ProcessStartTimeResult.Success"/>; two calls for the
+        /// same underlying process yield equal values, and a recycled PID yields a different value.
+        /// The failure values are deliberately distinct so that the orphan-lock detector can release
+        /// a lock only on positive evidence (see <see cref="ProcessStartTimeResult"/>).
         /// </summary>
-        public static bool TryGetActiveProcessStartTimeImplementation(int processId, out long startTime)
+        public static ProcessStartTimeResult TryGetActiveProcessStartTimeImplementation(int processId, out long startTime)
         {
             startTime = 0;
 
@@ -70,24 +73,52 @@ namespace GVFS.Platform.Windows
             {
                 if (process.IsInvalid)
                 {
-                    return false;
+                    // Classify the failure by the Win32 error so callers can distinguish "the holder
+                    // is gone" from "we could not tell". OpenProcess sets last error on failure and
+                    // the P/Invoke is declared SetLastError=true, so the value is preserved here.
+                    int error = Marshal.GetLastWin32Error();
+                    switch (error)
+                    {
+                        case ErrorInvalidParameter:
+                            // No process exists with this PID.
+                            return ProcessStartTimeResult.ProcessNotFound;
+
+                        case ErrorAccessDenied:
+                            // A process exists but we cannot open it. Because we only reach the
+                            // identity check for holders we successfully opened at acquire time,
+                            // and OpenProcess(QueryLimitedInformation) access is stable for a
+                            // process's lifetime, this means the PID now refers to a different
+                            // process than the original holder.
+                            return ProcessStartTimeResult.Inaccessible;
+
+                        default:
+                            // Transient/unclassified (e.g. ERROR_NOT_ENOUGH_MEMORY). We do not know
+                            // whether the original holder is alive.
+                            return ProcessStartTimeResult.Indeterminate;
+                    }
                 }
 
                 // GetProcessTimes succeeds for terminated processes whose kernel object still
                 // exists (e.g., an outstanding handle elsewhere). Confirm the process is still
                 // running before trusting the creation time as an identity marker.
-                if (!NativeMethods.GetExitCodeProcess(process, out uint exitCode) || exitCode != StillActive)
+                if (!NativeMethods.GetExitCodeProcess(process, out uint exitCode))
                 {
-                    return false;
+                    return ProcessStartTimeResult.Indeterminate;
+                }
+
+                if (exitCode != StillActive)
+                {
+                    // The process was opened but has already exited.
+                    return ProcessStartTimeResult.ProcessNotFound;
                 }
 
                 if (!NativeMethods.GetProcessTimes(process, out long creationTime, out _, out _, out _))
                 {
-                    return false;
+                    return ProcessStartTimeResult.Indeterminate;
                 }
 
                 startTime = creationTime;
-                return true;
+                return ProcessStartTimeResult.Success;
             }
         }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsPlatform.cs
@@ -255,7 +255,7 @@ namespace GVFS.Platform.Windows
             return WindowsPlatform.IsProcessActiveImplementation(processId, tryGetProcessById: true);
         }
 
-        public override bool TryGetActiveProcessStartTime(int processId, out long startTime)
+        public override ProcessStartTimeResult TryGetActiveProcessStartTime(int processId, out long startTime)
         {
             return WindowsPlatform.TryGetActiveProcessStartTimeImplementation(processId, out startTime);
         }

--- a/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/GVFSLockTests.cs
@@ -260,6 +260,125 @@ namespace GVFS.UnitTests.Common
             mockTracer.VerifyAll();
         }
 
+        /// <summary>
+        /// When the start-time read returns positive evidence that the holder is gone
+        /// (ProcessNotFound), the orphaned lock must be released.
+        /// </summary>
+        [TestCase]
+        public void TryAcquireLockForExternalRequestor_WhenHolderProcessNotFound()
+        {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ExternalLockHolderExited", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            mockTracer.Setup(x => x.SetGitCommandSessionId(string.Empty));
+            MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
+
+            mockPlatform.ActiveProcesses.Add(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes[DefaultLockData.PID] = 1000;
+            GVFSLock gvfsLock = new GVFSLock(mockTracer.Object);
+            NamedPipeMessages.LockData existingExternalHolder;
+            gvfsLock.TryAcquireLockForExternalRequestor(DefaultLockData, out existingExternalHolder).ShouldBeTrue();
+            this.ValidateLockHeld(gvfsLock, DefaultLockData);
+
+            // Positive evidence the holder is gone.
+            mockPlatform.ProcessStartTimeResults[DefaultLockData.PID] = ProcessStartTimeResult.ProcessNotFound;
+
+            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "456");
+            mockPlatform.ActiveProcesses.Add(newLockData.PID);
+            mockPlatform.ProcessStartTimes[newLockData.PID] = 3000;
+            gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeTrue();
+            existingExternalHolder.ShouldBeNull();
+            this.ValidateLockHeld(gvfsLock, newLockData);
+
+            mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
+            mockPlatform.ActiveProcesses.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimeResults.Remove(DefaultLockData.PID);
+            mockTracer.VerifyAll();
+        }
+
+        /// <summary>
+        /// When the holder's PID is now occupied by a process we cannot open (Inaccessible), the
+        /// original holder must be gone: we successfully opened it at acquire time, and that access
+        /// is stable for a process's lifetime, so an access-denied result means the PID was recycled
+        /// to a different process. The orphaned lock must be released.
+        /// </summary>
+        [TestCase]
+        public void TryAcquireLockForExternalRequestor_WhenHolderInaccessible()
+        {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "ExternalLockHolderExited", It.IsAny<EventMetadata>(), Keywords.Telemetry));
+            mockTracer.Setup(x => x.SetGitCommandSessionId(string.Empty));
+            MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
+
+            mockPlatform.ActiveProcesses.Add(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes[DefaultLockData.PID] = 1000;
+            GVFSLock gvfsLock = new GVFSLock(mockTracer.Object);
+            NamedPipeMessages.LockData existingExternalHolder;
+            gvfsLock.TryAcquireLockForExternalRequestor(DefaultLockData, out existingExternalHolder).ShouldBeTrue();
+            this.ValidateLockHeld(gvfsLock, DefaultLockData);
+
+            // The PID is now occupied by a process we cannot open.
+            mockPlatform.ProcessStartTimeResults[DefaultLockData.PID] = ProcessStartTimeResult.Inaccessible;
+
+            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "456");
+            mockPlatform.ActiveProcesses.Add(newLockData.PID);
+            mockPlatform.ProcessStartTimes[newLockData.PID] = 3000;
+            gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeTrue();
+            existingExternalHolder.ShouldBeNull();
+            this.ValidateLockHeld(gvfsLock, newLockData);
+
+            mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
+            mockPlatform.ActiveProcesses.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimeResults.Remove(DefaultLockData.PID);
+            mockTracer.VerifyAll();
+        }
+
+        /// <summary>
+        /// Anti-false-release guard: when the start-time read is Indeterminate (e.g. a transient
+        /// resource failure), we do NOT know whether the holder is alive, so the lock must be KEPT.
+        /// Releasing here could hand the lock to a second writer while the original git process is
+        /// still running -- the worst-case regression this hardening prevents.
+        /// </summary>
+        [TestCase]
+        public void TryAcquireLockForExternalRequestor_WhenHolderIndeterminateKeepsLock()
+        {
+            Mock<ITracer> mockTracer = new Mock<ITracer>(MockBehavior.Strict);
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Informational, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "TryAcquireLockExternal", It.IsAny<EventMetadata>()));
+            mockTracer.Setup(x => x.RelatedEvent(EventLevel.Verbose, "ExternalHolderLivenessIndeterminate", It.IsAny<EventMetadata>()));
+            MockPlatform mockPlatform = (MockPlatform)GVFSPlatform.Instance;
+
+            mockPlatform.ActiveProcesses.Add(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes[DefaultLockData.PID] = 1000;
+            GVFSLock gvfsLock = new GVFSLock(mockTracer.Object);
+            NamedPipeMessages.LockData existingExternalHolder;
+            gvfsLock.TryAcquireLockForExternalRequestor(DefaultLockData, out existingExternalHolder).ShouldBeTrue();
+            this.ValidateLockHeld(gvfsLock, DefaultLockData);
+
+            // We cannot determine whether the holder is alive.
+            mockPlatform.ProcessStartTimeResults[DefaultLockData.PID] = ProcessStartTimeResult.Indeterminate;
+
+            // A new requestor must be denied -- the lock is still held by the (possibly-alive) holder.
+            NamedPipeMessages.LockData newLockData = new NamedPipeMessages.LockData(4321, false, false, "git new", "456");
+            mockPlatform.ActiveProcesses.Add(newLockData.PID);
+            mockPlatform.ProcessStartTimes[newLockData.PID] = 3000;
+            gvfsLock.TryAcquireLockForExternalRequestor(newLockData, out existingExternalHolder).ShouldBeFalse();
+            this.ValidateExistingExternalHolder(DefaultLockData, existingExternalHolder);
+            this.ValidateLockHeld(gvfsLock, DefaultLockData);
+
+            mockPlatform.ActiveProcesses.Remove(DefaultLockData.PID);
+            mockPlatform.ActiveProcesses.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(DefaultLockData.PID);
+            mockPlatform.ProcessStartTimes.Remove(newLockData.PID);
+            mockPlatform.ProcessStartTimeResults.Remove(DefaultLockData.PID);
+            mockTracer.VerifyAll();
+        }
+
         private GVFSLock AcquireDefaultLock(MockPlatform mockPlatform, ITracer mockTracer)
         {
             GVFSLock gvfsLock = new GVFSLock(mockTracer);

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockPlatform.cs
@@ -53,6 +53,13 @@ namespace GVFS.UnitTests.Mock.Common
         /// </summary>
         public Dictionary<int, long> ProcessStartTimes { get; } = new Dictionary<int, long>();
 
+        /// <summary>
+        /// Optional per-PID result overrides for <see cref="TryGetActiveProcessStartTime"/>, used by
+        /// tests that exercise the non-Success outcomes (Inaccessible / Indeterminate). When a PID is
+        /// present here, the specified result is returned regardless of <see cref="ActiveProcesses"/>.
+        /// </summary>
+        public Dictionary<int, ProcessStartTimeResult> ProcessStartTimeResults { get; } = new Dictionary<int, ProcessStartTimeResult>();
+
         public override void ConfigureVisualStudio(string gitBinPath, ITracer tracer)
         {
             throw new NotSupportedException();
@@ -141,19 +148,31 @@ namespace GVFS.UnitTests.Mock.Common
             return this.ActiveProcesses.Contains(processId);
         }
 
-        public override bool TryGetActiveProcessStartTime(int processId, out long startTime)
+        public override ProcessStartTimeResult TryGetActiveProcessStartTime(int processId, out long startTime)
         {
+            startTime = 0;
+
+            // Explicit result override wins, so tests can exercise Inaccessible / Indeterminate.
+            if (this.ProcessStartTimeResults.TryGetValue(processId, out ProcessStartTimeResult overrideResult))
+            {
+                if (overrideResult == ProcessStartTimeResult.Success)
+                {
+                    startTime = this.ProcessStartTimes.TryGetValue(processId, out long overrideTime) ? overrideTime : processId;
+                }
+
+                return overrideResult;
+            }
+
             if (this.ActiveProcesses.Contains(processId))
             {
                 // If the test populated an explicit start time use that, otherwise fall back
                 // to a deterministic non-zero value so test scenarios that don't care about
                 // PID identity (the existing majority of unit tests) keep working.
                 startTime = this.ProcessStartTimes.TryGetValue(processId, out long stored) ? stored : processId;
-                return true;
+                return ProcessStartTimeResult.Success;
             }
 
-            startTime = 0;
-            return false;
+            return ProcessStartTimeResult.ProcessNotFound;
         }
 
         public override void IsServiceInstalledAndRunning(string name, out bool installed, out bool running)


### PR DESCRIPTION
## Summary

Risk-reduction hardening for the orphan-lock detection change merged in #1989, ahead of the GVFS 2.0 stabilization release. #1989 was flagged 🔴 (highest "worse-regression-than-it-fixes" tier) because it is a concurrency fix; this PR removes the one dangerous failure mode it introduced while keeping the fix it delivered.

**This does not reopen #1989** (already merged) — it is a focused follow-up off current `master`.

## The regression being removed

#1989 captures the lock holder's process **start time** at acquire and compares it at each orphan check to distinguish the real holder from an unrelated process that recycled its PID. Correct for the recycle case — but it collapsed **every** failure to read the start time into a single `bool false`, which the caller treats as "holder is gone → release the lock."

The dangerous path is a **transient** `OpenProcess(QUERY_LIMITED_INFORMATION)` failure (e.g. momentary resource pressure) for a holder that is **still alive**: the merged code releases the lock, admitting a second writer to the index. That is a **corruption-class** failure — strictly worse than the flaky hang #1989 fixed.

Note the pre-#1989 code did **not** have this exposure: its liveness check fell back to `Process.GetProcessById` when `OpenProcess` failed. #1989 dropped that fallback on the identity path. This PR restores "never release without positive evidence" without reintroducing the identity-blind `GetProcessById` check (which would defeat #1989's recycle detection).

## The change

`TryGetActiveProcessStartTime` now returns a **`ProcessStartTimeResult`** enum instead of `bool`:

| Result | Windows mapping | Orphan-check action |
|---|---|---|
| `Success` (time **==** captured) | opened, still active, same creation time | **Hold** (same holder) |
| `Success` (time **!=** captured) | opened, still active, different creation time | **Release** — `PidRecycled` (the #1989 case) |
| `ProcessNotFound` | `ERROR_INVALID_PARAMETER`, or opened-but-exited (exit ≠ `STILL_ACTIVE`) | **Release** — positive evidence gone |
| `Inaccessible` | `ERROR_ACCESS_DENIED` | **Release** — see gate argument |
| `Indeterminate` | any other error (`ERROR_NOT_ENOUGH_MEMORY`, `ERROR_NO_SYSTEM_RESOURCES`, …) | **Hold** + telemetry — we don't know, so we never false-release |

The Win32 error is read via `Marshal.GetLastWin32Error()` (the P/Invokes are already `SetLastError = true`).

### Why `Inaccessible` → Release is safe (acquire-time gate)

We only enter the identity-check path for a holder whose start time we **successfully read at acquire** — i.e. one this mount could `OpenProcess`. `OpenProcess` access is a stable function of the caller token and the target's protection level / DACL, and git/hooks never rewrite their own DACL. So a live original holder we could open before **cannot** later become inaccessible; an access-denied result means the PID now refers to a **different** process → releasing is correct. The pre-existing null-start-time fallback (when we couldn't read start time at acquire) is unchanged.

## Blast radius

- **In-memory, mount-side only.** The captured start time is never serialized; the named-pipe lock protocol is unchanged → no cross-version / wire-format impact.
- The only behavioral change vs. #1989 is: transient/unknown read failures now **hold** instead of release. Every case #1989 released on positive evidence still releases.

## Telemetry

The `Indeterminate` hold emits `ExternalHolderLivenessIndeterminate` (Verbose) so we can measure whether these transient failures ever occur in the field.

## Tests

Adds unit coverage for the new outcomes and keeps the existing identity tests:
- `WhenHolderProcessNotFound` → released
- `WhenHolderInaccessible` → released (gated-recycle)
- `WhenHolderIndeterminateKeepsLock` → **held** (the anti-false-release guard)
- retained: `WhenHolderPidRecycled`, `WhenHolderStartTimeMatches`

**Validation:** `dotnet build GVFS.UnitTests` clean; full `GVFS.UnitTests` suite **885 passed, 0 failed** (11 skipped by category); all 5 identity tests pass.

Assisted-by: Claude Opus 4.7
