### PR TITLE
HealthTests: wait for background ops before gvfs health

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -160,6 +160,7 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             List<int> directoryHydrationLevels,
             string enlistmentHealthStatus)
         {
+            this.Enlistment.WaitForBackgroundOperations();
             string rawOutput = this.Enlistment.Health(directory);
             List<string> healthOutputLines = new List<string>(rawOutput.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries));
 


### PR DESCRIPTION
## Summary

HealthTests read placeholder/modified-path counts via `gvfs health` immediately after hydrating files via `File.OpenWrite()`. Those writes trigger ProjFS callbacks that GVFS processes on a background queue, so the modified-paths database may not yet reflect the full set of transitions when the health verb samples it.

## Root cause

The race manifests as: fast-file count is still 5 (some Scripts/*.bat entries still counted as placeholders) when the test expects 3 after `TurnPlaceholdersIntoModifiedPaths`.

## Fix

Call `WaitForBackgroundOperations()` in `ValidateHealthOutputValues` before invoking the health verb, consistent with every other functional test that asserts modified-path state after a file operation (e.g. GitFilesTests, ModifiedPathsTests, CheckoutTests).

## Testing

- `GVFS.FunctionalTests` project builds clean (`dotnet build ... -c Debug`).
- Fix mirrors the existing pattern used by all other functional tests that assert modified-path state.