### PR TITLE
Mount: don't crash when auth is used before background init completes

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -21,6 +21,14 @@ namespace GVFS.Common.Git
         private readonly ICredentialStore credentialStore;
         private readonly string repoUrl;
 
+        // Signaled when initialization completes (success or failure). Callers of
+        // TryGetCredentials that arrive before initialization is done wait on this
+        // rather than throwing. This matters when mount starts virtualization while
+        // auth initialization is still running in the background (cache-server path):
+        // a directory enumeration can call TryGetCredentials before the background
+        // TryInitializeAndQueryGVFSConfig has set isInitialized.
+        private readonly ManualResetEventSlim initializationComplete = new ManualResetEventSlim(false);
+
         private int numberOfAttempts = 0;
         private DateTime lastAuthAttempt = DateTime.MinValue;
 
@@ -49,6 +57,14 @@ namespace GVFS.Common.Git
         }
 
         public bool IsAnonymous { get; private set; } = true;
+
+        /// <summary>
+        /// How long a caller of <see cref="TryGetCredentials"/> will wait for
+        /// initialization to complete before giving up with a retryable error.
+        /// Defaults to the maximum time initialization itself can take (a
+        /// background credential fetch). Overridable for tests.
+        /// </summary>
+        internal int InitializationWaitTimeoutMs { get; set; } = BackgroundCredentialTimeoutMs;
 
         private GitSsl GitSsl { get; }
 
@@ -157,7 +173,17 @@ namespace GVFS.Common.Git
         {
             if (!this.isInitialized)
             {
-                throw new InvalidOperationException("This auth instance must be initialized before it can be used");
+                // Initialization may still be running in the background (mount can
+                // start virtualization before the background auth/config query has
+                // finished when a cache server is configured). Wait for it to
+                // complete rather than throwing an unhandled exception into the
+                // virtualization callback, which would crash the mount process.
+                if (!this.initializationComplete.Wait(this.InitializationWaitTimeoutMs))
+                {
+                    credentialString = null;
+                    errorMessage = "Timed out waiting for authentication to initialize";
+                    return false;
+                }
             }
 
             credentialString = this.cachedCredentialString;
@@ -243,14 +269,14 @@ namespace GVFS.Common.Git
                 if (configRequestor.TryQueryGVFSConfig(false, out serverGVFSConfig, out httpStatus, out _))
                 {
                     this.IsAnonymous = true;
-                    this.isInitialized = true;
+                    this.MarkInitialized();
                     tracer.RelatedInfo("{0}: Anonymous access succeeded, config obtained in one request", nameof(this.TryInitializeAndQueryGVFSConfig));
                     return true;
                 }
 
                 if (httpStatus != HttpStatusCode.Unauthorized)
                 {
-                    this.isInitialized = true;
+                    this.MarkInitialized();
                     errorMessage = "Unable to query /gvfs/config";
                     tracer.RelatedWarning("{0}: Config query failed with status {1}", nameof(this.TryInitializeAndQueryGVFSConfig), httpStatus?.ToString() ?? "None");
                     return false;
@@ -265,12 +291,12 @@ namespace GVFS.Common.Git
                     // Mark initialized even on failure so TryGetCredentials can
                     // retry later (e.g., when mount proceeds with a cache server
                     // and object downloads need auth).
-                    this.isInitialized = true;
+                    this.MarkInitialized();
                     tracer.RelatedWarning("{0}: Credential fetch failed: {1}", nameof(this.TryInitializeAndQueryGVFSConfig), errorMessage);
                     return false;
                 }
 
-                this.isInitialized = true;
+                this.MarkInitialized();
 
                 // Retry with credentials using the same ConfigHttpRequestor (reuses HttpClient/connection)
                 HttpStatusCode? retryHttpStatus;
@@ -303,7 +329,7 @@ namespace GVFS.Common.Git
 
             if (this.TryCallGitCredential(tracer, out errorMessage))
             {
-                this.isInitialized = true;
+                this.MarkInitialized();
                 return true;
             }
 
@@ -383,6 +409,14 @@ namespace GVFS.Common.Git
         {
             this.lastAuthAttempt = DateTime.Now;
             this.numberOfAttempts++;
+        }
+
+        private void MarkInitialized()
+        {
+            // Publish isInitialized before signaling so a waiter that wakes up
+            // observes the initialized state.
+            this.isInitialized = true;
+            this.initializationComplete.Set();
         }
 
         private bool TryCallGitCredential(ITracer tracer, out string errorMessage, int timeoutMs = -1)

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GVFS.Common.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
@@ -271,6 +273,73 @@ namespace GVFS.UnitTests.Git
             dut.TryGetCredentials(tracer, out var newAuthString, out _).ShouldBeTrue();
             newAuthString.ShouldNotEqual(authString);
             gitProcess.CredentialRejections.ShouldBeEmpty();
+        }
+
+        [TestCase]
+        public void TryGetCredentialsBeforeInitializationDoesNotThrow()
+        {
+            // Regression test for a mount crash: when a cache server is configured,
+            // mount starts virtualization before the background auth/config query
+            // finishes initializing. A directory enumeration then calls
+            // TryGetCredentials while IsAnonymous has already been set false but
+            // initialization has not completed. The previous behavior threw an
+            // InvalidOperationException straight into the ProjFS callback, crashing
+            // the mount process. It must instead fail gracefully (retryable).
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+
+            // Keep the wait short so an uninitialized instance reports failure
+            // quickly instead of blocking for the full background timeout.
+            dut.InitializationWaitTimeoutMs = 10;
+
+            string authString = null;
+            string error = null;
+            bool result = true;
+
+            Assert.DoesNotThrow(() => result = dut.TryGetCredentials(tracer, out authString, out error));
+
+            result.ShouldBeFalse("TryGetCredentials should fail (not throw) before initialization completes");
+            error.ShouldNotBeNull("A retryable error message should be returned");
+        }
+
+        [TestCase]
+        public void TryGetCredentialsWaitsForBackgroundInitializationThenSucceeds()
+        {
+            // A caller that arrives before initialization completes should block
+            // until initialization finishes, then return the fetched credentials -
+            // this is the correct behavior for the background cache-server auth path.
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.InitializationWaitTimeoutMs = 30_000;
+
+            string authString = null;
+            string error = null;
+            bool result = false;
+
+            using (ManualResetEventSlim consumerStarted = new ManualResetEventSlim(false))
+            {
+                Task consumer = Task.Run(() =>
+                {
+                    consumerStarted.Set();
+                    result = dut.TryGetCredentials(tracer, out authString, out error);
+                });
+
+                // Ensure the consumer has begun waiting on initialization before we
+                // complete it, so we exercise the wait path rather than a no-op.
+                consumerStarted.Wait();
+                Thread.Sleep(50);
+
+                dut.TryInitializeAndRequireAuth(tracer, out _);
+
+                consumer.Wait(TimeSpan.FromSeconds(10)).ShouldBeTrue("Consumer should unblock once initialization completes");
+            }
+
+            result.ShouldBeTrue("TryGetCredentials should succeed after initialization: " + error);
+            authString.ShouldNotBeNull("A credential string should be returned");
         }
 
         private MockGitProcess GetGitProcess()


### PR DESCRIPTION
## Problem

When a cache server is configured locally, mount starts virtualization **without** waiting for the background auth/config query (introduced in #2034 — "don't block startup on auth when cache server is configured").

During that window `TryInitializeAndQueryGVFSConfig` has already published `IsAnonymous = false` but has **not yet** set `isInitialized` — the slow credential fetch runs in between:

```
this.IsAnonymous = false;                 // published early
... TryCallGitCredential (GCM, slow) ...
this.isInitialized = true;                // set only after the fetch
```

A directory enumeration that lands in this window flows `WindowsFileSystemVirtualizer.StartDirectoryEnumerationAsyncHandler` → `GitIndexProjection…PopulateSizesFromRemote` → `HttpRequestor.SendRequest` → `GitAuthentication.TryGetCredentials`, which saw `!IsAnonymous` and then **threw** `InvalidOperationException("This auth instance must be initialized before it can be used")`. Thrown into the ProjFS callback, this crashes the mount process:

```
Error {"Area":"WindowsFileSystemVirtualizer",
 "Exception":"System.InvalidOperationException: This auth instance must be initialized before it can be used
   at GVFS.Common.Git.GitAuthentication.TryGetCredentials(...)
   at GVFS.Common.Http.HttpRequestor.SendRequest(...)
   ...
   at GVFS.Platform.Windows.WindowsFileSystemVirtualizer.StartDirectoryEnumerationAsyncHandler(...)",
 "ErrorMessage":"StartDirectoryEnumerationAsyncHandler caught unhandled exception, exiting process"}
```

Reported against the latest prerelease when mounting a git worktree.

## Fix

Instead of throwing when called before initialization, `TryGetCredentials` now **waits** (bounded by `InitializationWaitTimeoutMs`, defaulting to the background credential timeout) for initialization to complete, then proceeds normally. If initialization never completes within the timeout it returns a retryable failure — `SendRequest` already treats a credential failure as `shouldRetry: true` — rather than crashing.

All initialization terminal paths now signal a `ManualResetEventSlim` through a new `MarkInitialized()` helper. No self-deadlock: initialization's own retry-with-credentials request runs *after* the flag is set, so the event is already signaled.

The change is **isolated to `GitAuthentication.cs`** so it can land independently of the separate change that will gate the background cache-auth behavior behind a config flag.

## Tests

Adds two deterministic unit tests (× the existing SSL fixture parameterization):

- `TryGetCredentialsBeforeInitializationDoesNotThrow` — a call before init returns a retryable failure instead of throwing.
- `TryGetCredentialsWaitsForBackgroundInitializationThenSucceeds` — a caller that arrives mid-init blocks until init completes, then returns credentials.

Verified the tests catch the regression: reintroducing the original `throw` fails exactly these cases; the fix makes them pass. Full unit suite: 886 passed, 0 failed.

A functional test is intentionally omitted: the crash depends on a millisecond-scale timing window during background init that a real mount almost never hits, so a functional test would be non-reproducing/flaky without an invasive product test-hook to delay auth init. The unit tests exercise the exact race deterministically.
