### PR TITLE
Mount: gate background cache-server auth behind gvfs.background-cache-auth

### DIFF
--- a/GVFS/GVFS.Common/GVFSConstants.cs
+++ b/GVFS/GVFS.Common/GVFSConstants.cs
@@ -51,6 +51,13 @@ namespace GVFS.Common
 
             public const string PrefetchUseIdx = GVFSPrefix + "prefetch-use-idx";
             public const bool PrefetchUseIdxDefault = false;
+
+            /* Gates the background (fire-and-forget) auth + /gvfs/config behavior on
+             * mount when a cache server is configured locally. When false (default),
+             * mount blocks on auth/config synchronously before starting virtualization.
+             * When true, auth runs in the background so mount is not delayed. */
+            public const string BackgroundCacheAuth = GVFSPrefix + "background-cache-auth";
+            public const bool BackgroundCacheAuthDefault = false;
         }
 
         public static class LocalGVFSConfig

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -132,19 +132,27 @@ namespace GVFS.Mount
             Stopwatch parallelTimer = Stopwatch.StartNew();
             bool hasCacheServer = this.cacheServer != null && !string.IsNullOrWhiteSpace(this.cacheServer.Url);
 
+            // Fire-and-forget background auth is gated behind gvfs.background-cache-auth
+            // (default off). When the flag is off, mount blocks on auth/config
+            // synchronously even if a cache server is configured (pre-existing behavior).
+            bool useBackgroundAuth = hasCacheServer && this.IsBackgroundCacheAuthEnabled();
+
             this.tracer.RelatedEvent(
                 EventLevel.Informational,
                 "MountPhase",
                 new EventMetadata
                 {
                     { "Phase", "ParallelMountStarted" },
+                    { "HasCacheServer", hasCacheServer },
+                    { "UseBackgroundAuth", useBackgroundAuth },
                     { "ElapsedMs", mountPhaseTimer.ElapsedMilliseconds },
                 },
                 Keywords.Telemetry);
 
-            // When a cache server is configured locally, auth/config is best-effort:
-            // mount can proceed without it. We still attempt it so GCM can pop up a
-            // renewal prompt for stale tokens, but we don't block mount on the result.
+            // With background auth enabled, auth/config is best-effort: mount can
+            // proceed without it. We still attempt it so GCM can pop up a renewal
+            // prompt for stale tokens, but we don't block mount on the result. A
+            // longer credential timeout is acceptable only because we don't block.
             var networkTask = Task.Run(() =>
             {
                 Stopwatch sw = Stopwatch.StartNew();
@@ -155,7 +163,7 @@ namespace GVFS.Mount
                 if (!this.enlistment.Authentication.TryInitializeAndQueryGVFSConfig(
                     this.tracer, this.enlistment, this.retryConfig,
                     out config, out authConfigError, out isAuthFailure,
-                    credentialTimeoutMs: hasCacheServer ? GitAuthentication.BackgroundCredentialTimeoutMs : GitAuthentication.DefaultCredentialTimeoutMs))
+                    credentialTimeoutMs: useBackgroundAuth ? GitAuthentication.BackgroundCredentialTimeoutMs : GitAuthentication.DefaultCredentialTimeoutMs))
                 {
                     if (hasCacheServer)
                     {
@@ -291,9 +299,9 @@ namespace GVFS.Mount
 
                 try
                 {
-                    if (hasCacheServer)
+                    if (useBackgroundAuth)
                     {
-                        // With a cache server, don't block mount on the network task.
+                        // With background auth, don't block mount on the network task.
                         // Auth runs in the background to warm credentials / pop GCM,
                         // but mount proceeds immediately using the local cache server URL.
                         localTask.Wait();
@@ -327,7 +335,10 @@ namespace GVFS.Mount
                     },
                     Keywords.Telemetry);
 
-                ServerGVFSConfig serverGVFSConfig = hasCacheServer ? null : networkTask.Result;
+                // Only background auth leaves the network task potentially unfinished;
+                // in that case we resolve the cache server from local config (null).
+                // Otherwise we waited on the network task and can use its result.
+                ServerGVFSConfig serverGVFSConfig = useBackgroundAuth ? null : networkTask.Result;
 
                 this.mountProgressMessage = "Resolving cache server";
                 CacheServerResolver cacheServerResolver = new CacheServerResolver(this.tracer, this.enlistment);
@@ -460,6 +471,31 @@ namespace GVFS.Mount
                     fileSystem),
                 "Failed to read git repo");
             return new GVFSContext(this.tracer, fileSystem, gitRepo, this.enlistment);
+        }
+
+        private bool IsBackgroundCacheAuthEnabled()
+        {
+            // Read the flag via libgit2 (in-process) rather than spawning git.exe.
+            // The GVFSContext (and its shared libgit2 repo) is not created until
+            // later in mount, so open a short-lived repo here just for the config
+            // read. Default to off on any failure.
+            try
+            {
+                using (LibGit2Repo repo = new LibGit2Repo(this.tracer, this.enlistment.WorkingDirectoryBackingRoot))
+                {
+                    return repo.GetConfigBool(GVFSConstants.GitConfig.BackgroundCacheAuth)
+                        ?? GVFSConstants.GitConfig.BackgroundCacheAuthDefault;
+                }
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedWarning(
+                    "Failed to read {0} config, defaulting to {1}: {2}",
+                    GVFSConstants.GitConfig.BackgroundCacheAuth,
+                    GVFSConstants.GitConfig.BackgroundCacheAuthDefault,
+                    e.Message);
+                return GVFSConstants.GitConfig.BackgroundCacheAuthDefault;
+            }
         }
 
         private void ValidateMountPoints()


### PR DESCRIPTION
## Summary

Part of GVFS 2.0 stabilization: keep destabilizing features compiled in but **off by default behind `gvfs.*` git-config flags**.

PR #2034 made mount run authentication + the `/gvfs/config` query as a **fire-and-forget background task** when a cache server URL is already configured locally, so mount doesn't block on auth. This PR gates that behavioral change behind a new flag and defaults it off, while keeping #2034's associated diagnostic/reliability improvements always on.

## Flag

- **`gvfs.background-cache-auth`** — default **`false`**.
- **Off (default):** mount blocks on auth + `/gvfs/config` **synchronously** before starting virtualization, even when a cache server is configured. The network task is awaited, so its config result is used and the synchronous (`Default`) credential timeout applies.
- **On:** the #2034 background behavior — mount proceeds without waiting on auth, using the local cache server URL, with the longer background credential timeout.

## What is gated vs. kept

Gating is a single derived condition, `useBackgroundAuth = hasCacheServer && flag`, applied to exactly the three things that constitute #2034's fire-and-forget behavior:

1. the wait decision (`localTask.Wait()` + background vs. `Task.WaitAll`),
2. the credential-timeout selection (background 120s vs. default 30s), and
3. the source of `serverGVFSConfig` (local/null vs. the awaited network result).

**Kept always-on** (unchanged, still keyed on `hasCacheServer`): the pre-existing cache-server fallback on auth failure, the distinct startup exit codes (`AuthenticationError`/`CredentialTimeout`/`RemoteGvfsConfigError`), the bounded credential timeout, and `ValidateGVFSVersion` leniency.

## Notes

- The flag is read via **libgit2 in-process** (a short-lived `LibGit2Repo`, since the `GVFSContext`/shared repo isn't created until later in mount), defaulting to off on any failure. No `git.exe` spawn.
- The resolved flag state is included in the existing `MountPhase`/`ParallelMountStarted` mount-log event (`HasCacheServer`, `UseBackgroundAuth`). No new client heartbeat telemetry is added — `gvfs.*` config is already captured collector-side.
- **Isolated to `GVFSConstants.cs` + `InProcessMount.cs`**; does not touch `GitAuthentication.cs`, so it does not conflict with the separate fix hardening `TryGetCredentials` against being called before initialization completes.

## Caveat (intentional)

With the flag off, mount **restores synchronous auth-blocking** when a cache server is configured — which #2034 was partly introduced to avoid (mount appearing unresponsive while auth hangs). That regression-to-prior-behavior is the intended stabilization default; the credential fetch remains bounded, and machines that need non-blocking mount can opt in with `git config gvfs.background-cache-auth true`.

## Testing

- Full unit suite: 882 passed, 0 failed.
- `GVFS.Mount` and `GVFS.Common` build clean.
