### PR TITLE
ci: run build.yaml on vnext

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ run-name: ${{ inputs.run_name || 'VFS for Git' }}
 
 on:
   pull_request:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, vnext ]
   push:
-    branches: [ master, releases/shipped ]
+    branches: [ master, releases/shipped, vnext ]
   workflow_dispatch:
     inputs:
       git_version:


### PR DESCRIPTION
## What
Adds `vnext` to `build.yaml`'s `pull_request` / `push` branch filters so PRs targeting the `vnext` feature-integration branch run the same CI as master (build + unit + functional tests) and produce the required status checks.

## Why
Branch model: `master` stays the shippable line (stabilization / bug-fixes; releases cut here); `vnext` accumulates next major/minor feature work until it's promoted to master via a normal reviewed PR.

Without this, PRs into `vnext` would produce no check runs and be un-mergeable once `vnext` is branch-protected to mirror master's required checks.

## Follow-ups (admin, not in this PR)
- Create a `vnext` ruleset mirroring master's policy (1 approval + code-owner + required CI checks `Validation` and `Build, Unit and Functional Tests Successful`, block force-push/deletion).

## Not included
- **Automatic master → vnext sync was cut** (per admins: too much security-approval overhead for a bypass-capable sync identity). Keeping master current in `vnext` will be done manually via normal reviewed merges instead.