### PR TITLE
Update default Microsoft Git version to v2.54.0.vfs.0.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ permissions:
   checks: read
 
 env:
-  GIT_VERSION: ${{ github.event.inputs.git_version || 'v2.54.0.vfs.0.4' }}
+  GIT_VERSION: ${{ github.event.inputs.git_version || 'v2.54.0.vfs.0.5' }}
 
 jobs:
   validate:


### PR DESCRIPTION
Update the default Microsoft Git version used by VFS for Git
to the newly promoted [`v2.54.0.vfs.0.5`](https://github.com/microsoft/git/releases/tag/v2.54.0.vfs.0.5) release.