### PR TITLE
Clone: surface the real clone failure instead of a misleading InvalidDataException

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -73,6 +73,31 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
+        [TestCase]
+        public void CloneWithNonExistentBranchFailsWithBranchError()
+        {
+            string newEnlistmentRoot = GVFSFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
+
+            ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);
+            processInfo.Arguments = $"clone {GVFSTestConfig.RepoToClone} {newEnlistmentRoot} --branch nonexistent/branch/that/does/not/exist";
+            processInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            processInfo.CreateNoWindow = true;
+            processInfo.WorkingDirectory = Path.GetDirectoryName(this.Enlistment.EnlistmentRoot);
+            processInfo.UseShellExecute = false;
+            processInfo.RedirectStandardOutput = true;
+
+            ProcessResult result = ProcessHelper.Run(processInfo);
+            result.ExitCode.ShouldEqual(GVFSGenericError);
+
+            // The clone should surface the real, actionable failure...
+            result.Output.ShouldContain("Remote branch nonexistent/branch/that/does/not/exist not found in upstream origin");
+
+            // ...and NOT the misleading downstream exception that used to be thrown when
+            // a LibGit2RepoInvoker was constructed against a src folder that was never created.
+            result.Output.ShouldNotContain(false, "Couldn't open repo");
+            result.Output.ShouldNotContain(false, "InvalidDataException");
+        }
+
         private void SubfolderCloneShouldFail()
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);

--- a/GVFS/GVFS/CommandLine/CloneVerb.cs
+++ b/GVFS/GVFS/CommandLine/CloneVerb.cs
@@ -152,7 +152,7 @@ namespace GVFS.CommandLine
 
                 CacheServerInfo cacheServer = null;
                 ServerGVFSConfig serverGVFSConfig = null;
-                bool trustPackIndexes;
+                bool trustPackIndexes = false;
 
                 using (JsonTracer tracer = new JsonTracer(GVFSConstants.GVFSEtwProviderName, "GVFSClone"))
                 {
@@ -248,10 +248,17 @@ namespace GVFS.CommandLine
                     {
                         tracer.RelatedError(cloneResult.ErrorMessage);
                     }
-
-                    using (var repo = new LibGit2RepoInvoker(tracer, enlistment.WorkingDirectoryBackingRoot))
+                    else
                     {
-                        trustPackIndexes = repo.GetConfigBoolOrDefault(GVFSConstants.GitConfig.TrustPackIndexes, GVFSConstants.GitConfig.TrustPackIndexesDefault);
+                        // Only inspect the freshly-cloned repo when the clone succeeded. On a failed
+                        // clone the 'src' working directory was never created, so constructing a
+                        // LibGit2RepoInvoker here would log a misleading "Couldn't open repo" warning
+                        // and throw an InvalidDataException that masks the real failure (e.g. the
+                        // "Remote branch ... not found in upstream origin" error surfaced below).
+                        using (var repo = new LibGit2RepoInvoker(tracer, enlistment.WorkingDirectoryBackingRoot))
+                        {
+                            trustPackIndexes = repo.GetConfigBoolOrDefault(GVFSConstants.GitConfig.TrustPackIndexes, GVFSConstants.GitConfig.TrustPackIndexesDefault);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

`gvfs clone <url> <dst> --branch <nonexistent-branch>` printed a misleading
downstream exception instead of the real, actionable failure. The console showed:

```
Cannot clone @ c:\s\osbr: System.IO.InvalidDataException: Couldn't open repo at C:\s\osbr\src: failed to resolve path 'C:\s\osbr\src': The system cannot find the file specified.
   at GVFS.Common.Git.LibGit2Repo..ctor(ITracer, String)
   ...
   at GVFS.CommandLine.CloneVerb.Execute()
```

…while the real error was only in the clone log, one line above an even-more-downstream warning:

```
[Error]   {"ErrorMessage":"Remote branch official/br_current_directes_dev not found in upstream origin"}
[Warning] {"WarningMessage":"Couldn't open repo at C:\s\osbr\src: failed to resolve path ..."}
```

## Root cause

In `CloneVerb.Execute()` the `LibGit2RepoInvoker` for the enlistment `src` folder
was constructed **unconditionally**, even after `cloneResult.Success == false`. On a
failed clone the `src` working directory was never created, so `LibGit2Repo`'s
constructor logged a `Couldn't open repo at ...\src` warning and threw an
`InvalidDataException`. That exception escaped the `using (tracer)` scope, bypassing
the existing `else` branch that prints `Error: <real message>`, and was caught by the
generic `catch (Exception)` handler that printed the misleading `Cannot clone @ ...:
InvalidDataException: Couldn't open repo` message.

## Fix

Guard the `LibGit2RepoInvoker` construction behind `cloneResult.Success` (and
initialize `trustPackIndexes = false`, since it is only read on the success path).
Failed clones now fall through to the existing `else` branch, which already prints
the real error:

```
Cannot clone @ c:\s\osbr
Error: Remote branch official/br_current_directes_dev not found in upstream origin
```

## Tests

Added `CloneTests.CloneWithNonExistentBranchFailsWithBranchError`, which clones with a
non-existent `--branch` and asserts:
- exit code is the generic error (3),
- output contains `Remote branch ... not found in upstream origin`,
- output does **not** contain `Couldn't open repo` / `InvalidDataException`.

## Validation

- `dotnet build GVFS/GVFS/GVFS.csproj -c Debug` — succeeded (0 errors).
- `GVFS.FunctionalTests` C# compiles; the new test exercises the fixed path (requires
  the full functional-test harness to execute).

Tracked by ADO Task 63117974 (parent Deliverable 60994157 — "Git reliability for razzle").
