### PR TITLE
Fail blob hydration cleanly on a malformed (NUL-byte) placeholder SHA

### DIFF
--- a/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
@@ -67,6 +67,26 @@ namespace GVFS.Common.Git
             Action<Stream, long> writeAction,
             out BlobHydrationFailureCategory failureCategory)
         {
+            // Short-circuit a malformed SHA (for example a corrupt placeholder's all-NUL
+            // content-id) before the retry loop. GitRepo already rejects it as a clean miss,
+            // but a bogus SHA can never be downloaded either (the server returns 404), so
+            // attempting it would only produce doomed download retries. Because the read is
+            // never satisfied, the caller re-requests it endlessly, which turns one corrupt
+            // placeholder into an unbounded error/retry storm. Fail fast and cheap instead.
+            // The cause stays categorized as Unexpected (no dedicated category); the caller
+            // tags its terminal telemetry from failureCategory below.
+            if (!SHA1Util.IsValidShaFormat(sha))
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("sha", SHA1Util.ToLoggableShaString(sha));
+                metadata.Add("RequestSource", requestSource.ToString());
+                metadata.Add(TracingConstants.MessageKey.WarningMessage, "TryCopyBlobContentStream: Refusing to hydrate blob with malformed SHA");
+                this.Tracer.RelatedEvent(EventLevel.Warning, nameof(this.TryCopyBlobContentStream) + "_MalformedBlobSha", metadata, Keywords.Telemetry);
+
+                failureCategory = BlobHydrationFailureCategory.Unexpected;
+                return false;
+            }
+
             // Track the outcome of the most recent attempt so that the terminal failure
             // telemetry can attribute the failure to a cause (network vs. object-missing vs.
             // local copy) that is otherwise collapsed into the bool return value below. The

--- a/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
@@ -208,6 +208,27 @@ namespace GVFS.Common.Git
             RequestSource requestSource,
             bool retryOnFailure)
         {
+            // Defense in depth for a malformed object id (for example a corrupt placeholder's
+            // all-NUL content-id). On .NET Framework Path.Combine threw ArgumentException on
+            // such a value; on modern .NET it does not, so a malformed SHA silently misses the
+            // local object store and would otherwise be sent to the cache server, which rejects
+            // the URL with HTTP 400 - and GVFS then erases a valid credential (HttpRequestor
+            // treats 400 as an auth failure), producing a credential-prompt storm. Callers other
+            // than blob hydration reach this method WITHOUT going through the
+            // TryCopyBlobContentStream guard - the git.exe read-object hook (NamedPipeMessage,
+            // via InProcessMount) and the gitattributes GVFSVerb - so reject a malformed SHA here
+            // for every caller before any request is built.
+            if (!SHA1Util.IsValidShaFormat(objectId))
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("sha", SHA1Util.ToLoggableShaString(objectId));
+                metadata.Add("RequestSource", requestSource.ToString());
+                metadata.Add(TracingConstants.MessageKey.WarningMessage, nameof(this.TryDownloadAndSaveObject) + ": Refusing to download object with malformed SHA");
+                this.Tracer.RelatedEvent(EventLevel.Warning, nameof(this.TryDownloadAndSaveObject) + "_MalformedBlobSha", metadata, Keywords.Telemetry);
+
+                return DownloadAndSaveObjectResult.Error;
+            }
+
             if (objectId == GVFSConstants.AllZeroSha)
             {
                 return DownloadAndSaveObjectResult.Error;

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -357,12 +357,20 @@ namespace GVFS.Common.Git
         private LooseBlobState GetLooseBlobState(string blobSha, Action<Stream, long> writeAction, out long size)
         {
             // A corrupt placeholder can carry a malformed content-id (for example 40 NUL
-            // bytes instead of a hex SHA). Such a value holds characters that are illegal
-            // in a file path, so Path.Combine below throws ArgumentException ("Illegal
-            // characters in path"). ArgumentException is not handled by RetryWrapper, so it
-            // bypasses both the retry logic and the download fallback and fails the
-            // hydration permanently. Reject the malformed SHA up front and report it as an
-            // invalid loose object, which the callers treat as a clean, non-retryable miss.
+            // bytes instead of a hex SHA). Reject it up front and report an invalid loose
+            // object, which the callers treat as a clean, non-retryable miss.
+            //
+            // The behavior of Path.Combine below is runtime-dependent, so validating here
+            // (rather than relying on an exception) is required on modern .NET:
+            //   - On .NET Framework, Path.Combine throws ArgumentException ("Illegal
+            //     characters in path") on the NUL bytes. ArgumentException is not handled by
+            //     RetryWrapper, so it bypasses both the retry logic and the download fallback
+            //     and fails the hydration permanently (a retry storm - the original symptom).
+            //   - On modern .NET (.NET Core/5+), Path.Combine no longer validates path
+            //     characters, so it does NOT throw; the bogus path simply misses on disk and
+            //     the request would fall through to a server download that the gateway rejects
+            //     with HTTP 400 (ICM 850075166). The download path is guarded separately in
+            //     GVFSGitObjects.TryDownloadAndSaveObject.
             if (!SHA1Util.IsValidShaFormat(blobSha))
             {
                 size = -1;

--- a/GVFS/GVFS.Common/Git/GitRepo.cs
+++ b/GVFS/GVFS.Common/Git/GitRepo.cs
@@ -113,6 +113,19 @@ namespace GVFS.Common.Git
         /// </summary>
         public virtual bool LooseObjectExists(string sha)
         {
+            // Guard against a malformed SHA (for example a corrupt placeholder's all-NUL
+            // content-id) so Path.Combine cannot throw ArgumentException below. Emit the same
+            // greppable Warning as the other malformed-SHA guards so a silent "does not exist"
+            // answer is still diagnosable in telemetry.
+            if (!SHA1Util.IsValidShaFormat(sha))
+            {
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("sha", SHA1Util.ToLoggableShaString(sha));
+                metadata.Add(TracingConstants.MessageKey.WarningMessage, nameof(this.LooseObjectExists) + ": Malformed SHA cannot exist as a loose object");
+                this.tracer.RelatedEvent(EventLevel.Warning, nameof(this.LooseObjectExists) + "_MalformedBlobSha", metadata, Keywords.Telemetry);
+                return false;
+            }
+
             if (GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem)
             {
                 sha = sha.ToLower();
@@ -343,6 +356,25 @@ namespace GVFS.Common.Git
 
         private LooseBlobState GetLooseBlobState(string blobSha, Action<Stream, long> writeAction, out long size)
         {
+            // A corrupt placeholder can carry a malformed content-id (for example 40 NUL
+            // bytes instead of a hex SHA). Such a value holds characters that are illegal
+            // in a file path, so Path.Combine below throws ArgumentException ("Illegal
+            // characters in path"). ArgumentException is not handled by RetryWrapper, so it
+            // bypasses both the retry logic and the download fallback and fails the
+            // hydration permanently. Reject the malformed SHA up front and report it as an
+            // invalid loose object, which the callers treat as a clean, non-retryable miss.
+            if (!SHA1Util.IsValidShaFormat(blobSha))
+            {
+                size = -1;
+
+                EventMetadata metadata = new EventMetadata();
+                metadata.Add("sha", SHA1Util.ToLoggableShaString(blobSha));
+                metadata.Add(TracingConstants.MessageKey.WarningMessage, nameof(this.GetLooseBlobState) + ": Refusing to build loose object path from malformed blob SHA");
+                this.tracer.RelatedEvent(EventLevel.Warning, nameof(this.GetLooseBlobState) + "_MalformedBlobSha", metadata, Keywords.Telemetry);
+
+                return LooseBlobState.Invalid;
+            }
+
             // Ensure SHA path is lowercase for case-sensitive filesystems
             if (GVFSPlatform.Instance.Constants.CaseSensitiveFileSystem)
             {

--- a/GVFS/GVFS.Common/SHA1Util.cs
+++ b/GVFS/GVFS.Common/SHA1Util.cs
@@ -9,7 +9,37 @@ namespace GVFS.Common
     {
         public static bool IsValidShaFormat(string sha)
         {
-            return sha.Length == 40 && sha.All(c => Uri.IsHexDigit(c));
+            return sha != null && sha.Length == 40 && sha.All(c => Uri.IsHexDigit(c));
+        }
+
+        /// <summary>
+        /// Returns a log-safe rendering of a value that was expected to be a
+        /// 40-character hex SHA but is not. Non-hex characters (for example the
+        /// NUL bytes of a corrupt placeholder content-id) are escaped as \uXXXX
+        /// so the value stays greppable in telemetry and carries no control
+        /// characters.
+        /// </summary>
+        public static string ToLoggableShaString(string sha)
+        {
+            if (sha == null)
+            {
+                return "(null)";
+            }
+
+            StringBuilder builder = new StringBuilder(sha.Length);
+            foreach (char c in sha)
+            {
+                if (Uri.IsHexDigit(c))
+                {
+                    builder.Append(c);
+                }
+                else
+                {
+                    builder.AppendFormat("\\u{0:x4}", (int)c);
+                }
+            }
+
+            return builder.ToString();
         }
 
         public static string SHA1HashStringForUTF8String(string s)

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -733,7 +733,7 @@ namespace GVFS.Platform.Windows
                 metadata.Add("streamGuid", streamGuid);
                 metadata.Add("triggeringProcessId", triggeringProcessId);
                 metadata.Add("triggeringProcessImageFileName", triggeringProcessImageFileName);
-                metadata.Add("sha", sha);
+                metadata.Add("sha", SHA1Util.ToLoggableShaString(sha));
                 metadata.Add("placeholderVersion", placeholderVersion);
                 metadata.Add("commandId", commandId);
 

--- a/GVFS/GVFS.UnitTests/Common/SHA1UtilTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/SHA1UtilTests.cs
@@ -1,6 +1,7 @@
 ﻿using GVFS.Common;
 using GVFS.Tests.Should;
 using NUnit.Framework;
+using System.Linq;
 using System.Text;
 
 namespace GVFS.UnitTests.Common
@@ -29,6 +30,30 @@ namespace GVFS.UnitTests.Common
         public void IsValidFullSHAIsFalseForEmptyString()
         {
             SHA1Util.IsValidShaFormat(string.Empty).ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void IsValidShaFormatIsFalseForNull()
+        {
+            SHA1Util.IsValidShaFormat(null).ShouldEqual(false);
+        }
+
+        [TestCase]
+        public void ToLoggableShaStringEscapesNonHexCharacters()
+        {
+            SHA1Util.ToLoggableShaString(null).ShouldEqual("(null)");
+            SHA1Util.ToLoggableShaString(new string('\0', 3)).ShouldEqual("\\u0000\\u0000\\u0000");
+            SHA1Util.ToLoggableShaString("abc\0").ShouldEqual("abc\\u0000");
+            SHA1Util.ToLoggableShaString("abcDEF123").ShouldEqual("abcDEF123");
+
+            // Control characters and non-ASCII / high code points must be escaped and padded to 4 hex digits.
+            SHA1Util.ToLoggableShaString("a\tb\n").ShouldEqual("a\\u0009b\\u000a");
+            SHA1Util.ToLoggableShaString("\u00e9\u1234").ShouldEqual("\\u00e9\\u1234");
+
+            // The realistic corrupt-content-id shape: a full 40-char value that is partly valid
+            // hex and partly NUL, rendered with the hex kept and the NULs escaped.
+            SHA1Util.ToLoggableShaString(new string('a', 20) + new string('\0', 20))
+                .ShouldEqual(new string('a', 20) + string.Concat(Enumerable.Repeat("\\u0000", 20)));
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -331,6 +331,36 @@ namespace GVFS.UnitTests.Git
         }
 
         [TestCase]
+        public void TryCopyBlobContentStreamFailsCleanlyForCorruptAllNullByteSha()
+        {
+            // A corrupt placeholder can present a content-id of 40 NUL bytes instead of a
+            // hex SHA. Those characters are illegal in a file path, so building a loose
+            // object path from them used to throw an unhandled ArgumentException that
+            // bypassed retry and download fallback and permanently failed (and retry-stormed)
+            // the hydration. The read must now fail cleanly with no exception.
+            this.AssertMalformedShaHydrationFailsCleanly(new string('\0', 40));
+        }
+
+        [TestCase]
+        public void TryCopyBlobContentStreamFailsCleanlyForOtherMalformedShas()
+        {
+            this.AssertMalformedShaHydrationFailsCleanly(string.Empty);
+            this.AssertMalformedShaHydrationFailsCleanly("0123456789");
+            this.AssertMalformedShaHydrationFailsCleanly(new string('0', 39));
+            this.AssertMalformedShaHydrationFailsCleanly("000000000000000000000000000000000000000g");
+
+            // 40 chars long but with a NUL embedded among hex digits — the realistic
+            // corrupt-content-id shape that actually reproduces the original "Illegal
+            // characters in path" ArgumentException (length passes, hex check fails).
+            this.AssertMalformedShaHydrationFailsCleanly(new string('0', 20) + "\0" + new string('0', 19));
+
+            // 40 chars long with an embedded backslash. Unlike NUL this would NOT have thrown
+            // pre-fix (backslash is a legal path separator), but it is still non-hex, so the
+            // guard must reject it as a clean miss rather than probe a bogus path.
+            this.AssertMalformedShaHydrationFailsCleanly(new string('a', 20) + "\\" + new string('a', 19));
+        }
+
+        [TestCase]
         public void CoalescesMultipleConcurrentRequestsForSameObject()
         {
             ManualResetEventSlim downloadStarted = new ManualResetEventSlim(false);
@@ -749,6 +779,62 @@ namespace GVFS.UnitTests.Git
                 Assert.Throws<RetryableException>(() => download(gitObjects));
                 inputStream.Dispose();
             }
+        }
+
+        private void AssertMalformedShaHydrationFailsCleanly(string malformedSha)
+        {
+            MockFileSystemWithCallbacks fileSystem = new MockFileSystemWithCallbacks();
+            fileSystem.OnFileExists = (path) =>
+            {
+                Assert.Fail("A malformed SHA must never be turned into a filesystem path");
+                return false;
+            };
+
+            MockTracer tracer = new MockTracer();
+            GVFSEnlistment enlistment = new GVFSEnlistment(TestEnlistmentRoot, "https://fakeRepoUrl", "fakeGitBinPath", authentication: null);
+            enlistment.InitializeCachePathsFromKey(TestLocalCacheRoot, TestObjectRoot);
+            GitRepo repo = new GitRepo(tracer, enlistment, fileSystem, () => new MockLibGit2Repo(tracer));
+            GVFSContext context = new GVFSContext(tracer, fileSystem, repo, enlistment);
+            GVFSGitObjects gitObjects = new UnsafeGVFSGitObjects(context, new MockHttpGitObjects());
+
+            // GitRepo layer: must not throw ArgumentException ("Illegal characters in path"),
+            // and must report a clean miss.
+            bool repoResult = true;
+            Assert.DoesNotThrow(
+                () => repoResult = repo.TryCopyBlobContentStream(
+                    malformedSha,
+                    (stream, length) => Assert.Fail("Should not copy any content for a malformed SHA")),
+                "GitRepo.TryCopyBlobContentStream must not throw for a malformed SHA");
+            repoResult.ShouldEqual(false);
+
+            // GVFSGitObjects layer: must fail fast with no throw. The out category stays
+            // Unexpected (a malformed SHA gets no dedicated telemetry category).
+            bool copied = true;
+            GVFSGitObjects.BlobHydrationFailureCategory failureCategory = GVFSGitObjects.BlobHydrationFailureCategory.None;
+            Assert.DoesNotThrow(
+                () => copied = gitObjects.TryCopyBlobContentStream(
+                    malformedSha,
+                    new CancellationToken(),
+                    GVFSGitObjects.RequestSource.FileStreamCallback,
+                    (stream, length) => Assert.Fail("Should not copy any content for a malformed SHA"),
+                    out failureCategory),
+                "GVFSGitObjects.TryCopyBlobContentStream must not throw for a malformed SHA");
+            copied.ShouldEqual(false);
+            failureCategory.ShouldEqual(GVFSGitObjects.BlobHydrationFailureCategory.Unexpected);
+
+            // The short-circuit must happen BEFORE the retry/download loop: a malformed SHA
+            // must never reach a server download. The retrier logs "Failed to provide blob
+            // contents" on every attempt, so its absence proves no download/retry ran.
+            bool anyDownloadAttemptLogged = tracer.RelatedErrorEvents
+                .Concat(tracer.RelatedWarningEvents)
+                .Any(e => e.Contains("Failed to provide blob contents"));
+            anyDownloadAttemptLogged.ShouldEqual(false);
+
+            // The corrupt-placeholder read must stay diagnosable: both guard layers emit their
+            // distinct greppable *_MalformedBlobSha event. Assert the emission so a regression
+            // that silently dropped the warning would fail here.
+            tracer.RelatedEventNames.ShouldContain(e => e == "GetLooseBlobState_MalformedBlobSha");
+            tracer.RelatedEventNames.ShouldContain(e => e == "TryCopyBlobContentStream_MalformedBlobSha");
         }
 
         private GVFSGitObjects CreateTestableGVFSGitObjects(GitObjectsHttpRequestor httpObjects, MockFileSystemWithCallbacks fileSystem)

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -361,6 +361,56 @@ namespace GVFS.UnitTests.Git
         }
 
         [TestCase]
+        public void TryDownloadAndSaveObjectDoesNotSendMalformedShaToServer()
+        {
+            // Regression for the customer HTTP-400 mode (ICM 850075166). On modern .NET a
+            // corrupt placeholder's all-NUL SHA does not throw in Path.Combine, so it misses
+            // locally and, without this guard, is sent to the cache server, which rejects the
+            // URL with HTTP 400 - and GVFS then erases a valid credential, producing a GCM
+            // prompt storm. This download path is reached by callers OTHER than blob hydration
+            // (the git.exe read-object hook via NamedPipeMessage, and the gitattributes
+            // GVFSVerb), which do not go through the TryCopyBlobContentStream guard, so it must
+            // be rejected at the download method itself for every request source.
+            MockFileSystemWithCallbacks fileSystem = new MockFileSystemWithCallbacks();
+            fileSystem.OnFileExists = (path) => false;
+            fileSystem.OnOpenFileStream = (path, mode, access) => new MemoryStream();
+
+            MockHttpGitObjects httpObjects = new MockHttpGitObjects();
+            GVFSGitObjects dut = this.CreateTestableGVFSGitObjects(httpObjects, fileSystem, out MockTracer tracer);
+
+            string[] malformedShas =
+            {
+                new string('\0', 40),
+                string.Empty,
+                new string('0', 39),
+                new string('0', 20) + "\0" + new string('0', 19),
+            };
+
+            GVFSGitObjects.RequestSource[] sources =
+            {
+                GVFSGitObjects.RequestSource.FileStreamCallback,
+                GVFSGitObjects.RequestSource.NamedPipeMessage,
+                GVFSGitObjects.RequestSource.GVFSVerb,
+            };
+
+            foreach (string malformedSha in malformedShas)
+            {
+                foreach (GVFSGitObjects.RequestSource source in sources)
+                {
+                    GitObjects.DownloadAndSaveObjectResult result = GitObjects.DownloadAndSaveObjectResult.Success;
+                    Assert.DoesNotThrow(
+                        () => result = dut.TryDownloadAndSaveObject(malformedSha, source),
+                        "TryDownloadAndSaveObject must not throw for a malformed SHA");
+                    result.ShouldEqual(GitObjects.DownloadAndSaveObjectResult.Error);
+                }
+            }
+
+            // No malformed SHA reached the network, and the rejection is diagnosable.
+            httpObjects.TryDownloadObjectsCallCount.ShouldEqual(0);
+            tracer.RelatedEventNames.ShouldContain(e => e == "TryDownloadAndSaveObject_MalformedBlobSha");
+        }
+
+        [TestCase]
         public void CoalescesMultipleConcurrentRequestsForSameObject()
         {
             ManualResetEventSlim downloadStarted = new ManualResetEventSlim(false);
@@ -884,6 +934,10 @@ namespace GVFS.UnitTests.Git
             public HttpStatusCode? StatusCodeToReturn { get; set; }
             public byte[] ContentBytesToServe { get; set; }
 
+            // Number of times a network download was actually attempted. Lets a test prove a
+            // malformed SHA is rejected before any request reaches the server.
+            public int TryDownloadObjectsCallCount { get; private set; }
+
             public static MemoryStream GetRandomStream(int size)
             {
                 Random randy = new Random(0);
@@ -913,6 +967,8 @@ namespace GVFS.UnitTests.Git
                 Action<RetryWrapper<GitObjectTaskResult>.ErrorEventArgs> onFailure,
                 bool preferBatchedLooseObjects)
             {
+                this.TryDownloadObjectsCallCount++;
+
                 if (this.StatusCodeToReturn.HasValue)
                 {
                     // Simulate the server returning a non-OK status (e.g. 404) so callers can exercise

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -16,6 +16,7 @@ namespace GVFS.UnitTests.Mock.Common
             this.RelatedInfoEvents = new List<string>();
             this.RelatedWarningEvents = new List<string>();
             this.RelatedErrorEvents = new List<string>();
+            this.RelatedEventNames = new List<string>();
         }
 
         public MockTracer StartActivityTracer { get; private set; }
@@ -25,6 +26,10 @@ namespace GVFS.UnitTests.Mock.Common
         public List<string> RelatedWarningEvents { get; }
         public List<string> RelatedErrorEvents { get; }
 
+        // Names of events reported via RelatedEvent (which, unlike RelatedInfo/Warning/Error,
+        // do not otherwise get recorded). Lets tests assert a specific diagnostic event fired.
+        public List<string> RelatedEventNames { get; }
+
         public void WaitForRelatedEvent()
         {
             this.waitEvent.WaitOne();
@@ -32,6 +37,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public void RelatedEvent(EventLevel error, string eventName, EventMetadata metadata)
         {
+            this.RelatedEventNames.Add(eventName);
             if (eventName == this.WaitRelatedEventName)
             {
                 this.waitEvent.Set();
@@ -40,6 +46,7 @@ namespace GVFS.UnitTests.Mock.Common
 
         public void RelatedEvent(EventLevel error, string eventName, EventMetadata metadata, Keywords keyword)
         {
+            this.RelatedEventNames.Add(eventName);
             if (eventName == this.WaitRelatedEventName)
             {
                 this.waitEvent.Set();


### PR DESCRIPTION
## Problem

When a user process reads a virtualized placeholder file whose stored content-id (SHA) is **corrupt — specifically 40 NUL bytes (`\u0000` × 40)** — GVFS builds a loose-object path from it with `Path.Combine`. What happens next depends on the .NET runtime, and the two shipped GVFS lines behave differently:

### On 1.0 (.NET Framework) — an unhandled `ArgumentException` and a retry storm

`Path.Combine` validates path characters and throws `System.ArgumentException: Illegal characters in path`:

```
System.ArgumentException: Illegal characters in path.
   at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
   at System.IO.Path.Combine(String path1, String path2, String path3)
   at GVFS.Common.Git.GitRepo.GetLooseBlobState(String blobSha, Action`2 writeAction, Int64& size)
   at GVFS.Common.Git.GitRepo.TryCopyBlobContentStream(String blobSha, Action`2 writeAction)
   at GVFS.Common.Git.GVFSGitObjects...TryCopyBlobContentStream...
   at GVFS.Platform.Windows.WindowsFileSystemVirtualizer.GetFileStreamHandlerAsyncHandler(...)
```

`ArgumentException` is **not** in `RetryWrapper.IsHandlableException` (only `HttpRequestException`, `IOException`, `RetryableException`), so it bypasses **both** the retry logic and the download fallback in `GVFSGitObjects.TryCopyBlobContentStream` and propagates to the virtualizer's outer `catch (Exception)`, which returns `FileNotAvailable` to ProjFS. The placeholder can never hydrate, so the failing read repeats indefinitely — a **retry storm**. This is the failure mode captured in field telemetry from the LKG build **1.0.26014.1** (see below).

### On 2.0 (.NET 10) — a bad request to the cache server, and an auth-popup storm

**Modern .NET removed the path-character validation from `Path.Combine`, so it no longer throws.** The bogus path simply misses on disk (`File.Exists` returns false), the read reports a clean local miss, and the request **falls through to the object download** — a URL built from the 40 NUL bytes is sent to the cache server. The Azure Application Gateway rejects the malformed URL with **HTTP 400** before any cache server sees it (empty `CacheName`).

That 400 then collides with a **separate** GVFS bug: `HttpRequestor` treats a 400 as an authentication failure and **erases an approved credential**. The next `git credential get` finds no credential and GCM shows a WAM account prompt; under a VS Code launch swarm many fire at once — an **auth-popup storm** (observed in **ICM 850075166** on GVFS `v2.0.26222.1`). The credential-erase half is fixed separately in **#2088** ("HttpRequestor: do not reject credentials on HTTP 400"); **this** PR stops the malformed request that provokes it.

**Takeaway:** the corrupt placeholder is the same on both lines; only the .NET runtime differs. The guard must therefore **proactively validate the SHA** (which works on both runtimes) rather than rely on `Path.Combine` throwing.

### Not `AllZeroSha`

This is **not** `GVFSConstants.AllZeroSha`. `AllZeroSha` is 40 ASCII `'0'` characters, which yields directory `"00"` and is a valid hex string (it neither throws nor is rejected here). The failing SHA is literally 40 NUL bytes — a corrupt placeholder content-id.

### Where the malformed SHA comes from

A placeholder's content-id is the 40-char SHA encoded as UTF-16 (80 bytes) and stored in the ProjFS placeholder reparse point (`FileSystemVirtualizer.ConvertShaToContentId` = `Encoding.Unicode.GetBytes(sha)`). On read, `GetShaFromContentId` decodes those 80 bytes with `Encoding.Unicode.GetString`. If that on-disk content-id region is zeroed — a corrupt placeholder from an interrupted/partial placeholder write, a crash/power-loss during placeholder creation, or disk corruption — the decode yields 40 `\u0000` characters. (What *writes* the corrupt content-id is a separate root-cause investigation; this PR hardens the read/download side.)

### Telemetry impact

Signature (1.0 retry-storm mode): `VFS.Error`, `ErrorMessage` contains `TryCopyBlobContentStream`, `Exception` contains `Illegal characters in path` and `GetLooseBlobState`.

- **Top blob-hydration failure cause on the LKG field build 1.0.26014.1** (38 machines).
- ~61 machines / ~6.2K events across 30 days; the corruption is **old and version-agnostic** (observed across ≥4 GVFS builds: 1.0.25164, 25314, 26014, 26098), and the **same 1–4 files per machine fail repeatedly for days** — the placeholder never self-heals.
- Produces **permanent** failures and retry storms — the worst single machine emitted **~2.49M** error events in 30 days.

On 2.0 the same corruption surfaces instead as the HTTP-400 / auth-popup mode described above (ICM 850075166).

## Fix

A minimal, surgical **behavior** fix (graceful-fail, defense-in-depth). Reject a malformed SHA — proactively, before it is turned into a filesystem path **or** a server request — at every relevant chokepoint:

- **`GitRepo.GetLooseBlobState`** returns `LooseBlobState.Invalid` (a clean, non-retryable miss) when the SHA is not 40 hex characters, so `Path.Combine` can never throw (1.0) or silently mis-path (2.0) here again.
- **`GitRepo.LooseObjectExists`** guards the same `Path.Combine`.
- **`GVFSGitObjects.TryCopyBlobContentStream`** short-circuits a malformed SHA **before** the retry loop, so a bogus SHA never triggers a doomed download or a retry storm on the hydration path.
- **`GVFSGitObjects.TryDownloadAndSaveObject`** (second commit) rejects a malformed object SHA at the **download chokepoint** — beside the existing `AllZeroSha` guard — for **every** request source, before any request URL is built. The hydration guard above only covers `TryCopyBlobContentStream`; two callers reach the download **directly** and bypass it: the **git.exe read-object hook** (`RequestSource.NamedPipeMessage`, via `InProcessMount`) and the **gitattributes `GVFSVerb`** (`RequestSource.GVFSVerb`). This is what closes the 2.0 HTTP-400 path for all callers.
- **`SHA1Util.IsValidShaFormat`** is now null-safe; **`SHA1Util.ToLoggableShaString`** renders the bad value with non-hex characters escaped (`\uXXXX`) so telemetry stays greppable and free of control characters.
- **`WindowsFileSystemVirtualizer.GetFileDataCallback`** routes the request's logged `sha` through `ToLoggableShaString`, so the terminal hydration-failure `RelatedError` (and every sink using that request metadata) can no longer record raw NUL/control bytes. No-op for a valid hex SHA.

All guard sites emit the same greppable Warning event (`*_MalformedBlobSha`, with the offending value under the `sha` metadata key) at **Warning** level, with no unhandled exception (an expected, handled corrupt-placeholder read is a Warning, not an Error). The `GetLooseBlobState` comment is corrected to document the two-runtime behavior (the `ArgumentException` is .NET-Framework-only), so a future reader understands why validating — not catching — is what makes the guard correct on modern .NET.

### Telemetry category stays "Unexpected"

Per an existing decision, a malformed SHA gets **no dedicated telemetry category**. This branch was developed on top of the (now-merged) blob-hydration telemetry work (#2071), which added `out BlobHydrationFailureCategory` to `TryCopyBlobContentStream`; the malformed-SHA short-circuit sets `failureCategory = Unexpected`. The case previously reached the virtualizer's outer `catch` and was tagged `Unexpected` there; now that it no longer throws, it returns cleanly and the virtualizer tags its terminal telemetry `Unexpected` **via the out-param** — same bucket, no double-logging, no new category. The paired `*_MalformedBlobSha` warning lets an analyst separate this deterministic case from genuinely-unexpected exceptions.

### Relationship to other PRs

- **#2071** (merged): added `out BlobHydrationFailureCategory`. This branch was developed on top of it and has since been **rebased onto `master`**, so the diff below is just this fix.
- **#2088** (`HttpRequestor: do not reject credentials on HTTP 400`): fixes the credential-erase half of the ICM 850075166 auth-popup storm. Independent of this PR — that change stops the credential erase; this change stops the malformed 400 request that triggers it. Both are wanted.

### Not in scope (follow-up)

- **No placeholder repair.** This PR fails gracefully. A read-time **self-heal** that re-derives the authoritative SHA from the git-index projection and rewrites the corrupt placeholder — with a `detected → repaired / repair-failed` telemetry funnel — is a separate follow-up PR (#2081) **targeting `vnext` (2.1)**: it is new, destabilizing behavior for an old, non-2.0-regressing problem, so it does not belong in the 2.0 stabilization line. This PR's graceful-fail guards remain the fallback for the repair-miss case.
- **Root cause of the corruption** (what writes a NUL-byte content-id) is tracked separately.

## Tests

- `GVFSGitObjectsTests.TryCopyBlobContentStreamFailsCleanlyForCorruptAllNullByteSha` / `...ForOtherMalformedShas`: a 40-NUL-byte SHA, a 40-char SHA with an embedded path-illegal character, and other malformed SHAs return `false` from **both** `GitRepo.TryCopyBlobContentStream` and `GVFSGitObjects.TryCopyBlobContentStream` with **no** `ArgumentException` (`Assert.DoesNotThrow`), **no download/retry** is attempted, the out category is `Unexpected`, and the `*_MalformedBlobSha` diagnostic events are actually emitted (verified via a small `MockTracer` enhancement that records `RelatedEvent` names).
- `GVFSGitObjectsTests.TryDownloadAndSaveObjectDoesNotSendMalformedShaToServer`: a malformed SHA returns `Error` across `FileStreamCallback` / `NamedPipeMessage` / `GVFSVerb`, **never reaches the network** (the mock's download call count stays 0), and is logged — the regression test for the 2.0 HTTP-400 mode.
- `SHA1UtilTests`: null-safety and `ToLoggableShaString` escaping (mixed valid/NUL, control chars, high code points).
- Full unit suite: **903 passed, 0 failed** (11 pre-existing ignores).

## Review

Reviewed with a multi-lens self-review (correctness / security / design / tests / async / risk-rollout) over two iterations; feedback applied (consistent `*_MalformedBlobSha` event names and `sha` metadata key across all guards; escaped telemetry at the single virtualizer chokepoint; explicit no-throw / no-download / emission assertions). No outstanding code findings; the only rollout note is to re-point any dashboard/alert keyed on the old `Illegal characters in path` exception signature at the new `*_MalformedBlobSha` events / the `Unexpected` category tag (the top-level hydration-failure `RelatedError` still fires, so affected machines remain visible).
