### PR TITLE
Mount: retry hook copy and tolerate transiently-locked hooks

### DIFF
--- a/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
+++ b/GVFS/GVFS.Common/FileSystem/HooksInstaller.cs
@@ -2,7 +2,6 @@
 using GVFS.Common.Tracing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -183,7 +182,7 @@ namespace GVFS.Common.FileSystem
                 {
                     if (retriesLeft == 0)
                     {
-                        errorMessage = re.InnerException.ToString();
+                        errorMessage = (re.InnerException ?? re).ToString();
                         return false;
                     }
 
@@ -209,7 +208,7 @@ namespace GVFS.Common.FileSystem
             return TryUpdateHook(context, hook.Name, installedHookPath, enlistmentHookPath, out errorMessage);
         }
 
-        private static bool TryUpdateHook(
+        internal static bool TryUpdateHook(
             GVFSContext context,
             string hookName,
             string installedHookPath,
@@ -228,47 +227,66 @@ namespace GVFS.Common.FileSystem
             {
                 copyHook = true;
 
-                EventMetadata metadata = new EventMetadata();
-                metadata.Add("Area", "Mount");
-                metadata.Add(nameof(enlistmentHookPath), enlistmentHookPath);
-                metadata.Add(nameof(installedHookPath), installedHookPath);
-                metadata.Add(TracingConstants.MessageKey.WarningMessage, hookName + " not found in enlistment, copying from installation folder");
-                context.Tracer.RelatedWarning(hookName + " MissingFromEnlistment", metadata);
+                EventMetadata metadata = CreateHookEventMetadata(installedHookPath, enlistmentHookPath);
+                metadata.Add("HookUpdateResult", "MissingFromEnlistment");
+                context.Tracer.RelatedWarning(metadata, hookName + " not found in enlistment, copying from installation folder", Keywords.Telemetry);
             }
             else
             {
                 try
                 {
-                    FileVersionInfo enlistmentVersion = FileVersionInfo.GetVersionInfo(enlistmentHookPath);
-                    FileVersionInfo installedVersion = FileVersionInfo.GetVersionInfo(installedHookPath);
-                    copyHook = enlistmentVersion.FileVersion != installedVersion.FileVersion;
+                    // Compare the enlistment hook against the installed hook by FileVersion.
+                    // These native hook binaries embed their GVFS version in the PE version
+                    // resource, so the version differs only when a GVFS upgrade changed the
+                    // hook - which is rare (roughly monthly) compared to daily mounts. So the
+                    // common daily mount does no copy, and a copy happens on the first mount
+                    // after an upgrade.
+                    copyHook = !HookVersionsMatch(context, installedHookPath, enlistmentHookPath);
                 }
                 catch (Exception e)
                 {
-                    EventMetadata metadata = new EventMetadata();
-                    metadata.Add("Area", "Mount");
-                    metadata.Add(nameof(enlistmentHookPath), enlistmentHookPath);
-                    metadata.Add(nameof(installedHookPath), installedHookPath);
+                    // Reading the version opens the hook files, either of which can be
+                    // transiently locked (open handle, AV scan) - the same failure class the
+                    // copy path is hardened against. Do not fail the mount here: assume the
+                    // enlistment hook may be stale, set copyHook so the resilient copy path
+                    // runs (retry with backoff, then the "already matches" recheck). If a lock
+                    // persists, that path reports the error after exhausting retries.
+                    EventMetadata metadata = CreateHookEventMetadata(installedHookPath, enlistmentHookPath);
                     metadata.Add("Exception", e.ToString());
-                    context.Tracer.RelatedError(metadata, "Failed to compare " + hookName + " version");
-                    errorMessage = "Error comparing " + hookName + " versions. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.WorkingDirectoryRoot);
-                    return false;
+                    metadata.Add("HookUpdateResult", "CompareFailed");
+                    context.Tracer.RelatedWarning(metadata, "Failed to compare " + hookName + " version; will attempt to refresh the hook", Keywords.Telemetry);
+                    copyHook = true;
                 }
             }
 
             if (copyHook)
             {
-                try
+                // Retry the copy with backoff, matching the clone-time InstallHooks path.
+                // The enlistment hook can be transiently locked (open handle, AV scan),
+                // in which case the rename fails with a RetryableException wrapping
+                // ERROR_ACCESS_DENIED. A transient lock must not be fatal to the mount.
+                if (!TryHooksInstallationAction(() => CopyHook(context, installedHookPath, enlistmentHookPath), out string copyError))
                 {
-                    CopyHook(context, installedHookPath, enlistmentHookPath);
-                }
-                catch (Exception e)
-                {
-                    EventMetadata metadata = new EventMetadata();
-                    metadata.Add("Area", "Mount");
-                    metadata.Add(nameof(enlistmentHookPath), enlistmentHookPath);
-                    metadata.Add(nameof(installedHookPath), installedHookPath);
-                    metadata.Add("Exception", e.ToString());
+                    // The copy could not complete after retries. If the enlistment hook
+                    // already matches the installed one, the binary is correct and the
+                    // lock is harmless - treat it as success rather than killing the mount.
+                    if (HookExistsAndVersionMatches(context, installedHookPath, enlistmentHookPath))
+                    {
+                        EventMetadata alreadyCorrect = CreateHookEventMetadata(installedHookPath, enlistmentHookPath);
+                        alreadyCorrect.Add("CopyError", copyError);
+                        alreadyCorrect.Add("HookUpdateResult", "LockedButAlreadyCorrect");
+                        context.Tracer.RelatedWarning(
+                            alreadyCorrect,
+                            hookName + " could not be re-copied but already matches the installed hook; continuing",
+                            Keywords.Telemetry);
+
+                        errorMessage = null;
+                        return true;
+                    }
+
+                    EventMetadata metadata = CreateHookEventMetadata(installedHookPath, enlistmentHookPath);
+                    metadata.Add("Exception", copyError);
+                    metadata.Add("HookUpdateResult", "CopyFailed");
                     context.Tracer.RelatedError(metadata, "Failed to copy " + hookName + " to enlistment");
                     errorMessage = "Error copying " + hookName + " to enlistment. " + ConsoleHelper.GetGVFSLogMessage(context.Enlistment.WorkingDirectoryRoot);
                     return false;
@@ -277,6 +295,55 @@ namespace GVFS.Common.FileSystem
 
             errorMessage = null;
             return true;
+        }
+
+        /// <summary>
+        /// Seeds an <see cref="EventMetadata"/> with the fields common to every mount-time
+        /// hook-update outcome. Callers add an outcome-specific "HookUpdateResult" value (and
+        /// any exception detail) so all outcomes are queryable by that field.
+        /// </summary>
+        private static EventMetadata CreateHookEventMetadata(string installedHookPath, string enlistmentHookPath)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("Area", "Mount");
+            metadata.Add(nameof(enlistmentHookPath), enlistmentHookPath);
+            metadata.Add(nameof(installedHookPath), installedHookPath);
+            return metadata;
+        }
+
+        /// <summary>
+        /// Returns true only when both files report the same, non-empty FileVersion. An
+        /// absent/empty version is treated as "cannot confirm identical" (not a match), so the
+        /// resilient copy path runs. Otherwise two version-less binaries would compare equal
+        /// (string.Equals(null, null) == true) and the hook would never be refreshed, silently
+        /// defeating the self-heal this comparison provides. Both files must exist.
+        /// </summary>
+        private static bool HookVersionsMatch(GVFSContext context, string installedHookPath, string enlistmentHookPath)
+        {
+            string installedVersion = context.FileSystem.GetFileVersion(installedHookPath);
+            string enlistmentVersion = context.FileSystem.GetFileVersion(enlistmentHookPath);
+
+            return !string.IsNullOrEmpty(installedVersion)
+                && string.Equals(installedVersion, enlistmentVersion, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns true only when the enlistment hook exists and its FileVersion matches the
+        /// installed hook. Any failure to read or compare (for example, the file is exclusively
+        /// locked) is treated as "does not match" so callers do not mistake an unknown state
+        /// for success.
+        /// </summary>
+        private static bool HookExistsAndVersionMatches(GVFSContext context, string installedHookPath, string enlistmentHookPath)
+        {
+            try
+            {
+                return context.FileSystem.FileExists(enlistmentHookPath)
+                    && HookVersionsMatch(context, installedHookPath, enlistmentHookPath);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public class HooksConfigurationException : Exception

--- a/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
+++ b/GVFS/GVFS.Common/FileSystem/PhysicalFileSystem.cs
@@ -258,19 +258,9 @@ namespace GVFS.Common.FileSystem
             return Directory.GetFiles(directoryPath, mask);
         }
 
-        public virtual FileVersionInfo GetVersionInfo(string path)
+        public virtual string GetFileVersion(string path)
         {
-            return FileVersionInfo.GetVersionInfo(path);
-        }
-
-        public virtual bool FileVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
-        {
-            return versionInfo1.FileVersion == versionInfo2.FileVersion;
-        }
-
-        public virtual bool ProductVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
-        {
-            return versionInfo1.ProductVersion == versionInfo2.ProductVersion;
+            return FileVersionInfo.GetVersionInfo(path).FileVersion;
         }
 
         public bool TryWriteTempFileAndRename(string destinationPath, string contents, out Exception handledException)
@@ -310,7 +300,7 @@ namespace GVFS.Common.FileSystem
             }
         }
 
-        public bool TryCopyToTempFileAndRename(string sourcePath, string destinationPath, out Exception handledException)
+        public virtual bool TryCopyToTempFileAndRename(string sourcePath, string destinationPath, out Exception handledException)
         {
             handledException = null;
             string tempFilePath = destinationPath + ".temp";

--- a/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerMountUpdateTests.cs
+++ b/GVFS/GVFS.UnitTests/CommandLine/HooksInstallerMountUpdateTests.cs
@@ -1,0 +1,321 @@
+﻿using GVFS.Common;
+using GVFS.Common.FileSystem;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.FileSystem;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+
+namespace GVFS.UnitTests.CommandLine
+{
+    [TestFixture]
+    public class HooksInstallerMountUpdateTests
+    {
+        private const string HookName = "GVFS.ReadObjectHook";
+        private const string RootPath = "mock:";
+        private static readonly string InstalledDir = Path.Combine(RootPath, "installed");
+        private static readonly string EnlistmentDir = Path.Combine(RootPath, "enlistment");
+        private static readonly string InstalledHookPath = Path.Combine(InstalledDir, "GVFS.ReadObjectHook.exe");
+        private static readonly string EnlistmentHookPath = Path.Combine(EnlistmentDir, "GVFS.ReadObjectHook.exe");
+
+        private const string InstalledContent = "installed-hook-binary-v2";
+        private const string OldEnlistmentContent = "old-hook-binary-v1";
+
+        [TestCase]
+        public void IdenticalHookIsNotCopied()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: InstalledContent);
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(0, "Identical hooks must not be re-copied");
+        }
+
+        [TestCase]
+        public void DifferentHookIsCopiedOnce()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(1);
+            fileSystem.ReadAllText(EnlistmentHookPath).ShouldEqual(InstalledContent);
+        }
+
+        [TestCase]
+        public void MissingHookIsCopied()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: null);
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(1);
+            fileSystem.ReadAllText(EnlistmentHookPath).ShouldEqual(InstalledContent);
+        }
+
+        [TestCase]
+        public void HookIsCopiedWhenVersionDiffersEvenIfContentIsIdentical()
+        {
+            // Production compares FileVersion, not content. If the version differs, the hook
+            // must be refreshed even when the bytes happen to match. The double models version
+            // independently of content so this case is representable.
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: InstalledContent);
+            fileSystem.SetFileVersion(InstalledHookPath, "2.0.0.0");
+            fileSystem.SetFileVersion(EnlistmentHookPath, "1.0.0.0");
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(1, "A version difference must trigger a copy even when content matches");
+            fileSystem.GetFileVersion(EnlistmentHookPath).ShouldEqual("2.0.0.0", "The copied hook must carry the installed version");
+        }
+
+        [TestCase]
+        public void HookIsNotCopiedWhenVersionMatchesEvenIfContentDiffers()
+        {
+            // Production compares FileVersion, not content. If the version matches, no copy
+            // happens even when the bytes differ. This pins that the comparison is by version.
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            fileSystem.SetFileVersion(InstalledHookPath, "2.0.0.0");
+            fileSystem.SetFileVersion(EnlistmentHookPath, "2.0.0.0");
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(0, "A matching version must not trigger a copy even when content differs");
+        }
+
+        [TestCase]
+        public void HookIsCopiedWhenBothVersionsAreNull()
+        {
+            // GetFileVersion returns null for a binary with no version resource. Two null
+            // versions must NOT be treated as identical (string.Equals(null, null) == true);
+            // otherwise a version-less hook would never be refreshed. The hook must be copied.
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: InstalledContent);
+            fileSystem.SetFileVersion(InstalledHookPath, null);
+            fileSystem.SetFileVersion(EnlistmentHookPath, null);
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(1, "An unknown (null) version must force a copy rather than be assumed identical");
+        }
+
+        [TestCase]
+        public void TransientCopyFailureIsRetriedAndSucceeds()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            fileSystem.FailCopyCount = 2;
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            fileSystem.CopyAttempts.ShouldEqual(3, "The copy must be retried past two transient failures");
+            fileSystem.ReadAllText(EnlistmentHookPath).ShouldEqual(InstalledContent);
+        }
+
+        [TestCase]
+        public void LockedButAlreadyCorrectHookDoesNotFailMount()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            fileSystem.AlwaysFailCopy = true;
+            fileSystem.WriteCorrectDestinationOnFailure = true;
+            MockTracer tracer = new MockTracer();
+            GVFSContext context = this.CreateContext(fileSystem, tracer);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue("A locked hook that already matches the installed hook must not fail the mount");
+            errorMessage.ShouldBeNull();
+            tracer.RelatedErrorEvents.Count.ShouldEqual(0, "A locked-but-correct hook must not log an error");
+        }
+
+        [TestCase]
+        public void CompareFailureDoesNotHardFailMountAndRefreshesHook()
+        {
+            // The enlistment hook is transiently locked such that reading its version to
+            // compare throws. The mount must not hard-fail on the compare; it must fall
+            // through to the resilient copy path and refresh the hook.
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            fileSystem.ThrowOnGetVersionPath = EnlistmentHookPath;
+            MockTracer tracer = new MockTracer();
+            GVFSContext context = this.CreateContext(fileSystem, tracer);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeTrue(errorMessage);
+            errorMessage.ShouldBeNull();
+            tracer.RelatedErrorEvents.Count.ShouldEqual(0, "A compare failure must not be fatal to the mount");
+            fileSystem.CopyAttempts.ShouldBeAtLeast(1, "The hook must be refreshed after a compare failure");
+            fileSystem.ReadAllText(EnlistmentHookPath).ShouldEqual(InstalledContent);
+        }
+
+        [TestCase]
+        public void MissingInstalledHookFailsWithoutCopying()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent, includeInstalled: false);
+            GVFSContext context = this.CreateContext(fileSystem);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeFalse();
+            errorMessage.ShouldNotBeNull();
+            errorMessage.ShouldContain("cannot be found");
+            fileSystem.CopyAttempts.ShouldEqual(0, "A missing installed hook must not trigger a copy");
+        }
+
+        [TestCase]
+        public void PersistentCopyFailureFailsMount()
+        {
+            CopyControllableFileSystem fileSystem = this.CreateFileSystem(enlistmentContent: OldEnlistmentContent);
+            fileSystem.AlwaysFailCopy = true;
+            MockTracer tracer = new MockTracer();
+            GVFSContext context = this.CreateContext(fileSystem, tracer);
+
+            bool result = HooksInstaller.TryUpdateHook(context, HookName, InstalledHookPath, EnlistmentHookPath, out string errorMessage);
+
+            result.ShouldBeFalse();
+            errorMessage.ShouldNotBeNull();
+            errorMessage.ShouldContain(HookName);
+            tracer.RelatedErrorEvents.Count.ShouldBeAtLeast(1);
+        }
+
+        private CopyControllableFileSystem CreateFileSystem(string enlistmentContent, bool includeInstalled = true)
+        {
+            MockDirectory root = new MockDirectory(
+                RootPath,
+                new[]
+                {
+                    new MockDirectory(InstalledDir, folders: null, files: null),
+                    new MockDirectory(EnlistmentDir, folders: null, files: null),
+                },
+                files: null);
+
+            CopyControllableFileSystem fileSystem = new CopyControllableFileSystem(root);
+            if (includeInstalled)
+            {
+                fileSystem.WriteAllText(InstalledHookPath, InstalledContent);
+            }
+
+            if (enlistmentContent != null)
+            {
+                fileSystem.WriteAllText(EnlistmentHookPath, enlistmentContent);
+            }
+
+            return fileSystem;
+        }
+
+        private GVFSContext CreateContext(CopyControllableFileSystem fileSystem, MockTracer tracer = null)
+        {
+            return new GVFSContext(
+                tracer ?? new MockTracer(),
+                fileSystem,
+                repository: null,
+                new MockGVFSEnlistment());
+        }
+
+        private sealed class CopyControllableFileSystem : MockFileSystem
+        {
+            private readonly Dictionary<string, string> explicitVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            public CopyControllableFileSystem(MockDirectory rootDirectory)
+                : base(rootDirectory)
+            {
+            }
+
+            public int CopyAttempts { get; private set; }
+
+            public int FailCopyCount { get; set; }
+
+            public bool AlwaysFailCopy { get; set; }
+
+            public bool WriteCorrectDestinationOnFailure { get; set; }
+
+            public string ThrowOnGetVersionPath { get; set; }
+
+            /// <summary>
+            /// Pins a path's FileVersion independently of its content, so tests can model the
+            /// real decoupling between a PE version resource and file bytes (including a null
+            /// version). A path with no explicit version falls back to its stored text, which
+            /// keeps the common "version tracks content" tests simple.
+            /// </summary>
+            public void SetFileVersion(string path, string version)
+            {
+                this.explicitVersions[path] = version;
+            }
+
+            public override string GetFileVersion(string path)
+            {
+                if (this.ThrowOnGetVersionPath != null && path == this.ThrowOnGetVersionPath)
+                {
+                    throw new IOException("The process cannot access the file because it is being used by another process.");
+                }
+
+                if (this.explicitVersions.TryGetValue(path, out string version))
+                {
+                    return version;
+                }
+
+                return this.ReadAllText(path);
+            }
+
+            public override bool TryCopyToTempFileAndRename(string sourcePath, string destinationPath, out Exception handledException)
+            {
+                this.CopyAttempts++;
+
+                if (this.AlwaysFailCopy || this.CopyAttempts <= this.FailCopyCount)
+                {
+                    if (this.WriteCorrectDestinationOnFailure)
+                    {
+                        // Simulate another writer (or the lock holder) leaving the correct
+                        // binary in place even though our rename could not complete.
+                        this.PropagateHook(sourcePath, destinationPath);
+                    }
+
+                    handledException = new Win32Exception(5, "Access is denied");
+                    return false;
+                }
+
+                this.PropagateHook(sourcePath, destinationPath);
+                handledException = null;
+                return true;
+            }
+
+            // Model an on-disk copy: the destination takes the source's content AND its
+            // version, so the two converge exactly as they would after a real file copy.
+            private void PropagateHook(string sourcePath, string destinationPath)
+            {
+                this.WriteAllText(destinationPath, this.ReadAllText(sourcePath));
+
+                if (this.explicitVersions.TryGetValue(sourcePath, out string sourceVersion))
+                {
+                    this.explicitVersions[destinationPath] = sourceVersion;
+                }
+                else
+                {
+                    this.explicitVersions.Remove(destinationPath);
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/GVFS/GVFS.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -5,7 +5,6 @@ using GVFS.Tests.Should;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 
 namespace GVFS.UnitTests.Mock.FileSystem
@@ -336,21 +335,6 @@ namespace GVFS.UnitTests.Mock.FileSystem
             }
 
             return files.ToArray();
-        }
-
-        public override FileVersionInfo GetVersionInfo(string path)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override bool FileVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override bool ProductVersionsMatch(FileVersionInfo versionInfo1, FileVersionInfo versionInfo2)
-        {
-            throw new NotImplementedException();
         }
 
         private Stream CreateAndOpenFileStream(string path)


### PR DESCRIPTION
## Problem

On the GVFS 2.0 line, mount startup fails roughly twice as often as the `1.0.26014.1` LKG it will replace. The dominant **2.0-specific** actionable cause is the mount-time git-hook update.

After a GVFS upgrade changes a native hook binary, the next mount re-copies it into the enlistment's `.git/hooks` via a copy-to-temp-then-rename (`HooksInstaller.TryUpdateHook`). The rename can fail transiently with `Win32Exception (5)` `ERROR_ACCESS_DENIED` when the existing enlistment hook is locked (open handle, AV scan). `CopyHook` flags that failure retryable, but the mount-time call site failed **immediately with no retry** — unlike the clone-time `InstallHooks` path, which retries with exponential backoff via `TryHooksInstallationAction`. The failed update calls `FailMountAndExit`, so the mount process exits and the client's `WaitUntilMounted` handshake reports "Pipe is broken" / "exited before pipe ready".

Telemetry: inner exception `Win32Exception (5): Failed to move '<hook>' to '<hook>'` wrapped in `RetryableException` on the "Failed to copy `<hook>` to enlistment" error; 28 machines / 332 events, all on 2.x, zero on 1.x.

## Fix

**1 — Retry the hook copy at mount time (primary).** Wrap the mount-time `CopyHook` in the existing `TryHooksInstallationAction` retry helper (3× exponential backoff), matching the clone-time path. A transient `ACCESS_DENIED` rename is now retried, not fatal to the mount.

**2 — Tolerate locked-but-already-correct.** After retries are exhausted, if the enlistment hook already matches the installed one, treat it as success instead of `FailMountAndExit` — a locked-but-already-correct hook must not kill the mount.

**3 — Compare-path resilience.** Reading the hook version opens the enlistment hook, which can be transiently locked too. A compare failure no longer hard-fails the mount; it logs a telemetry warning and falls through to the resilient copy path (retry, then the already-correct recheck).

### Change detection

The change detection still compares the hook **FileVersion**. These native (C++) hook binaries embed their GVFS version in the PE version resource, so the version differs only when a GVFS upgrade changed the hook — rare (~monthly) compared to daily mounts — so the common mount does no copy, and a copy happens on the first mount after an upgrade. (Confirmed against the installed 2.0.26196.1 hooks: the version resource is present and correct, so the FileVersion check is reliable for these binaries.)

The comparison now reads the version through a small `context.FileSystem.GetFileVersion(path)` seam instead of a direct static `FileVersionInfo` call, so the mount-time path can be unit-tested. The unused `FileVersionInfo`-returning `GetVersionInfo`/`FileVersionsMatch`/`ProductVersionsMatch` (and their mock overrides) are removed.

## Observability

The locked-but-already-correct success path and the compare-failure path emit with `Keywords.Telemetry` and a stable `HookUpdateResult` field, so rollout can measure how often mounts coast through a transient lock.

## Misc

Worktree behavior is unchanged (`InProcessMount` already skips hook install for worktrees). `PhysicalFileSystem.TryCopyToTempFileAndRename` is made `virtual` so the copy path can be unit-tested.

## Tests

Adds `GVFS.UnitTests.CommandLine.HooksInstallerMountUpdateTests`:
- identical hook is not copied
- different / missing hook is copied
- a transient copy failure is retried and then succeeds
- a locked-but-already-correct hook does not fail the mount
- a persistent copy failure still fails the mount
- a compare failure refreshes the hook without failing the mount
- a missing installed hook fails without copying

Full unit suite: **884 passed, 0 failed** (11 pre-existing skips).
