### PR TITLE
Attribute wrapped blob-hydration failures to their inner cause

### DIFF
--- a/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
@@ -3,6 +3,7 @@ using GVFS.Common.Tracing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -89,9 +90,18 @@ namespace GVFS.Common.Git
                     {
                         metadata.Add("Exception", errorArgs.Error.ToString());
 
-                        // An IOException here can also originate in the download/network layer, but
-                        // we cannot tell where it came from, so it is bucketed as local IO.
-                        category = errorArgs.Error is IOException
+                        // A RetryableException wraps its real cause in InnerException, so inspect the
+                        // inner exception rather than the RetryableException type. On this branch the
+                        // exception arrives from Context.Repository.TryCopyBlobContentStream - typically
+                        // StreamUtil wrapping an IOException while reading a corrupt/truncated local
+                        // loose object (UnauthorizedAccessException/Win32Exception are treated the same
+                        // as they belong to the local disk/IO family). Without this unwrap every
+                        // RetryableException - the single largest hydration-failure bucket in the field -
+                        // is misattributed to NetworkUnavailable even when the cause is local disk/IO. A
+                        // stream-read IOException can still originate in the download layer, but we cannot
+                        // tell where it came from, so it is bucketed as local IO.
+                        Exception rootError = (errorArgs.Error as RetryableException)?.InnerException ?? errorArgs.Error;
+                        category = rootError is IOException || rootError is UnauthorizedAccessException || rootError is Win32Exception
                             ? BlobHydrationFailureCategory.LocalIO
                             : BlobHydrationFailureCategory.NetworkUnavailable;
                     }

--- a/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GVFSGitObjectsTests.cs
@@ -1,6 +1,7 @@
 ﻿using GVFS.Common;
 using GVFS.Common.Git;
 using GVFS.Common.Http;
+using GVFS.Common.Tracing;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Category;
 using GVFS.UnitTests.Mock;
@@ -13,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 
@@ -30,6 +32,24 @@ namespace GVFS.UnitTests.Git
             0x78, 0x01, 0x4B, 0xCA, 0xC9, 0x4F, 0x52, 0x30, 0x62,
             0x48, 0xE4, 0x02, 0x00, 0x0E, 0x64, 0x02, 0x5D
         };
+
+        [SetUp]
+        public void SetUp()
+        {
+            // These tests deliberately drive the retrier to failure, which records failures on the
+            // process-global RetryCircuitBreaker. Reset it before each test so an accumulation of
+            // failures from earlier tests cannot open the circuit and fast-fail a later test with a
+            // circuit-open RetryableException (which would otherwise be mis-read as its cause).
+            RetryCircuitBreaker.Reset();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Reset on exit too, so this fixture cannot leave the process-global circuit dirty for a
+            // later breaker-sensitive fixture (NUnit does not guarantee cross-fixture ordering).
+            RetryCircuitBreaker.Reset();
+        }
 
         [TestCase]
         [Category(CategoryConstants.ExceptionExpected)]
@@ -173,6 +193,84 @@ namespace GVFS.UnitTests.Git
             failureCategory.ShouldEqual(GVFSGitObjects.BlobHydrationFailureCategory.LocalCopyFailed);
             string terminalError = tracer.RelatedErrorEvents.First(e => e.Contains("Failed to provide blob contents"));
             terminalError.ShouldContain("\"BlobHydrationFailureCategory\":\"LocalCopyFailed\"");
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TerminalBlobHydrationFailureUnwrapsRetryableLocalIOException()
+        {
+            // A RetryableException reaches this branch from Context.Repository.TryCopyBlobContentStream -
+            // e.g. StreamUtil wrapping an IOException while reading a corrupt/truncated local loose
+            // object. Its inner cause must be attributed to LocalIO, not NetworkUnavailable. Regression
+            // guard for the RetryableException.InnerException unwrap in the failure categorization.
+            this.AssertRetryableCauseMapsToCategory(
+                new RetryableException("wrapped local IO failure", new IOException("The device is not ready.")),
+                GVFSGitObjects.BlobHydrationFailureCategory.LocalIO);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TerminalBlobHydrationFailureUnwrapsRetryableUnauthorizedAccessAsLocalIO()
+        {
+            // UnauthorizedAccessException belongs to the local disk/IO family and must map to LocalIO
+            // after the InnerException unwrap.
+            this.AssertRetryableCauseMapsToCategory(
+                new RetryableException("wrapped local access failure", new UnauthorizedAccessException("Access to the path is denied.")),
+                GVFSGitObjects.BlobHydrationFailureCategory.LocalIO);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TerminalBlobHydrationFailureUnwrapsRetryableWin32AsLocalIO()
+        {
+            // Win32Exception (here a disk-full native error) belongs to the local disk/IO family and
+            // must map to LocalIO after the InnerException unwrap.
+            this.AssertRetryableCauseMapsToCategory(
+                new RetryableException("wrapped local Win32 failure", new System.ComponentModel.Win32Exception(112)),
+                GVFSGitObjects.BlobHydrationFailureCategory.LocalIO);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TerminalBlobHydrationFailureKeepsRetryableNonLocalInnerAsNetworkUnavailable()
+        {
+            // A RetryableException whose inner cause is NOT a local disk/IO type (here an
+            // HttpRequestException) must stay NetworkUnavailable - this proves the unwrap does not
+            // over-attribute to LocalIO.
+            this.AssertRetryableCauseMapsToCategory(
+                new RetryableException("wrapped network failure", new HttpRequestException("Connection refused.")),
+                GVFSGitObjects.BlobHydrationFailureCategory.NetworkUnavailable);
+        }
+
+        [TestCase]
+        [Category(CategoryConstants.ExceptionExpected)]
+        public void TerminalBlobHydrationFailureTagsRetryableNetworkAsNetworkUnavailable()
+        {
+            // A RetryableException with no inner exception (a bare network-flakiness signal, e.g. a
+            // null download stream) is genuinely outside gvfs.exe's control, so it stays
+            // NetworkUnavailable after the InnerException unwrap.
+            this.AssertRetryableCauseMapsToCategory(
+                new RetryableException("Stream is null (this could be a result of network flakiness), retrying."),
+                GVFSGitObjects.BlobHydrationFailureCategory.NetworkUnavailable);
+        }
+
+        private void AssertRetryableCauseMapsToCategory(RetryableException thrownException, GVFSGitObjects.BlobHydrationFailureCategory expected)
+        {
+            GitRepo throwingRepo = new ThrowingGitRepo(new MockTracer(), thrownException);
+            MockHttpGitObjects httpObjects = new MockHttpGitObjects();
+            GVFSGitObjects dut = this.CreateTestableGVFSGitObjects(httpObjects, throwingRepo, out MockTracer tracer);
+
+            bool copied = dut.TryCopyBlobContentStream(
+                ValidTestObjectFileSha1,
+                new CancellationToken(),
+                GVFSGitObjects.RequestSource.FileStreamCallback,
+                (stream, length) => Assert.Fail("Should not be able to call copy stream callback"),
+                out GVFSGitObjects.BlobHydrationFailureCategory failureCategory);
+
+            copied.ShouldEqual(false);
+            failureCategory.ShouldEqual(expected);
+            string terminalError = tracer.RelatedErrorEvents.First(e => e.Contains("Failed to provide blob contents"));
+            terminalError.ShouldContain("\"BlobHydrationFailureCategory\":\"" + expected + "\"");
         }
 
         [TestCase]
@@ -658,6 +756,18 @@ namespace GVFS.UnitTests.Git
             return this.CreateTestableGVFSGitObjects(httpObjects, fileSystem, out _);
         }
 
+        private GVFSGitObjects CreateTestableGVFSGitObjects(GitObjectsHttpRequestor httpObjects, GitRepo repo, out MockTracer tracer)
+        {
+            MockTracer localTracer = new MockTracer();
+            tracer = localTracer;
+            GVFSEnlistment enlistment = new GVFSEnlistment(TestEnlistmentRoot, "https://fakeRepoUrl", "fakeGitBinPath", authentication: null);
+            enlistment.InitializeCachePathsFromKey(TestLocalCacheRoot, TestObjectRoot);
+
+            GVFSContext context = new GVFSContext(localTracer, new MockFileSystemWithCallbacks(), repo, enlistment);
+            GVFSGitObjects dut = new UnsafeGVFSGitObjects(context, httpObjects);
+            return dut;
+        }
+
         private GVFSGitObjects CreateTestableGVFSGitObjects(GitObjectsHttpRequestor httpObjects, MockFileSystemWithCallbacks fileSystem, out MockTracer tracer)
         {
             MockTracer localTracer = new MockTracer();
@@ -759,6 +869,22 @@ namespace GVFS.UnitTests.Git
                 : base(context, objectRequestor)
             {
                 this.checkData = false;
+            }
+        }
+
+        private sealed class ThrowingGitRepo : GitRepo
+        {
+            private readonly Exception toThrow;
+
+            public ThrowingGitRepo(ITracer tracer, Exception toThrow)
+                : base(tracer)
+            {
+                this.toThrow = toThrow;
+            }
+
+            public override bool TryCopyBlobContentStream(string blobSha, Action<Stream, long> writeAction)
+            {
+                throw this.toThrow;
             }
         }
 


### PR DESCRIPTION
## What

Attribute a wrapped blob-hydration failure to its real inner cause when categorizing telemetry.

`RetryableException` carries the real cause in `InnerException`. The `BlobHydrationFailureCategory`
logic added in #2071 checked the `RetryableException` type itself:

```csharp
category = errorArgs.Error is IOException ? LocalIO : NetworkUnavailable;
```

`RetryableException` is not an `IOException`, so **every** `RetryableException` was tagged
`NetworkUnavailable` - even when it wrapped a local disk/IO cause. This over-counts the
"external / network" slice and under-counts `LocalIO`.

This matters because `RetryableException` is the **largest** blob-hydration failure bucket in the
field (~255 os.2020 mount machines, ~2.85M events in 30 days).

## Change

- Unwrap `RetryableException.InnerException` before categorizing.
- Map `IOException` / `UnauthorizedAccessException` / `Win32Exception` (the local disk/IO family) to
  `LocalIO`.
- A `RetryableException` whose inner cause is not local (e.g. `HttpRequestException`), or that has no
  inner cause, stays `NetworkUnavailable`.
- **Telemetry metadata only. No behavior change.** The Warning-while-retrying / Error-on-terminal
  split is unchanged.

### Which path actually reaches this branch

On this branch the `RetryableException` arrives from `Context.Repository.TryCopyBlobContentStream` -
typically `StreamUtil` wrapping an `IOException` while reading a corrupt or truncated **local loose
object** (or the ProjFS write callback failing). Note: a `RetryableException` thrown while *writing*
a loose object (e.g. a full disk during download) is caught by the inner download retrier and
surfaces as `DownloadFailed` (no exception on the outer handler), so it does **not** reach this
branch. `UnauthorizedAccessException` / `Win32Exception` are mapped to `LocalIO` because they belong
to the same local disk/IO family.

## Testing

- Full unit suite: **898 passed, 0 failed** (11 pre-existing skips).
- Per-cause tests: `IOException`, `UnauthorizedAccessException`, `Win32Exception` -> `LocalIO`;
  `HttpRequestException` (non-local inner) and a bare no-inner `RetryableException` ->
  `NetworkUnavailable`.
- The fixture resets the process-global `RetryCircuitBreaker` in **both** `SetUp` and `TearDown` so
  these failure-driving tests cannot open the circuit for one another or leave it dirty for a later
  fixture.

## Rollout note (metadata distribution)

This moves a large volume of failures from `NetworkUnavailable` to `LocalIO`. The dashboard folds
**both** into "external", so the external-vs-actionable split is unaffected, but any *per-category*
`NetworkUnavailable` / `LocalIO` trend or alert will show a one-time step change at the deploy
boundary. Annotate the boundary and re-baseline per-category thresholds before using this data for a
release-readiness comparison. Fully reversible (pure metadata).

## Relationship to #2071

Follow-up to #2071 (now **merged**), which introduced `BlobHydrationFailureCategory`. This branch has
been rebased onto `master`, so the diff is just the unwrap change (two files).

## Companion

Consumes the `BlobHydrationFailureCategory` tag from #2071. The dashboard-side split that reads these
tags is EngSys PR 16223444 in `devprod.git.telemetry`.
