### PR TITLE
gvfs health: distinguish directory-scoped status from repository status

### DIFF
--- a/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/EnlistmentPerFixture/HealthTests.cs
@@ -262,9 +262,10 @@ namespace GVFS.FunctionalTests.Tests.EnlistmentPerFixture
 
         private void ValidateEnlistmentStatus(string outputLine, string statusMessage)
         {
-            // Regex to extract the status message for the enlistment
-            // "Repository status: <status-message>"
-            Match lineMatch = Regex.Match(outputLine, @"^Repository status:\s*(.*)$");
+            // Regex to extract the status message for the enlistment. The verb prints
+            // "Repository status: <status-message>" when the calculation covers the whole enlistment,
+            // and "Directory status (<path>): <status-message>" when scoped to a subdirectory.
+            Match lineMatch = Regex.Match(outputLine, @"^(?:Repository status|Directory status \([^)]*\)):\s*(.*)$");
 
             string outputtedStatusMessage = lineMatch.Groups[1].Value;
 

--- a/GVFS/GVFS/CommandLine/HealthVerb.cs
+++ b/GVFS/GVFS/CommandLine/HealthVerb.cs
@@ -208,7 +208,23 @@ namespace GVFS.CommandLine
 
             bool healthyRepo = (enlistmentHealthData.PlaceholderPercentage + enlistmentHealthData.ModifiedPathsPercentage) < MaximumHealthyHydration;
 
-            this.Output.WriteLine("\nRepository status: " + (healthyRepo ? "OK" : "Highly Hydrated"));
+            // Only label the summary as "Repository status" when the calculation actually covered
+            // the whole enlistment. When the user scoped the check to a subdirectory (via -d or by
+            // running from a subdirectory of the enlistment) the number describes only that subtree,
+            // so label it accordingly to avoid falsely reporting the repository as highly hydrated.
+            bool isWholeRepo = string.IsNullOrEmpty(enlistmentHealthData.TargetDirectory)
+                || enlistmentHealthData.TargetDirectory == GVFSConstants.GitPathSeparatorString;
+
+            string statusLabel = isWholeRepo
+                ? "Repository status"
+                : "Directory status (" + enlistmentHealthData.TargetDirectory.TrimEnd(GVFSConstants.GitPathSeparator) + ")";
+
+            this.Output.WriteLine("\n" + statusLabel + ": " + (healthyRepo ? "OK" : "Highly Hydrated"));
+
+            if (!isWholeRepo)
+            {
+                this.Output.WriteLine("To see the full repository status, switch to the root of the repository and re-run 'gvfs health'.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The health verb always labeled its final line 'Repository status: ...' even when the calculation was scoped to a subdirectory (via -d or when run from a subdirectory of the enlistment). That could report a highly hydrated subtree as 'Highly Hydrated' at the repository level, which is misleading.

When TargetDirectory is non-empty, print 'Directory status (<path>): ...' instead and add a hint suggesting the user re-run from the repo root for the full-repo status. Update the functional test regex to accept either label.