### PR TITLE
Update default Microsoft Git version to v2.55.0.vfs.0.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ permissions:
   checks: read
 
 env:
-  GIT_VERSION: ${{ github.event.inputs.git_version || 'v2.55.0.vfs.0.6' }}
+  GIT_VERSION: ${{ github.event.inputs.git_version || 'v2.55.0.vfs.0.8' }}
 
 jobs:
   validate:


### PR DESCRIPTION
Update the default Microsoft Git version used by VFS for Git
to the newly promoted [`v2.55.0.vfs.0.8`](https://github.com/microsoft/git/releases/tag/v2.55.0.vfs.0.8) release.