### PR TITLE
Read git config strings via a config snapshot in LibGit2Repo

### DIFF
--- a/GVFS/GVFS.Common/Git/LibGit2Repo.cs
+++ b/GVFS/GVFS.Common/Git/LibGit2Repo.cs
@@ -259,18 +259,39 @@ namespace GVFS.Common.Git
             }
             try
             {
-                string value;
-                Native.ResultCode resultCode = Native.Config.GetString(out value, configHandle, name);
-                if (resultCode == Native.ResultCode.NotFound)
+                // git_config_get_string returns a borrowed pointer whose lifetime is tied to the
+                // config, so libgit2 only allows it on a snapshot (read-only) config. Calling it on
+                // the live config returned by git_repository_config fails with "get_string called on
+                // a live config object". Snapshot the config first, then read the string from it.
+                IntPtr snapshotHandle;
+                if (Native.Config.Snapshot(out snapshotHandle, configHandle) != Native.ResultCode.Success)
                 {
-                    return null;
-                }
-                else if (resultCode != Native.ResultCode.Success)
-                {
-                    throw new LibGit2Exception($"Failed to get config value for '{name}': {Native.GetLastError()}");
+                    throw new LibGit2Exception($"Failed to snapshot config for '{name}': {Native.GetLastError()}");
                 }
 
-                return value;
+                try
+                {
+                    // git_config_get_string yields a borrowed pointer owned by the (snapshot)
+                    // config, so it is retrieved as an IntPtr and copied manually. Marshalling it
+                    // directly as an out string would make the interop marshaller free the pointer
+                    // with CoTaskMemFree, corrupting libgit2's heap (mismatched allocator).
+                    IntPtr valuePtr;
+                    Native.ResultCode resultCode = Native.Config.GetString(out valuePtr, snapshotHandle, name);
+                    if (resultCode == Native.ResultCode.NotFound)
+                    {
+                        return null;
+                    }
+                    else if (resultCode != Native.ResultCode.Success)
+                    {
+                        throw new LibGit2Exception($"Failed to get config value for '{name}': {Native.GetLastError()}");
+                    }
+
+                    return valuePtr == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(valuePtr);
+                }
+                finally
+                {
+                    Native.Config.Free(snapshotHandle);
+                }
             }
             finally
             {
@@ -585,8 +606,11 @@ namespace GVFS.Common.Git
                 [DllImport(Git2NativeLibName, EntryPoint = "git_config_open_default")]
                 public static extern ResultCode GetGlobalAndSystemConfig(out IntPtr configHandle);
 
+                [DllImport(Git2NativeLibName, EntryPoint = "git_config_snapshot")]
+                public static extern ResultCode Snapshot(out IntPtr snapshotConfigHandle, IntPtr configHandle);
+
                 [DllImport(Git2NativeLibName, EntryPoint = "git_config_get_string")]
-                public static extern ResultCode GetString(out string value, IntPtr configHandle, string name);
+                public static extern ResultCode GetString(out IntPtr value, IntPtr configHandle, string name);
 
                 [DllImport(Git2NativeLibName, EntryPoint = "git_config_get_multivar_foreach")]
                 public static extern ResultCode GetMultivarForeach(

--- a/GVFS/GVFS.FunctionalTests/Tests/LibGit2ConfigTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/LibGit2ConfigTests.cs
@@ -1,0 +1,79 @@
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System.IO;
+using GitProcess = GVFS.FunctionalTests.Tools.GitProcess;
+
+namespace GVFS.FunctionalTests.Tests
+{
+    /// <summary>
+    /// Exercises the real libgit2 (git2.dll) config-read path in <see cref="LibGit2Repo"/>
+    /// against a plain on-disk git repository. This is a regression guard for the
+    /// "get_string called on a live config object" failure, which no mock-based unit
+    /// test can catch because it only manifests through the native P/Invoke.
+    /// </summary>
+    [TestFixture]
+    public class LibGit2ConfigTests
+    {
+        private const string StringConfigKey = "gvfs.functionaltests-teststring";
+        private const string StringConfigValue = "libgit2-value-42";
+        private const string BoolConfigKey = "gvfs.functionaltests-testbool";
+        private const string MissingConfigKey = "gvfs.functionaltests-missing";
+
+        private string repoRoot;
+
+        [OneTimeSetUp]
+        public void CreateRepo()
+        {
+            this.repoRoot = Path.Combine(Path.GetTempPath(), "GVFS.LibGit2ConfigTests_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(this.repoRoot);
+
+            GitProcess.Invoke(this.repoRoot, "init");
+            GitProcess.Invoke(this.repoRoot, "config user.name \"Functional Test User\"");
+            GitProcess.Invoke(this.repoRoot, "config user.email \"functional@test.com\"");
+            GitProcess.Invoke(this.repoRoot, $"config {StringConfigKey} {StringConfigValue}");
+            GitProcess.Invoke(this.repoRoot, $"config {BoolConfigKey} true");
+        }
+
+        [OneTimeTearDown]
+        public void DeleteRepo()
+        {
+            if (this.repoRoot != null)
+            {
+                RepositoryHelpers.DeleteTestDirectory(this.repoRoot);
+            }
+        }
+
+        [TestCase]
+        public void GetConfigStringReturnsValueFromLiveConfig()
+        {
+            // Before the snapshot fix this threw LibGit2Exception
+            // ("get_string called on a live config object") and callers silently
+            // fell back to their default value.
+            using (LibGit2Repo repo = new LibGit2Repo(NullTracer.Instance, this.repoRoot))
+            {
+                repo.GetConfigString(StringConfigKey).ShouldEqual(StringConfigValue);
+            }
+        }
+
+        [TestCase]
+        public void GetConfigStringReturnsNullWhenKeyMissing()
+        {
+            using (LibGit2Repo repo = new LibGit2Repo(NullTracer.Instance, this.repoRoot))
+            {
+                repo.GetConfigString(MissingConfigKey).ShouldBeNull();
+            }
+        }
+
+        [TestCase]
+        public void GetConfigBoolReturnsValueFromLiveConfig()
+        {
+            using (LibGit2Repo repo = new LibGit2Repo(NullTracer.Instance, this.repoRoot))
+            {
+                repo.GetConfigBool(BoolConfigKey).ShouldEqual(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`LibGit2Repo.GetConfigString` read a git config value with the native
`git_config_get_string`. It called that function on the **live** config object
returned by `git_repository_config`. libgit2 does not allow
`git_config_get_string` on a live config and fails with `get_string called on
a live config object`. The read then threw `LibGit2Exception`, so callers
silently fell back to their default value instead of the configured value.

A second, latent defect sat in the same P/Invoke: `git_config_get_string`
returns a **borrowed** `const char*` owned by the config, but it was marshalled
as an `out string`. The interop marshaller frees an out-string buffer with
`CoTaskMemFree` — a mismatched-allocator free of memory libgit2 still owns,
which corrupts the heap. The live-config error masked this because the call
never returned a string; fixing the first bug makes the call succeed and would
expose the corruption.

## Fix

- Take a `git_config_snapshot` of the live config and read the string from the
  snapshot, then free the snapshot. `git_config_get_string` is valid on a
  snapshot config.
- Change the `git_config_get_string` binding to return an `IntPtr` and copy the
  value with `Marshal.PtrToStringUTF8`, which never frees the borrowed pointer.
  This matches the manual marshalling already used by `GitConfigEntry`.
- A missing key still returns `null`, so the caller default applies without a
  spurious error. `git_config_get_bool` parses its value rather than returning
  a borrowed pointer, so `GetConfigBool` is unchanged.

## Tests

Adds `LibGit2ConfigTests`, a functional test that exercises the real libgit2
(`git2.dll`) config path against a plain on-disk git repository: it sets a
string and a bool config value, reads them back through `LibGit2Repo`, and
asserts a missing key returns `null`. A unit test cannot cover this because the
unit tests mock the native layer; the failure only appears through the real
P/Invoke. The test fails before this change and passes after.

Unit suite: 909 passed, 0 failed locally. The functional test was not run
locally (the native C++ projects need a toolset not available on this machine);
the PR validation build runs it.
