### PR TITLE
Do not erase an approved credential on a single blob-download rejection

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -13,6 +13,17 @@ namespace GVFS.Common.Git
     public class GitAuthentication
     {
         private const double MaxBackoffSeconds = 30;
+
+        // An already-approved credential (one the server has accepted at least once this
+        // generation) is only erased after this many *consecutive* rejections with no
+        // intervening success. A single intermittent or transient non-auth blob-download
+        // failure (e.g. a spurious 401/400/302, or one classified as auth under load) must
+        // not erase a credential that sibling requests are still using successfully, because
+        // erasing it forces a GCM re-auth and can trigger a consent-popup storm. A credential
+        // that has never succeeded (e.g. a genuinely expired PAT at first use) is still erased
+        // on the first rejection, so normal re-authentication is unaffected.
+        private const int DefaultRejectionThresholdForApprovedCredential = 3;
+
         public const int DefaultCredentialTimeoutMs = 30_000;
         public const int BackgroundCredentialTimeoutMs = 120_000;
 
@@ -31,6 +42,11 @@ namespace GVFS.Common.Git
 
         private int numberOfAttempts = 0;
         private DateTime lastAuthAttempt = DateTime.MinValue;
+
+        // Consecutive rejections of the currently-cached credential since the last successful
+        // use. Reset to 0 on every approval (successful use) and on erase. Used to gate erasing
+        // an already-approved credential (see RejectionThresholdForApprovedCredential).
+        private int consecutiveRejections = 0;
 
         private string cachedCredentialString;
         private bool isCachedCredentialStringApproved = false;
@@ -66,6 +82,13 @@ namespace GVFS.Common.Git
         /// </summary>
         internal int InitializationWaitTimeoutMs { get; set; } = BackgroundCredentialTimeoutMs;
 
+        /// <summary>
+        /// Number of consecutive rejections (with no intervening success) required
+        /// before an already-approved credential is erased. See
+        /// <see cref="DefaultRejectionThresholdForApprovedCredential"/>. Overridable for tests.
+        /// </summary>
+        internal int RejectionThresholdForApprovedCredential { get; set; } = DefaultRejectionThresholdForApprovedCredential;
+
         private GitSsl GitSsl { get; }
 
         public void ApproveCredentials(ITracer tracer, string credentialString)
@@ -77,6 +100,11 @@ namespace GVFS.Common.Git
                 {
                     this.numberOfAttempts = 0;
                     this.lastAuthAttempt = DateTime.MinValue;
+
+                    // A successful use clears the consecutive-rejection count so that only an
+                    // uninterrupted run of rejections (no intervening success) can erase the
+                    // credential.
+                    this.consecutiveRejections = 0;
 
                     // Tell Git to store the valid credential if we haven't already
                     // done so for this cached credential.
@@ -112,6 +140,12 @@ namespace GVFS.Common.Git
             lock (this.gitAuthLock)
             {
                 string cachedCredentialAtStartOfReject = this.cachedCredentialString;
+
+                // Snapshot the approved-state now: the reload below (TryCallGitCredential)
+                // unconditionally clears isCachedCredentialStringApproved even when it re-fetches
+                // an identical credential, so we cannot read the flag after the reload.
+                bool wasApprovedAtStartOfReject = this.isCachedCredentialStringApproved;
+
                 // Don't stomp a different credential
                 if (credentialString == cachedCredentialAtStartOfReject && cachedCredentialAtStartOfReject != null)
                 {
@@ -124,12 +158,44 @@ namespace GVFS.Common.Git
                         {
                             // If the store already had a different credential, we don't want to reject it without trying it.
                             this.isCachedCredentialStringApproved = false;
+                            this.consecutiveRejections = 0;
                             return;
                         }
                     }
                     else
                     {
                         tracer.RelatedWarning(getCredentialError);
+                    }
+
+                    // Defer erasing an already-approved credential until it has been rejected
+                    // several times in a row with no intervening success. This stops a single
+                    // intermittent/transient non-auth blob-download failure - one of many
+                    // concurrent downloads sharing this credential - from erasing a credential
+                    // that is actually valid, which forces a GCM re-auth and can cause a
+                    // consent-popup storm. A never-approved credential (e.g. a genuinely expired
+                    // PAT at first use) is not gated and is erased immediately below. This check
+                    // runs after the reload above so a credential that genuinely changed
+                    // underneath us is still detected and adopted (above), not deferred; at this
+                    // point the cached credential is unchanged from the approved one.
+                    if (wasApprovedAtStartOfReject)
+                    {
+                        this.consecutiveRejections++;
+                        if (this.consecutiveRejections < this.RejectionThresholdForApprovedCredential)
+                        {
+                            // The reload cleared the approved flag; restore it because the
+                            // credential is unchanged and the server has already accepted it, so
+                            // the next rejection is still gated and the count keeps accumulating.
+                            this.isCachedCredentialStringApproved = true;
+
+                            EventMetadata deferMetadata = new EventMetadata();
+                            deferMetadata.Add("consecutiveRejections", this.consecutiveRejections);
+                            deferMetadata.Add("threshold", this.RejectionThresholdForApprovedCredential);
+                            tracer.RelatedEvent(
+                                EventLevel.Informational,
+                                "RejectCredentials_DeferredForApprovedCredential",
+                                deferMetadata);
+                            return;
+                        }
                     }
 
                     // If we can we should pass the actual username/password values we used (and found to be invalid)
@@ -159,6 +225,7 @@ namespace GVFS.Common.Git
 
                     this.cachedCredentialString = null;
                     this.isCachedCredentialStringApproved = false;
+                    this.consecutiveRejections = 0;
 
                     // Backoff may have already been incremented by a failure in TryCallGitCredential
                     if (attemptsBeforeCheckingExistingCredential == this.numberOfAttempts)

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -60,6 +60,11 @@ namespace GVFS.UnitTests.Git
             GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
             dut.TryInitializeAndRequireAuth(tracer, out _);
 
+            // This test exercises backoff reset after success, independent of the
+            // consecutive-rejection gate; erase an approved credential on the first
+            // rejection so each iteration forwards exactly one rejection.
+            dut.RejectionThresholdForApprovedCredential = 1;
+
             string authString;
             string error;
 
@@ -273,6 +278,101 @@ namespace GVFS.UnitTests.Git
             dut.TryGetCredentials(tracer, out var newAuthString, out _).ShouldBeTrue();
             newAuthString.ShouldNotEqual(authString);
             gitProcess.CredentialRejections.ShouldBeEmpty();
+        }
+
+        [TestCase]
+        public void ApprovedCredentialIsNotErasedUntilThresholdConsecutiveRejections()
+        {
+            // Regression test for a credential-rejection storm: a credential the server has
+            // already accepted must survive intermittent/transient non-auth failures. It is
+            // only erased after a run of consecutive rejections with no intervening success.
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.TryInitializeAndRequireAuth(tracer, out _);
+            dut.RejectionThresholdForApprovedCredential = 3;
+
+            string authString;
+            string error;
+
+            dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
+            dut.ApproveCredentials(tracer, authString);
+
+            // The first (threshold - 1) rejections of an approved credential are deferred.
+            for (int i = 0; i < dut.RejectionThresholdForApprovedCredential - 1; ++i)
+            {
+                dut.RejectCredentials(tracer, authString);
+            }
+
+            gitProcess.CredentialRejections.Count.ShouldEqual(0, "Approved credential should not be erased before the threshold");
+            dut.TryGetCredentials(tracer, out string stillCachedAuth, out error).ShouldEqual(true);
+            stillCachedAuth.ShouldEqual(authString, "The approved credential should still be cached and reused");
+
+            // The threshold-th consecutive rejection erases the credential.
+            dut.RejectCredentials(tracer, authString);
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1, "Approved credential should be erased once the threshold is reached");
+
+            dut.TryGetCredentials(tracer, out string refreshedAuth, out error).ShouldEqual(true);
+            refreshedAuth.ShouldNotEqual(authString, "A new credential should be fetched after erasing the old one");
+        }
+
+        [TestCase]
+        public void SuccessResetsConsecutiveRejectionCount()
+        {
+            // A successful use between rejections resets the consecutive-rejection count, so a
+            // credential that keeps succeeding is never erased no matter how many isolated
+            // rejections it accumulates over time.
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.TryInitializeAndRequireAuth(tracer, out _);
+            dut.RejectionThresholdForApprovedCredential = 3;
+
+            string authString;
+            string error;
+
+            dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
+            dut.ApproveCredentials(tracer, authString);
+
+            // Accumulate rejections just short of the threshold...
+            dut.RejectCredentials(tracer, authString);
+            dut.RejectCredentials(tracer, authString);
+
+            // ...then a success resets the count.
+            dut.ApproveCredentials(tracer, authString);
+
+            // Another run just short of the threshold must still not erase the credential.
+            dut.RejectCredentials(tracer, authString);
+            dut.RejectCredentials(tracer, authString);
+
+            gitProcess.CredentialRejections.Count.ShouldEqual(0, "A success between rejections should reset the consecutive-rejection count");
+            dut.TryGetCredentials(tracer, out string stillCachedAuth, out error).ShouldEqual(true);
+            stillCachedAuth.ShouldEqual(authString, "The credential should still be cached and reused after an intervening success");
+        }
+
+        [TestCase]
+        public void NeverApprovedCredentialIsErasedOnFirstRejection()
+        {
+            // A credential the server has never accepted (e.g. a genuinely expired PAT at first
+            // use) is not gated: it is erased on the first rejection so normal re-auth is fast.
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.TryInitializeAndRequireAuth(tracer, out _);
+            dut.RejectionThresholdForApprovedCredential = 3;
+
+            string authString;
+            string error;
+
+            dut.TryGetCredentials(tracer, out authString, out error).ShouldEqual(true, "Failed to get initial credential");
+
+            // No ApproveCredentials call - the credential was never accepted by the server.
+            dut.RejectCredentials(tracer, authString);
+
+            gitProcess.CredentialRejections["mock://repoUrl"].Count.ShouldEqual(1, "A never-approved credential should be erased on the first rejection");
         }
 
         [TestCase]


### PR DESCRIPTION
## Problem

GVFS erases the cached credential and issues `git credential reject` whenever an
object-download response is 401, 400, or 302. On-demand loose-blob downloads run
many at a time and share one cached credential. When one download fails - even
intermittently, or for a non-auth reason misclassified as an auth failure under
load - the erase removes a credential that sibling downloads are still using
successfully. The erase forces a re-authentication and can start a
credential-manager consent-popup storm.

The single-rejection erase has no protection: `GitAuthentication.RejectCredentials`
had only a guard against erasing a *different* credential than the one that
failed. It had no consecutive-failure gate, so one bad response among many good
ones erased a valid credential.

## Fix

Gate the erase of an already-approved credential. A credential the server has
accepted at least once this generation is only erased after several consecutive
rejections with no intervening success. Any successful use resets the count.

A credential that has never succeeded (for example a genuinely expired token at
first use) is still erased on the first rejection, so normal re-authentication is
not affected.

The gate runs after the existing reload-from-store check, so a credential that
genuinely changed underneath us is still detected and adopted rather than
deferred.

## Tests

Adds unit tests for the new behavior: an approved credential survives up to the
threshold, a success between rejections resets the count, and a never-approved
credential still erases on the first rejection. The full unit-test suite passes.
