### PR TITLE
HttpRequestor: do not reject credentials on HTTP 400

### DIFF
--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -232,7 +232,7 @@ namespace GVFS.Common.Http
                         shouldRetry = false;
                         errorMessage = "Anonymous request was rejected with a 401";
                     }
-                    else if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.BadRequest || response.StatusCode == HttpStatusCode.Redirect)
+                    else if (ShouldRejectCredentials(response.StatusCode))
                     {
                         this.authentication.RejectCredentials(this.Tracer, authString);
                         if (!this.authentication.IsBackingOff)
@@ -324,6 +324,24 @@ namespace GVFS.Common.Http
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Determines whether an HTTP status code indicates an authentication failure
+        /// that warrants rejecting (erasing) the stored credential.
+        /// </summary>
+        /// <remarks>
+        /// Only 401 (Unauthorized) and 302 (Redirect to the Azure DevOps sign-in page)
+        /// are genuine authentication failures. A 400 (Bad Request) is a request/formatting
+        /// problem (e.g. a malformed object URL), NOT an expired credential - an expired or
+        /// invalid credential always returns 401 or 302. Rejecting credentials on 400 erased
+        /// valid credentials and caused a storm of credential-manager popups, so 400 must NOT
+        /// reject credentials.
+        /// </remarks>
+        internal static bool ShouldRejectCredentials(HttpStatusCode statusCode)
+        {
+            return statusCode == HttpStatusCode.Unauthorized ||
+                   statusCode == HttpStatusCode.Redirect;
         }
 
         private static string GetSingleHeaderOrEmpty(HttpHeaders headers, string headerName)

--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -232,7 +232,7 @@ namespace GVFS.Common.Http
                         shouldRetry = false;
                         errorMessage = "Anonymous request was rejected with a 401";
                     }
-                    else if (ShouldRejectCredentials(response.StatusCode))
+                    else if (ShouldRejectCredentials(response.StatusCode, errorMessage))
                     {
                         this.authentication.RejectCredentials(this.Tracer, authString);
                         if (!this.authentication.IsBackingOff)
@@ -327,21 +327,55 @@ namespace GVFS.Common.Http
         }
 
         /// <summary>
-        /// Determines whether an HTTP status code indicates an authentication failure
+        /// The message the Azure DevOps GVFS cache server returns in a 400 (Bad Request)
+        /// body when the request carried no parseable Basic Authorization header - i.e.
+        /// the one 400 that genuinely means "authentication required".
+        /// </summary>
+        /// <remarks>
+        /// Mirrors the cache server's own message, emitted by
+        /// GvfsHttpHandler.PrepareContextAsync as
+        /// $"A valid {scheme} {header} header is required." with scheme="Basic" and
+        /// header="Authorization". Kept as a literal (not a format) so a substring match
+        /// stays robust if the server text is wrapped or prefixed.
+        /// </remarks>
+        internal const string CacheServerAuthRequiredBadRequestMessage = "A valid Basic Authorization header is required.";
+
+        /// <summary>
+        /// Determines whether an HTTP response indicates an authentication failure
         /// that warrants rejecting (erasing) the stored credential.
         /// </summary>
         /// <remarks>
-        /// Only 401 (Unauthorized) and 302 (Redirect to the Azure DevOps sign-in page)
-        /// are genuine authentication failures. A 400 (Bad Request) is a request/formatting
-        /// problem (e.g. a malformed object URL), NOT an expired credential - an expired or
-        /// invalid credential always returns 401 or 302. Rejecting credentials on 400 erased
-        /// valid credentials and caused a storm of credential-manager popups, so 400 must NOT
-        /// reject credentials.
+        /// 401 (Unauthorized) and 302 (Redirect to the Azure DevOps sign-in page) are
+        /// always genuine authentication failures. A 400 (Bad Request) is usually NOT an
+        /// auth failure - a present-but-expired/invalid credential returns 401, and a
+        /// malformed request (e.g. a corrupt object SHA in the loose-object URL) returns a
+        /// 400 that has nothing to do with credentials. Rejecting credentials on every 400
+        /// erased valid credentials and caused a storm of credential-manager popups.
+        ///
+        /// The one exception: the GVFS cache server returns a 400 (instead of a 401) when
+        /// the request carried no parseable Basic Authorization header. That single 400 is
+        /// genuinely "authentication required", and microsoft/git's git-gvfs-helper maps it
+        /// to a 401 for the same reason (its normalize step notes the cache server "sends a
+        /// somewhat bogus 400 instead of the normal 401 when AUTH is required", and its TODO
+        /// asks to confirm the response body - which is exactly what we do here). We only
+        /// treat a 400 as an auth failure when the body matches that specific message.
         /// </remarks>
-        internal static bool ShouldRejectCredentials(HttpStatusCode statusCode)
+        internal static bool ShouldRejectCredentials(HttpStatusCode statusCode, string responseBody)
         {
-            return statusCode == HttpStatusCode.Unauthorized ||
-                   statusCode == HttpStatusCode.Redirect;
+            if (statusCode == HttpStatusCode.Unauthorized ||
+                statusCode == HttpStatusCode.Redirect)
+            {
+                return true;
+            }
+
+            if (statusCode == HttpStatusCode.BadRequest &&
+                responseBody != null &&
+                responseBody.IndexOf(CacheServerAuthRequiredBadRequestMessage, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static string GetSingleHeaderOrEmpty(HttpHeaders headers, string headerName)

--- a/GVFS/GVFS.UnitTests/Http/HttpRequestorTests.cs
+++ b/GVFS/GVFS.UnitTests/Http/HttpRequestorTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using GVFS.Common.Http;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+
+namespace GVFS.UnitTests.Http
+{
+    [TestFixture]
+    public class HttpRequestorTests
+    {
+        [TestCase]
+        public void Unauthorized401RejectsCredentials()
+        {
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Unauthorized)
+                .ShouldEqual(true, "A 401 is a definitive auth failure and must reject credentials");
+        }
+
+        [TestCase]
+        public void Redirect302RejectsCredentials()
+        {
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Redirect)
+                .ShouldEqual(true, "A 302 is the Azure DevOps sign-in redirect and must reject credentials");
+        }
+
+        [TestCase]
+        public void BadRequest400DoesNotRejectCredentials()
+        {
+            // A 400 is a request/formatting problem, not an expired credential.
+            // An expired or invalid credential always returns 401 or 302, never 400. Rejecting
+            // credentials on 400 erased valid credentials and caused a credential-popup storm.
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.BadRequest)
+                .ShouldEqual(false, "A 400 is not an auth failure and must NOT reject credentials");
+        }
+
+        [TestCase]
+        public void CommonNonAuthStatusesDoNotRejectCredentials()
+        {
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.NotFound)
+                .ShouldEqual(false, "A 404 must NOT reject credentials");
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.InternalServerError)
+                .ShouldEqual(false, "A 500 must NOT reject credentials");
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.RequestTimeout)
+                .ShouldEqual(false, "A 408 must NOT reject credentials");
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Http/HttpRequestorTests.cs
+++ b/GVFS/GVFS.UnitTests/Http/HttpRequestorTests.cs
@@ -11,35 +11,68 @@ namespace GVFS.UnitTests.Http
         [TestCase]
         public void Unauthorized401RejectsCredentials()
         {
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Unauthorized)
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Unauthorized, responseBody: null)
                 .ShouldEqual(true, "A 401 is a definitive auth failure and must reject credentials");
         }
 
         [TestCase]
         public void Redirect302RejectsCredentials()
         {
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Redirect)
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.Redirect, responseBody: null)
                 .ShouldEqual(true, "A 302 is the Azure DevOps sign-in redirect and must reject credentials");
         }
 
         [TestCase]
-        public void BadRequest400DoesNotRejectCredentials()
+        public void BadRequest400WithAuthRequiredMessageRejectsCredentials()
         {
-            // A 400 is a request/formatting problem, not an expired credential.
-            // An expired or invalid credential always returns 401 or 302, never 400. Rejecting
-            // credentials on 400 erased valid credentials and caused a credential-popup storm.
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.BadRequest)
-                .ShouldEqual(false, "A 400 is not an auth failure and must NOT reject credentials");
+            // The GVFS cache server returns a 400 (instead of a 401) when the request carried
+            // no parseable Basic Authorization header. That single 400 genuinely means
+            // "authentication required", so it must reject credentials. We recognize it by the
+            // cache server's response body.
+            HttpRequestor.ShouldRejectCredentials(
+                    HttpStatusCode.BadRequest,
+                    HttpRequestor.CacheServerAuthRequiredBadRequestMessage)
+                .ShouldEqual(true, "A 400 whose body is the cache server's auth-required message must reject credentials");
+        }
+
+        [TestCase]
+        public void BadRequest400AuthRequiredMessageMatchIsCaseInsensitiveAndSubstring()
+        {
+            // The match is a case-insensitive substring so it stays robust if the server
+            // wraps or prefixes the text.
+            HttpRequestor.ShouldRejectCredentials(
+                    HttpStatusCode.BadRequest,
+                    "Error: a valid basic authorization header is required. (request 123)")
+                .ShouldEqual(true, "The auth-required message match must be a case-insensitive substring");
+        }
+
+        [TestCase]
+        public void BadRequest400WithNonAuthBodyDoesNotRejectCredentials()
+        {
+            // The storm case: a corrupt placeholder SHA makes the cache server return a 400
+            // with an "Invalid ObjectId" body. That is NOT an auth failure and must not erase
+            // a valid credential.
+            HttpRequestor.ShouldRejectCredentials(
+                    HttpStatusCode.BadRequest,
+                    "Error processing GVFS request: Invalid ObjectId in the URI.")
+                .ShouldEqual(false, "A non-auth 400 (e.g. invalid object id) must NOT reject credentials");
+        }
+
+        [TestCase]
+        public void BadRequest400WithNullBodyDoesNotRejectCredentials()
+        {
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.BadRequest, responseBody: null)
+                .ShouldEqual(false, "A 400 with no body must NOT reject credentials");
         }
 
         [TestCase]
         public void CommonNonAuthStatusesDoNotRejectCredentials()
         {
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.NotFound)
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.NotFound, responseBody: null)
                 .ShouldEqual(false, "A 404 must NOT reject credentials");
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.InternalServerError)
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.InternalServerError, responseBody: null)
                 .ShouldEqual(false, "A 500 must NOT reject credentials");
-            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.RequestTimeout)
+            HttpRequestor.ShouldRejectCredentials(HttpStatusCode.RequestTimeout, responseBody: null)
                 .ShouldEqual(false, "A 408 must NOT reject credentials");
         }
     }


### PR DESCRIPTION
## Summary

GVFS erased a valid credential when an object-download response was HTTP 400, which
triggered a storm of Git Credential Manager popups.

Most 400s are not authentication failures. A present-but-expired or invalid
credential returns **401** (or **302**, the Azure DevOps sign-in redirect). A
malformed request — for example a corrupt object SHA that produces an invalid
loose-object URL — returns a **400** that has nothing to do with credentials.
Rejecting credentials on every 400 erased good credentials.

There is **one** genuine exception, confirmed in the Azure DevOps cache-server
source: the cache server returns a **400 (not a 401)** when the request carried no
parseable `Basic` `Authorization` header, with the body
`"A valid Basic Authorization header is required."`. That single 400 really does
mean "authentication required". microsoft/git's `git-gvfs-helper` maps the same
cache-server 400 to a 401 for this reason, and its own TODO says to confirm the
response body — which is exactly what this change does.

## Change

- In `HttpRequestor.SendRequest`, the credential-rejection decision is now
  **body-aware** via `ShouldRejectCredentials(HttpStatusCode, string responseBody)`:
  - **401** and **302** always reject credentials.
  - **400** rejects credentials only when the response body matches the cache
    server's auth-required message (case-insensitive substring).
  - Every other **400** (and 404 / 5xx / timeouts) does not reject credentials and
    flows through the generic, non-auth error path. 400 remains non-retryable
    (`ShouldRetry` never included it).
- The auth-required message is kept as a named constant
  (`CacheServerAuthRequiredBadRequestMessage`) that mirrors the cache server's own
  string (`GvfsHttpHandler.PrepareContextAsync`).

### Why 400 is (almost) never an auth failure — but sometimes is

Verified against the Azure DevOps GVFS cache-server source and its L2 tests:

- **No / unparseable `Authorization` header** → **400** `"A valid Basic Authorization header is required."` — genuinely "auth required" (this is the case we still reject on).
- **Present but bad / expired / unauthorized credential** → **401** (cache server surfaces the `/gvfs/auth` result).
- **Valid credential + corrupt object SHA** → **400** `"…Invalid ObjectId in the URI."` — a request problem, not auth. This is the storm trigger; it must not erase the credential.
- **Valid credential + missing object** → **404**.

The cache server's own L2 test asserts exactly this: no auth header → `BadRequest`
(400); bad PAT → `Unauthorized` (401).

## Tests

`GVFS.UnitTests/Http/HttpRequestorTests.cs`:

- 401 and 302 reject credentials.
- 400 with the cache server's auth-required body rejects credentials (and the match
  is a case-insensitive substring).
- 400 with a non-auth body (e.g. "Invalid ObjectId in the URI") does **not** reject.
- 400 with no body does **not** reject.
- 404 / 500 / 408 do **not** reject.

All new tests pass (7/7); full unit-test suite passes.
