### PR TITLE
Fix build break: return DownloadAttemptResult from the malformed-SHA guard

### DIFF
--- a/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
+++ b/GVFS/GVFS.Common/Git/GVFSGitObjects.cs
@@ -264,7 +264,7 @@ namespace GVFS.Common.Git
                 metadata.Add(TracingConstants.MessageKey.WarningMessage, nameof(this.TryDownloadAndSaveObject) + ": Refusing to download object with malformed SHA");
                 this.Tracer.RelatedEvent(EventLevel.Warning, nameof(this.TryDownloadAndSaveObject) + "_MalformedBlobSha", metadata, Keywords.Telemetry);
 
-                return DownloadAndSaveObjectResult.Error;
+                return new DownloadAttemptResult(DownloadAndSaveObjectResult.Error, httpStatusCode: null);
             }
 
             if (objectId == GVFSConstants.AllZeroSha)


### PR DESCRIPTION
Fixes a build break on `master` caused by a merge-order semantic conflict
between two changes that were each green on their own branch:

- One change added a malformed-SHA guard that early-returned
  `DownloadAndSaveObjectResult.Error`.
- The other changed `TryDownloadAndSaveObject` to return `DownloadAttemptResult`
  (the result enum plus an HTTP status code).

Merged together, the guard returned the bare enum where a `DownloadAttemptResult`
was expected, so the build failed with:

```
GVFSGitObjects.cs(267,24): error CS0029: Cannot implicitly convert type
'DownloadAndSaveObjectResult' to 'GVFSGitObjects.DownloadAttemptResult'
```

**Fix:** wrap the error in a `DownloadAttemptResult` with a null status code,
matching the `AllZeroSha` guard immediately below it.

**Verification:** `GVFS.Common` builds clean; full unit suite passes (917 passed,
0 failed, 11 skipped).
