### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Look for prior successful runs
       id: check
       if: github.event.inputs.git_version == ''
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         result-encoding: string
@@ -199,7 +199,7 @@ jobs:
 
     - name: Checkout source
       if: steps.check.outputs.result == ''
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Validate Microsoft Git version
       if: steps.check.outputs.result == ''
@@ -249,7 +249,7 @@ jobs:
 
     - name: Upload microsoft/git installers
       if: steps.check.outputs.result == ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: MicrosoftGit
         path: MicrosoftGit
@@ -269,7 +269,7 @@ jobs:
     - name: Skip this job if there is a previous successful run
       if: needs.validate.outputs.skip != ''
       id: skip
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.info(`Skipping: There already is a successful run: ${{ needs.validate.outputs.skip }}`)
@@ -277,19 +277,19 @@ jobs:
 
     - name: Checkout source
       if: steps.skip.outputs.result != 'true'
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         path: src
 
     - name: Install .NET SDK
       if: steps.skip.outputs.result != 'true'
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         global-json-file: src/global.json
 
     - name: Add MSBuild to PATH
       if: steps.skip.outputs.result != 'true'
-      uses: microsoft/setup-msbuild@v3.0.0
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
     - name: Build VFS for Git
       if: steps.skip.outputs.result != 'true'
@@ -308,21 +308,21 @@ jobs:
 
     - name: Upload functional tests drop
       if: steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: FunctionalTests_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: artifacts\GVFS.FunctionalTests
 
     - name: Upload FastFetch drop
       if: steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: FastFetch_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: artifacts\FastFetch
 
     - name: Upload GVFS installer
       if: steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: GVFS_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: artifacts\GVFS.Installers

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Skip this job if there is a previous successful run
       if: inputs.skip != ''
       id: skip
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.info(`Skipping: There already is a successful run: ${{ inputs.skip }}`)
@@ -80,7 +80,7 @@ jobs:
       id: download-git
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.git_artifact_name }}
         path: git
@@ -90,7 +90,7 @@ jobs:
 
     - name: Download Git installer (retry)
       if: steps.skip.outputs.result != 'true' && steps.download-git.outcome == 'failure'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.git_artifact_name }}
         path: git
@@ -102,7 +102,7 @@ jobs:
       id: download-gvfs
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: GVFS_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: gvfs
@@ -112,7 +112,7 @@ jobs:
 
     - name: Download GVFS installer (retry)
       if: steps.skip.outputs.result != 'true' && steps.download-gvfs.outcome == 'failure'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: GVFS_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: gvfs
@@ -124,7 +124,7 @@ jobs:
       id: download-ft
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: FunctionalTests_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: ft
@@ -134,7 +134,7 @@ jobs:
 
     - name: Download functional tests drop (retry)
       if: steps.skip.outputs.result != 'true' && steps.download-ft.outcome == 'failure'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: FunctionalTests_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: ft
@@ -145,7 +145,7 @@ jobs:
     - name: Download FastFetch drop
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: FastFetch_${{ matrix.configuration }}_${{ matrix.architecture }}
         path: ft
@@ -189,7 +189,7 @@ jobs:
 
     - name: Upload installation logs
       if: always() && steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       continue-on-error: true
       with:
         name: ${{ env.ARTIFACT_PREFIX }}InstallationLogs_${{ env.FT_MATRIX_NAME }}
@@ -208,14 +208,14 @@ jobs:
 
     - name: Upload functional test results
       if: always() && steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}FunctionalTests_Results_${{ env.FT_MATRIX_NAME }}
         path: TestResult.xml
 
     - name: Upload Git trace2 output
       if: always() && steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}GitTrace2_${{ env.FT_MATRIX_NAME }}
         path: C:\temp\git-trace2.log

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Skip this job if there is a previous successful run
       if: inputs.skip != ''
       id: skip
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.info(`Skipping: There already is a successful run: ${{ inputs.skip }}`)
@@ -66,14 +66,14 @@ jobs:
       id: download-git
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: MicrosoftGit
         path: git
 
     - name: Download Git installer (retry)
       if: steps.skip.outputs.result != 'true' && steps.download-git.outcome == 'failure'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: MicrosoftGit
         path: git
@@ -82,14 +82,14 @@ jobs:
       id: download-gvfs
       if: steps.skip.outputs.result != 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: GVFS_${{ matrix.configuration }}_x64
         path: gvfs-new
 
     - name: Download current GVFS installer (retry)
       if: steps.skip.outputs.result != 'true' && steps.download-gvfs.outcome == 'failure'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: GVFS_${{ matrix.configuration }}_x64
         path: gvfs-new
@@ -370,7 +370,7 @@ jobs:
 
     - name: Upload service logs
       if: always() && steps.skip.outputs.result != 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       continue-on-error: true
       with:
         name: UpgradeTest_Logs_${{ matrix.scenario }}


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
