### PR TITLE
Update libgit2 overlay to v1.9.7 and fix safe.directory case matching on Windows

### DIFF
--- a/overlays/libgit2/README.md
+++ b/overlays/libgit2/README.md
@@ -5,8 +5,9 @@ version and optionally carry patches ahead of upstream releases.
 
 ## Current version
 
-**libgit2 v1.9.4** — latest v1.9.x release (2026-05-22). Matches the version
-pinned by the official vcpkg port. v1.9.x is the last of the libgit2 1.x line.
+**libgit2 v1.9.7** — latest v1.9.x release (2026-08-13). This is ahead of the
+official vcpkg port, which pins v1.9.3 at the baseline recorded in
+`vcpkg-configuration.json`. v1.9.x is the last of the libgit2 1.x line.
 
 ## Patches
 
@@ -21,8 +22,21 @@ pinned by the official vcpkg port. v1.9.x is the last of the libgit2 1.x line.
   (2026-06-07), which fixes handle-leak, static-handle, and
   uninitialized-token bugs present in the original PR #7200 diff. See the
   provenance table below. The patch is **not yet in any libgit2 release**
-  (latest is v1.9.4; expected to ship upstream in v2.0, no ETA), so it
+  (latest is v1.9.7; expected to ship upstream in v2.0, no ETA), so it
   remains necessary until the pinned port moves to a libgit2 that includes it.
+- `safe-directory-icase.diff` — compare `safe.directory` allowlist entries
+  against the repository path case-insensitively on Windows
+  ([libgit2/libgit2#7037](https://github.com/libgit2/libgit2/issues/7037)).
+  Git canonicalizes both paths with `real_pathdup` before comparing, so an
+  entry like `c:/repo` matches a repository recorded as `C:/repo` (a
+  drive-letter case mismatch is the common case). libgit2 used a
+  case-sensitive `strcmp`, so the repository failed to open with a spurious
+  `GIT_EOWNER` ownership error. The fix switches the comparison to
+  `STRCMP_CASESELECT` gated on `GIT_WIN32`; POSIX stays case-sensitive. The
+  upstream change is on fork branch `tyrielv/safe-directory-drive-case`
+  (commit `6074349`) with a PR pending against libgit2/libgit2 `main`. The
+  patch is **not yet in any libgit2 release**, so it remains necessary until
+  the pinned port moves to a libgit2 that includes it.
 
 Additional patches can be added to the `PATCHES` list in `portfile.cmake`
 to apply fixes that haven't shipped in an official libgit2 release yet.
@@ -35,10 +49,11 @@ and then modified as noted below.
 
 | File | Source | Changes |
 |------|--------|---------|
-| `vcpkg.json` | Official vcpkg port | Unchanged |
+| `vcpkg.json` | Official vcpkg port | Version bumped to v1.9.7 (`version-semver`); otherwise unchanged. |
 | `dependencies.diff` | Official vcpkg port | Unchanged |
 | `portfile.cmake` | Official vcpkg port | Removed patches not needed for MSVC x64: `c-standard.diff` (C99 inline keyword — MSVC handles natively), `cli-include-dirs.diff` (CLI tool build — we set `BUILD_CLI=OFF`), `mingw-winhttp.diff` (MinGW only) |
 | `non-elevated-admin-owner.diff` | libgit2 `main` (commits `cc477ee` + `f9f36a6` + `44c05e5`, merge `e805a16`) | Matches the version merged to `main` on 2026-06-07, not the original [PR #7200](https://github.com/libgit2/libgit2/pull/7200) diff. Maintainer follow-ups fixed a `linked_token` handle leak, replaced a non-thread-safe `static HANDLE` with a per-call local, corrected the `*linked_token = NULL` failure path (with `CloseHandle`), and hoisted `current_user_sid()` so `linked_token` is always populated before both branches use it. |
+| `safe-directory-icase.diff` | libgit2 fork `tyrielv/safe-directory-drive-case` (commit `6074349`) | Rebased onto v1.9.7. The upstream commit targets `main`, whose `validate_ownership_cb` has an extra `%(prefix)`/`is_prefix` branch that v1.9.7 lacks, so this overlay carries only the single-comparison hunk adapted to v1.9.7 (`STRCMP_CASESELECT` in place of `strcmp`). The upstream commit's Windows-only tests in `tests/libgit2/repo/open.c` are omitted because the overlay builds with `BUILD_TESTS=OFF`. |
 | `README.md` | New | VFSForGit-specific documentation |
 
 When updating to a new libgit2 version, compare these files against the

--- a/overlays/libgit2/portfile.cmake
+++ b/overlays/libgit2/portfile.cmake
@@ -2,11 +2,12 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libgit2/libgit2
     REF "v${VERSION}"
-    SHA512 85036ade3aca33c5283605ae9de21a7948ec5952bc8cd468aa024ca873851a56ab0ebe62f95c0da109df9163875e9687a377d3df69728d434cc258b3f845ef0c
+    SHA512 96924a4fd87669ad91d40669946cd249b646f3ce85380fc12b553b6c20338ff3c1df5faa6f168b2ca12ed20c8309116a05021f9710ee7ff61e5b8a249172b0ba
     HEAD_REF main
     PATCHES
         dependencies.diff
         non-elevated-admin-owner.diff
+        safe-directory-icase.diff
 )
 
 file(REMOVE_RECURSE

--- a/overlays/libgit2/safe-directory-icase.diff
+++ b/overlays/libgit2/safe-directory-icase.diff
@@ -1,0 +1,33 @@
+diff --git a/src/libgit2/repository.c b/src/libgit2/repository.c
+index 9fed12c..86df7fd 100644
+--- a/src/libgit2/repository.c
++++ b/src/libgit2/repository.c
+@@ -557,6 +557,18 @@ typedef struct {
+ 	bool *is_safe;
+ } validate_ownership_data;
+ 
++/*
++ * Windows paths are compared case-insensitively; Git canonicalizes
++ * both the repository path and the configured `safe.directory` entry
++ * to their on-disk form, so eg `c:/repo` matches `C:/Repo`. POSIX
++ * filesystems are case-sensitive, so compare exactly there.
++ */
++#ifdef GIT_WIN32
++# define OWNERSHIP_PATH_IGNORE_CASE 1
++#else
++# define OWNERSHIP_PATH_IGNORE_CASE 0
++#endif
++
+ static int validate_ownership_cb(const git_config_entry *entry, void *payload)
+ {
+ 	validate_ownership_data *data = payload;
+@@ -608,7 +620,8 @@ static int validate_ownership_cb(const git_config_entry *entry, void *payload)
+ 		if (strncmp(test_path, "%(prefix)//", strlen("%(prefix)//")) == 0)
+ 			test_path += strlen("%(prefix)/");
+ 
+-		if (strcmp(test_path, data->repo_path) == 0)
++		if (STRCMP_CASESELECT(OWNERSHIP_PATH_IGNORE_CASE,
++				test_path, data->repo_path) == 0)
+ 			*data->is_safe = true;
+ 	}
+ 

--- a/overlays/libgit2/vcpkg.json
+++ b/overlays/libgit2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgit2",
-  "version-semver": "1.9.4",
+  "version-semver": "1.9.7",
   "description": "A C library implementing the Git core methods with a solid API",
   "homepage": "https://github.com/libgit2/libgit2",
   "license": null,


### PR DESCRIPTION
## Summary

Update the pinned libgit2 vcpkg overlay from v1.9.4 to v1.9.7 (the latest 1.9.x release) and add a patch that makes `safe.directory` allowlist matching case-insensitive on Windows.

## Problem

On Windows, Git canonicalizes both the repository path and each `safe.directory` allowlist entry to their on-disk form before it compares them, so the match is effectively case-insensitive over the whole path, including the drive letter. libgit2 compared the paths with a case-sensitive `strcmp`, so an entry like `c:/repo` did not match a repository recorded as `C:/repo`. A drive-letter case mismatch is the common case. The repository then failed to open with a spurious `GIT_EOWNER` ownership error.

## Fix

The patch switches the comparison to `STRCMP_CASESELECT` gated on `GIT_WIN32`. POSIX filesystems stay case-sensitive. It carries the fix from libgit2 issue [#7037](https://github.com/libgit2/libgit2/issues/7037), rebased onto v1.9.7. The upstream commit targets libgit2 `main`, whose `validate_ownership_cb` has an extra `%(prefix)` handling branch that v1.9.7 lacks, so the overlay carries only the single-comparison hunk. The upstream Windows-only tests are omitted because the overlay builds with `BUILD_TESTS=OFF`.

## Changes

- `overlays/libgit2/safe-directory-icase.diff` — new patch (issue #7037)
- `overlays/libgit2/portfile.cmake` — add the patch to `PATCHES`; bump `SHA512`
- `overlays/libgit2/vcpkg.json` — `version-semver` 1.9.4 → 1.9.7
- `overlays/libgit2/README.md` — document the patch and the version bump

## Verification

- All three overlay patches apply cleanly to the v1.9.7 source.
- A full vcpkg build of libgit2 v1.9.7 (`x64-windows-dynamic`) with the overlay compiles `repository.c` and produces `git2.dll`.
