### PR TITLE
Fix upgrade tests when the LKG release has multiple installers

### DIFF
--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -118,8 +118,18 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
 
-        $lkgInstaller = (Get-ChildItem gvfs-lkg\SetupGVFS*.exe).FullName
-        $newInstaller = (Get-ChildItem gvfs-new\SetupGVFS*.exe).FullName
+        # Releases now publish both x64 and arm64 installers. These tests run
+        # on an x64 runner and download the x64 "new" installer, so select the
+        # x64 LKG installer. The x64 installer has no architecture suffix; the
+        # arm64 one is named "SetupGVFS.<version>-arm64.exe".
+        $lkgInstaller = (Get-ChildItem gvfs-lkg\SetupGVFS*.exe |
+          Where-Object { $_.Name -notmatch '-arm64\.exe$' } |
+          Select-Object -First 1).FullName
+        if (-not $lkgInstaller) { throw "No x64 LKG installer found in gvfs-lkg" }
+        $newInstaller = (Get-ChildItem gvfs-new\SetupGVFS*.exe |
+          Where-Object { $_.Name -notmatch '-arm64\.exe$' } |
+          Select-Object -First 1).FullName
+        if (-not $newInstaller) { throw "No x64 installer found in gvfs-new" }
         $installDir = "C:\Program Files\VFS for Git"
         $testRepo = "https://dev.azure.com/gvfs/ci/_git/ForTests"
         $enlistment = "C:\gvfs-upgrade-test"

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -118,18 +118,25 @@ jobs:
       run: |
         $ErrorActionPreference = 'Stop'
 
-        # Releases now publish both x64 and arm64 installers. These tests run
-        # on an x64 runner and download the x64 "new" installer, so select the
-        # x64 LKG installer. The x64 installer has no architecture suffix; the
-        # arm64 one is named "SetupGVFS.<version>-arm64.exe".
-        $lkgInstaller = (Get-ChildItem gvfs-lkg\SetupGVFS*.exe |
-          Where-Object { $_.Name -notmatch '-arm64\.exe$' } |
-          Select-Object -First 1).FullName
-        if (-not $lkgInstaller) { throw "No x64 LKG installer found in gvfs-lkg" }
-        $newInstaller = (Get-ChildItem gvfs-new\SetupGVFS*.exe |
-          Where-Object { $_.Name -notmatch '-arm64\.exe$' } |
-          Select-Object -First 1).FullName
-        if (-not $newInstaller) { throw "No x64 installer found in gvfs-new" }
+        # Releases publish both x64 and arm64 installers. The x64 installer
+        # keeps the historical suffix-less name "SetupGVFS.<version>.exe"; other
+        # architectures add a suffix (e.g. "SetupGVFS.<version>-arm64.exe").
+        # These tests run on an x64 runner, so select the x64 installer by its
+        # suffix-less name and require exactly one match, rather than picking an
+        # arbitrary file when the directory holds more than one installer.
+        # NOTE: arm64 upgrade is not exercised here because the runner is x64;
+        # arm64 upgrade coverage is a known gap for when arm64 runners exist.
+        function Select-X64Installer($directory) {
+          $installers = @(Get-ChildItem "$directory\SetupGVFS*.exe" |
+            Where-Object { $_.Name -match '^SetupGVFS\.[\d.]+\.exe$' })
+          if ($installers.Count -ne 1) {
+            throw "Expected exactly one x64 installer in '$directory', found $($installers.Count): $($installers.Name -join ', ')"
+          }
+          return $installers[0].FullName
+        }
+
+        $lkgInstaller = Select-X64Installer "gvfs-lkg"
+        $newInstaller = Select-X64Installer "gvfs-new"
         $installDir = "C:\Program Files\VFS for Git"
         $testRepo = "https://dev.azure.com/gvfs/ci/_git/ForTests"
         $enlistment = "C:\gvfs-upgrade-test"


### PR DESCRIPTION
## Problem

The `staging-upgrade` upgrade test (and every scenario in `upgrade-tests.yaml`) failed with:

```
Start-Process: Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'FilePath'.
```

The job picks the last-known-good installer with:

```powershell
$lkgInstaller = (Get-ChildItem gvfs-lkg\SetupGVFS*.exe).FullName
```

Now that releases publish **both** an x64 and an arm64 installer (`SetupGVFS.<version>.exe` and `SetupGVFS.<version>-arm64.exe`), the glob matches two files, so `.FullName` returns an array. `Start-Process -FilePath` then rejects the array.

## Fix

Select the x64 installer explicitly. The x64 installer has no architecture suffix; the arm64 one ends in `-arm64.exe`. The upgrade tests run on an x64 runner and download the x64 "new" installer, so the x64 LKG installer is the correct match.

- Filter out the arm64 installer and take the first match for both the LKG and the "new" installer selection.
- Throw a clear error if no x64 installer is found, instead of failing later inside `Start-Process`.

## Testing

- Verified the PowerShell snippet parses with no errors.
- Verified the regex keeps `SetupGVFS.2.0.26229.1.exe` and drops `SetupGVFS.2.0.26229.1-arm64.exe`.
