### PR TITLE
Fix clone authentication when includeIf is in git config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ Skips `dotnet publish`, AOT, native C++ projects, payload assembly, installer.
 For changes that need the GVFS payload (`gvfs.exe`, hooks, service) but not
 an installer. `PublishAot=false` skips ilc (~3–4 min saved);
 `SkipCreateInstaller=true` skips Inno Setup (~95 s saved).
-`GVFS.Payload` cascades to its dependencies (GVFS, GVFS.Mount, GVFS.Hooks,
-GVFS.Service) via `ProjectReference`.
+`GVFS.Payload` only assembles the payload directory — it does **not** build or
+publish the projects it copies from (see the warning below).
 
 > **Prerequisite: the native C++ projects must already be built.** They are
 > `.vcxproj` (see [Native C++ projects](#native-c-projects-need-msbuild-not-dotnet-build)
@@ -78,10 +78,13 @@ GVFS.Service) via `ProjectReference`.
 ```powershell
 dotnet publish src\GVFS\GVFS.FunctionalTests\GVFS.FunctionalTests.csproj `
     -c Debug /p:PublishAot=false
+dotnet publish src\GVFS\GVFS\GVFS.csproj `
+    -c Debug /p:PublishAot=false
 dotnet publish src\GVFS\GVFS.Payload\GVFS.Payload.csproj `
     -c Debug /p:PublishAot=false /p:SkipCreateInstaller=true
 
-src\scripts\RunFunctionalTests-Dev.ps1 Debug --test=GVFS.FunctionalTests.Tests.<Namespace>.<Class>.<Method>
+src\scripts\RunFunctionalTests-Dev.ps1 -Configuration Debug -Arch x64 `
+    --test=GVFS.FunctionalTests.Tests.<Namespace>.<Class>.<Method>
 ```
 
 `layout.bat` (invoked by GVFS.Payload) `xcopy`s from each project's `publish\`
@@ -89,10 +92,38 @@ or native-output directory — the C# projects do not require AOT, so
 `PublishAot=false` produces a fully functional test payload. The native
 hook binaries are copied straight from the vcxproj output.
 
+> **⚠️ Publish each changed project explicitly — `GVFS.Payload` does not do it
+> for you.** `GVFS.Payload.csproj` is a `Microsoft.Build.NoTargets` project with
+> **no `ProjectReference` items at all**; its `CreatePayload` target just runs
+> `layout.bat`, which `xcopy`s from each project's existing output/publish
+> directory. Nothing in that chain rebuilds or republishes those projects, so a
+> project you did not publish contributes whatever was left there by the last
+> `Build.bat` — an AOT binary that predates your edit. The build succeeds and the
+> test then runs stale code, which looks exactly like "my fix did not work".
+>
+> Verify the payload actually changed before you trust a functional-test result:
+>
+> ```powershell
+> Get-Item out\GVFS.Payload\bin\Debug\win-x64\GVFS.exe |
+>     Format-List LastWriteTime, Length
+> ```
+>
+> A ~27 MB `GVFS.exe` is the AOT build from `Build.bat`; a ~160 KB one is the
+> `PublishAot=false` build from the command above. If the timestamp predates
+> your edit, publish the project that owns the changed code and re-run the
+> payload publish. The same applies to `GVFS.Mount`, `GVFS.Hooks`, and
+> `GVFS.Service` when you change those.
+
 `RunFunctionalTests-Dev.ps1` runs functional tests against the build output
 without requiring admin or a system-wide install. It launches the test
 service as a console process. Each invocation gets a unique service name
 and data dir, so concurrent runs from different worktrees don't collide.
+
+> **Pass `-Configuration` and `-Arch` by name.** The script's first two
+> positional parameters are `Configuration` and `Arch`, so a bare
+> `RunFunctionalTests-Dev.ps1 Debug --test=...` binds `--test=...` to `-Arch`
+> and fails its `ValidateSet`. Name both parameters, then let `--test=` fall
+> through to `ExtraArgs`.
 
 ### Path C — Installer build (~5 min — only when you need an installer)
 
@@ -136,11 +167,11 @@ participate in the C# inner-loop paths above.
 ```powershell
 # ✅ Correct
 & "out\GVFS.UnitTests\bin\...\GVFS.UnitTests.exe"  --test "GVFS.UnitTests.Common.WorktreeInfoTests"
-src\scripts\RunFunctionalTests-Dev.ps1 Debug       --test=GVFS.FunctionalTests.Tests.GVFSVerbTests.UnknownVerb
+src\scripts\RunFunctionalTests-Dev.ps1 -Configuration Debug -Arch x64 --test=GVFS.FunctionalTests.Tests.GVFSVerbTests.UnknownVerb
 
 # ❌ Wrong — silently runs the entire suite
 & "out\GVFS.UnitTests\bin\...\GVFS.UnitTests.exe"  --where "class =~ Worktree"
-src\scripts\RunFunctionalTests-Dev.ps1 Debug       --where "cat == Smoke"
+src\scripts\RunFunctionalTests-Dev.ps1 -Configuration Debug -Arch x64 --where "cat == Smoke"
 ```
 
 For unit tests, `--where` is merely annoying (the whole suite runs in

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -210,10 +210,9 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            Result result = this.InvokeGitAgainstDotGitFolder(
+            Result result = this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
                 GenerateCredentialVerbCommand("reject"),
                 stdin => stdin.Write(stdinConfig),
-                null,
                 usePreCommandHook: false);
 
             if (result.ExitCodeIsFailure)
@@ -238,10 +237,9 @@ namespace GVFS.Common.Git
 
             string stdinConfig = sb.ToString();
 
-            Result result = this.InvokeGitAgainstDotGitFolder(
+            Result result = this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
                 GenerateCredentialVerbCommand("approve"),
                 stdin => stdin.Write(stdinConfig),
-                null,
                 usePreCommandHook: false);
 
             if (result.ExitCodeIsFailure)
@@ -275,10 +273,9 @@ namespace GVFS.Common.Git
             {
                 // See GetFromConfig for why pre-command hook is disabled
                 // for bootstrap-time git operations.
-                Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
+                Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
                     "credential fill",
                     stdin => stdin.Write("protocol=cert\npath=" + certificatePath + "\nusername=\n\n"),
-                    parseStdOutLine: null,
                     usePreCommandHook: false);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
@@ -328,18 +325,20 @@ namespace GVFS.Common.Git
 
             using (ITracer activity = tracer.StartActivity(nameof(this.TryGetCredential), EventLevel.Informational))
             {
-                // See GetFromConfig for why pre-command hook is disabled
-                // for bootstrap-time git operations.
-                Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
+                Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
                     GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
-                    parseStdOutLine: null,
+                    out bool usedDotGitFolder,
                     usePreCommandHook: false,
                     timeoutMs: timeoutMs);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
                 {
                     EventMetadata errorData = new EventMetadata();
+
+                    // Records whether repo-local configuration (and therefore a
+                    // repo-local credential.helper) was visible to git.
+                    errorData.Add(nameof(usedDotGitFolder), usedDotGitFolder);
 
                     if (gitCredentialOutput.Errors.StartsWith("Operation timed out"))
                     {
@@ -442,7 +441,13 @@ namespace GVFS.Common.Git
         public bool TryGetConfigUrlMatch(string section, string repositoryUrl, out Dictionary<string, GitConfigSetting> configSettings)
         {
             // See GetFromConfig for why pre-command hook is disabled.
-            Result result = this.InvokeGitAgainstDotGitFolder($"config --get-urlmatch {section} {repositoryUrl}", usePreCommandHook: false);
+            // This runs from the GitAuthentication constructor, which happens before
+            // clone creates the enlistment, so it must tolerate a missing .git folder.
+            Result result = this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
+                $"config --get-urlmatch {section} {repositoryUrl}",
+                writeStdIn: null,
+                usePreCommandHook: false);
+
             if (result.ExitCodeIsFailure)
             {
                 configSettings = null;
@@ -1109,7 +1114,8 @@ namespace GVFS.Common.Git
             string command,
             Action<StreamWriter> writeStdIn,
             Action<string> parseStdOutLine,
-            int timeout = -1)
+            int timeout = -1,
+            bool usePreCommandHook = true)
         {
             return this.InvokeGitImpl(
                 command,
@@ -1118,7 +1124,91 @@ namespace GVFS.Common.Git
                 useReadObjectHook: false,
                 writeStdIn: writeStdIn,
                 parseStdOutLine: parseStdOutLine,
-                timeoutMs: timeout);
+                timeoutMs: timeout,
+                usePreCommandHook: usePreCommandHook);
+        }
+
+        /// <summary>
+        /// Invokes git.exe against an enlistment's .git folder when that folder exists,
+        /// and outside the enlistment when it does not.
+        /// </summary>
+        /// <remarks>
+        /// For commands that prefer an enlistment's configuration but do not require a
+        /// repository to run. Naming a --git-dir that is absent is not merely redundant:
+        /// git resolves that path before it evaluates an 'includeIf "gitdir:..."'
+        /// condition, so a user who has such a section in their config gets
+        /// "fatal: Invalid path ...: No such file or directory" and the command never
+        /// runs. The condition does not have to match for this to happen.
+        ///
+        /// The credential verbs need this because 'gvfs clone' authenticates before it
+        /// creates the enlistment. This method should be used only with commands that
+        /// still behave correctly with no repository, because there is no repo-local
+        /// configuration to read on the fallback path.
+        /// </remarks>
+        private Result InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
+            string command,
+            Action<StreamWriter> writeStdIn,
+            Action<string> parseStdOutLine = null,
+            bool usePreCommandHook = true,
+            int timeoutMs = -1)
+        {
+            return this.InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
+                command,
+                writeStdIn,
+                out bool _,
+                parseStdOutLine,
+                usePreCommandHook,
+                timeoutMs);
+        }
+
+        /// <summary>
+        /// Overload that reports which route was taken, so callers can record it.
+        /// </summary>
+        /// <param name="usedDotGitFolder">
+        /// True when --git-dir was passed and repo-local configuration was therefore
+        /// visible to git; false when the command ran with no repository.
+        /// </param>
+        private Result InvokeGitAgainstDotGitFolderOrOutsideEnlistment(
+            string command,
+            Action<StreamWriter> writeStdIn,
+            out bool usedDotGitFolder,
+            Action<string> parseStdOutLine = null,
+            bool usePreCommandHook = true,
+            int timeoutMs = -1)
+        {
+            // Evaluate once so the reported route always matches the route taken.
+            usedDotGitFolder = this.DotGitRootExists();
+
+            if (usedDotGitFolder)
+            {
+                return this.InvokeGitAgainstDotGitFolder(
+                    command,
+                    writeStdIn,
+                    parseStdOutLine,
+                    usePreCommandHook: usePreCommandHook,
+                    timeoutMs: timeoutMs);
+            }
+
+            return this.InvokeGitOutsideEnlistment(
+                command,
+                writeStdIn,
+                parseStdOutLine,
+                timeout: timeoutMs,
+                usePreCommandHook: usePreCommandHook);
+        }
+
+        /// <summary>
+        /// Determines whether the enlistment's .git exists. In a linked worktree .git is a
+        /// file that points at the real git directory rather than a folder, so check for both.
+        /// </summary>
+        private bool DotGitRootExists()
+        {
+            if (string.IsNullOrEmpty(this.dotGitRoot))
+            {
+                return false;
+            }
+
+            return Directory.Exists(this.dotGitRoot) || File.Exists(this.dotGitRoot);
         }
 
         /// <summary>

--- a/GVFS/GVFS.FunctionalTests/Tests/CloneAuthTests.cs
+++ b/GVFS/GVFS.FunctionalTests/Tests/CloneAuthTests.cs
@@ -1,0 +1,163 @@
+using GVFS.FunctionalTests.Tools;
+using GVFS.Tests.Should;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace GVFS.FunctionalTests.Tests
+{
+    /// <summary>
+    /// Tests for the authentication step of 'gvfs clone', which runs before the
+    /// enlistment's src folder exists.
+    /// </summary>
+    [TestFixture]
+    public class CloneAuthTests
+    {
+        private const int GVFSGenericError = 3;
+
+        /// <summary>
+        /// The message GVFS reports when it cannot reach the server at all. It must not
+        /// appear in these tests: it means the clone failed before it asked for
+        /// credentials, so the test proved nothing.
+        /// </summary>
+        private const string ConfigQueryFailed = "Unable to query /gvfs/config";
+
+        private string testRoot;
+
+        /// <summary>
+        /// A URL that always requires authentication, so that 'gvfs clone' runs
+        /// 'git credential fill' instead of succeeding anonymously. The project does
+        /// not exist, but Azure DevOps answers with 401 before it checks existence,
+        /// which is what this test needs. The host comes from the configured test
+        /// repo so that no new network dependency is introduced.
+        /// </summary>
+        private static string AuthRequiredRepoUrl
+        {
+            get
+            {
+                Uri repoToClone = new Uri(Properties.Settings.Default.RepoToClone);
+                return repoToClone.GetLeftPart(UriPartial.Authority) + "/NoSuchProject/_git/NoSuchRepo";
+            }
+        }
+
+        [SetUp]
+        public void CreateTestRoot()
+        {
+            this.testRoot = Path.Combine(
+                Properties.Settings.Default.EnlistmentRoot,
+                "CloneAuthTests_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+            Directory.CreateDirectory(this.testRoot);
+        }
+
+        [TearDown]
+        public void DeleteTestRoot()
+        {
+            RepositoryHelpers.DeleteTestDirectory(this.testRoot);
+        }
+
+        /// <summary>
+        /// 'gvfs clone' must reach the credential helper when the user's global config
+        /// contains an 'includeIf "gitdir:..."' section. Git resolves the --git-dir path
+        /// before it evaluates the condition, so passing the not-yet-created src folder
+        /// makes git fail with "Invalid path" instead of asking for credentials.
+        /// </summary>
+        [TestCase]
+        public void CloneAuthenticatesWhenGitConfigContainsIncludeIfGitDir()
+        {
+            string globalConfig = this.WriteGlobalConfig(includeIfGitDir: true);
+            string enlistmentRoot = Path.Combine(this.testRoot, "enlistment");
+
+            ProcessResult result = this.RunClone(enlistmentRoot, globalConfig);
+
+            ShouldFailInTheCredentialHelper(result);
+        }
+
+        /// <summary>
+        /// Control for <see cref="CloneAuthenticatesWhenGitConfigContainsIncludeIfGitDir"/>.
+        /// Without the includeIf section the same clone must reach the credential helper.
+        /// </summary>
+        [TestCase]
+        public void CloneAuthenticatesWhenGitConfigHasNoIncludeIf()
+        {
+            string globalConfig = this.WriteGlobalConfig(includeIfGitDir: false);
+            string enlistmentRoot = Path.Combine(this.testRoot, "enlistment");
+
+            ProcessResult result = this.RunClone(enlistmentRoot, globalConfig);
+
+            ShouldFailInTheCredentialHelper(result);
+        }
+
+        /// <summary>
+        /// Asserts that the clone reached the credential helper and failed there.
+        /// </summary>
+        /// <remarks>
+        /// The positive assertions matter as much as the negative ones. A clone that
+        /// cannot reach the server also exits with <see cref="GVFSGenericError"/> and
+        /// prints neither "Invalid path" nor "No such file or directory", so a test that
+        /// only checks for the absence of those strings passes when the network is down
+        /// and proves nothing.
+        /// </remarks>
+        private static void ShouldFailInTheCredentialHelper(ProcessResult result)
+        {
+            string output = result.Output + result.Errors;
+
+            // No credentials are available, so the clone must fail.
+            result.ExitCode.ShouldEqual(GVFSGenericError, output);
+
+            // It must have got as far as authentication, and the server must have
+            // answered, otherwise the rest of this test is meaningless.
+            output.ShouldContain("Authenticating...Failed");
+            output.ShouldNotContain(false, ConfigQueryFailed);
+
+            // It must fail because the credential helper produced no password, not
+            // because git could not resolve the src folder that clone has not created
+            // yet.
+            output.ShouldNotContain(true, "Invalid path", "No such file or directory");
+        }
+
+        private string WriteGlobalConfig(bool includeIfGitDir)
+        {
+            // An empty helper value clears the credential helper list, so git fails
+            // immediately instead of showing an interactive credential prompt.
+            string contents = "[credential]\n\thelper =\n";
+
+            if (includeIfGitDir)
+            {
+                string includedConfig = Path.Combine(this.testRoot, "included.gitconfig");
+                File.WriteAllText(includedConfig, string.Empty);
+
+                // The condition never matches. Git still resolves the repository's
+                // gitdir before it compares the pattern, which is what triggers the
+                // failure this test guards against.
+                contents +=
+                    "[includeIf \"gitdir:NoSuchDirectory/\"]\n" +
+                    "\tpath = " + includedConfig.Replace('\\', '/') + "\n";
+            }
+
+            string globalConfig = Path.Combine(this.testRoot, "global.gitconfig");
+            File.WriteAllText(globalConfig, contents);
+            return globalConfig;
+        }
+
+        private ProcessResult RunClone(string enlistmentRoot, string globalConfig)
+        {
+            ProcessStartInfo processInfo = new ProcessStartInfo(GVFSTestConfig.PathToGVFS);
+            processInfo.Arguments = $"clone {AuthRequiredRepoUrl} \"{enlistmentRoot}\" --no-mount --no-prefetch";
+            processInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            processInfo.CreateNoWindow = true;
+            processInfo.WorkingDirectory = this.testRoot;
+            processInfo.UseShellExecute = false;
+            processInfo.RedirectStandardOutput = true;
+            processInfo.RedirectStandardError = true;
+
+            // Point git at the test's config instead of the config of the user running
+            // the tests, so the test controls whether includeIf is present.
+            processInfo.EnvironmentVariables["GIT_CONFIG_GLOBAL"] = globalConfig;
+            processInfo.EnvironmentVariables["GIT_CONFIG_SYSTEM"] = Path.Combine(this.testRoot, "system.gitconfig");
+            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+
+            return ProcessHelper.Run(processInfo);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/Git/GitProcessCredentialTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Git/GitProcessCredentialTests.cs
@@ -1,0 +1,209 @@
+using GVFS.Common.Git;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.Git;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace GVFS.UnitTests.Common.Git
+{
+    /// <summary>
+    /// Verifies which repository the credential verbs run against.
+    /// </summary>
+    /// <remarks>
+    /// Credential helpers must see repo-local configuration, so the credential verbs
+    /// normally run against the enlistment's .git folder. During 'gvfs clone' that
+    /// folder does not exist yet, and git refuses to resolve a --git-dir that is not
+    /// there when the user's config contains an 'includeIf "gitdir:..."' section.
+    /// </remarks>
+    [TestFixture]
+    public class GitProcessCredentialTests
+    {
+        private const string CredentialFillCommandPrefix = "-c " + GitConfigSetting.CredentialUseHttpPath + "=true credential fill";
+        private const string CredentialApproveCommandPrefix = "-c " + GitConfigSetting.CredentialUseHttpPath + "=true credential approve";
+        private const string CredentialRejectCommandPrefix = "-c " + GitConfigSetting.CredentialUseHttpPath + "=true credential reject";
+        private const string RepoUrl = "mock://repoUrl";
+
+        private string testRoot;
+
+        [SetUp]
+        public void CreateTestRoot()
+        {
+            this.testRoot = Path.Combine(Path.GetTempPath(), "GitProcessCredentialTests_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+            Directory.CreateDirectory(this.testRoot);
+        }
+
+        [TearDown]
+        public void DeleteTestRoot()
+        {
+            if (Directory.Exists(this.testRoot))
+            {
+                Directory.Delete(this.testRoot, recursive: true);
+            }
+        }
+
+        [TestCase]
+        public void CredentialVerbDoesNotUseGitDirWhenDotGitIsMissing()
+        {
+            // 'gvfs clone' authenticates before it creates the enlistment, so the
+            // credential verb must not name a .git folder that does not exist yet.
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+
+            string dotGitDirectoryUsed = this.RunCredentialFill(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void CredentialVerbUsesGitDirWhenDotGitIsAFolder()
+        {
+            // In an established enlistment the credential helper must still see the
+            // repository's local configuration.
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+            string dotGitRoot = Path.Combine(workingDirectoryRoot, ".git");
+            Directory.CreateDirectory(dotGitRoot);
+
+            string dotGitDirectoryUsed = this.RunCredentialFill(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldEqual(dotGitRoot);
+        }
+
+        [TestCase]
+        public void CredentialVerbUsesGitDirWhenDotGitIsAWorktreeFile()
+        {
+            // A linked worktree has a .git file that points at the real git directory
+            // instead of a .git folder. That is still a valid repository.
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+            Directory.CreateDirectory(workingDirectoryRoot);
+            string dotGitRoot = Path.Combine(workingDirectoryRoot, ".git");
+            File.WriteAllText(dotGitRoot, "gitdir: " + Path.Combine(this.testRoot, "worktrees", "src"));
+
+            string dotGitDirectoryUsed = this.RunCredentialFill(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldEqual(dotGitRoot);
+        }
+
+        [TestCase]
+        public void StoreCredentialDoesNotUseGitDirWhenDotGitIsMissing()
+        {
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+
+            string dotGitDirectoryUsed = this.RunStoreCredential(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void StoreCredentialUsesGitDirWhenDotGitIsAFolder()
+        {
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+            string dotGitRoot = Path.Combine(workingDirectoryRoot, ".git");
+            Directory.CreateDirectory(dotGitRoot);
+
+            string dotGitDirectoryUsed = this.RunStoreCredential(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldEqual(dotGitRoot);
+        }
+
+        [TestCase]
+        public void DeleteCredentialDoesNotUseGitDirWhenDotGitIsMissing()
+        {
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+
+            string dotGitDirectoryUsed = this.RunDeleteCredential(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldBeNull();
+        }
+
+        [TestCase]
+        public void DeleteCredentialUsesGitDirWhenDotGitIsAFolder()
+        {
+            string workingDirectoryRoot = Path.Combine(this.testRoot, "src");
+            string dotGitRoot = Path.Combine(workingDirectoryRoot, ".git");
+            Directory.CreateDirectory(dotGitRoot);
+
+            string dotGitDirectoryUsed = this.RunDeleteCredential(workingDirectoryRoot);
+
+            dotGitDirectoryUsed.ShouldEqual(dotGitRoot);
+        }
+
+        private static MockGitProcess CreateGitProcess(string workingDirectoryRoot, string verbCommandPrefix)
+        {
+            MockGitProcess gitProcess = new MockGitProcess(Path.Combine("mock:", "git"), workingDirectoryRoot);
+            gitProcess.SetExpectedCommandResult(
+                verbCommandPrefix,
+                () => new GitProcess.Result("username=mockUser\npassword=mockPassword\n", string.Empty, GitProcess.Result.SuccessCode),
+                matchPrefix: true);
+
+            return gitProcess;
+        }
+
+        /// <summary>
+        /// Returns the --git-dir used by the single git invocation the caller triggered.
+        /// </summary>
+        /// <remarks>
+        /// Takes the count from before the invocation so that the assertion stays valid
+        /// if a credential verb ever makes more than one git call.
+        /// </remarks>
+        private static string SingleDotGitDirectoryUsed(MockGitProcess gitProcess, int countBeforeInvocation)
+        {
+            gitProcess.DotGitDirectoriesUsed.Count.ShouldEqual(
+                countBeforeInvocation + 1,
+                "Expected exactly one git invocation for the credential verb");
+
+            return gitProcess.DotGitDirectoriesUsed[countBeforeInvocation];
+        }
+
+        private string RunCredentialFill(string workingDirectoryRoot)
+        {
+            MockGitProcess gitProcess = CreateGitProcess(workingDirectoryRoot, CredentialFillCommandPrefix);
+            int countBeforeInvocation = gitProcess.DotGitDirectoriesUsed.Count;
+
+            gitProcess.TryGetCredential(
+                new MockTracer(),
+                RepoUrl,
+                out string username,
+                out string password,
+                out string error)
+                .ShouldBeTrue(error);
+
+            gitProcess.CommandsRun.ShouldContain(x => x.StartsWith(CredentialFillCommandPrefix, StringComparison.Ordinal));
+            return SingleDotGitDirectoryUsed(gitProcess, countBeforeInvocation);
+        }
+
+        private string RunStoreCredential(string workingDirectoryRoot)
+        {
+            MockGitProcess gitProcess = CreateGitProcess(workingDirectoryRoot, CredentialApproveCommandPrefix);
+            int countBeforeInvocation = gitProcess.DotGitDirectoriesUsed.Count;
+
+            gitProcess.TryStoreCredential(
+                new MockTracer(),
+                RepoUrl,
+                "mockUser",
+                "mockPassword",
+                out string error)
+                .ShouldBeTrue(error);
+
+            gitProcess.CommandsRun.ShouldContain(x => x.StartsWith(CredentialApproveCommandPrefix, StringComparison.Ordinal));
+            return SingleDotGitDirectoryUsed(gitProcess, countBeforeInvocation);
+        }
+
+        private string RunDeleteCredential(string workingDirectoryRoot)
+        {
+            MockGitProcess gitProcess = CreateGitProcess(workingDirectoryRoot, CredentialRejectCommandPrefix);
+            int countBeforeInvocation = gitProcess.DotGitDirectoriesUsed.Count;
+
+            gitProcess.TryDeleteCredential(
+                new MockTracer(),
+                RepoUrl,
+                "mockUser",
+                "mockPassword",
+                out string error)
+                .ShouldBeTrue(error);
+
+            gitProcess.CommandsRun.ShouldContain(x => x.StartsWith(CredentialRejectCommandPrefix, StringComparison.Ordinal));
+            return SingleDotGitDirectoryUsed(gitProcess, countBeforeInvocation);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Git/MockGitProcess.cs
@@ -17,17 +17,26 @@ namespace GVFS.UnitTests.Mock.Git
         public MockGitProcess()
             : base(new MockGVFSEnlistment())
         {
-            this.CommandsRun = new List<string>();
-            this.StoredCredentials = new Dictionary<string, Credential>(StringComparer.OrdinalIgnoreCase);
-            this.CredentialApprovals = new Dictionary<string, List<Credential>>();
-            this.CredentialRejections = new Dictionary<string, List<Credential>>();
+            this.Initialize();
         }
 
-        public List<string> CommandsRun { get; }
+        public MockGitProcess(string gitBinPath, string workingDirectoryRoot)
+            : base(gitBinPath, workingDirectoryRoot)
+        {
+            this.Initialize();
+        }
+
+        public List<string> CommandsRun { get; private set; }
         public bool ShouldFail { get; set; }
-        public Dictionary<string, Credential> StoredCredentials { get; }
-        public Dictionary<string, List<Credential>> CredentialApprovals { get; }
-        public Dictionary<string, List<Credential>> CredentialRejections { get; }
+        public Dictionary<string, Credential> StoredCredentials { get; private set; }
+        public Dictionary<string, List<Credential>> CredentialApprovals { get; private set; }
+        public Dictionary<string, List<Credential>> CredentialRejections { get; private set; }
+
+        /// <summary>
+        /// The value passed as --git-dir for each invocation, in the order the
+        /// invocations happened. An entry is null when no --git-dir was passed.
+        /// </summary>
+        public List<string> DotGitDirectoriesUsed { get; private set; }
 
         public void SetExpectedCommandResult(string command, Func<Result> result, bool matchPrefix = false)
         {
@@ -87,6 +96,7 @@ namespace GVFS.UnitTests.Mock.Git
             bool usePrecommandHook = true)
         {
             this.CommandsRun.Add(command);
+            this.DotGitDirectoriesUsed.Add(dotGitDirectory);
 
             if (this.ShouldFail)
             {
@@ -123,6 +133,15 @@ namespace GVFS.UnitTests.Mock.Git
                 /* Future: result.Output should be set to null in this case */
             }
             return result;
+        }
+
+        private void Initialize()
+        {
+            this.CommandsRun = new List<string>();
+            this.DotGitDirectoriesUsed = new List<string>();
+            this.StoredCredentials = new Dictionary<string, Credential>(StringComparer.OrdinalIgnoreCase);
+            this.CredentialApprovals = new Dictionary<string, List<Credential>>();
+            this.CredentialRejections = new Dictionary<string, List<Credential>>();
         }
 
         public class Credential


### PR DESCRIPTION
`gvfs clone` cannot authenticate when the user's git config contains an
`includeIf "gitdir:..."` section. The clone fails with:

```
Authenticating...Failed.
Cannot clone because authentication failed:
fatal: Invalid path '<enlistment>/src': No such file or directory
```

## Cause

Clone authenticates before it creates the enlistment, but the credential verbs
run against the enlistment's `.git` folder through `--git-dir`:

1. `CloneVerb` builds a `GVFSEnlistment` whose `GitProcess` targets `<root>\src\.git`.
2. `CloneVerb` authenticates. Only `<root>` exists at this point.
3. `TryGetCredential` runs `git credential fill` with `--git-dir="<root>\src\.git"`.
4. Git resolves that path so it can evaluate the `includeIf` condition, does not
   find it, and aborts before it asks for credentials.

The condition does not have to match. Git resolves the repository path before it
compares the pattern, so any `gitdir:` condition triggers the failure. An
`includeIf "onbranch:..."` condition does not, because it needs no path.

This affects VFS for Git only. Plain `git clone` reaches the credential helper
normally with the same config.

## Fix

Pass `--git-dir` only when `.git` exists. Credential helpers still see repo-local
configuration in an established enlistment. Before clone creates the repository
there is no repo-local configuration to read, so nothing is lost by omitting it.

A linked worktree stores `.git` as a file that points at the real git directory
rather than as a folder, so the check accepts both. Git resolves the `gitdir:`
pointer in that file, so the shared repository's configuration is still used.

Two other pre-repository git calls are routed the same way, because they fail
identically during clone:

- `TryGetConfigUrlMatch` runs from the `GitAuthentication` **constructor**. When it
  failed, `GitSsl` was never constructed and the user's `http.sslCert` /
  client-certificate configuration was silently dropped.
- `TryGetCertificatePassword` is itself a `credential fill`.

Without these, a user with `includeIf` **and** certificate authentication was
still broken.

The fix is deliberately narrow. Always running the credential verbs outside the
enlistment would also fix the reported failure, but it would stop credential
helpers from reading a repository's local `credential.*` configuration after
clone. Four of the new unit tests fail if someone widens it that way.

The chosen route is recorded in the credential failure metadata, so a later
report of "the wrong credentials were used" can be diagnosed from the logs.

## Tests

New unit tests cover all three states of `.git`, for all three credential verbs
(`fill`, `approve`, `reject`):

| `.git` state | `--git-dir` passed |
| --- | --- |
| absent (during clone) | no |
| folder (normal enlistment) | yes |
| file (linked worktree) | yes |

New functional tests clone with and without an `includeIf` section and confirm
that both reach the credential helper. The test without the section is the
control: it passes before and after this change, which shows the other test fails
only because of the `includeIf` section.

The functional tests assert that authentication was actually reached, not only
that the failure message changed. A clone that cannot reach the server exits with
the same code and prints neither of the strings under test, so absence checks
alone would pass with no network and prove nothing.

Verified by mutation. Forcing `--git-dir` on always fails 3 unit tests. Dropping
it always fails 4. A real clone of an authenticated repository with an `includeIf`
section fails on the unfixed build and succeeds on the fixed one.

## Branch

This targets `vnext` rather than `master`. The defective code path is identical
in `v1.0.26014.1`, so this is a long-standing defect and not a 2.0 regression.
It changes runtime behavior on the credential path, so it soaks in `vnext`.

## Also included

Two corrections to `AGENTS.md` that this work proved wrong:

- `GVFS.Payload` has **no** `ProjectReference` items and never builds or publishes
  the projects `layout.bat` copies from. A project you did not publish contributes
  a binary from an earlier build, so the functional tests can silently exercise
  stale code. The documented steps now publish each changed project explicitly and
  show how to confirm the payload actually changed.
- `RunFunctionalTests-Dev.ps1` binds positional arguments to `-Arch`, so
  `RunFunctionalTests-Dev.ps1 Debug --test=...` fails its `ValidateSet`. The
  documented invocations now name both parameters.
