### PR TITLE
Do not trace raw credential output

### DIFF
--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -306,7 +306,8 @@ namespace GVFS.Common.Git
 
                 if (!success)
                 {
-                    metadata.Add("Output", gitCredentialOutput.Output);
+                    // Never trace the raw output: it can contain the secret itself.
+                    metadata.Add("OutputKeys", GetCredentialOutputKeys(gitCredentialOutput.Output));
                 }
 
                 activity.Stop(metadata);
@@ -370,7 +371,8 @@ namespace GVFS.Common.Git
                 metadata.Add("Success", success);
                 if (!success)
                 {
-                    metadata.Add("Output", gitCredentialOutput.Output);
+                    // Never trace the raw output: it can contain the secret itself.
+                    metadata.Add("OutputKeys", GetCredentialOutputKeys(gitCredentialOutput.Output));
                 }
 
                 activity.Stop(metadata);
@@ -1073,6 +1075,32 @@ namespace GVFS.Common.Git
         private static string GenerateCredentialVerbCommand(string verb)
         {
             return $"-c {GitConfigSetting.CredentialUseHttpPath}=true credential {verb}";
+        }
+
+        /// <summary>
+        /// Summarizes the output of "git credential fill" for diagnostics.
+        /// The output is a list of "key=value" lines that can include the
+        /// plaintext secret, so only the key names are returned. The values
+        /// must never reach telemetry or the log.
+        /// </summary>
+        private static string GetCredentialOutputKeys(string credentialOutput)
+        {
+            if (string.IsNullOrEmpty(credentialOutput))
+            {
+                return string.Empty;
+            }
+
+            IEnumerable<string> keys = credentialOutput
+                .Split('\n')
+                .Select(line => line.Trim('\r'))
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .Select(line =>
+                {
+                    int separatorIndex = line.IndexOf('=');
+                    return separatorIndex > 0 ? line.Substring(0, separatorIndex) : "<malformed>";
+                });
+
+            return string.Join(",", keys);
         }
 
         private static string ParseValue(string contents, string prefix)

--- a/GVFS/GVFS.UnitTests/Common/Git/GitProcessCredentialTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/Git/GitProcessCredentialTests.cs
@@ -1,0 +1,79 @@
+using GVFS.Common.Git;
+using GVFS.Common.Tracing;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using GVFS.UnitTests.Mock.Git;
+using NUnit.Framework;
+using System.Linq;
+
+namespace GVFS.UnitTests.Common.Git
+{
+    [TestFixture]
+    public class GitProcessCredentialTests
+    {
+        private const string SecretValue = "S3cretSentinelValueThatMustNotBeTraced";
+        private const string AzureDevOpsUseHttpPathString = "-c credential.\"https://dev.azure.com\".useHttpPath=true";
+
+        [TestCase]
+        public void TryGetCredentialDoesNotTraceSecretWhenParseFails()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = new MockGitProcess();
+
+            // The secret is on the last line and has no terminating newline, so the parse fails.
+            gitProcess.SetExpectedCommandResult(
+                $"{AzureDevOpsUseHttpPathString} credential fill",
+                () => new GitProcess.Result(
+                    "protocol=https\nhost=example.com\nusername=someone\npassword=" + SecretValue,
+                    string.Empty,
+                    GitProcess.Result.SuccessCode));
+
+            gitProcess.TryGetCredential(tracer, "mock://repoUrl", out _, out _, out _)
+                .ShouldBeFalse("Parse of the credential output must fail for this test");
+
+            EventMetadata metadata = GetActivityMetadata(tracer);
+            AssertNoSecret(metadata);
+            metadata["OutputKeys"].ShouldEqual("protocol,host,username,password");
+        }
+
+        [TestCase]
+        public void TryGetCertificatePasswordDoesNotTraceSecretWhenParseFails()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = new MockGitProcess();
+
+            // The secret is on the last line and has no terminating newline, so the parse fails.
+            gitProcess.SetExpectedCommandResult(
+                "credential fill",
+                () => new GitProcess.Result(
+                    "protocol=cert\npath=mock://certificate\npassword=" + SecretValue,
+                    string.Empty,
+                    GitProcess.Result.SuccessCode));
+
+            gitProcess.TryGetCertificatePassword(tracer, "mock://certificate", out _, out _)
+                .ShouldBeFalse("Parse of the credential output must fail for this test");
+
+            EventMetadata metadata = GetActivityMetadata(tracer);
+            AssertNoSecret(metadata);
+            metadata["OutputKeys"].ShouldEqual("protocol,path,password");
+        }
+
+        private static EventMetadata GetActivityMetadata(MockTracer tracer)
+        {
+            MockTracer activityTracer = tracer.StartActivityTracer;
+            activityTracer.ShouldNotBeNull("The credential call must start an activity");
+            activityTracer.StoppedActivityMetadata.Count.ShouldEqual(1);
+
+            return activityTracer.StoppedActivityMetadata.Single();
+        }
+
+        private static void AssertNoSecret(EventMetadata metadata)
+        {
+            foreach (object value in metadata.Values)
+            {
+                string text = value?.ToString() ?? string.Empty;
+                text.Contains(SecretValue).ShouldBeFalse("Credential output must not be traced: " + text);
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Common/MockTracer.cs
@@ -17,6 +17,7 @@ namespace GVFS.UnitTests.Mock.Common
             this.RelatedWarningEvents = new List<string>();
             this.RelatedErrorEvents = new List<string>();
             this.RelatedEventNames = new List<string>();
+            this.StoppedActivityMetadata = new List<EventMetadata>();
         }
 
         public MockTracer StartActivityTracer { get; private set; }
@@ -29,6 +30,10 @@ namespace GVFS.UnitTests.Mock.Common
         // Names of events reported via RelatedEvent (which, unlike RelatedInfo/Warning/Error,
         // do not otherwise get recorded). Lets tests assert a specific diagnostic event fired.
         public List<string> RelatedEventNames { get; }
+
+        // Metadata passed to Stop when an activity ends. Lets tests assert on
+        // what an activity reports, including that a secret is not present.
+        public List<EventMetadata> StoppedActivityMetadata { get; }
 
         public void WaitForRelatedEvent()
         {
@@ -136,6 +141,11 @@ namespace GVFS.UnitTests.Mock.Common
 
         public TimeSpan Stop(EventMetadata metadata)
         {
+            if (metadata != null)
+            {
+                this.StoppedActivityMetadata.Add(metadata);
+            }
+
             return TimeSpan.Zero;
         }
 


### PR DESCRIPTION
## Problem

`GitProcess.TryGetCredential` and `GitProcess.TryGetCertificatePassword` added the raw stdout of `git credential fill` to the activity metadata when the parse of that output failed.

`git credential fill` writes its result as a list of `key=value` lines:

```
protocol=https
host=example.com
username=someone
password=<plaintext secret>
```

The methods compute `success` from whether the expected values parsed. A helper can return a secret and still fail the parse — for example the username is absent, or the last line has no terminating newline, so `ParseValue` returns null. On that path the code wrote the entire raw stdout, including the plaintext secret, into the log and into telemetry.

## Fix

Trace only the key names that the credential helper returned. A new private helper `GetCredentialOutputKeys` maps the output to a comma-joined list of key names, and the metadata key changes from `Output` to `OutputKeys`. Knowing which keys came back keeps the diagnostic value; the values never leave the process.

## Tests

`GitProcessCredentialTests` covers both methods. Each test makes the parse fail with a distinctive sentinel secret in the output, then asserts that the sentinel is absent from every value in the activity metadata and that `OutputKeys` lists the expected key names.

`MockTracer` now records the metadata that is passed to `Stop`, so tests can inspect what an activity reports.

Verified by mutation: with the redaction reverted, both tests fail on the secret assertion. With the fix in place the unit-test suite is green (919 passed, 0 failed).

## Notes

This targets `vnext`. The defect is long-standing, not a 2.0 regression, and the change alters what the credential path reports at runtime.

Scope is limited to the telemetry leak. The credential routing is not touched.
