### PR TITLE
Document why GitProcess does not use Enlistment.DotGitRoot

### DIFF
--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -64,6 +64,13 @@ namespace GVFS.Common
             // Override DotGitRoot to point to the shared .git directory.
             // The base constructor sets it to WorkingDirectoryBackingRoot/.git
             // which is a file (not directory) in worktrees.
+            //
+            // NOTE: DotGitRoot is the SHARED git directory, and is used for shared state that GVFS
+            // reads or writes directly on disk (objects, objects/info/alternates, hooks). It is
+            // deliberately NOT what GitProcess passes as --git-dir; GitProcess uses the worktree's own
+            // ".git" file so git resolves per-worktree HEAD/index/refs as well as the shared state.
+            // See GitProcess's constructor. Per-worktree paths that GVFS touches directly must come
+            // from Worktree.WorktreeGitDir (see GitIndexPath), never from DotGitRoot.
             this.DotGitRoot = worktreeInfo.SharedGitDir;
 
             this.DotGVFSRoot = Path.Combine(worktreeInfo.WorktreeGitDir, GVFSPlatform.Instance.Constants.DotGVFSRoot);

--- a/GVFS/GVFS.Common/Git/GitProcess.cs
+++ b/GVFS/GVFS.Common/Git/GitProcess.cs
@@ -101,8 +101,34 @@ namespace GVFS.Common.Git
 
             if (this.workingDirectoryRoot != null)
             {
+                // This is deliberately NOT Enlistment.DotGitRoot. In a linked worktree those two
+                // values differ, and each is correct for its own purpose:
+                //
+                //   Enlistment.DotGitRoot -> the SHARED .git directory of the main repo. GVFS uses it
+                //                            for shared state it manages directly on disk (objects,
+                //                            objects/info/alternates, hooks).
+                //   this.dotGitRoot       -> "<workingDirectoryRoot>\.git", which in a linked worktree
+                //                            is a FILE containing "gitdir: <shared>/.git/worktrees/<name>".
+                //
+                // We pass this.dotGitRoot as --git-dir. Git follows the gitdir: pointer, so it resolves
+                // BOTH the per-worktree state (HEAD, index, per-worktree refs, reflog) and, via the
+                // commondir file, the shared state (config, objects, packed-refs). Passing
+                // Enlistment.DotGitRoot instead would silently bind every command to the MAIN worktree's
+                // HEAD and index -- e.g. "rev-parse HEAD" and "name-rev --name-only HEAD" would report the
+                // main worktree's branch and commit while running inside a linked worktree.
                 this.dotGitRoot = Path.Combine(this.workingDirectoryRoot, GVFSConstants.DotGit.Root);
             }
+        }
+
+        /// <summary>
+        /// The path passed as --git-dir to every InvokeGitAgainstDotGitFolder call.
+        /// In a linked worktree this is the worktree's own .git file, NOT
+        /// <see cref="Enlistment.DotGitRoot"/> (the shared .git directory). See the constructor
+        /// for why the two intentionally differ.
+        /// </summary>
+        public string GitDirectoryPath
+        {
+            get { return this.dotGitRoot; }
         }
 
         public static string ExpireTimeDateString

--- a/GVFS/GVFS.UnitTests/Common/WorktreeEnlistmentTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WorktreeEnlistmentTests.cs
@@ -1,4 +1,5 @@
 using GVFS.Common;
+using GVFS.Common.Git;
 using GVFS.Tests.Should;
 using NUnit.Framework;
 using System.IO;
@@ -89,6 +90,31 @@ namespace GVFS.UnitTests.Common
         {
             GVFSEnlistment enlistment = this.CreateWorktreeEnlistment();
             enlistment.DotGitRoot.ShouldEqual(this.sharedGitDir);
+        }
+
+        [TestCase]
+        public void GitProcessUsesWorktreeGitFileNotSharedGitDir()
+        {
+            // GitProcess passes its own git dir as --git-dir. For a worktree that must be the
+            // worktree's ".git" file, which git resolves to both the per-worktree state
+            // (HEAD, index, refs) and, through commondir, the shared state (config, objects).
+            // Using DotGitRoot (the shared .git directory) would bind every command to the
+            // MAIN worktree's HEAD and index instead.
+            GVFSEnlistment enlistment = this.CreateWorktreeEnlistment();
+            GitProcess gitProcess = new GitProcess(enlistment);
+
+            gitProcess.GitDirectoryPath.ShouldEqual(Path.Combine(this.worktreePath, ".git"));
+            gitProcess.GitDirectoryPath.ShouldNotEqual(enlistment.DotGitRoot);
+        }
+
+        [TestCase]
+        public void WorkingDirectoryBackingRootIsWorktreePath()
+        {
+            // GitProcess derives its --git-dir from WorkingDirectoryBackingRoot. If the worktree
+            // constructor ever redirected this to the primary enlistment, GitProcess would silently
+            // start operating on the main worktree.
+            GVFSEnlistment enlistment = this.CreateWorktreeEnlistment();
+            enlistment.WorkingDirectoryBackingRoot.ShouldEqual(this.worktreePath);
         }
 
         [TestCase]


### PR DESCRIPTION
## Summary

In a linked git worktree, `Enlistment.DotGitRoot` and the git directory that `GitProcess` passes as `--git-dir` point at different locations:

| Field | Value in a linked worktree |
|---|---|
| `Enlistment.DotGitRoot` | the **shared** `.git` directory of the main repo |
| `GitProcess` git dir | `<worktree>\.git` — a **file** holding `gitdir: <shared>/.git/worktrees/<name>` |

This looks like an inconsistency. It is not. Each value is correct for its own purpose, and the divergence is load-bearing.

Git follows the `gitdir:` pointer, so the worktree `.git` file resolves the per-worktree state (`HEAD`, index, per-worktree refs, reflog) **and**, through `commondir`, the shared state (config, objects, `packed-refs`). `DotGitRoot` is used for shared state that VFS for Git reads or writes directly on disk (objects, `objects/info/alternates`, hooks).

## Why "aligning" the two would be a regression

Changing `GitProcess` to read `Enlistment.DotGitRoot` binds every command to the **main** worktree. Verified against a real worktree with divergent `HEAD`s (git 2.55):

| `--git-dir` | `rev-parse --abbrev-ref HEAD` | `log -1 --format=%s HEAD` |
|---|---|---|
| `<worktree>\.git` (current behavior) | `feature` ✅ | `onfeature` ✅ |
| `<shared>\.git` (`DotGitRoot`) | `main` ❌ | `onmaster` ❌ |

So from inside a linked worktree, `rev-parse`, `name-rev`, `branch`, `symbolic-ref`, `update-ref`, and `read-tree` would all silently operate on the wrong worktree.

The second `GitProcess(gitBinPath, workingDirectoryRoot)` constructor needs no change — it has no `Enlistment` to consult, and its computed path is already the correct one.

## What this PR changes

Nothing functional. It documents the divergence and pins it with tests so a future "cleanup" cannot quietly introduce the regression above.

- `GitProcess.cs` — comment explaining why the git dir is deliberately not `Enlistment.DotGitRoot`; new `GitDirectoryPath` accessor so the value is testable.
- `GVFSEnlistment.cs` — comment recording that `DotGitRoot` is shared-state-only, and that per-worktree paths must come from `Worktree.WorktreeGitDir` (as `GitIndexPath` already does).
- `WorktreeEnlistmentTests.cs` — two tests pinning the current values.

## Testing

- Full unit suite: **919 passed, 0 failed, 11 skipped** — identical before and after.
- Mutation-verified: applying the rejected change (`GitProcess` reading `Enlistment.DotGitRoot`) fails `GitProcessUsesWorktreeGitFileNotSharedGitDir` and nothing else, confirming the new test actually pins the behavior.

## Note for reviewers

The audit behind this PR also found callers that use `DotGitRoot` for genuinely **per-worktree** state, where `GitIndexPath` already resolves correctly — `FileSystemCallbacks.cs` (watches the main repo's `logs/HEAD`), `GitIndexGenerator.cs`, `RepairJobs/GitIndexRepairJob.cs`, `DehydrateVerb.cs`, and `FastFetch/CheckoutPrefetcher.cs`. Those are real divergences with real blast radius, and are deliberately left out of this PR to keep it a no-op. They will be evaluated separately.

Targets `vnext`: long-standing behavior, not a 2.0 regression.
