### PR TITLE
Do not fall back to anonymous when the /gvfs/config probe is indeterminate

### DIFF
--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -84,7 +84,7 @@ namespace GVFS.Common.Git
         /// probe outcome - anonymous success, 401, or an indeterminate network
         /// failure - can be driven deterministically.
         /// </summary>
-        internal Func<ITracer, Enlistment, RetryConfig, IGVFSConfigRequestor> ConfigRequestorFactory { get; set; }
+        internal IGVFSConfigRequestor ConfigRequestorOverride { get; set; }
 
         private GitSsl GitSsl { get; }
 
@@ -280,15 +280,21 @@ namespace GVFS.Common.Git
             errorMessage = null;
             isAuthFailure = false;
 
-            using (IGVFSConfigRequestor configRequestor = this.ConfigRequestorFactory != null
-                ? this.ConfigRequestorFactory(tracer, enlistment, retryConfig)
-                : new ConfigHttpRequestor(tracer, enlistment, retryConfig))
+            IGVFSConfigRequestor configRequestor = this.ConfigRequestorOverride ?? new ConfigHttpRequestor(tracer, enlistment, retryConfig);
+            using (configRequestor)
             {
                 HttpStatusCode? httpStatus;
 
                 // First attempt without credentials. If anonymous access works,
                 // we get the config in a single request.
-                if (configRequestor.TryQueryGVFSConfig(false, out serverGVFSConfig, out httpStatus, out _))
+                //
+                // forceAnonymous is required, not incidental: this probe is what
+                // DETERMINES whether the server allows anonymous access, so it must
+                // not consult the answer it is computing. Without it, SendRequest
+                // sees IsAnonymous == false and calls TryGetCredentials, which waits
+                // for the initialization this very call stack is performing - a
+                // self-deadlock that stalls every mount until the wait times out.
+                if (configRequestor.TryQueryGVFSConfig(false, out serverGVFSConfig, out httpStatus, out _, forceAnonymous: true))
                 {
                     this.IsAnonymous = true;
                     this.MarkInitialized();
@@ -313,10 +319,27 @@ namespace GVFS.Common.Git
                     // already latched - so re-initialization throws. Mount proceeds
                     // when a cache server is configured, so the repo stays mounted but
                     // cannot hydrate or enumerate until it is remounted.
+                    // Assigning IsAnonymous here is defensive: the field already
+                    // defaults to false and no earlier path in this method can set it
+                    // true without returning, so this states the outcome explicitly
+                    // rather than relying on the default staying false.
                     this.IsAnonymous = false;
                     this.MarkInitialized();
                     errorMessage = "Unable to query /gvfs/config";
-                    tracer.RelatedWarning("{0}: Config query failed with status {1}; assuming authentication is required", nameof(this.TryInitializeAndQueryGVFSConfig), httpStatus?.ToString() ?? "None");
+
+                    // Emit this with Keywords.Telemetry so the population hitting an
+                    // indeterminate probe is measurable in the field. The plain
+                    // RelatedWarning(string, params object[]) overload traces with
+                    // Keywords.None, which TelemetryDaemonEventListener filters out.
+                    EventMetadata indeterminateMetadata = new EventMetadata(new Dictionary<string, object>
+                    {
+                        ["Area"] = nameof(GitAuthentication),
+                        ["HttpStatus"] = httpStatus?.ToString() ?? "None",
+                    });
+                    tracer.RelatedWarning(
+                        indeterminateMetadata,
+                        $"{nameof(this.TryInitializeAndQueryGVFSConfig)}: Config query failed with status {httpStatus?.ToString() ?? "None"}; assuming authentication is required",
+                        Keywords.Telemetry);
                     return false;
                 }
 

--- a/GVFS/GVFS.Common/Git/GitAuthentication.cs
+++ b/GVFS/GVFS.Common/Git/GitAuthentication.cs
@@ -56,7 +56,19 @@ namespace GVFS.Common.Git
             }
         }
 
-        public bool IsAnonymous { get; private set; } = true;
+        /// <summary>
+        /// True only when the server is known to allow anonymous access.
+        /// </summary>
+        /// <remarks>
+        /// This defaults to false, because anonymous access is an affirmative
+        /// determination that requires a successful unauthenticated probe of
+        /// /gvfs/config. While this is true,
+        /// <see cref="Http.HttpRequestor.SendRequest"/> omits the Authorization
+        /// header and never calls <see cref="TryGetCredentials"/>, so a default of
+        /// true makes every request unauthenticated when the probe does not run or
+        /// does not complete.
+        /// </remarks>
+        public bool IsAnonymous { get; private set; }
 
         /// <summary>
         /// How long a caller of <see cref="TryGetCredentials"/> will wait for
@@ -65,6 +77,14 @@ namespace GVFS.Common.Git
         /// background credential fetch). Overridable for tests.
         /// </summary>
         internal int InitializationWaitTimeoutMs { get; set; } = BackgroundCredentialTimeoutMs;
+
+        /// <summary>
+        /// Test seam for the /gvfs/config probe. When null, production code uses
+        /// <see cref="ConfigHttpRequestor"/>. Unit tests substitute a fake so the
+        /// probe outcome - anonymous success, 401, or an indeterminate network
+        /// failure - can be driven deterministically.
+        /// </summary>
+        internal Func<ITracer, Enlistment, RetryConfig, IGVFSConfigRequestor> ConfigRequestorFactory { get; set; }
 
         private GitSsl GitSsl { get; }
 
@@ -260,7 +280,9 @@ namespace GVFS.Common.Git
             errorMessage = null;
             isAuthFailure = false;
 
-            using (ConfigHttpRequestor configRequestor = new ConfigHttpRequestor(tracer, enlistment, retryConfig))
+            using (IGVFSConfigRequestor configRequestor = this.ConfigRequestorFactory != null
+                ? this.ConfigRequestorFactory(tracer, enlistment, retryConfig)
+                : new ConfigHttpRequestor(tracer, enlistment, retryConfig))
             {
                 HttpStatusCode? httpStatus;
 
@@ -276,9 +298,25 @@ namespace GVFS.Common.Git
 
                 if (httpStatus != HttpStatusCode.Unauthorized)
                 {
+                    // The probe did not determine whether the server allows anonymous
+                    // access. It failed for a reason unrelated to authentication - a
+                    // timeout, a 5xx, or a socket error. Assume authentication is
+                    // required. If the server does allow anonymous access it ignores
+                    // the Authorization header we then send.
+                    //
+                    // Treating this as anonymous is unrecoverable for the life of the
+                    // process: SendRequest would omit the Authorization header on every
+                    // later request and never call TryGetCredentials, the Azure DevOps
+                    // cache server answers 400 ("A valid Basic Authorization header is
+                    // required."), a 400 is not retryable, RejectCredentials is a no-op
+                    // because no credential was ever cached, and initialization is
+                    // already latched - so re-initialization throws. Mount proceeds
+                    // when a cache server is configured, so the repo stays mounted but
+                    // cannot hydrate or enumerate until it is remounted.
+                    this.IsAnonymous = false;
                     this.MarkInitialized();
                     errorMessage = "Unable to query /gvfs/config";
-                    tracer.RelatedWarning("{0}: Config query failed with status {1}", nameof(this.TryInitializeAndQueryGVFSConfig), httpStatus?.ToString() ?? "None");
+                    tracer.RelatedWarning("{0}: Config query failed with status {1}; assuming authentication is required", nameof(this.TryInitializeAndQueryGVFSConfig), httpStatus?.ToString() ?? "None");
                     return false;
                 }
 

--- a/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
@@ -17,7 +17,7 @@ namespace GVFS.Common.Http
             this.repoUrl = enlistment.RepoUrl;
         }
 
-        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage)
+        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage, bool forceAnonymous = false)
         {
             serverGVFSConfig = null;
             httpStatus = null;
@@ -56,7 +56,8 @@ namespace GVFS.Common.Http
                         gvfsConfigEndpoint,
                         HttpMethod.Get,
                         requestContent: null,
-                        cancellationToken: CancellationToken.None))
+                        cancellationToken: CancellationToken.None,
+                        forceAnonymous: forceAnonymous))
                     {
                         if (response.HasErrors)
                         {

--- a/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/ConfigHttpRequestor.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace GVFS.Common.Http
 {
-    public class ConfigHttpRequestor : HttpRequestor
+    public class ConfigHttpRequestor : HttpRequestor, IGVFSConfigRequestor
     {
         private readonly string repoUrl;
 

--- a/GVFS/GVFS.Common/Http/HttpRequestor.cs
+++ b/GVFS/GVFS.Common/Http/HttpRequestor.cs
@@ -98,17 +98,31 @@ namespace GVFS.Common.Http
             }
         }
 
+        /// <param name="forceAnonymous">
+        /// Sends the request without credentials regardless of the authentication
+        /// state. Required by the /gvfs/config probe that DETERMINES whether the
+        /// server allows anonymous access: that probe runs before initialization
+        /// completes, so it must not call <see cref="GitAuthentication.TryGetCredentials"/>,
+        /// which would wait for the initialization this very request is part of.
+        /// </param>
         protected GitEndPointResponseData SendRequest(
             long requestId,
             Uri requestUri,
             HttpMethod httpMethod,
             string requestContent,
             CancellationToken cancellationToken,
-            MediaTypeWithQualityHeaderValue acceptType = null)
+            MediaTypeWithQualityHeaderValue acceptType = null,
+            bool forceAnonymous = false)
         {
+            // Resolve the anonymous decision once. Another thread can change
+            // IsAnonymous while this request is in flight, and the credential
+            // gate, the Authorization header, and the response handling below
+            // must all agree on a single value.
+            bool sendAnonymous = forceAnonymous || this.authentication.IsAnonymous;
+
             string authString = null;
             string errorMessage;
-            if (!this.authentication.IsAnonymous &&
+            if (!sendAnonymous &&
                 !this.authentication.TryGetCredentials(this.Tracer, out authString, out errorMessage))
             {
                 return new GitEndPointResponseData(
@@ -127,7 +141,7 @@ namespace GVFS.Common.Http
 
             request.Headers.UserAgent.Add(this.userAgentHeader);
 
-            if (!this.authentication.IsAnonymous)
+            if (!sendAnonymous)
             {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authString);
             }
@@ -205,7 +219,7 @@ namespace GVFS.Common.Http
                     string contentType = GetSingleHeaderOrEmpty(response.Content.Headers, "Content-Type");
                     responseMetadata.Add("ContentType", contentType);
 
-                    if (!this.authentication.IsAnonymous)
+                    if (!sendAnonymous)
                     {
                         this.authentication.ApproveCredentials(this.Tracer, authString);
                     }
@@ -227,8 +241,11 @@ namespace GVFS.Common.Http
                     bool shouldRetry = ShouldRetry(response.StatusCode);
 
                     if (response.StatusCode == HttpStatusCode.Unauthorized &&
-                        this.authentication.IsAnonymous)
+                        sendAnonymous)
                     {
+                        // The request carried no credentials, so there is nothing to
+                        // reject. For the initial probe this is the definitive answer
+                        // that the server requires authentication.
                         shouldRetry = false;
                         errorMessage = "Anonymous request was rejected with a 401";
                     }

--- a/GVFS/GVFS.Common/Http/IGVFSConfigRequestor.cs
+++ b/GVFS/GVFS.Common/Http/IGVFSConfigRequestor.cs
@@ -10,7 +10,7 @@ namespace GVFS.Common.Http
     /// driven with a deterministic probe outcome in unit tests. Production code
     /// always uses <see cref="ConfigHttpRequestor"/>.
     /// </summary>
-    public interface IGVFSConfigRequestor : IDisposable
+    internal interface IGVFSConfigRequestor : IDisposable
     {
         /// <summary>
         /// Queries /gvfs/config.
@@ -22,7 +22,12 @@ namespace GVFS.Common.Http
         /// never produced an HTTP response (for example a DNS or socket failure).
         /// </param>
         /// <param name="errorMessage">The failure description when this returns false.</param>
+        /// <param name="forceAnonymous">
+        /// Sends the request without credentials regardless of the authentication
+        /// state. The probe that determines whether the server allows anonymous
+        /// access must set this.
+        /// </param>
         /// <returns>True when the config was retrieved.</returns>
-        bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage);
+        bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage, bool forceAnonymous = false);
     }
 }

--- a/GVFS/GVFS.Common/Http/IGVFSConfigRequestor.cs
+++ b/GVFS/GVFS.Common/Http/IGVFSConfigRequestor.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net;
+
+namespace GVFS.Common.Http
+{
+    /// <summary>
+    /// Queries the server's /gvfs/config endpoint. Extracted from
+    /// <see cref="ConfigHttpRequestor"/> so that
+    /// <see cref="Git.GitAuthentication.TryInitializeAndQueryGVFSConfig"/> can be
+    /// driven with a deterministic probe outcome in unit tests. Production code
+    /// always uses <see cref="ConfigHttpRequestor"/>.
+    /// </summary>
+    public interface IGVFSConfigRequestor : IDisposable
+    {
+        /// <summary>
+        /// Queries /gvfs/config.
+        /// </summary>
+        /// <param name="logErrors">Whether to trace failures as errors.</param>
+        /// <param name="serverGVFSConfig">The parsed config when this returns true.</param>
+        /// <param name="httpStatus">
+        /// The HTTP status the server responded with, or null when the request
+        /// never produced an HTTP response (for example a DNS or socket failure).
+        /// </param>
+        /// <param name="errorMessage">The failure description when this returns false.</param>
+        /// <returns>True when the config was retrieved.</returns>
+        bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage);
+    }
+}

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -345,6 +345,50 @@ namespace GVFS.UnitTests.Git
             authString.ShouldNotBeNull("A credential string should be returned");
         }
 
+        /// <summary>
+        /// The initial /gvfs/config probe is what DETERMINES whether the server
+        /// allows anonymous access, so it must be sent without credentials.
+        /// <see cref="GVFS.Common.Http.HttpRequestor.SendRequest"/> gates the
+        /// Authorization header on <see cref="GitAuthentication.IsAnonymous"/> and
+        /// calls <see cref="GitAuthentication.TryGetCredentials"/> when it is false.
+        /// Because <c>IsAnonymous</c> now defaults to false, an unforced probe would
+        /// take that path and block on <c>initializationComplete</c> - the event that
+        /// only this same call stack can set - stalling every mount for the whole
+        /// wait timeout, on every retry.
+        /// </summary>
+        [TestCase]
+        public void InitialConfigProbeIsSentWithoutCredentials()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+            MockGVFSConfigRequestor requestor = MockGVFSConfigRequestor.AnonymousSucceeds();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+
+            // Keep the failure fast: if the probe ever does wait for initialization,
+            // this bounds the stall instead of hanging the suite.
+            dut.InitializationWaitTimeoutMs = 500;
+            dut.ConfigRequestorOverride = requestor;
+
+            bool credentialsRequestedDuringProbe = false;
+            requestor.OnQuery = forceAnonymous =>
+            {
+                // Mirror HttpRequestor.SendRequest's credential gate exactly.
+                bool sendAnonymous = forceAnonymous || dut.IsAnonymous;
+                if (!sendAnonymous)
+                {
+                    credentialsRequestedDuringProbe = true;
+                    dut.TryGetCredentials(tracer, out _, out _);
+                }
+            };
+
+            dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out _)
+                .ShouldEqual(true, "The anonymous probe should have succeeded");
+
+            requestor.LastQueryForcedAnonymous.ShouldEqual(true, "The initial config probe must be forced anonymous so it cannot wait on its own initialization");
+            credentialsRequestedDuringProbe.ShouldEqual(false, "The initial config probe must not require credentials");
+        }
+
         [TestCase]
         public void AuthIsNotAnonymousBeforeInitialization()
         {
@@ -363,7 +407,7 @@ namespace GVFS.UnitTests.Git
             MockGVFSConfigRequestor requestor = MockGVFSConfigRequestor.AnonymousSucceeds();
 
             GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
-            dut.ConfigRequestorFactory = (t, e, r) => requestor;
+            dut.ConfigRequestorOverride = requestor;
 
             dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out bool isAuthFailure)
                 .ShouldEqual(true, "An anonymous server should initialize successfully");
@@ -380,7 +424,7 @@ namespace GVFS.UnitTests.Git
             MockGitProcess gitProcess = this.GetGitProcess();
 
             GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
-            dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.RequiresAuthentication();
+            dut.ConfigRequestorOverride = MockGVFSConfigRequestor.RequiresAuthentication();
 
             dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out _);
 
@@ -399,33 +443,27 @@ namespace GVFS.UnitTests.Git
         /// so the probe never runs again. Mount proceeds when a cache server is
         /// configured, so the repo stays mounted but cannot hydrate or enumerate.
         /// </summary>
-        [TestCase]
-        public void IndeterminateConfigProbeDoesNotLeaveAuthAnonymous()
+        [TestCase(HttpStatusCode.RequestTimeout)]
+        [TestCase(HttpStatusCode.InternalServerError)]
+        [TestCase(HttpStatusCode.ServiceUnavailable)]
+        [TestCase(HttpStatusCode.BadRequest)]
+        [TestCase(null)]
+        public void IndeterminateConfigProbeDoesNotLeaveAuthAnonymous(HttpStatusCode? status)
         {
-            foreach (HttpStatusCode? status in new HttpStatusCode?[]
-            {
-                HttpStatusCode.RequestTimeout,
-                HttpStatusCode.InternalServerError,
-                HttpStatusCode.ServiceUnavailable,
-                HttpStatusCode.BadRequest,
-                null,
-            })
-            {
-                MockTracer tracer = new MockTracer();
-                MockGitProcess gitProcess = this.GetGitProcess();
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
 
-                GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
-                dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.Indeterminate(status);
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.ConfigRequestorOverride = MockGVFSConfigRequestor.Indeterminate(status);
 
-                dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out bool isAuthFailure)
-                    .ShouldEqual(false, $"A config query that failed with {status?.ToString() ?? "no response"} should report failure");
+            dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out bool isAuthFailure)
+                .ShouldEqual(false, $"A config query that failed with {status?.ToString() ?? "no response"} should report failure");
 
-                dut.IsAnonymous.ShouldEqual(
-                    false,
-                    $"An indeterminate config probe ({status?.ToString() ?? "no response"}) must not leave auth in anonymous mode");
+            dut.IsAnonymous.ShouldEqual(
+                false,
+                $"An indeterminate config probe ({status?.ToString() ?? "no response"}) must not leave auth in anonymous mode");
 
-                isAuthFailure.ShouldEqual(false, "An indeterminate failure is not an authentication failure");
-            }
+            isAuthFailure.ShouldEqual(false, "An indeterminate failure is not an authentication failure");
         }
 
         [TestCase]
@@ -435,7 +473,7 @@ namespace GVFS.UnitTests.Git
             MockGitProcess gitProcess = this.GetGitProcess();
 
             GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
-            dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.Indeterminate(HttpStatusCode.RequestTimeout);
+            dut.ConfigRequestorOverride = MockGVFSConfigRequestor.Indeterminate(HttpStatusCode.RequestTimeout);
 
             dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out _);
 

--- a/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
+++ b/GVFS/GVFS.UnitTests/Git/GitAuthenticationTests.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using GVFS.Common;
 using GVFS.Common.Git;
 using GVFS.Tests;
 using GVFS.Tests.Should;
 using GVFS.UnitTests.Mock.Common;
 using GVFS.UnitTests.Mock.Git;
+using GVFS.UnitTests.Mock.Http;
 using NUnit.Framework;
 
 namespace GVFS.UnitTests.Git
@@ -340,6 +343,109 @@ namespace GVFS.UnitTests.Git
 
             result.ShouldBeTrue("TryGetCredentials should succeed after initialization: " + error);
             authString.ShouldNotBeNull("A credential string should be returned");
+        }
+
+        [TestCase]
+        public void AuthIsNotAnonymousBeforeInitialization()
+        {
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+
+            dut.IsAnonymous.ShouldEqual(false, "Auth must not report anonymous before a probe has proven the server allows it");
+        }
+
+        [TestCase]
+        public void AnonymousConfigProbeSuccessLeavesAuthAnonymous()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+            MockGVFSConfigRequestor requestor = MockGVFSConfigRequestor.AnonymousSucceeds();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.ConfigRequestorFactory = (t, e, r) => requestor;
+
+            dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out bool isAuthFailure)
+                .ShouldEqual(true, "An anonymous server should initialize successfully");
+
+            dut.IsAnonymous.ShouldEqual(true, "A successful unauthenticated probe means the server allows anonymous access");
+            isAuthFailure.ShouldEqual(false, "An anonymous success is not an auth failure");
+            requestor.QueryCount.ShouldEqual(1, "An anonymous server needs only the single unauthenticated query");
+        }
+
+        [TestCase]
+        public void UnauthorizedConfigProbeRequiresAuthentication()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.RequiresAuthentication();
+
+            dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out _);
+
+            dut.IsAnonymous.ShouldEqual(false, "A 401 from the unauthenticated probe means credentials are required");
+            dut.TryGetCredentials(tracer, out string authString, out _).ShouldEqual(true, "Credentials should be available after a 401 probe");
+            authString.ShouldNotBeNull("A credential should have been fetched");
+        }
+
+        /// <summary>
+        /// A config query that fails for a reason unrelated to authentication - a
+        /// timeout, a 5xx, or a socket error - says nothing about whether the server
+        /// allows anonymous access. Treating it as anonymous is unrecoverable:
+        /// HttpRequestor.SendRequest omits the Authorization header and never calls
+        /// TryGetCredentials while IsAnonymous is true, the Azure DevOps cache server
+        /// answers 400, a 400 is not retryable, and initialization is already latched
+        /// so the probe never runs again. Mount proceeds when a cache server is
+        /// configured, so the repo stays mounted but cannot hydrate or enumerate.
+        /// </summary>
+        [TestCase]
+        public void IndeterminateConfigProbeDoesNotLeaveAuthAnonymous()
+        {
+            foreach (HttpStatusCode? status in new HttpStatusCode?[]
+            {
+                HttpStatusCode.RequestTimeout,
+                HttpStatusCode.InternalServerError,
+                HttpStatusCode.ServiceUnavailable,
+                HttpStatusCode.BadRequest,
+                null,
+            })
+            {
+                MockTracer tracer = new MockTracer();
+                MockGitProcess gitProcess = this.GetGitProcess();
+
+                GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+                dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.Indeterminate(status);
+
+                dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out bool isAuthFailure)
+                    .ShouldEqual(false, $"A config query that failed with {status?.ToString() ?? "no response"} should report failure");
+
+                dut.IsAnonymous.ShouldEqual(
+                    false,
+                    $"An indeterminate config probe ({status?.ToString() ?? "no response"}) must not leave auth in anonymous mode");
+
+                isAuthFailure.ShouldEqual(false, "An indeterminate failure is not an authentication failure");
+            }
+        }
+
+        [TestCase]
+        public void IndeterminateConfigProbeStillAuthenticatesLaterRequests()
+        {
+            MockTracer tracer = new MockTracer();
+            MockGitProcess gitProcess = this.GetGitProcess();
+
+            GitAuthentication dut = new GitAuthentication(gitProcess, "mock://repoUrl");
+            dut.ConfigRequestorFactory = (t, e, r) => MockGVFSConfigRequestor.Indeterminate(HttpStatusCode.RequestTimeout);
+
+            dut.TryInitializeAndQueryGVFSConfig(tracer, null, new RetryConfig(), out _, out _, out _);
+
+            // Mount proceeds past this failure when a cache server is configured, so
+            // object downloads and directory enumeration must still be able to
+            // authenticate rather than silently issuing unauthenticated requests.
+            dut.IsAnonymous.ShouldEqual(false, "Later requests must send an Authorization header");
+            dut.TryGetCredentials(tracer, out string authString, out string error)
+                .ShouldEqual(true, "Credentials should still be obtainable after an indeterminate probe: " + error);
+            authString.ShouldNotBeNull("A credential should have been fetched");
         }
 
         private MockGitProcess GetGitProcess()

--- a/GVFS/GVFS.UnitTests/Mock/Http/MockGVFSConfigRequestor.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Http/MockGVFSConfigRequestor.cs
@@ -1,5 +1,6 @@
 using GVFS.Common;
 using GVFS.Common.Http;
+using System;
 using System.Net;
 
 namespace GVFS.UnitTests.Mock.Http
@@ -9,7 +10,7 @@ namespace GVFS.UnitTests.Mock.Http
     /// with a fixed /gvfs/config probe outcome so the anonymous / authenticated /
     /// indeterminate branches can be tested without a server.
     /// </summary>
-    public class MockGVFSConfigRequestor : IGVFSConfigRequestor
+    internal class MockGVFSConfigRequestor : IGVFSConfigRequestor
     {
         private readonly bool succeedAnonymously;
         private readonly HttpStatusCode? statusCode;
@@ -20,7 +21,22 @@ namespace GVFS.UnitTests.Mock.Http
             this.statusCode = statusCode;
         }
 
+        /// <summary>
+        /// Number of times the probe was issued.
+        /// </summary>
         public int QueryCount { get; private set; }
+
+        /// <summary>
+        /// The value of <paramref name="forceAnonymous"/> on the most recent probe.
+        /// </summary>
+        public bool LastQueryForcedAnonymous { get; private set; }
+
+        /// <summary>
+        /// Runs while the probe is "in flight", so a test can observe the
+        /// authentication state that a real requestor would see at that moment.
+        /// The argument is the probe's <c>forceAnonymous</c> value.
+        /// </summary>
+        public Action<bool> OnQuery { get; set; }
 
         /// <summary>
         /// The server allows anonymous access: the unauthenticated probe returns the config.
@@ -48,9 +64,11 @@ namespace GVFS.UnitTests.Mock.Http
             return new MockGVFSConfigRequestor(succeedAnonymously: false, statusCode: statusCode);
         }
 
-        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage)
+        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage, bool forceAnonymous = false)
         {
             this.QueryCount++;
+            this.LastQueryForcedAnonymous = forceAnonymous;
+            this.OnQuery?.Invoke(forceAnonymous);
 
             httpStatus = this.statusCode;
 

--- a/GVFS/GVFS.UnitTests/Mock/Http/MockGVFSConfigRequestor.cs
+++ b/GVFS/GVFS.UnitTests/Mock/Http/MockGVFSConfigRequestor.cs
@@ -1,0 +1,73 @@
+using GVFS.Common;
+using GVFS.Common.Http;
+using System.Net;
+
+namespace GVFS.UnitTests.Mock.Http
+{
+    /// <summary>
+    /// Drives <see cref="GVFS.Common.Git.GitAuthentication.TryInitializeAndQueryGVFSConfig"/>
+    /// with a fixed /gvfs/config probe outcome so the anonymous / authenticated /
+    /// indeterminate branches can be tested without a server.
+    /// </summary>
+    public class MockGVFSConfigRequestor : IGVFSConfigRequestor
+    {
+        private readonly bool succeedAnonymously;
+        private readonly HttpStatusCode? statusCode;
+
+        private MockGVFSConfigRequestor(bool succeedAnonymously, HttpStatusCode? statusCode)
+        {
+            this.succeedAnonymously = succeedAnonymously;
+            this.statusCode = statusCode;
+        }
+
+        public int QueryCount { get; private set; }
+
+        /// <summary>
+        /// The server allows anonymous access: the unauthenticated probe returns the config.
+        /// </summary>
+        public static MockGVFSConfigRequestor AnonymousSucceeds()
+        {
+            return new MockGVFSConfigRequestor(succeedAnonymously: true, statusCode: HttpStatusCode.OK);
+        }
+
+        /// <summary>
+        /// The server requires authentication: the unauthenticated probe returns 401.
+        /// </summary>
+        public static MockGVFSConfigRequestor RequiresAuthentication()
+        {
+            return new MockGVFSConfigRequestor(succeedAnonymously: false, statusCode: HttpStatusCode.Unauthorized);
+        }
+
+        /// <summary>
+        /// The probe failed for a reason that says nothing about authentication, so
+        /// whether the server allows anonymous access is unknown. Pass null for
+        /// <paramref name="statusCode"/> to model a failure with no HTTP response at all.
+        /// </summary>
+        public static MockGVFSConfigRequestor Indeterminate(HttpStatusCode? statusCode)
+        {
+            return new MockGVFSConfigRequestor(succeedAnonymously: false, statusCode: statusCode);
+        }
+
+        public bool TryQueryGVFSConfig(bool logErrors, out ServerGVFSConfig serverGVFSConfig, out HttpStatusCode? httpStatus, out string errorMessage)
+        {
+            this.QueryCount++;
+
+            httpStatus = this.statusCode;
+
+            if (this.succeedAnonymously)
+            {
+                serverGVFSConfig = new ServerGVFSConfig();
+                errorMessage = null;
+                return true;
+            }
+
+            serverGVFSConfig = null;
+            errorMessage = "Mock config query failure";
+            return false;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

A mount can end up permanently unauthenticated, and only a remount clears it.

`GitAuthentication.TryInitializeAndQueryGVFSConfig` probes `/gvfs/config` without
credentials. The probe has three outcomes, but the code only handled two:

| Probe outcome | Meaning | Old behavior |
|---|---|---|
| 200 | Server allows anonymous access | `IsAnonymous = true` ✔ |
| 401 | Credentials required | `IsAnonymous = false` ✔ |
| **timeout / 5xx / socket error** | **Unknown** | **`IsAnonymous` left at its default `true`** ✘ |

The third case is indeterminate — it says nothing about authentication. Leaving
`IsAnonymous` at its `true` default silently downgrades the process to anonymous.

## Why it never recovers

`HttpRequestor.SendRequest` short-circuits on `IsAnonymous`:

```csharp
if (!this.authentication.IsAnonymous &&
    !this.authentication.TryGetCredentials(this.Tracer, out authString, out errorMessage))
```

So while `IsAnonymous` is true:

1. No `Authorization` header is sent, and `TryGetCredentials` is **never called** —
   `git credential fill` never runs, so no credential is ever fetched.
2. The Azure DevOps cache server answers with **400** and the body
   `A valid Basic Authorization header is required.`
3. A 400 is not retryable, so `RetryWrapper` aborts immediately.
4. `RejectCredentials` is a no-op, because its guard requires a non-null cached
   credential and none was ever cached.
5. `MarkInitialized()` already ran, so `TryInitializeAndQueryGVFSConfig` throws
   `InvalidOperationException("Already initialized")` if called again — the probe
   never re-runs.

Every recovery path is closed. The state persists for the life of the process.

## User impact

Mount does not fail on this, because when a cache server is configured
`InProcessMount` deliberately continues ("Mount will proceed with fallback cache
server"). The repo mounts and looks healthy, but cannot download objects or blob
sizes. Directory enumeration fails with `SizesUnavailableException`, so
`StartDirectoryEnumerationAsyncHandler` returns an error and **git reports tracked
files as deleted**. Each enumeration retries and fails identically, flooding the
mount log.

Observed on a large enlistment: the config query timed out at mount, then ~35,000
auth errors and ~29,600 `SizesUnavailableException` in roughly one hour, with the
mount log growing past 70 MB. `git status` showed millions of phantom deletions.
Zero `TryGetCredential` events appeared in the entire log, while a separate
`gvfs prefetch` process authenticated normally against the same repo at the same
time — the classic signature of the process being stuck anonymous. Remounting
fixed it immediately.

## The fix

Anonymous access becomes an affirmative determination: it requires a successful
unauthenticated probe.

- `IsAnonymous` now defaults to **false**.
- The indeterminate branch sets `IsAnonymous = false` explicitly and says so in
  the warning it traces.

If the server really does allow anonymous access, it ignores the `Authorization`
header GVFS sends after an indeterminate probe. The failure mode is now a
possible credential prompt instead of a mount that cannot serve files.

The default flip also closes a related gap: a request issued before initialization
completes previously went out anonymous. It now goes through `TryGetCredentials`,
which already waits on `initializationComplete`.

## Not a 2.0 regression

`v1.0.26098.1` has the same `!IsAnonymous && TryGetCredentials(...)` short-circuit
in `SendRequest` and the same `hasCacheServer` fallback in mount, and its
indeterminate branch also never assigns `IsAnonymous`. 1.0 reaches the identical
stuck-anonymous state. This targets `vnext` rather than `master`, because it
changes behavior on the authentication path for a long-standing defect rather than
repairing something 2.0 broke.

## Known tradeoff (reviewer input welcome)

After an indeterminate probe, a genuinely **anonymous** server is now latched into requiring credentials for the life of the process, because `MarkInitialized` prevents a re-probe. A server that permits anonymous access simply ignores the Authorization header, so the real exposure is narrow: an anonymous repo, with no cached credential, after a transient probe failure — which could newly prompt via GCM.

## Tests

`GitAuthenticationTests` — 6 tests covering all three probe outcomes plus the probe's own anonymity:

- `InitialConfigProbeIsSentWithoutCredentials` — **the regression test for the bug above.** Mirrors `SendRequest`'s credential gate exactly (`forceAnonymous || IsAnonymous`) and asserts no credential is requested during the probe. `InitializationWaitTimeoutMs` is lowered to 500 ms so a regression fails fast instead of hanging the suite.
- `AuthIsNotAnonymousBeforeInitialization` — pins the new default.
- `IndeterminateConfigProbeDoesNotLeaveAuthAnonymous` — five real `[TestCase(...)]` rows (`RequestTimeout`, `InternalServerError`, `ServiceUnavailable`, `BadRequest`, and no HTTP response) so each status reports independently.
- `IndeterminateConfigProbeStillAuthenticatesLaterRequests` — credentials remain obtainable afterward.
- `AnonymousConfigProbeSuccessLeavesAuthAnonymous`, `UnauthorizedConfigProbeRequiresAuthentication` — guards against over-correcting.

**Mutation testing, corrected.** The original description claimed each half of the fix independently failed three tests. That was wrong — it reflected a *combined* revert. Re-run per half:

| Mutation | Result |
| --- | --- |
| Remove `forceAnonymous: true` from the probe | fails `InitialConfigProbeIsSentWithoutCredentials` |
| Revert `IsAnonymous` default to `true` | fails `AuthIsNotAnonymousBeforeInitialization` (1 test, not 3) |
| Delete the explicit `IsAnonymous = false` on the indeterminate branch | **fails nothing** |

The third result is expected: with the default now `false`, that assignment cannot change behavior. It is kept as defensive symmetry so each branch states its own outcome, and is commented as such.

Full unit suite: **948 tests, 0 failed** (11 pre-existing ignored). StyleCop clean.

## Why no functional test

The repro needs `/gvfs/config` to fail transiently while the cache-server path stays reachable. The functional suite clones from a live server and has no HTTP fault-injection seam, and the config endpoint URL derives from the same `RepoUrl` as object downloads, so the two cannot be failed independently. A true end-to-end unit test is also not yet possible here: `HttpRequestor` has no `HttpMessageHandler` seam on `vnext` (#2082 adds one). The new test therefore mirrors the production gate rather than driving `SendRequest` directly.
