### PR TITLE
Report the real reason a mount fails instead of a broken pipe

### DIFF
--- a/GVFS/GVFS.Common/GVFSEnlistment.cs
+++ b/GVFS/GVFS.Common/GVFSEnlistment.cs
@@ -281,7 +281,9 @@ namespace GVFS.Common
                         }
                         else if (getStatusResponse.MountStatus == NamedPipeMessages.GetStatus.MountFailed)
                         {
-                            errorMessage = string.Format("Failed to mount at {0}", enlistmentRoot);
+                            errorMessage = !string.IsNullOrWhiteSpace(getStatusResponse.MountError)
+                                ? getStatusResponse.MountError
+                                : string.Format("Failed to mount at {0}", enlistmentRoot);
                             tracer.RelatedError($"{nameof(WaitUntilMounted)}: Mount failed: {errorMessage}");
                             return false;
                         }

--- a/GVFS/GVFS.Common/NamedPipes/MountFailureReporter.cs
+++ b/GVFS/GVFS.Common/NamedPipes/MountFailureReporter.cs
@@ -52,13 +52,13 @@ namespace GVFS.Common.NamedPipes
         /// <summary>
         /// Cap on how long to wait once a client is known to be polling.
         /// </summary>
-        public const int DefaultReportTimeoutMs = 2000;
+        internal const int DefaultReportTimeoutMs = 2000;
 
         /// <summary>
         /// Cap used when no client has received a status yet. It only has to cover the
         /// gap between the pipe opening and the client's first poll.
         /// </summary>
-        public const int DefaultNoClientTimeoutMs = 500;
+        internal const int DefaultNoClientTimeoutMs = 500;
 
         /// <summary>
         /// Grace period after a client reads the failure. Any client can satisfy the
@@ -66,7 +66,7 @@ namespace GVFS.Common.NamedPipes
         /// "gvfs status" polls the same pipe. Keeping this above the client's 100ms poll
         /// interval means the mounting client still gets its answer on its next poll.
         /// </summary>
-        public const int DefaultDrainMs = 150;
+        internal const int DefaultDrainMs = 150;
 
         private readonly ITracer tracer;
         private readonly int reportTimeoutMs;
@@ -216,6 +216,10 @@ namespace GVFS.Common.NamedPipes
 
         public void Dispose()
         {
+            // InProcessMount deliberately does not call this: it holds the reporter for
+            // the life of the process and leaves through Environment.Exit, which reclaims
+            // the handle. Do not dispose while a thread is inside
+            // WaitForClientToReadFailure -- WaitOne on a disposed handle throws.
             this.failureReported.Dispose();
         }
     }

--- a/GVFS/GVFS.Common/NamedPipes/MountFailureReporter.cs
+++ b/GVFS/GVFS.Common/NamedPipes/MountFailureReporter.cs
@@ -1,0 +1,222 @@
+using GVFS.Common.Tracing;
+using System;
+using System.Threading;
+
+namespace GVFS.Common.NamedPipes
+{
+    /// <summary>
+    /// The result of a thread trying to take ownership of the mount-failure path.
+    /// </summary>
+    public enum MountFailureOwnership
+    {
+        /// <summary>
+        /// The calling thread now owns reporting and must drive it to process exit.
+        /// </summary>
+        Owner,
+
+        /// <summary>
+        /// The calling thread already owned reporting and has re-entered, because
+        /// something threw while it was reporting and an outer catch block called back
+        /// in. It must not wait again: it would block forever on a signal that it is
+        /// itself responsible for observing.
+        /// </summary>
+        Reentrant,
+
+        /// <summary>
+        /// Another thread owns reporting and will exit the process. The calling thread
+        /// must not continue with a half-initialized mount.
+        /// </summary>
+        NotOwner,
+    }
+
+    /// <summary>
+    /// Server half of the mount-failure handshake: keeps a failed mount process alive
+    /// just long enough for a client to read the reason over the named pipe.
+    /// </summary>
+    /// <remarks>
+    /// Without this, the mount process sets <c>MountFailed</c> and exits immediately.
+    /// The client polls GetStatus every 100ms, so it usually loses the race, the pipe
+    /// breaks mid-request, and the user sees a transport error instead of the cause.
+    /// <para>
+    /// The wait is deliberately short. Until the process exits it still holds the mount
+    /// lock and the named pipe, so a longer wait delays the user's next mount attempt.
+    /// </para>
+    /// <para>
+    /// This type owns only the handshake state. Process-exit policy stays with the
+    /// caller. The client half of the same protocol is
+    /// <see cref="GVFSEnlistment.WaitUntilMounted(ITracer, string, string, bool, out string, Action{string})"/>.
+    /// </para>
+    /// </remarks>
+    public sealed class MountFailureReporter : IDisposable
+    {
+        /// <summary>
+        /// Cap on how long to wait once a client is known to be polling.
+        /// </summary>
+        public const int DefaultReportTimeoutMs = 2000;
+
+        /// <summary>
+        /// Cap used when no client has received a status yet. It only has to cover the
+        /// gap between the pipe opening and the client's first poll.
+        /// </summary>
+        public const int DefaultNoClientTimeoutMs = 500;
+
+        /// <summary>
+        /// Grace period after a client reads the failure. Any client can satisfy the
+        /// wait, and it is not necessarily the one that is mounting -- a concurrent
+        /// "gvfs status" polls the same pipe. Keeping this above the client's 100ms poll
+        /// interval means the mounting client still gets its answer on its next poll.
+        /// </summary>
+        public const int DefaultDrainMs = 150;
+
+        private readonly ITracer tracer;
+        private readonly int reportTimeoutMs;
+        private readonly int noClientTimeoutMs;
+        private readonly int drainMs;
+        private readonly ManualResetEvent failureReported;
+
+        private volatile string failureMessage;
+        private volatile bool namedPipeReady;
+        private volatile bool clientReceivedStatus;
+
+        // 0 means no thread owns the failure path yet.
+        private int owningThreadId;
+
+        public MountFailureReporter(ITracer tracer)
+            : this(tracer, DefaultReportTimeoutMs, DefaultNoClientTimeoutMs, DefaultDrainMs)
+        {
+        }
+
+        /// <summary>
+        /// Test constructor. Lets unit tests use short timeouts so they do not pay the
+        /// production waits.
+        /// </summary>
+        internal MountFailureReporter(ITracer tracer, int reportTimeoutMs, int noClientTimeoutMs, int drainMs)
+        {
+            this.tracer = tracer;
+            this.reportTimeoutMs = reportTimeoutMs;
+            this.noClientTimeoutMs = noClientTimeoutMs;
+            this.drainMs = drainMs;
+            this.failureReported = new ManualResetEvent(false);
+        }
+
+        /// <summary>
+        /// The reason the mount failed, or null if the mount has not failed. Sent to the
+        /// client in the GetStatus response.
+        /// </summary>
+        public string FailureMessage
+        {
+            get { return this.failureMessage; }
+        }
+
+        /// <summary>
+        /// Formats a failure message without letting the formatting itself throw.
+        /// </summary>
+        /// <remarks>
+        /// Callers pass messages built from external text (exception strings, server
+        /// responses) that can contain unbalanced braces. A FormatException here would
+        /// mask the failure being reported, so fall back to the unformatted string.
+        /// </remarks>
+        public static string FormatFailure(string error, object[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return error;
+            }
+
+            try
+            {
+                return string.Format(error, args);
+            }
+            catch (FormatException)
+            {
+                return error;
+            }
+        }
+
+        /// <summary>
+        /// Records that the named pipe server is accepting requests. Failures before this
+        /// point cannot be reported over the pipe and must not wait for a reader.
+        /// </summary>
+        public void OnNamedPipeReady()
+        {
+            this.namedPipeReady = true;
+        }
+
+        /// <summary>
+        /// Attempts to take ownership of the mount-failure path, publishing
+        /// <paramref name="message"/> as the reason if this call wins.
+        /// </summary>
+        public MountFailureOwnership TryTakeOwnership(string message)
+        {
+            int currentThreadId = Environment.CurrentManagedThreadId;
+            int previousOwner = Interlocked.CompareExchange(ref this.owningThreadId, currentThreadId, 0);
+
+            if (previousOwner == currentThreadId)
+            {
+                return MountFailureOwnership.Reentrant;
+            }
+
+            if (previousOwner != 0)
+            {
+                return MountFailureOwnership.NotOwner;
+            }
+
+            this.failureMessage = message;
+            return MountFailureOwnership.Owner;
+        }
+
+        /// <summary>
+        /// Records that a GetStatus response reached a client, and releases
+        /// <see cref="WaitForClientToReadFailure"/> when that response carried the
+        /// failure.
+        /// </summary>
+        /// <param name="carriedMountFailure">
+        /// True when the delivered response reported MountFailed.
+        /// </param>
+        public void OnStatusDelivered(bool carriedMountFailure)
+        {
+            // Only count a client that actually received a status. Recording this before
+            // the send succeeds would let a client that connected and then disconnected
+            // extend the post-failure wait.
+            this.clientReceivedStatus = true;
+
+            if (carriedMountFailure)
+            {
+                this.failureReported.Set();
+            }
+        }
+
+        /// <summary>
+        /// Blocks until a client has read the failure, or until a short timeout elapses.
+        /// Returns immediately when no client could possibly read it.
+        /// </summary>
+        public void WaitForClientToReadFailure()
+        {
+            if (!this.namedPipeReady)
+            {
+                // No client can read the failure. The caller detects this case by
+                // watching the mount process exit code instead.
+                return;
+            }
+
+            int timeoutMs = this.clientReceivedStatus ? this.reportTimeoutMs : this.noClientTimeoutMs;
+
+            if (this.failureReported.WaitOne(timeoutMs))
+            {
+                Thread.Sleep(this.drainMs);
+            }
+            else
+            {
+                this.tracer.RelatedWarning(
+                    null,
+                    $"{nameof(this.WaitForClientToReadFailure)}: No client read the mount failure within {timeoutMs}ms. Exiting anyway.",
+                    Keywords.Telemetry);
+            }
+        }
+
+        public void Dispose()
+        {
+            this.failureReported.Dispose();
+        }
+    }
+}

--- a/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
+++ b/GVFS/GVFS.Common/NamedPipes/NamedPipeMessages.cs
@@ -36,6 +36,14 @@ namespace GVFS.Common.NamedPipes
             {
                 public string MountStatus { get; set; }
                 public string MountProgress { get; set; }
+
+                /// <summary>
+                /// Why the mount failed. Set only when <see cref="MountStatus"/> is
+                /// <see cref="MountFailed"/>, so the client can report the real cause
+                /// instead of a generic failure message.
+                /// </summary>
+                public string MountError { get; set; }
+
                 public string EnlistmentRoot { get; set; }
                 public string LocalCacheRoot { get; set; }
                 public string RepoUrl { get; set; }

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -41,6 +41,19 @@ namespace GVFS.Mount
         // reliably trigger a commit pack download.
         private const int TrackedTreeCapacity = MissingTreeThresholdForDownloadingCommitPack * 20;
 
+        // Bounds how long a failed mount stays alive so a client can read the reason.
+        // Kept short on purpose: until the process exits it still holds the mount lock
+        // and its named pipe, so a user retrying "gvfs mount" would be told the repo is
+        // already mounted. The wait normally ends on the client's next poll (~100ms).
+        private const int MountFailureReportTimeoutMs = 2000;
+
+        // Used instead when no client has polled GetStatus yet. It only has to cover the
+        // narrow window between the pipe opening and MountVerb's first poll.
+        private const int MountFailureNoClientTimeoutMs = 500;
+
+        // Lets the response drain to the client before the pipe goes away.
+        private const int MountFailureDrainMs = 50;
+
         private readonly bool showDebugWindow;
 
         private FileSystemCallbacks fileSystemCallbacks;
@@ -58,6 +71,24 @@ namespace GVFS.Mount
 
         private volatile MountState currentState;
         private volatile string mountProgressMessage;
+
+        // Why the mount failed. Sent to the client in the GetStatus response so it can
+        // report the real cause rather than a generic "failed to mount" message.
+        private volatile string mountFailureMessage;
+
+        // Set once the named pipe server is accepting requests. Failures before that
+        // point cannot be reported over the pipe, so they must not wait for a reader.
+        private volatile bool namedPipeReady;
+
+        // Set once a client has polled GetStatus, which means somebody is waiting for
+        // the mount result and is worth holding the process open for.
+        private volatile bool clientPolledStatus;
+
+        // Signaled after a GetStatus response carrying MountFailed is written to a client.
+        private ManualResetEvent mountFailureReported;
+
+        // Ensures only the first thread to fail the mount tears down and exits.
+        private int mountFailureLatch;
 
         // When false (default), the mount process does not surface progress phase
         // strings over the named pipe, so the CLI falls back to its static spinner.
@@ -82,6 +113,7 @@ namespace GVFS.Mount
             this.enlistment = enlistment;
             this.showDebugWindow = showDebugWindow;
             this.unmountEvent = new ManualResetEvent(false);
+            this.mountFailureReported = new ManualResetEvent(false);
             this.missingTreeTracker = new MissingTreeTracker(tracer, TrackedTreeCapacity);
         }
 
@@ -258,6 +290,8 @@ namespace GVFS.Mount
             this.mountProgressMessage = "Authenticating and validating";
             using (NamedPipeServer pipeServer = this.StartNamedPipe())
             {
+                this.namedPipeReady = true;
+
                 this.tracer.RelatedEvent(
                     EventLevel.Informational,
                     $"{nameof(this.Mount)}_StartedNamedPipe",
@@ -633,6 +667,24 @@ namespace GVFS.Mount
             }
         }
 
+        private static string FormatMountFailure(string error, object[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return error;
+            }
+
+            try
+            {
+                return string.Format(error, args);
+            }
+            catch (FormatException)
+            {
+                // Never let message formatting mask the failure we are reporting.
+                return error;
+            }
+        }
+
         private void FailMountAndExit(string error, params object[] args)
         {
             this.FailMountAndExit(ReturnCode.GenericError, error, args);
@@ -640,6 +692,15 @@ namespace GVFS.Mount
 
         private void FailMountAndExit(ReturnCode returnCode, string error, params object[] args)
         {
+            if (Interlocked.CompareExchange(ref this.mountFailureLatch, 1, 0) != 0)
+            {
+                // Another thread already owns the failure path and will exit the process.
+                // Block rather than return: every caller of FailMountAndExit assumes it
+                // never returns and would otherwise run on with a half-initialized mount.
+                Thread.Sleep(Timeout.Infinite);
+            }
+
+            this.mountFailureMessage = FormatMountFailure(error, args);
             this.currentState = MountState.MountFailed;
 
             this.tracer.RelatedError(error, args);
@@ -649,13 +710,56 @@ namespace GVFS.Mount
                 Console.ReadLine();
             }
 
-            if (this.fileSystemCallbacks != null)
+            // Report the failure before tearing anything down. Disposal can be slow, and a
+            // secondary exception thrown from it would kill the process before the client
+            // ever reads the reason -- which is what made mount failures surface as
+            // BrokenPipeException instead of the real cause.
+            this.WaitForMountFailureToBeReported();
+
+            try
             {
-                this.fileSystemCallbacks.Dispose();
-                this.fileSystemCallbacks = null;
+                if (this.fileSystemCallbacks != null)
+                {
+                    this.fileSystemCallbacks.Dispose();
+                    this.fileSystemCallbacks = null;
+                }
+            }
+            catch (Exception e)
+            {
+                this.tracer.RelatedWarning($"{nameof(this.FailMountAndExit)}: Exception while disposing file system callbacks: {e}");
             }
 
             Environment.Exit((int)returnCode);
+        }
+
+        /// <summary>
+        /// Blocks until a client has read the MountFailed status, or until a short
+        /// timeout elapses. The process keeps the mount lock and the named pipe until it
+        /// exits, so this wait must stay short or it blocks the user's next mount attempt.
+        /// </summary>
+        private void WaitForMountFailureToBeReported()
+        {
+            if (!this.namedPipeReady)
+            {
+                // The pipe is not serving requests yet, so no client can read the
+                // failure. MountVerb detects this case by watching the mount process
+                // exit code instead.
+                return;
+            }
+
+            int timeoutMs = this.clientPolledStatus
+                ? MountFailureReportTimeoutMs
+                : MountFailureNoClientTimeoutMs;
+
+            if (this.mountFailureReported.WaitOne(timeoutMs))
+            {
+                Thread.Sleep(MountFailureDrainMs);
+            }
+            else
+            {
+                this.tracer.RelatedWarning(
+                    $"{nameof(this.WaitForMountFailureToBeReported)}: No client read the mount failure within {timeoutMs}ms. Exiting anyway.");
+            }
         }
 
         private T CreateOrReportAndExit<T>(Func<T> factory, string reportMessage)
@@ -1418,6 +1522,10 @@ namespace GVFS.Mount
 
         private void HandleGetStatusRequest(NamedPipeServer.Connection connection)
         {
+            this.clientPolledStatus = true;
+
+            MountState state = this.currentState;
+
             NamedPipeMessages.GetStatus.Response response = new NamedPipeMessages.GetStatus.Response();
             response.EnlistmentRoot = this.enlistment.WorkingDirectoryRoot;
             response.LocalCacheRoot = !string.IsNullOrWhiteSpace(this.enlistment.LocalCacheRoot) ? this.enlistment.LocalCacheRoot : this.enlistment.GitObjectsRoot;
@@ -1426,7 +1534,7 @@ namespace GVFS.Mount
             response.LockStatus = this.context?.Repository?.GVFSLock != null ? this.context.Repository.GVFSLock.GetStatus() : "Unavailable";
             response.DiskLayoutVersion = $"{GVFSPlatform.Instance.DiskLayoutUpgrade.Version.CurrentMajorVersion}.{GVFSPlatform.Instance.DiskLayoutUpgrade.Version.CurrentMinorVersion}";
 
-            switch (this.currentState)
+            switch (state)
             {
                 case MountState.Mounting:
                     response.MountStatus = NamedPipeMessages.GetStatus.Mounting;
@@ -1448,6 +1556,7 @@ namespace GVFS.Mount
 
                 case MountState.MountFailed:
                     response.MountStatus = NamedPipeMessages.GetStatus.MountFailed;
+                    response.MountError = this.mountFailureMessage;
                     break;
 
                 default:
@@ -1455,7 +1564,13 @@ namespace GVFS.Mount
                     break;
             }
 
-            connection.TrySendResponse(response.ToJson());
+            bool sent = connection.TrySendResponse(response.ToJson());
+
+            if (sent && state == MountState.MountFailed)
+            {
+                // The client now has the reason, so FailMountAndExit can stop waiting.
+                this.mountFailureReported.Set();
+            }
         }
 
         private void HandleUnmountRequest(NamedPipeServer.Connection connection)

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -41,22 +41,6 @@ namespace GVFS.Mount
         // reliably trigger a commit pack download.
         private const int TrackedTreeCapacity = MissingTreeThresholdForDownloadingCommitPack * 20;
 
-        // Bounds how long a failed mount stays alive so a client can read the reason.
-        // Kept short on purpose: until the process exits it still holds the mount lock
-        // and its named pipe, so a user retrying "gvfs mount" would be told the repo is
-        // already mounted. The wait normally ends on the client's next poll (~100ms).
-        private const int MountFailureReportTimeoutMs = 2000;
-
-        // Used instead when no client has polled GetStatus yet. It only has to cover the
-        // narrow window between the pipe opening and MountVerb's first poll.
-        private const int MountFailureNoClientTimeoutMs = 500;
-
-        // Lets the response drain, and covers the case where a different client (a
-        // concurrent "gvfs status") consumed the report signal. It must exceed the
-        // client's 100ms GetStatus poll interval so the mounting client still gets its
-        // answer on the next poll.
-        private const int MountFailureDrainMs = 150;
-
         private readonly bool showDebugWindow;
 
         private FileSystemCallbacks fileSystemCallbacks;
@@ -75,24 +59,9 @@ namespace GVFS.Mount
         private volatile MountState currentState;
         private volatile string mountProgressMessage;
 
-        // Why the mount failed. Sent to the client in the GetStatus response so it can
-        // report the real cause rather than a generic "failed to mount" message.
-        private volatile string mountFailureMessage;
-
-        // Set once the named pipe server is accepting requests. Failures before that
-        // point cannot be reported over the pipe, so they must not wait for a reader.
-        private volatile bool namedPipeReady;
-
-        // Set once a client has polled GetStatus, which means somebody is waiting for
-        // the mount result and is worth holding the process open for.
-        private volatile bool clientPolledStatus;
-
-        // Signaled after a GetStatus response carrying MountFailed is written to a client.
-        private ManualResetEvent mountFailureReported;
-
-        // Identifies the thread that owns the mount-failure path, so a re-entrant call on
-        // that same thread exits instead of waiting on itself. 0 means no owner yet.
-        private int mountFailureOwnerThreadId;
+        // Keeps the pipe answering GetStatus after a failure so the client can read the
+        // reason, instead of racing this process to exit and seeing a broken pipe.
+        private readonly MountFailureReporter mountFailureReporter;
 
         // When false (default), the mount process does not surface progress phase
         // strings over the named pipe, so the CLI falls back to its static spinner.
@@ -117,7 +86,7 @@ namespace GVFS.Mount
             this.enlistment = enlistment;
             this.showDebugWindow = showDebugWindow;
             this.unmountEvent = new ManualResetEvent(false);
-            this.mountFailureReported = new ManualResetEvent(false);
+            this.mountFailureReporter = new MountFailureReporter(tracer);
             this.missingTreeTracker = new MissingTreeTracker(tracer, TrackedTreeCapacity);
         }
 
@@ -294,7 +263,7 @@ namespace GVFS.Mount
             this.mountProgressMessage = "Authenticating and validating";
             using (NamedPipeServer pipeServer = this.StartNamedPipe())
             {
-                this.namedPipeReady = true;
+                this.mountFailureReporter.OnNamedPipeReady();
 
                 this.tracer.RelatedEvent(
                     EventLevel.Informational,
@@ -671,24 +640,6 @@ namespace GVFS.Mount
             }
         }
 
-        private static string FormatMountFailure(string error, object[] args)
-        {
-            if (args == null || args.Length == 0)
-            {
-                return error;
-            }
-
-            try
-            {
-                return string.Format(error, args);
-            }
-            catch (FormatException)
-            {
-                // Never let message formatting mask the failure we are reporting.
-                return error;
-            }
-        }
-
         private void FailMountAndExit(string error, params object[] args)
         {
             this.FailMountAndExit(ReturnCode.GenericError, error, args);
@@ -696,36 +647,31 @@ namespace GVFS.Mount
 
         private void FailMountAndExit(ReturnCode returnCode, string error, params object[] args)
         {
-            // Format before taking the latch. RelatedError would otherwise format a second
+            // Format before taking ownership. RelatedError would otherwise format a second
             // time without protection, and a throw there would re-enter this method from an
             // outer catch block.
-            string failureMessage = FormatMountFailure(error, args);
+            string failureMessage = MountFailureReporter.FormatFailure(error, args);
 
-            int currentThreadId = Environment.CurrentManagedThreadId;
-            int owningThreadId = Interlocked.CompareExchange(ref this.mountFailureOwnerThreadId, currentThreadId, 0);
-
-            if (owningThreadId == currentThreadId)
+            switch (this.mountFailureReporter.TryTakeOwnership(failureMessage))
             {
-                // Re-entered on the reporting thread, because something below threw and an
-                // outer catch called back in. The failure was already reported, so exit
-                // rather than wait again -- waiting here would block forever on a signal
-                // this thread is itself responsible for observing.
-                this.tracer.RelatedWarning(
-                    null,
-                    $"{nameof(this.FailMountAndExit)}: Re-entered while reporting a mount failure: {failureMessage}",
-                    Keywords.Telemetry);
-                Environment.Exit((int)returnCode);
+                case MountFailureOwnership.Reentrant:
+                    // Something below threw and an outer catch called back in. The failure
+                    // was already reported, so exit rather than wait on ourselves.
+                    this.tracer.RelatedWarning(
+                        null,
+                        $"{nameof(this.FailMountAndExit)}: Re-entered while reporting a mount failure: {failureMessage}",
+                        Keywords.Telemetry);
+                    Environment.Exit((int)returnCode);
+                    break;
+
+                case MountFailureOwnership.NotOwner:
+                    // Another thread owns the failure path and will exit the process. Block
+                    // rather than return: every caller of FailMountAndExit assumes it never
+                    // returns and would otherwise run on with a half-initialized mount.
+                    BlockUntilProcessExits();
+                    break;
             }
 
-            if (owningThreadId != 0)
-            {
-                // Another thread owns the failure path and will exit the process. Block
-                // rather than return: every caller of FailMountAndExit assumes it never
-                // returns and would otherwise run on with a half-initialized mount.
-                BlockUntilProcessExits();
-            }
-
-            this.mountFailureMessage = failureMessage;
             this.currentState = MountState.MountFailed;
 
             this.tracer.RelatedError(failureMessage);
@@ -739,7 +685,7 @@ namespace GVFS.Mount
             // secondary exception thrown from it would kill the process before the client
             // ever reads the reason -- which is what made mount failures surface as
             // BrokenPipeException instead of the real cause.
-            this.WaitForMountFailureToBeReported();
+            this.mountFailureReporter.WaitForClientToReadFailure();
 
             try
             {
@@ -769,42 +715,6 @@ namespace GVFS.Mount
         private static void BlockUntilProcessExits()
         {
             Thread.Sleep(Timeout.Infinite);
-        }
-
-        /// <summary>
-        /// Blocks until a client has read the MountFailed status, or until a short
-        /// timeout elapses. The process keeps the mount lock and the named pipe until it
-        /// exits, so this wait must stay short or it blocks the user's next mount attempt.
-        /// </summary>
-        private void WaitForMountFailureToBeReported()
-        {
-            if (!this.namedPipeReady)
-            {
-                // The pipe is not serving requests yet, so no client can read the
-                // failure. MountVerb detects this case by watching the mount process
-                // exit code instead.
-                return;
-            }
-
-            int timeoutMs = this.clientPolledStatus
-                ? MountFailureReportTimeoutMs
-                : MountFailureNoClientTimeoutMs;
-
-            if (this.mountFailureReported.WaitOne(timeoutMs))
-            {
-                // Any client can satisfy the wait, and the one that read the failure is not
-                // necessarily the one that is mounting -- a concurrent "gvfs status" polls
-                // the same pipe. Staying alive for longer than the client's poll interval
-                // means the mounting client still gets its answer on its next poll.
-                Thread.Sleep(MountFailureDrainMs);
-            }
-            else
-            {
-                this.tracer.RelatedWarning(
-                    null,
-                    $"{nameof(this.WaitForMountFailureToBeReported)}: No client read the mount failure within {timeoutMs}ms. Exiting anyway.",
-                    Keywords.Telemetry);
-            }
         }
 
         private T CreateOrReportAndExit<T>(Func<T> factory, string reportMessage)
@@ -1599,7 +1509,7 @@ namespace GVFS.Mount
 
                 case MountState.MountFailed:
                     response.MountStatus = NamedPipeMessages.GetStatus.MountFailed;
-                    response.MountError = this.mountFailureMessage;
+                    response.MountError = this.mountFailureReporter.FailureMessage;
                     break;
 
                 default:
@@ -1611,16 +1521,7 @@ namespace GVFS.Mount
 
             if (sent)
             {
-                // Only count a client that actually received a status. Setting this on
-                // entry would let a client that connected and then disconnected extend the
-                // post-failure wait.
-                this.clientPolledStatus = true;
-
-                if (state == MountState.MountFailed)
-                {
-                    // The client now has the reason, so FailMountAndExit can stop waiting.
-                    this.mountFailureReported.Set();
-                }
+                this.mountFailureReporter.OnStatusDelivered(carriedMountFailure: state == MountState.MountFailed);
             }
         }
 

--- a/GVFS/GVFS.Mount/InProcessMount.cs
+++ b/GVFS/GVFS.Mount/InProcessMount.cs
@@ -51,8 +51,11 @@ namespace GVFS.Mount
         // narrow window between the pipe opening and MountVerb's first poll.
         private const int MountFailureNoClientTimeoutMs = 500;
 
-        // Lets the response drain to the client before the pipe goes away.
-        private const int MountFailureDrainMs = 50;
+        // Lets the response drain, and covers the case where a different client (a
+        // concurrent "gvfs status") consumed the report signal. It must exceed the
+        // client's 100ms GetStatus poll interval so the mounting client still gets its
+        // answer on the next poll.
+        private const int MountFailureDrainMs = 150;
 
         private readonly bool showDebugWindow;
 
@@ -87,8 +90,9 @@ namespace GVFS.Mount
         // Signaled after a GetStatus response carrying MountFailed is written to a client.
         private ManualResetEvent mountFailureReported;
 
-        // Ensures only the first thread to fail the mount tears down and exits.
-        private int mountFailureLatch;
+        // Identifies the thread that owns the mount-failure path, so a re-entrant call on
+        // that same thread exits instead of waiting on itself. 0 means no owner yet.
+        private int mountFailureOwnerThreadId;
 
         // When false (default), the mount process does not surface progress phase
         // strings over the named pipe, so the CLI falls back to its static spinner.
@@ -692,18 +696,39 @@ namespace GVFS.Mount
 
         private void FailMountAndExit(ReturnCode returnCode, string error, params object[] args)
         {
-            if (Interlocked.CompareExchange(ref this.mountFailureLatch, 1, 0) != 0)
+            // Format before taking the latch. RelatedError would otherwise format a second
+            // time without protection, and a throw there would re-enter this method from an
+            // outer catch block.
+            string failureMessage = FormatMountFailure(error, args);
+
+            int currentThreadId = Environment.CurrentManagedThreadId;
+            int owningThreadId = Interlocked.CompareExchange(ref this.mountFailureOwnerThreadId, currentThreadId, 0);
+
+            if (owningThreadId == currentThreadId)
             {
-                // Another thread already owns the failure path and will exit the process.
-                // Block rather than return: every caller of FailMountAndExit assumes it
-                // never returns and would otherwise run on with a half-initialized mount.
-                Thread.Sleep(Timeout.Infinite);
+                // Re-entered on the reporting thread, because something below threw and an
+                // outer catch called back in. The failure was already reported, so exit
+                // rather than wait again -- waiting here would block forever on a signal
+                // this thread is itself responsible for observing.
+                this.tracer.RelatedWarning(
+                    null,
+                    $"{nameof(this.FailMountAndExit)}: Re-entered while reporting a mount failure: {failureMessage}",
+                    Keywords.Telemetry);
+                Environment.Exit((int)returnCode);
             }
 
-            this.mountFailureMessage = FormatMountFailure(error, args);
+            if (owningThreadId != 0)
+            {
+                // Another thread owns the failure path and will exit the process. Block
+                // rather than return: every caller of FailMountAndExit assumes it never
+                // returns and would otherwise run on with a half-initialized mount.
+                BlockUntilProcessExits();
+            }
+
+            this.mountFailureMessage = failureMessage;
             this.currentState = MountState.MountFailed;
 
-            this.tracer.RelatedError(error, args);
+            this.tracer.RelatedError(failureMessage);
             if (this.showDebugWindow)
             {
                 Console.WriteLine("\nPress Enter to Exit");
@@ -726,10 +751,24 @@ namespace GVFS.Mount
             }
             catch (Exception e)
             {
-                this.tracer.RelatedWarning($"{nameof(this.FailMountAndExit)}: Exception while disposing file system callbacks: {e}");
+                // Traced with Telemetry because this used to be a process-fatal crash. Without
+                // the keyword the failure it replaced would become invisible in the field.
+                this.tracer.RelatedWarning(
+                    null,
+                    $"{nameof(this.FailMountAndExit)}: Exception while disposing file system callbacks: {e}",
+                    Keywords.Telemetry);
             }
 
             Environment.Exit((int)returnCode);
+        }
+
+        /// <summary>
+        /// Parks the calling thread until another thread exits the process. Used where a
+        /// method must not return but is not the thread that owns the exit.
+        /// </summary>
+        private static void BlockUntilProcessExits()
+        {
+            Thread.Sleep(Timeout.Infinite);
         }
 
         /// <summary>
@@ -753,12 +792,18 @@ namespace GVFS.Mount
 
             if (this.mountFailureReported.WaitOne(timeoutMs))
             {
+                // Any client can satisfy the wait, and the one that read the failure is not
+                // necessarily the one that is mounting -- a concurrent "gvfs status" polls
+                // the same pipe. Staying alive for longer than the client's poll interval
+                // means the mounting client still gets its answer on its next poll.
                 Thread.Sleep(MountFailureDrainMs);
             }
             else
             {
                 this.tracer.RelatedWarning(
-                    $"{nameof(this.WaitForMountFailureToBeReported)}: No client read the mount failure within {timeoutMs}ms. Exiting anyway.");
+                    null,
+                    $"{nameof(this.WaitForMountFailureToBeReported)}: No client read the mount failure within {timeoutMs}ms. Exiting anyway.",
+                    Keywords.Telemetry);
             }
         }
 
@@ -1522,8 +1567,6 @@ namespace GVFS.Mount
 
         private void HandleGetStatusRequest(NamedPipeServer.Connection connection)
         {
-            this.clientPolledStatus = true;
-
             MountState state = this.currentState;
 
             NamedPipeMessages.GetStatus.Response response = new NamedPipeMessages.GetStatus.Response();
@@ -1566,10 +1609,18 @@ namespace GVFS.Mount
 
             bool sent = connection.TrySendResponse(response.ToJson());
 
-            if (sent && state == MountState.MountFailed)
+            if (sent)
             {
-                // The client now has the reason, so FailMountAndExit can stop waiting.
-                this.mountFailureReported.Set();
+                // Only count a client that actually received a status. Setting this on
+                // entry would let a client that connected and then disconnected extend the
+                // post-failure wait.
+                this.clientPolledStatus = true;
+
+                if (state == MountState.MountFailed)
+                {
+                    // The client now has the reason, so FailMountAndExit can stop waiting.
+                    this.mountFailureReported.Set();
+                }
             }
         }
 

--- a/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
+++ b/GVFS/GVFS.Platform.Windows/HResultExtensions.cs
@@ -6,6 +6,12 @@ namespace GVFS.Platform.Windows
     {
         public const int GenericProjFSError = -2147024579; // returned by ProjFS::DeleteFile() on Win server 2016 while deleting a partial file
 
+        // HRESULT_FROM_WIN32(ERROR_FILE_SYSTEM_VIRTUALIZATION_NOT_AVAILABLE (478)):
+        // "The file system minifilter cannot attach to the developer volume." Returned by
+        // StartVirtualizing when PrjFlt is not on the volume's allowed-filter list, which
+        // is the default on a ReFS Dev Drive.
+        public const int FileSystemVirtualizationNotAvailable = unchecked((int)0x800701DE);
+
         private const int FacilityNtBit = 0x10000000; // FACILITY_NT_BIT
         private const int FacilityWin32 = 7;          // FACILITY_WIN32
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -836,6 +836,14 @@ namespace GVFS.Platform.Windows
             {
                 this.Context.Tracer.RelatedError($"{nameof(this.virtualizationInstance.StartVirtualizing)} failed: " + result.ToString("X") + "(" + result.ToString("G") + ")");
                 error = "Failed to start virtualization instance (" + result.ToString() + ")";
+
+                if ((int)result == HResultExtensions.FileSystemVirtualizationNotAvailable)
+                {
+                    error += ". The ProjFS filter (PrjFlt) cannot attach to this volume. "
+                        + "If the enlistment is on a Dev Drive, allow the filter on that volume from an elevated command prompt: "
+                        + "fsutil devdrv setfiltersallowed PrjFlt";
+                }
+
                 return false;
             }
 

--- a/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
+++ b/GVFS/GVFS.Platform.Windows/WindowsFileSystemVirtualizer.cs
@@ -839,9 +839,7 @@ namespace GVFS.Platform.Windows
 
                 if ((int)result == HResultExtensions.FileSystemVirtualizationNotAvailable)
                 {
-                    error += ". The ProjFS filter (PrjFlt) cannot attach to this volume. "
-                        + "If the enlistment is on a Dev Drive, allow the filter on that volume from an elevated command prompt: "
-                        + "fsutil devdrv setfiltersallowed PrjFlt";
+                    error += ". " + BuildProjFsAttachRemedy(this.Context.Enlistment.WorkingDirectoryRoot);
                 }
 
                 return false;
@@ -853,6 +851,48 @@ namespace GVFS.Platform.Windows
         protected override void OnPossibleTombstoneFolderCreated(string relativePath)
         {
             this.FileSystemCallbacks.OnPossibleTombstoneFolderCreated(relativePath);
+        }
+
+        /// <summary>
+        /// Builds the user-facing remedy for
+        /// ERROR_FILE_SYSTEM_VIRTUALIZATION_NOT_AVAILABLE, which a Dev Drive returns when
+        /// PrjFlt is not on its allowed-filter list.
+        /// </summary>
+        /// <remarks>
+        /// "fsutil devdrv setFiltersAllowed" REPLACES the allowed list, and without
+        /// /volume it replaces the list for every developer volume on the machine. So the
+        /// message must tell the user to read the current list first and include it, or
+        /// following this advice would drop filters the machine already requires (an
+        /// anti-malware filter, for example).
+        /// </remarks>
+        private static string BuildProjFsAttachRemedy(string enlistmentRoot)
+        {
+            string volume;
+            try
+            {
+                volume = Path.GetPathRoot(enlistmentRoot)?.TrimEnd(Path.DirectorySeparatorChar);
+            }
+            catch (ArgumentException)
+            {
+                volume = null;
+            }
+
+            if (string.IsNullOrEmpty(volume))
+            {
+                volume = "<volume>";
+            }
+
+            return "The ProjFS filter (PrjFlt) cannot attach to this volume. "
+                + $"If {volume} is a Dev Drive, PrjFlt must be on its allowed-filter list. "
+                + "From an elevated command prompt, list the filters that are already allowed:"
+                + Environment.NewLine
+                + $"    fsutil devdrv query {volume}"
+                + Environment.NewLine
+                + "then set the list again with PrjFlt added to it:"
+                + Environment.NewLine
+                + $"    fsutil devdrv setFiltersAllowed /f /volume {volume} \"<filters listed above>,PrjFlt\""
+                + Environment.NewLine
+                + "setFiltersAllowed replaces the list, so keep the existing entries";
         }
 
         private static void StreamCopyBlockTo(Stream input, Stream destination, long numBytes, byte[] buffer)

--- a/GVFS/GVFS.UnitTests/Common/MountFailureReporterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/MountFailureReporterTests.cs
@@ -1,0 +1,205 @@
+using GVFS.Common.NamedPipes;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Common
+{
+    /// <summary>
+    /// Covers the server half of the mount-failure handshake. Before this state machine
+    /// was extracted from InProcessMount it lived in GVFS.Mount, which GVFS.UnitTests
+    /// cannot reference, so none of it was covered.
+    /// </summary>
+    [TestFixture]
+    public class MountFailureReporterTests
+    {
+        private const int ReportTimeoutMs = 2000;
+        private const int NoClientTimeoutMs = 200;
+        private const int DrainMs = 20;
+
+        [TestCase]
+        public void FirstThreadTakesOwnershipAndPublishesTheMessage()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.FailureMessage.ShouldBeNull();
+
+                reporter.TryTakeOwnership("the real reason").ShouldEqual(MountFailureOwnership.Owner);
+                reporter.FailureMessage.ShouldEqual("the real reason");
+            }
+        }
+
+        [TestCase]
+        public void SameThreadCallingTwiceIsReentrantRatherThanBlocked()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.TryTakeOwnership("first").ShouldEqual(MountFailureOwnership.Owner);
+
+                // A throw inside the reporting path can make an outer catch block call
+                // back in on the same thread. That must not be treated as a second thread,
+                // or the caller would park forever holding the mount lock and the pipe.
+                reporter.TryTakeOwnership("second").ShouldEqual(MountFailureOwnership.Reentrant);
+
+                // The re-entrant call must not overwrite the reason already published.
+                reporter.FailureMessage.ShouldEqual("first");
+            }
+        }
+
+        [TestCase]
+        public void SecondThreadIsNotTheOwner()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.TryTakeOwnership("first").ShouldEqual(MountFailureOwnership.Owner);
+
+                MountFailureOwnership fromOtherThread = MountFailureOwnership.Owner;
+                Task other = Task.Run(() => fromOtherThread = reporter.TryTakeOwnership("second"));
+                other.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+                fromOtherThread.ShouldEqual(MountFailureOwnership.NotOwner);
+                reporter.FailureMessage.ShouldEqual("first");
+            }
+        }
+
+        [TestCase]
+        public void WaitReturnsImmediatelyWhenThePipeNeverOpened()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.TryTakeOwnership("failed before the pipe opened");
+
+                // No client can read the failure, so the process must not linger holding
+                // the mount lock. The caller falls back to the process exit code.
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(NoClientTimeoutMs));
+            }
+        }
+
+        [TestCase]
+        public void WaitUsesTheShortTimeoutWhenNoClientHasReceivedAStatus()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.OnNamedPipeReady();
+                reporter.TryTakeOwnership("nobody is listening");
+
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                // Should give up after the no-client timeout, well short of the full one.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(NoClientTimeoutMs - 50));
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(ReportTimeoutMs));
+            }
+        }
+
+        [TestCase]
+        public void WaitReturnsOnceAClientReadsTheFailure()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.OnNamedPipeReady();
+                reporter.TryTakeOwnership("the real reason");
+                reporter.OnStatusDelivered(carriedMountFailure: true);
+
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                // Returns as soon as the failure was delivered, plus the drain.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(NoClientTimeoutMs));
+            }
+        }
+
+        [TestCase]
+        public void DeliveringANonFailureStatusDoesNotReleaseTheWait()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.OnNamedPipeReady();
+
+                // A client polled while the mount was still in progress. That proves
+                // somebody is listening, but it did not carry the failure.
+                reporter.OnStatusDelivered(carriedMountFailure: false);
+                reporter.TryTakeOwnership("the real reason");
+
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                // Must wait for the failure itself to be read, using the longer timeout
+                // because a client is known to be polling.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(ReportTimeoutMs - 100));
+            }
+        }
+
+        [TestCase]
+        public void WaitIsReleasedByAClientThatReadsTheFailureLater()
+        {
+            using (MountFailureReporter reporter = CreateReporter())
+            {
+                reporter.OnNamedPipeReady();
+                reporter.OnStatusDelivered(carriedMountFailure: false);
+                reporter.TryTakeOwnership("the real reason");
+
+                Task client = Task.Run(() =>
+                {
+                    Thread.Sleep(100);
+                    reporter.OnStatusDelivered(carriedMountFailure: true);
+                });
+
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                client.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+                // Released by the delivery, not by the timeout.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(ReportTimeoutMs - 100));
+            }
+        }
+
+        [TestCase]
+        public void FormatFailureAppliesArguments()
+        {
+            MountFailureReporter.FormatFailure("Error: {0}", new object[] { "boom" })
+                .ShouldEqual("Error: boom");
+        }
+
+        [TestCase]
+        public void FormatFailureLeavesTheMessageAloneWhenThereAreNoArguments()
+        {
+            // A pre-built message can legitimately contain braces, so it must not be run
+            // through string.Format when there is nothing to substitute.
+            MountFailureReporter.FormatFailure("a message with {braces} in it", null)
+                .ShouldEqual("a message with {braces} in it");
+
+            MountFailureReporter.FormatFailure("a message with {braces} in it", new object[0])
+                .ShouldEqual("a message with {braces} in it");
+        }
+
+        [TestCase]
+        public void FormatFailureFallsBackWhenTheFormatStringIsMalformed()
+        {
+            // Failure text is built from exception messages and server responses, which
+            // can contain unbalanced braces. Formatting must never throw and mask the
+            // failure being reported.
+            string result = MountFailureReporter.FormatFailure("unbalanced {0} and {", new object[] { "value" });
+
+            result.ShouldEqual("unbalanced {0} and {");
+        }
+
+        private static MountFailureReporter CreateReporter()
+        {
+            return new MountFailureReporter(new MockTracer(), ReportTimeoutMs, NoClientTimeoutMs, DrainMs);
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/MountFailureReporterTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/MountFailureReporterTests.cs
@@ -17,7 +17,10 @@ namespace GVFS.UnitTests.Common
     [TestFixture]
     public class MountFailureReporterTests
     {
-        private const int ReportTimeoutMs = 2000;
+        // Deliberately much smaller than the production defaults: these only have to be
+        // far enough apart to tell the two timeout paths apart, and one test has to wait
+        // the long one out in real time.
+        private const int ReportTimeoutMs = 600;
         private const int NoClientTimeoutMs = 200;
         private const int DrainMs = 20;
 
@@ -96,7 +99,7 @@ namespace GVFS.UnitTests.Common
                 elapsed.Stop();
 
                 // Should give up after the no-client timeout, well short of the full one.
-                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(NoClientTimeoutMs - 50));
+                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThan(NoClientTimeoutMs / 2));
                 Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(ReportTimeoutMs));
             }
         }
@@ -136,8 +139,9 @@ namespace GVFS.UnitTests.Common
                 elapsed.Stop();
 
                 // Must wait for the failure itself to be read, using the longer timeout
-                // because a client is known to be polling.
-                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(ReportTimeoutMs - 100));
+                // because a client is known to be polling. Asserting above the SHORT
+                // timeout is what proves the long path was selected.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThan(NoClientTimeoutMs * 2));
             }
         }
 
@@ -152,7 +156,7 @@ namespace GVFS.UnitTests.Common
 
                 Task client = Task.Run(() =>
                 {
-                    Thread.Sleep(100);
+                    Thread.Sleep(50);
                     reporter.OnStatusDelivered(carriedMountFailure: true);
                 });
 
@@ -163,8 +167,50 @@ namespace GVFS.UnitTests.Common
                 client.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
                 // Released by the delivery, not by the timeout.
-                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(ReportTimeoutMs - 100));
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(ReportTimeoutMs));
             }
+        }
+
+        [TestCase]
+        public void ProductionDefaultsSelectTheShorterTimeoutWhenNoClientIsListening()
+        {
+            // Everything else builds the reporter through the internal test constructor,
+            // so this is the only cover for the public constructor and its forwarding of
+            // the Default* constants. Without it, swapping DefaultReportTimeoutMs and
+            // DefaultNoClientTimeoutMs would ship unnoticed.
+            using (MountFailureReporter reporter = new MountFailureReporter(new MockTracer()))
+            {
+                reporter.OnNamedPipeReady();
+                reporter.TryTakeOwnership("nobody is listening");
+
+                Stopwatch elapsed = Stopwatch.StartNew();
+                reporter.WaitForClientToReadFailure();
+                elapsed.Stop();
+
+                // The no-client timeout must be the one used, and it must be meaningfully
+                // shorter than the timeout used once a client is known to be polling.
+                Assert.That(elapsed.ElapsedMilliseconds, Is.GreaterThan(MountFailureReporter.DefaultNoClientTimeoutMs / 2));
+                Assert.That(elapsed.ElapsedMilliseconds, Is.LessThan(MountFailureReporter.DefaultReportTimeoutMs));
+            }
+        }
+
+        [TestCase]
+        public void ProductionDefaultsAreOrderedSensibly()
+        {
+            // A failed mount holds the mount lock and the named pipe until it exits, so
+            // these bound how long a user's next "gvfs mount" is delayed.
+            Assert.That(
+                MountFailureReporter.DefaultNoClientTimeoutMs,
+                Is.LessThan(MountFailureReporter.DefaultReportTimeoutMs),
+                "Waiting for a client that has never polled must not take longer than waiting for one that has.");
+
+            // The drain has to outlast the client's 100ms GetStatus poll interval, or a
+            // concurrent "gvfs status" can consume the report signal and the mounting
+            // client never gets its answer.
+            Assert.That(
+                MountFailureReporter.DefaultDrainMs,
+                Is.GreaterThan(100),
+                "The drain must exceed the client's GetStatus poll interval.");
         }
 
         [TestCase]

--- a/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
@@ -1,0 +1,98 @@
+using GVFS.Common;
+using GVFS.Common.NamedPipes;
+using GVFS.Tests.Should;
+using GVFS.UnitTests.Mock.Common;
+using NUnit.Framework;
+using System;
+using System.IO.Pipes;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Common
+{
+    [TestFixture]
+    public class WaitUntilMountedFailureReportingTests
+    {
+        private const string EnlistmentRoot = "C:\\fake\\root";
+
+        [TestCase]
+        public void ReportsTheMountErrorSentByTheMountProcess()
+        {
+            const string MountError =
+                "Error: Failed to start virtualization instance (-2147024418). "
+                + "The ProjFS filter (PrjFlt) cannot attach to this volume.";
+
+            string errorMessage = RunAgainstMountFailedServer(MountError);
+
+            errorMessage.ShouldEqual(MountError);
+        }
+
+        [TestCase]
+        public void FallsBackToGenericMessageWhenNoMountErrorIsSent()
+        {
+            string errorMessage = RunAgainstMountFailedServer(mountError: null);
+
+            errorMessage.ShouldEqual("Failed to mount at " + EnlistmentRoot);
+        }
+
+        /// <summary>
+        /// Stands in for GVFS.Mount: answers a single GetStatus request with MountFailed,
+        /// then returns the error message WaitUntilMounted produced.
+        /// </summary>
+        /// <remarks>
+        /// Uses a raw <see cref="NamedPipeServerStream"/> rather than
+        /// <see cref="NamedPipeServer"/>, because the latter goes through
+        /// GVFSPlatform.CreatePipeByName, which the unit-test mock platform does not
+        /// support.
+        /// </remarks>
+        private static string RunAgainstMountFailedServer(string mountError)
+        {
+            string pipeName = "GVFS_test_mount_failed_" + Guid.NewGuid().ToString("N");
+
+            NamedPipeMessages.GetStatus.Response response = new NamedPipeMessages.GetStatus.Response
+            {
+                MountStatus = NamedPipeMessages.GetStatus.MountFailed,
+                MountError = mountError,
+                EnlistmentRoot = EnlistmentRoot,
+            };
+
+            string responseJson = response.ToJson();
+
+            using (NamedPipeServerStream serverStream = new NamedPipeServerStream(
+                pipeName,
+                PipeDirection.InOut,
+                maxNumberOfServerInstances: 1))
+            {
+                Task serverTask = Task.Run(() =>
+                {
+                    serverStream.WaitForConnection();
+
+                    NamedPipeStreamReader reader = new NamedPipeStreamReader(serverStream);
+                    NamedPipeStreamWriter writer = new NamedPipeStreamWriter(serverStream);
+
+                    // WaitUntilMounted sends GetStatus and stops on the first
+                    // MountFailed response, so one exchange is enough.
+                    reader.ReadMessage();
+                    writer.WriteMessage(responseJson);
+                });
+
+                try
+                {
+                    string errorMessage;
+                    bool result = GVFSEnlistment.WaitUntilMounted(
+                        new MockTracer(),
+                        pipeName,
+                        EnlistmentRoot,
+                        unattended: false,
+                        out errorMessage);
+
+                    result.ShouldBeFalse();
+                    return errorMessage;
+                }
+                finally
+                {
+                    serverTask.Wait(TimeSpan.FromSeconds(30));
+                }
+            }
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
@@ -90,7 +90,7 @@ namespace GVFS.UnitTests.Common
                 }
                 finally
                 {
-                    serverTask.Wait(TimeSpan.FromSeconds(30));
+                    serverTask.Wait(TimeSpan.FromSeconds(5));
                 }
             }
         }

--- a/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
+++ b/GVFS/GVFS.UnitTests/Common/WaitUntilMountedFailureReportingTests.cs
@@ -90,7 +90,11 @@ namespace GVFS.UnitTests.Common
                 }
                 finally
                 {
-                    serverTask.Wait(TimeSpan.FromSeconds(5));
+                    // Surfaces a hung server task instead of silently disposing the stream
+                    // out from under it, which would fault an unobserved task and hide the
+                    // real cause of a failure.
+                    serverTask.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue(
+                        "The stand-in mount server should have answered and completed.");
                 }
             }
         }

--- a/GVFS/GVFS.UnitTests/Virtualization/Background/BackgroundFileSystemTaskRunnerDisposeTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Background/BackgroundFileSystemTaskRunnerDisposeTests.cs
@@ -1,0 +1,45 @@
+using GVFS.Virtualization.Background;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Virtualization.Background
+{
+    [TestFixture]
+    public class BackgroundFileSystemTaskRunnerDisposeTests
+    {
+        [TestCase]
+        public void DisposeDoesNotThrowWhenBackgroundThreadIsStillRunning()
+        {
+            using (ManualResetEventSlim releaseBackgroundThread = new ManualResetEventSlim(false))
+            {
+                Task backgroundThread = Task.Factory.StartNew(
+                    () => releaseBackgroundThread.Wait(),
+                    TaskCreationOptions.LongRunning);
+
+                try
+                {
+                    TestableBackgroundFileSystemTaskRunner runner = new TestableBackgroundFileSystemTaskRunner();
+                    runner.SetBackgroundThreadForTests(backgroundThread);
+
+                    // FileSystemCallbacks.Dispose() disposes this runner on the failed-mount
+                    // path, without calling Shutdown first, so the background thread is still
+                    // running. Calling Task.Dispose on a task that has not completed throws
+                    // InvalidOperationException, which stopped GVFS.Mount from reporting why
+                    // the mount failed. This guards against reintroducing that call.
+                    Assert.DoesNotThrow(() => runner.Dispose());
+                }
+                finally
+                {
+                    releaseBackgroundThread.Set();
+                    backgroundThread.Wait();
+                    backgroundThread.Dispose();
+                }
+            }
+        }
+
+        private class TestableBackgroundFileSystemTaskRunner : BackgroundFileSystemTaskRunner
+        {
+        }
+    }
+}

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/GitIndexProjectionDisposeTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/GitIndexProjectionDisposeTests.cs
@@ -23,10 +23,11 @@ namespace GVFS.UnitTests.Virtualization.Projection
                     projection.SetIndexParsingThreadForTests(parsingThread);
 
                     // A failed mount disposes the projection without calling Shutdown, so
-                    // the parsing thread is still running here. Disposing a Task that has
-                    // not completed throws InvalidOperationException, and that secondary
-                    // exception used to kill GVFS.Mount before it could report why the
-                    // mount failed -- leaving the client with a broken pipe.
+                    // the parsing thread is still running here. Calling Task.Dispose on a
+                    // task that has not completed throws InvalidOperationException, and
+                    // that secondary exception used to kill GVFS.Mount before it could
+                    // report why the mount failed -- leaving the client with a broken pipe.
+                    // This guards against reintroducing that call.
                     Assert.DoesNotThrow(() => projection.Dispose());
                 }
                 finally
@@ -36,20 +37,6 @@ namespace GVFS.UnitTests.Virtualization.Projection
                     parsingThread.Dispose();
                 }
             }
-        }
-
-        [TestCase]
-        public void DisposeDisposesIndexParsingThreadOnceItHasCompleted()
-        {
-            // Never use Task.CompletedTask here: it is a runtime-wide singleton, and
-            // disposing it breaks every later await in the process.
-            Task parsingThread = Task.Factory.StartNew(() => { }, TaskCreationOptions.LongRunning);
-            parsingThread.Wait();
-
-            TestableGitIndexProjection projection = new TestableGitIndexProjection();
-            projection.SetIndexParsingThreadForTests(parsingThread);
-
-            Assert.DoesNotThrow(() => projection.Dispose());
         }
 
         private class TestableGitIndexProjection : GitIndexProjection

--- a/GVFS/GVFS.UnitTests/Virtualization/Projection/GitIndexProjectionDisposeTests.cs
+++ b/GVFS/GVFS.UnitTests/Virtualization/Projection/GitIndexProjectionDisposeTests.cs
@@ -1,0 +1,59 @@
+using GVFS.Virtualization.Projection;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GVFS.UnitTests.Virtualization.Projection
+{
+    [TestFixture]
+    public class GitIndexProjectionDisposeTests
+    {
+        [TestCase]
+        public void DisposeDoesNotThrowWhenIndexParsingThreadIsStillRunning()
+        {
+            using (ManualResetEventSlim releaseParsingThread = new ManualResetEventSlim(false))
+            {
+                Task parsingThread = Task.Factory.StartNew(
+                    () => releaseParsingThread.Wait(),
+                    TaskCreationOptions.LongRunning);
+
+                try
+                {
+                    TestableGitIndexProjection projection = new TestableGitIndexProjection();
+                    projection.SetIndexParsingThreadForTests(parsingThread);
+
+                    // A failed mount disposes the projection without calling Shutdown, so
+                    // the parsing thread is still running here. Disposing a Task that has
+                    // not completed throws InvalidOperationException, and that secondary
+                    // exception used to kill GVFS.Mount before it could report why the
+                    // mount failed -- leaving the client with a broken pipe.
+                    Assert.DoesNotThrow(() => projection.Dispose());
+                }
+                finally
+                {
+                    releaseParsingThread.Set();
+                    parsingThread.Wait();
+                    parsingThread.Dispose();
+                }
+            }
+        }
+
+        [TestCase]
+        public void DisposeDisposesIndexParsingThreadOnceItHasCompleted()
+        {
+            // Never use Task.CompletedTask here: it is a runtime-wide singleton, and
+            // disposing it breaks every later await in the process.
+            Task parsingThread = Task.Factory.StartNew(() => { }, TaskCreationOptions.LongRunning);
+            parsingThread.Wait();
+
+            TestableGitIndexProjection projection = new TestableGitIndexProjection();
+            projection.SetIndexParsingThreadForTests(parsingThread);
+
+            Assert.DoesNotThrow(() => projection.Dispose());
+        }
+
+        private class TestableGitIndexProjection : GitIndexProjection
+        {
+        }
+    }
+}

--- a/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
+++ b/GVFS/GVFS.Virtualization/Background/BackgroundFileSystemTaskRunner.cs
@@ -122,13 +122,27 @@ namespace GVFS.Virtualization.Background
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Test seam. Puts the runner into the "background thread is still running" state
+        /// that a failed mount produces, without needing a real repo.
+        /// </summary>
+        internal void SetBackgroundThreadForTests(Task backgroundTask)
+        {
+            this.backgroundThread = backgroundTask;
+        }
+
         protected void Dispose(bool disposing)
         {
             if (disposing)
             {
                 if (this.backgroundThread != null)
                 {
-                    this.backgroundThread.Dispose();
+                    // Deliberately not calling Task.Dispose. A Task holds no unmanaged
+                    // resources, and Task.Dispose throws InvalidOperationException unless
+                    // the task has reached a completion state. A failed mount disposes the
+                    // callbacks without calling Shutdown first, so this thread is still
+                    // running and that throw would prevent the mount process from
+                    // reporting why the mount failed.
                     this.backgroundThread = null;
                 }
                 if (this.backgroundTasks != null)

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -739,17 +739,13 @@ namespace GVFS.Virtualization.Projection
 
                 if (this.indexParsingThread != null)
                 {
-                    // Task.Dispose throws InvalidOperationException unless the task has
-                    // reached a completion state. A failed mount disposes the projection
-                    // without calling Shutdown first, so the parsing thread is still
-                    // running here. Skip the Dispose in that case: a Task owns no
-                    // unmanaged resources, and throwing would kill the mount process
-                    // before it can report why the mount failed.
-                    if (this.indexParsingThread.IsCompleted)
-                    {
-                        this.indexParsingThread.Dispose();
-                    }
-
+                    // Deliberately not calling Task.Dispose. A Task holds no unmanaged
+                    // resources, Task.Dispose is legacy IAsyncResult wait-handle cleanup,
+                    // and it throws InvalidOperationException unless the task has reached
+                    // a completion state. A failed mount disposes the projection without
+                    // calling Shutdown first, so the parsing thread is still running here
+                    // and that throw would kill the mount process before it can report
+                    // why the mount failed.
                     this.indexParsingThread = null;
                 }
             }

--- a/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
+++ b/GVFS/GVFS.Virtualization/Projection/GitIndexProjection.cs
@@ -706,6 +706,15 @@ namespace GVFS.Virtualization.Projection
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Test seam. Puts the projection into the "index parsing thread is still
+        /// running" state that a failed mount produces, without needing a real repo.
+        /// </summary>
+        internal void SetIndexParsingThreadForTests(Task indexParsingTask)
+        {
+            this.indexParsingThread = indexParsingTask;
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
@@ -730,7 +739,17 @@ namespace GVFS.Virtualization.Projection
 
                 if (this.indexParsingThread != null)
                 {
-                    this.indexParsingThread.Dispose();
+                    // Task.Dispose throws InvalidOperationException unless the task has
+                    // reached a completion state. A failed mount disposes the projection
+                    // without calling Shutdown first, so the parsing thread is still
+                    // running here. Skip the Dispose in that case: a Task owns no
+                    // unmanaged resources, and throwing would kill the mount process
+                    // before it can report why the mount failed.
+                    if (this.indexParsingThread.IsCompleted)
+                    {
+                        this.indexParsingThread.Dispose();
+                    }
+
                     this.indexParsingThread = null;
                 }
             }


### PR DESCRIPTION
## Problem

`gvfs mount` reports a transport error instead of the real failure:

```
Could not connect to GVFS.Mount: GVFS.Common.NamedPipes.BrokenPipeException: Unable to send: GetStatus
 ---> System.IO.IOException: Pipe is broken.
```

The message names no cause and no remedy. `GVFS.Mount` had already diagnosed the
real problem and written it to its own log:

```
Error {"ErrorMessage":"StartVirtualizing failed: 800701DE(-2147024418)"}
Error {"ErrorMessage":"Error: Failed to start virtualization instance (-2147024418). Please confirm that gvfs clone completed without error."}
```

`0x800701DE` is `ERROR_FILE_SYSTEM_VIRTUALIZATION_NOT_AVAILABLE` — "The file
system minifilter cannot attach to the developer volume." PrjFlt was not on the
Dev Drive filter allow-list. The user had to read the mount log to find that out.

This was a regression. 1.0 attached ProjFS in the client process, so an attach
failure printed `Attaching ProjFS to volume...Failed` on the console the user was
looking at. 2.0 delegates ProjFS setup to `GVFS.Mount` and depends on the named
pipe to carry the error back — and that did not happen.

## Why the reason was lost

Two defects combined.

**1. A secondary exception killed the process.** After `StartVirtualizing`
failed, `FailMountAndExit` called `fileSystemCallbacks.Dispose()`, which reached
`GitIndexProjection.Dispose(bool)` and called `Task.Dispose()` on the still
running `indexParsingThread`. `Shutdown()` had never run, so the task was not in
a completion state:

```
System.InvalidOperationException: A task may only be disposed if it is in a completion state
```

That exception escaped before the process could serve a `GetStatus` response.

**2. The process exited before the client could poll.** Even without the
exception, `FailMountAndExit` called `Environment.Exit` immediately after setting
`MountState.MountFailed`. `WaitUntilMounted` polls `GetStatus` every 100ms, so
the process usually died first. `MountState.MountFailed` and the
`GetStatus.MountFailed` response already existed and were already polled for —
they were simply never observed.

## Changes

- **`GitIndexProjection.Dispose(bool)`** disposes the index-parsing task only
  once it has completed. A `Task` holds no unmanaged resources, so skipping the
  call is safe, and disposal no longer throws during a failed mount.

- **`InProcessMount.FailMountAndExit`** keeps the named pipe answering
  `GetStatus` after a failure, and exits once a client has read `MountFailed`.
  The wait is deliberately short — until the process exits it still holds the
  mount lock and its named pipe, and a `gvfs mount` retry inside that window hits
  `IsExistingPipeListening` and is told *"The repo at ... is already mounted"*
  with exit code `Success`. So the wait is capped at 2 seconds, or 500ms when no
  client has polled `GetStatus` at all, and normally ends on the client's next
  poll (~100ms). Failures raised before the pipe server starts do not wait —
  `MountVerb` already detects those through the mount process exit code.
  Callbacks are disposed *after* the failure is reported, and disposal exceptions
  are logged instead of terminating the process. A latch makes the first failing
  thread the only one that tears down and exits.

- **`GetStatus.Response` carries a `MountError` field**, so `WaitUntilMounted`
  prints the mount process's own message instead of the generic
  `Failed to mount at <path>`.

- **`0x800701DE` is translated into an actionable message.** `StartVirtualizing`
  failures with `ERROR_FILE_SYSTEM_VIRTUALIZATION_NOT_AVAILABLE` now name the
  cause and the remedy, including the enlistment's own volume. The message
  deliberately tells the user to read the current allowed-filter list first,
  because `fsutil devdrv setFiltersAllowed` **replaces** the list rather than
  appending to it — and without `/volume` it applies to every developer volume
  on the machine.

Automatically enabling the ProjFS filter on a Dev Drive is out of scope here.
This PR changes error reporting only.

## Tests

Two new unit test fixtures:

- `GitIndexProjectionDisposeTests` — disposing a projection whose parsing thread
  is still running must not throw, and a completed task must still be disposed.
- `WaitUntilMountedFailureReportingTests` — `WaitUntilMounted` must surface
  `MountError` when the mount process sends one, and fall back to the generic
  message when it does not. Drives a real named pipe.

Both fixtures were mutation-checked: reverting either production fix makes the
corresponding test fail.

```
Test Count: 964, Passed: 953, Failed: 0, Skipped: 11   (baseline: 960)
```

## Manual verification

Verified end-to-end on a real ReFS Dev Drive (`E:`, ARM64, PrjFlt **not** on the
allowed-filter list), cloning and mounting `ForTests` unelevated.

**Baseline — installed 2.0.26229.1, the exact version from the report:**

```
Mounting...Failed.
Could not connect to GVFS.Mount: GVFS.Common.NamedPipes.BrokenPipeException: Unable to send: GetStatus
 ---> System.IO.IOException: Pipe is broken.
```

with the real cause visible only in the mount log, along with the secondary exception:

```
Error {"ErrorMessage":"StartVirtualizing failed: 800701DE(-2147024418)"}
Error {"ErrorMessage":"Failed to initialize src folder callbacks. System.InvalidOperationException:
  A task may only be disposed if it is in a completion state ...
  at GVFS.Virtualization.Projection.GitIndexProjection.Dispose(Boolean)
  at GVFS.Virtualization.FileSystemCallbacks.Dispose()"}
```

**With this change:**

```
Mounting...Failed.
Error: Failed to start virtualization instance (-2147024418). The ProjFS filter (PrjFlt)
cannot attach to this volume. If E: is a Dev Drive, PrjFlt must be on its allowed-filter
list. From an elevated command prompt, list the filters that are already allowed:
    fsutil devdrv query E:
then set the list again with PrjFlt added to it:
    fsutil devdrv setFiltersAllowed /f /volume E: "<filters listed above>,PrjFlt"
setFiltersAllowed replaces the list, so keep the existing entries.
```

The mount log for that run contains no `InvalidOperationException` and no disposal
warning. A back-to-back `gvfs mount` retry printed the real error both times — no
spurious "already mounted".

### A second copy of the disposal bug, found only by the repro

The first round of fixes was **incomplete**. Re-running the repro showed the
`InvalidOperationException` still being thrown — this time from
`BackgroundFileSystemTaskRunner.Dispose`, which disposes its own still-running `Task` on
the same `FileSystemCallbacks.Dispose()` path. The report survived only because of the
new defensive `try/catch`. Both classes now drop the `Task.Dispose()` call outright: a
`Task` holds no unmanaged resources and `Task.Dispose` is legacy `IAsyncResult`
wait-handle cleanup. Both have mutation-checked regression tests.

### On the post-failure pipe lifetime

The mount process stays alive briefly after a failure so the client can read the reason.
This does **not** meaningfully extend the window in which `IsExistingPipeListening`
reports "already mounted": `StartNamedPipe()` runs early — before network auth, cache
resolution, hooks, and virtualization — so the pipe is already listening for the entire
mount attempt. Measured on the baseline run, the pipe was open **1,147 ms before** the
failure even occurred, on a tiny test repo; on a real enlistment it is far longer. This
change appends at most 2s, and typically ~150ms, to a pre-existing and larger window.

## Branch target

`master`. This restores an error message that 1.0 produced and 2.0 lost, so it is
a 2.0 regression fix and in scope for stabilization.


